### PR TITLE
fix: remove single quote in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Join us on Discord: https://discord.gg/agvGJaZXy5!
 
 ```fish 
 python3 -m venv .venv
- . .venv/bin/activate.fish # or activate.sh if you don't use fish
+ . .venv/bin/activate.fish # or activate.sh if you do not use fish
 ```
 3. Install `elodin`, and `matplotlib` with
 


### PR DESCRIPTION
The presence of a `'` was causing issues when copy and pasting the code into someone's terminal. Removed it

fixes https://github.com/elodin-sys/elodin/issues/6