### PR TITLE
Added doc-comments to tensor.rs

### DIFF
--- a/libs/nox/src/tensor.rs
+++ b/libs/nox/src/tensor.rs
@@ -33,15 +33,11 @@ where
 /// Trait for items that can be represented as tensors.
 /// Specifies the type of the item, its tensor representation, and dimensionality.
 pub trait TensorItem {
-    /// The type of the item that can be converted from an operation.
     type Item: FromOp;
-    /// The tensor type associated with the item.
     type Tensor<D>
     where
         D: TensorDim;
-    /// The dimensionality of the tensor.
     type Dim: TensorDim;
-    /// The element type of the tensor.
     const ELEM: ElementType;
 }
 
@@ -73,7 +69,6 @@ impl<T, D: TensorDim> FromOp for Tensor<T, D> {
 
 /// Trait for collapsing a tensor into a simpler form, typically by reducing its dimensionality.
 pub trait Collapse {
-    /// The output type after the collapse operation.
     type Out;
     /// Collapses the tensor into a simpler form.
     fn collapse(self) -> Self::Out;
@@ -409,13 +404,9 @@ impl<T, D: TensorDim> AsBuffer for Tensor<T, D, Buffer> {
 /// Trait for mapping dimensions in tensor operations.
 /// Allows for transforming and replacing dimensions in tensor types.
 pub trait MapDim<D> {
-    /// The item associated with the dimension mapping.
     type Item: TensorDim;
-    /// The dimension resulting from the mapping.
     type MappedDim: TensorDim;
-    /// The type resulting from replacing the mapped dimension with a new dimension `Dim`.
     type ReplaceMappedDim<Dim: TensorDim>: TensorDim;
-    /// The index of the dimension being mapped.
     const MAPPED_DIM: usize;
 }
 
@@ -522,7 +513,6 @@ impl<const N: usize> DefaultMap for Const<N> {
 
 /// Trait representing the concatenation of dimensions.
 pub trait DimConcat<A, B> {
-    /// The resulting dimension type after concatenation.
     type Output;
 }
 
@@ -624,7 +614,6 @@ impl<T: TensorItem, D: TensorDim + DefaultMap> Tensor<T, D, crate::Op> {
 
 /// Trait for broadcasting dimensions in tensor operations, used to unify dimensions for element-wise operations.
 pub trait BroadcastDim<D1, D2> {
-    /// The resulting dimension type after broadcasting.
     type Output: TensorDim;
 }
 
@@ -673,7 +662,6 @@ impl<T: TensorItem, D: TensorDim> Tensor<T, D> {
 
 /// Trait for indexing into tensors, allowing for the extraction of sub-tensors or elements based on indices.
 pub trait TensorIndex<T, D: TensorDim> {
-    /// The output type resulting from the indexing operation.
     type Output;
 
     /// Performs the indexing operation on a tensor, returning the result.

--- a/libs/nox/src/tensor.rs
+++ b/libs/nox/src/tensor.rs
@@ -11,8 +11,7 @@ use std::{
 };
 use xla::{ArrayElement, ElementType, NativeType};
 
-/// Represents a tensor with a specific type `T`, dimensionality `D`, and parameterization `P`.
-/// `P` dictates the underlying representation and operations available on the tensor.
+/// Represents a tensor with a specific type `T`, dimensionality `D`, and underlying representation `P`.
 #[repr(transparent)]
 pub struct Tensor<T, D: TensorDim, P: Param = Op> {
     pub(crate) inner: P::Inner,


### PR DESCRIPTION
Following the discussion in [issue11](https://github.com/elodin-sys/elodin/issues/11), here is a PR adding doc comments to `tensor.rs`. This is a first test in introducing AI-generated comments to document the library faster, making it easier to pick up by new users.

Here is a preview of what it looks like in conditions (`cargo doc --open --no-deps --all-features`):

![image](https://github.com/elodin-sys/elodin/assets/11976184/b12fd7fc-83d3-4b84-bec2-fc9b016dea36)
![image](https://github.com/elodin-sys/elodin/assets/11976184/b96035e6-54bd-4763-ad88-26c97334767b)

This is a test to think about the viability of this approach. Do feel free to comment and criticize (things can definitely be streamlined by hand, this PR had no manual tweak of the comments so far)!

For archival purposes, here is the prompt used to generate the comments (with GPT-4):

```
You will be given code from `nox`, a Rust implementation of JAX. Your goal is to doc-comment the code:
* adding a top-level doc comment (describing the current file's function),
* doc comment the functions (helping users understand the arguments and outputs of the function),
* doc comment types and traits.

Your output should be only the doc comments and headers, no need to include the rest of the code.

Also, keep your comments short and useful. No point in stating the obvious or writing a long sentence where a short one would do. Those comments should be there to help a new user understand how to use the library from a quick look.
```