### PR TITLE
Added doc-comments to Nox

### DIFF
--- a/libs/nox/src/builder.rs
+++ b/libs/nox/src/builder.rs
@@ -1,6 +1,8 @@
+//! Provides tools for constructing tensor operations and managing parameters.
 use crate::{Noxpr, Op, ScalarDim, Tensor};
 use std::cell::{RefCell, UnsafeCell};
 
+/// A builder for constructing tensor computations and managing tensor parameters.
 pub struct Builder {
     pub(crate) params: RefCell<Vec<Noxpr>>,
     pub(crate) mut_params: boxcar::Vec<UnsafeCell<Tensor<f32, ScalarDim, Op>>>,
@@ -8,6 +10,7 @@ pub struct Builder {
 }
 
 impl Builder {
+    /// Creates a new `Builder` instance with empty parameter lists.
     pub fn new() -> Self {
         Self {
             params: RefCell::new(vec![]),
@@ -16,6 +19,9 @@ impl Builder {
         }
     }
 
+    /// Registers an alias between two parameters by their indices.
+    ///
+    /// This is used to track and manage aliasing between parameters for operations that require or enforce it.
     pub fn setup_alias(&mut self, param_index: u64, alias_index: u64) {
         self.aliased_indexes.push((param_index, alias_index));
     }

--- a/libs/nox/src/client.rs
+++ b/libs/nox/src/client.rs
@@ -28,12 +28,12 @@ impl Client {
         }
     }
 
-    /// Disables optimizations in the compilation options.
+    /// Disables XLA optimizations.
     pub fn disable_optimizations(&mut self) {
         self.compile_options.disable_optimizations();
     }
 
-    /// Compiles an XLA computation into an executable using the client's compile options.
+    /// Compiles an XLA computation into a kernel using the client's compile options.
     pub fn compile(
         &self,
         comp: &xla::XlaComputation,
@@ -47,10 +47,10 @@ impl Client {
         xla::PjRtClient::cpu().map(Client::new).map_err(Error::from)
     }
 
-    /// Creates a new `Client` using the default GPU backend with memory settings.
+    /// Creates a new [`Client`] using the GPU backend with default memory settings
     /// By default the backend is either CUDA or Metal depending on your OS.
     ///
-    /// This functions uses a default memory fraction of `0.95` and does not preallocate any memory.
+    /// This function uses a default memory fraction of `0.95` and does not preallocate any memory.
     pub fn gpu() -> Result<Self, Error> {
         const DEFAULT_MEMORY_PERCENT: f64 = 0.95;
         xla::PjRtClient::gpu(DEFAULT_MEMORY_PERCENT, false)

--- a/libs/nox/src/client.rs
+++ b/libs/nox/src/client.rs
@@ -1,7 +1,9 @@
+//! Provides functionality for managing a client that interfaces with the XLA (Accelerated Linear Algebra) library.
 use std::ops::Deref;
 
 use crate::Error;
 
+/// Represents a high-level client for the XLA library, encapsulating compile options and client behaviors.
 #[derive(Clone)]
 pub struct Client {
     pjrt_client: xla::PjRtClient,
@@ -11,12 +13,14 @@ pub struct Client {
 impl Deref for Client {
     type Target = xla::PjRtClient;
 
+    /// Returns a reference to the underlying PJRT client.
     fn deref(&self) -> &Self::Target {
         &self.pjrt_client
     }
 }
 
 impl Client {
+    /// Creates a new `Client` with a provided PJRT client.
     fn new(pjrt_client: xla::PjRtClient) -> Self {
         Client {
             pjrt_client,
@@ -24,10 +28,12 @@ impl Client {
         }
     }
 
+    /// Disables optimizations in the compilation options.
     pub fn disable_optimizations(&mut self) {
         self.compile_options.disable_optimizations();
     }
 
+    /// Compiles an XLA computation into an executable using the client's compile options.
     pub fn compile(
         &self,
         comp: &xla::XlaComputation,
@@ -36,16 +42,15 @@ impl Client {
             .compile_with_options(comp, self.compile_options.clone())
     }
 
-    /// Create a new [`Client`] using the CPU based backend.
+    /// Creates a new `Client` using the default CPU backend.
     pub fn cpu() -> Result<Self, Error> {
         xla::PjRtClient::cpu().map(Client::new).map_err(Error::from)
     }
 
-    /// Create a new [`Client`] using a GPU based backend.
+    /// Creates a new `Client` using the default GPU backend with memory settings.
     /// By default the backend is either CUDA or Metal depending on your OS.
     ///
-    /// This functions uses the default memory fraction of `0.95`,
-    /// and does not preallocate any memory
+    /// This functions uses a default memory fraction of `0.95` and does not preallocate any memory.
     pub fn gpu() -> Result<Self, Error> {
         const DEFAULT_MEMORY_PERCENT: f64 = 0.95;
         xla::PjRtClient::gpu(DEFAULT_MEMORY_PERCENT, false)
@@ -53,12 +58,12 @@ impl Client {
             .map_err(Error::from)
     }
 
-    /// Create a new [`Client`] using a GPU based backend, with the specified memory percent.
+    /// Creates a new `Client` using the GPU backend with custom memory settings.
     /// By default the backend is either CUDA or Metal depending on your OS.
     ///
-    /// This function allows you to customize the memory limit, and preallocation behavior of the backend.
-    /// The first argument is the memory limit in the range [0..1.0].
-    /// The second paremeter is whether to preallocate memory or not.
+    /// # Parameters
+    /// - `mem_limit`: Memory limit in the range [0..1.0].
+    /// - `prealloc`: Whether to preallocate memory or not.
     pub fn gpu_with_memory_limit(mem_limit: f64, prealloc: bool) -> Result<Self, Error> {
         xla::PjRtClient::gpu(mem_limit, prealloc)
             .map(Client::new)

--- a/libs/nox/src/comp.rs
+++ b/libs/nox/src/comp.rs
@@ -1,4 +1,4 @@
-//! Provides the `Comp` struct which encapsulates XLA computations and methods for their manipulation.
+//! Provides the `Comp` struct which encapsulates an XLA computation with type information.
 use std::marker::PhantomData;
 
 use crate::{BufferForm, Client, Exec};
@@ -15,7 +15,7 @@ impl<T: BufferForm, R> Comp<T, R> {
         self.comp.to_hlo_text()
     }
 
-    /// Compiles the XLA computation into an executable, utilizing the specified client for execution environment context.
+    /// Compiles the XLA computation into a kernel.
     pub fn compile(&self, client: &Client) -> Result<Exec<T::BufferTy, R>, xla::Error> {
         let exec = client.compile(&self.comp)?;
         Ok(Exec {

--- a/libs/nox/src/comp.rs
+++ b/libs/nox/src/comp.rs
@@ -1,17 +1,21 @@
+//! Provides the `Comp` struct which encapsulates XLA computations and methods for their manipulation.
 use std::marker::PhantomData;
 
 use crate::{BufferForm, Client, Exec};
 
+/// Represents an XLA computation, parameterized over input and return types.
 pub struct Comp<T, R> {
     pub comp: xla::XlaComputation,
     pub(crate) phantom: PhantomData<(T, R)>,
 }
 
 impl<T: BufferForm, R> Comp<T, R> {
+    /// Converts the computation to a human-readable HLO (High Level Optimizer) text format.
     pub fn to_hlo_text(&self) -> Result<String, xla::Error> {
         self.comp.to_hlo_text()
     }
 
+    /// Compiles the XLA computation into an executable, utilizing the specified client for execution environment context.
     pub fn compile(&self, client: &Client) -> Result<Exec<T::BufferTy, R>, xla::Error> {
         let exec = client.compile(&self.comp)?;
         Ok(Exec {

--- a/libs/nox/src/comp_fn.rs
+++ b/libs/nox/src/comp_fn.rs
@@ -1,4 +1,4 @@
-//! Defines traits and structures for constructing functions and transforming them into executable formats.
+//! Defines traits and structures for constructing functions and transforming them into computational graphs.
 use crate::{
     ArrayTy, Builder, Comp, Dim, IntoOp, Noxpr, NoxprFn, NoxprTy, Op, Tensor, TensorItem, XlaDim,
 };

--- a/libs/nox/src/comp_fn.rs
+++ b/libs/nox/src/comp_fn.rs
@@ -1,4 +1,4 @@
-//! Defines traits and structures for constructing computational functions and transforming them into executable formats.
+//! Defines traits and structures for constructing functions and transforming them into executable formats.
 use crate::{
     ArrayTy, Builder, Comp, Dim, IntoOp, Noxpr, NoxprFn, NoxprTy, Op, Tensor, TensorItem, XlaDim,
 };

--- a/libs/nox/src/comp_fn.rs
+++ b/libs/nox/src/comp_fn.rs
@@ -1,11 +1,15 @@
+//! Defines traits and structures for constructing computational functions and transforming them into executable formats.
 use crate::{
     ArrayTy, Builder, Comp, Dim, IntoOp, Noxpr, NoxprFn, NoxprTy, Op, Tensor, TensorItem, XlaDim,
 };
 use std::{any, marker::PhantomData};
 
+/// Represents a computational function that can be converted into an XLA computation.
 pub trait CompFn<T, R>: Send + Sync {
+    /// Computes the result of the function, using a mutable reference to a `Builder` to construct the computation.
     fn compute(&self, builder: &mut Builder) -> R;
 
+    /// Builds the computational graph (`NoxprFn`) of the function.
     fn build_expr(&self) -> Result<NoxprFn, crate::Error>
     where
         R: IntoOp,
@@ -29,6 +33,9 @@ pub trait CompFn<T, R>: Send + Sync {
         })
     }
 
+    /// Converts the computational function into a compiled `Comp` type, which is executable within an XLA environment.
+    ///
+    /// This method is a convenience function that builds the expression and compiles it into a ready-to-execute form.
     fn build(&self) -> Result<Comp<T, R>, crate::Error>
     where
         R: IntoOp,
@@ -43,10 +50,17 @@ pub trait CompFn<T, R>: Send + Sync {
     }
 }
 
+/// Provides functionality to construct an item from a `Builder`.
 pub trait FromBuilder {
+    /// Defines the type of item that can be constructed from a `Builder`.
     type Item<'a>;
 
+    /// Constructs an item from the `Builder`.
     fn from_builder(builder: &Builder) -> Self::Item<'_>;
+
+    /// Indicates whether the constructed item has mutable borrow semantics within the builder context.
+    ///
+    /// Default implementation returns `false`, implying no mutable borrows are made.
     fn is_mut_borrowed() -> bool {
         false
     }

--- a/libs/nox/src/constant.rs
+++ b/libs/nox/src/constant.rs
@@ -1,9 +1,12 @@
+//! Provides an extension trait for creating constant representations of various data structures like scalars, vectors, matrices, and quaternions in a computational context.
 use crate::{ArrayTy, Matrix, Noxpr, Quaternion, Scalar, Vector};
 use nalgebra::{Const, IsContiguous, Storage};
 use smallvec::smallvec;
 use xla::{ArrayElement, NativeType};
 
+/// Trait to convert a given type into a constant representation suitable for computations.
 pub trait ConstantExt<Out> {
+    /// Returns a new constant representation of the implementing type.
     fn constant(&self) -> Out;
 }
 

--- a/libs/nox/src/error.rs
+++ b/libs/nox/src/error.rs
@@ -1,29 +1,54 @@
+//! Provides error definitions.
 use thiserror::Error;
 
+/// Enumerates possible error types that can occur within the Nox tensor operations.
 #[derive(Error, Debug)]
 pub enum Error {
+    /// Error propagated from underlying XLA library.
     #[error("xla error {0}")]
     Xla(#[from] xla::Error),
+
+    /// Error indicating that the length of the vmap axis does not match the number of inputs.
     #[error("vmap axis len must be same as input len")]
     WrongAxisLen,
+
+    /// Error when an argument passed to vmap is not batchable.
     #[error("vmap arguments must be batchable")]
     UnbatchableArgument,
+
+    /// Error when vmap is called without any arguments.
     #[error("vmap requires at least one argument")]
     VmapArgsEmpty,
+
+    /// Error when the length of in_axes does not match the number of vmap arguments.
     #[error("vmap requires in axis length to equal arguments length")]
     VmapInAxisMismatch,
+
+    /// Error when a JAX primitive operation encounters incompatible data types.
     #[error("this jaxpr has an incompatible dtype")]
     IncompatibleDType,
+
+    /// Error when attempting to extract a tuple element from a non-tuple type.
     #[error("get tuple element can only be called on a tuple")]
     GetTupleElemWrongType,
+
+    /// Error for out-of-bounds access in indexing operations.
     #[error("out of bounds access")]
     OutOfBoundsAccess,
+
+    /// Error propagated from Python operations via PyO3.
     #[error("pyo3 error {0}")]
     PyO3(#[from] pyo3::PyErr),
+
+    /// Error when the scan operation does not receive exactly two arguments.
     #[error("scan must have two arguments")]
     ScanWrongArgCount,
+
+    /// Error when no arguments are provided to a scan operation.
     #[error("scan must have at least one input")]
     ScanMissingArg,
+
+    /// Error when the dimensions of all scan arguments do not match.
     #[error("all scan arguments must have the same first dim")]
     ScanShapeMismatch,
 }

--- a/libs/nox/src/exec.rs
+++ b/libs/nox/src/exec.rs
@@ -1,4 +1,4 @@
-//! Provides functionality for executing operations and transferring data between host and device.
+//! Provides functionality for executing operations and transferring data between host and client device.
 use crate::{AsBuffer, BufferArg, BufferForm, Client, FromPjrtBuffer};
 use paste::paste;
 use std::marker::PhantomData;
@@ -14,7 +14,7 @@ pub trait ToHost {
     /// The type of data to be transferred to the host.
     type HostTy;
 
-    /// Transfers data from the device to the host.
+    /// Transfers data from the client device to the host.
     fn to_host(&self) -> Self::HostTy;
 }
 

--- a/libs/nox/src/exec.rs
+++ b/libs/nox/src/exec.rs
@@ -3,7 +3,7 @@ use crate::{AsBuffer, BufferArg, BufferForm, Client, FromPjrtBuffer};
 use paste::paste;
 use std::marker::PhantomData;
 
-/// Represents an executable compiled from an XLA computation, parameterized over input `T` and result `R` types.
+/// Represents an executable compiled from an XLA computation.
 pub struct Exec<T, R> {
     pub(crate) exec: xla::PjRtLoadedExecutable,
     pub(crate) phantom: PhantomData<(T, R)>,

--- a/libs/nox/src/exec.rs
+++ b/libs/nox/src/exec.rs
@@ -1,15 +1,20 @@
+//! Provides functionality for executing operations and transferring data between host and device.
 use crate::{AsBuffer, BufferArg, BufferForm, Client, FromPjrtBuffer};
 use paste::paste;
 use std::marker::PhantomData;
 
+/// Represents an executable compiled from an XLA computation, parameterized over input `T` and result `R` types.
 pub struct Exec<T, R> {
     pub(crate) exec: xla::PjRtLoadedExecutable,
     pub(crate) phantom: PhantomData<(T, R)>,
 }
 
+/// Defines a trait for converting computation results from device-specific representations to host types.
 pub trait ToHost {
+    /// The type of data to be transferred to the host.
     type HostTy;
 
+    /// Transfers data from the device to the host.
     fn to_host(&self) -> Self::HostTy;
 }
 

--- a/libs/nox/src/exec.rs
+++ b/libs/nox/src/exec.rs
@@ -30,6 +30,7 @@ macro_rules! impl_exec {
             $($ty: AsBuffer, )*
         {
             paste! {
+                #[doc = "Executes the compiled XLA computation with provided arguments."]
                 pub fn run<$([<arg_$ty>]: BufferArg<$ty>,)*>(&self, client: &Client, $(mut $ty: [<arg_$ty>],)*) -> Result<R::BufferTy, xla::Error> {
                     let mut args = xla::BufferArgsRef::default();
                     $(

--- a/libs/nox/src/exec.rs
+++ b/libs/nox/src/exec.rs
@@ -9,7 +9,7 @@ pub struct Exec<T, R> {
     pub(crate) phantom: PhantomData<(T, R)>,
 }
 
-/// Defines a trait for converting computation results from device-specific representations to host types.
+/// Defines a trait for converting computation results from client device representations to host types.
 pub trait ToHost {
     /// The type of data to be transferred to the host.
     type HostTy;

--- a/libs/nox/src/fields.rs
+++ b/libs/nox/src/fields.rs
@@ -1,4 +1,4 @@
-//! Defines the `Field` trait for scalar operations and constants, supporting basic arithmetic, matrix multiplication, and associated utilities for types like integers and floating-point numbers.
+//! Defines the `Field` trait for scalar operations and constants, supporting basic arithmetic, matrix multiplication, and associated utilities for numerical types.
 use std::ops::{Add, Div, Mul, Sub};
 
 use crate::{Scalar, TensorItem};

--- a/libs/nox/src/fields.rs
+++ b/libs/nox/src/fields.rs
@@ -1,7 +1,10 @@
+//! Defines the `Field` trait for scalar operations and constants, supporting basic arithmetic, matrix multiplication, and associated utilities for types like integers and floating-point numbers.
 use std::ops::{Add, Div, Mul, Sub};
 
 use crate::{Scalar, TensorItem};
 
+/// Represents a mathematical field, supporting basic arithmetic operations,
+/// matrix multiplication, and the generation of standard constants.
 pub trait Field:
     TensorItem<Elem = Self>
     + Copy
@@ -11,22 +14,32 @@ pub trait Field:
     + Div<Output = Self>
     + MatMul
 {
+    /// Returns a scalar tensor representing the additive identity (zero).
     fn zero() -> Scalar<Self>
     where
         Self: Sized;
+
+    /// Returns a scalar tensor representing the multiplicative identity (one).
     fn one() -> Scalar<Self>
     where
         Self: Sized;
+
+    /// Returns a scalar tensor representing the integer two.
     fn two() -> Scalar<Self>
     where
         Self: Sized;
 
+    /// Returns the primitive type representing zero.
     fn zero_prim() -> Self
     where
         Self: Sized;
+
+    /// Returns the primitive type representing one.
     fn one_prim() -> Self
     where
         Self: Sized;
+
+    /// Returns the primitive type representing two.
     fn two_prim() -> Self
     where
         Self: Sized;
@@ -75,6 +88,7 @@ impl_real_closed_field!(u16, 0, 1, 2);
 impl_real_closed_field!(u32, 0, 1, 2);
 impl_real_closed_field!(u64, 0, 1, 2);
 
+/// Trait for performing matrix multiplication.
 pub trait MatMul {
     /// Perform a matrix multiplication.
     ///

--- a/libs/nox/src/jax.rs
+++ b/libs/nox/src/jax.rs
@@ -1,3 +1,7 @@
+//! This module provides utilities for converting `Noxpr` expressions to `Jax` operations in Python.
+//!
+//! It interfaces with `pyo3` to execute operations within a Python environment using Jax libraries.
+//! Additionally, it includes the implementation of `JaxTracer` which manages the caching and translation of expressions.
 use pyo3::{
     exceptions::PyValueError,
     prelude::*,
@@ -11,12 +15,14 @@ use xla::{ArrayElement, ElementType, Literal};
 use crate::{BinaryOp, CompFn, Error, IntoOp, Noxpr, NoxprFn, NoxprId, NoxprNode};
 
 impl Noxpr {
+    /// Converts a `Noxpr` expression to a `Jax` operation using a tracer.
     pub fn to_jax(&self) -> Result<PyObject, Error> {
         let mut tracer = JaxTracer::new();
         tracer.visit(self)
     }
 }
 
+/// Traces `Noxpr` expressions and generates corresponding `Jax` operations.
 #[derive(Clone)]
 pub struct JaxTracer {
     lax: PyObject,
@@ -25,6 +31,7 @@ pub struct JaxTracer {
 }
 
 impl JaxTracer {
+    /// Initializes a new tracer with references to the Jax libraries.
     pub fn new() -> Self {
         Python::with_gil(|py| {
             let lax = py.import_bound("jax.lax").unwrap().into();
@@ -37,6 +44,7 @@ impl JaxTracer {
         })
     }
 
+    /// Visits a `Noxpr` expression and recursively translates it into a `Jax` operation.
     pub fn visit(&mut self, expr: &Noxpr) -> Result<PyObject, Error> {
         let id = expr.id();
         if let Some(op) = self.cache.get(&id) {
@@ -234,23 +242,27 @@ impl JaxTracer {
         Ok(op)
     }
 
+    /// Helper function to retrieve operands for a binary operation.
     #[inline]
     fn visit_binary_op(&mut self, op: &BinaryOp) -> Result<(PyObject, PyObject), Error> {
         Ok((self.visit(&op.lhs)?, self.visit(&op.rhs)?))
     }
 
+    /// Helper function to visit binary operations and apply the corresponding Jax method.
     #[inline]
     fn visit_binary_lax(&mut self, op: &BinaryOp, method: &str) -> Result<PyObject, Error> {
         let (lhs, rhs) = self.visit_binary_op(op)?;
         Python::with_gil(|py| self.lax.call_method1(py, method, (lhs, rhs))).map_err(Error::PyO3)
     }
 
+    /// Helper function to visit unary operations and apply the corresponding Jax method.
     #[inline]
     fn visit_unary_lax(&mut self, op: &Noxpr, method: &str) -> Result<PyObject, Error> {
         let inner = self.visit(op)?;
         Python::with_gil(|py| self.lax.call_method1(py, method, (inner,))).map_err(Error::PyO3)
     }
 
+    /// Wraps a `NoxprFn` into a callable Jax representation.
     fn visit_fn(&mut self, op: &NoxprFn) -> JaxNoxprFn {
         JaxNoxprFn {
             tracer: self.clone(),
@@ -259,6 +271,7 @@ impl JaxTracer {
     }
 }
 
+/// A Python callable wrapper for `NoxprFn` to be used in `Jax`.
 #[pyo3::prelude::pyclass]
 struct JaxNoxprFn {
     tracer: JaxTracer,
@@ -267,6 +280,7 @@ struct JaxNoxprFn {
 
 #[pyo3::prelude::pymethods]
 impl JaxNoxprFn {
+    /// Executes the function by translating it to a `Jax` operation.
     #[allow(unused_variables)]
     #[pyo3(signature = (*args, **kwargs))]
     fn __call__(
@@ -291,6 +305,7 @@ impl Default for JaxTracer {
     }
 }
 
+/// Converts a `Literal` to a Jax numpy array.
 fn literal_to_arr<T: ArrayElement + numpy::Element + bytemuck::Pod>(
     data: &Literal,
     shape: &SmallVec<[i64; 4]>,
@@ -309,6 +324,7 @@ fn literal_to_arr<T: ArrayElement + numpy::Element + bytemuck::Pod>(
     })
 }
 
+/// Maps `ElementType` to Python `dtype` strings.
 pub fn dtype(elem: &ElementType) -> Result<&'static str, Error> {
     match elem {
         ElementType::S8 => Ok("int8"),
@@ -329,6 +345,7 @@ pub fn dtype(elem: &ElementType) -> Result<&'static str, Error> {
     }
 }
 
+/// Executes a computational function and converts the result to a `Jax` operation.
 pub fn call_comp_fn<T, R: IntoOp>(
     func: impl CompFn<T, R>,
     args: &[PyObject],

--- a/libs/nox/src/jax.rs
+++ b/libs/nox/src/jax.rs
@@ -1,7 +1,4 @@
 //! This module provides utilities for converting `Noxpr` expressions to `Jax` operations in Python.
-//!
-//! It interfaces with `pyo3` to execute operations within a Python environment using Jax libraries.
-//! Additionally, it includes the implementation of `JaxTracer` which manages the caching and translation of expressions.
 use pyo3::{
     exceptions::PyValueError,
     prelude::*,

--- a/libs/nox/src/local_backend.rs
+++ b/libs/nox/src/local_backend.rs
@@ -285,6 +285,7 @@ where
 macro_rules! impl_op {
     ($op:tt, $op_trait:tt, $fn_name:tt) => {
         impl<T1: Copy, D1: ArrayDim + TensorDim + XlaDim> Array<T1, D1> {
+            #[doc = concat!("This function performs the `", stringify!($op_trait), "` operation on two arrays.")]
             pub fn $fn_name<D2: ArrayDim + TensorDim + XlaDim>(
                 &self,
                 b: &Array<T1, D2>,

--- a/libs/nox/src/local_backend.rs
+++ b/libs/nox/src/local_backend.rs
@@ -1,4 +1,4 @@
-//! Provides functionality for creating and manipulating multidimensional arrays with type-safe dimensions and operations.
+//! Provides a local, non-XLA backend for operating on Tensors.
 use nalgebra::{constraint::ShapeConstraint, Const, Dyn};
 use smallvec::SmallVec;
 use std::{
@@ -95,7 +95,7 @@ pub trait ArrayBuf<T>: Clone {
     fn as_mut_buf(&mut self) -> &mut [T];
 }
 
-/// Extends `ArrayBuf` for uninitialized memory management, crucial for safe and efficient array initialization.
+/// Extends `ArrayBuf` for uninitialized memory management.
 pub trait ArrayBufUnit<T>: ArrayBuf<MaybeUninit<T>> {
     fn uninit(dims: &[usize]) -> Self;
 
@@ -348,7 +348,7 @@ impl_op!(-, Sub, sub);
 impl_op!(/, Div, div);
 
 impl<T1: Copy, D1: ArrayDim + TensorDim + XlaDim> Array<T1, D1> {
-    /// Generates an iterator over the elements of the array after applying broadcasting to new dimensions.
+    /// Generates an iterator over the elements of the array after broadcasting to new dimensions.
     pub fn broadcast_iter(
         &self,
         new_dims: impl AsMut<[usize]> + AsRef<[usize]> + Clone,

--- a/libs/nox/src/local_backend.rs
+++ b/libs/nox/src/local_backend.rs
@@ -231,8 +231,11 @@ impl<const D1: usize, const D2: usize, const D3: usize, T: Copy + Clone> ArrayBu
     }
 }
 
+/// Trait marking types that can be instantiated as uninitialized memory blocks.
 pub trait MaybeUnitMarker {
     type Init;
+
+    /// Creates an uninitialized instance of the type.
     fn uninit() -> Self;
 }
 
@@ -529,21 +532,26 @@ impl<T1: Copy, D1: ArrayDim + TensorDim + XlaDim> Array<T1, D1> {
     }
 }
 
+/// Represents a type resulting from combining dimensions of two arrays during concatenation operations.
 type ConcatDim<D1, D2> = ReplaceMappedDim<
     <D2 as DefaultMap>::DefaultMapDim,
     D1,
     AddDim<DefaultMappedDim<D1>, DefaultMappedDim<D2>>,
 >;
 
+/// Represents a type resulting from multiplying a dimension by a constant, used in expanding arrays.
 pub type ConcatManyDim<D1, const N: usize> =
     ReplaceMappedDim<<D1 as DefaultMap>::DefaultMapDim, D1, MulDim<DefaultMappedDim<D1>, Const<N>>>;
 
+/// Represents a type resulting from multiplication operations between two dimensions.
 pub type MulDim<A, B> = <A as nalgebra::DimMul<B>>::Output;
 
+/// Trait to enable retrieving a specified dimension type from a composite dimension.
 pub trait DimGet<D: Dim> {
     type Output: Dim;
 }
 
+/// Type alias for the result of a get operation, providing a sliced view of the array.
 pub type GetDim<D> = <ShapeConstraint as DimGet<D>>::Output;
 
 impl<const N: usize> DimGet<Const<N>> for ShapeConstraint {
@@ -617,6 +625,7 @@ impl<'a, T, S: AsRef<[usize]>, I: AsMut<[usize]>, D: AsRef<[usize]>> Iterator
     }
 }
 
+/// Backend implementation for local computation on arrays.
 pub struct LocalBackend;
 
 impl Repr for LocalBackend {

--- a/libs/nox/src/local_backend.rs
+++ b/libs/nox/src/local_backend.rs
@@ -261,12 +261,14 @@ impl<T1: Copy, D1: ArrayDim + TensorDim + XlaDim> Array<MaybeUninit<T1>, D1>
 where
     D1::Buf<MaybeUninit<T1>>: ArrayBufUnit<T1>,
 {
+    /// Constructs an uninitialized array given dimensions.
     fn uninit(dims: &[usize]) -> Self {
         Self {
             buf: D1::Buf::<MaybeUninit<T1>>::uninit(dims),
         }
     }
 
+    /// Transitions the array from uninitialized to initialized state, assuming all values are initialized.
     unsafe fn assume_init(self) -> Array<T1, D1>
     where
         <D1 as ArrayDim>::Buf<MaybeUninit<T1>>: ArrayBufUnit<T1, Init = <D1 as ArrayDim>::Buf<T1>>,
@@ -342,6 +344,7 @@ impl_op!(-, Sub, sub);
 impl_op!(/, Div, div);
 
 impl<T1: Copy, D1: ArrayDim + TensorDim + XlaDim> Array<T1, D1> {
+    /// Generates an iterator over the elements of the array after applying broadcasting to new dimensions.
     pub fn broadcast_iter(
         &self,
         new_dims: impl AsMut<[usize]> + AsRef<[usize]> + Clone,
@@ -384,6 +387,7 @@ impl<T1: Copy, D1: ArrayDim + TensorDim + XlaDim> Array<T1, D1> {
         })
     }
 
+    /// Performs a dot product between two arrays and returns a new array.
     fn dot<D2>(
         &self,
         right: &Array<T1, D2>,
@@ -441,6 +445,7 @@ impl<T1: Copy, D1: ArrayDim + TensorDim + XlaDim> Array<T1, D1> {
         }
     }
 
+    /// Concatenates two arrays along the first dimension.
     pub fn concat<D2: Dim + DefaultMap>(
         &self,
         right: &Array<T1, D2>,
@@ -474,6 +479,7 @@ impl<T1: Copy, D1: ArrayDim + TensorDim + XlaDim> Array<T1, D1> {
         unsafe { out.assume_init() }
     }
 
+    /// Concatenates multiple arrays into a single array along a specified dimension.
     pub fn concat_many<const N: usize>(args: [&Array<T1, D1>; N]) -> Array<T1, ConcatManyDim<D1, N>>
     where
         DefaultMappedDim<D1>: nalgebra::DimMul<Const<N>> + nalgebra::Dim,
@@ -503,6 +509,7 @@ impl<T1: Copy, D1: ArrayDim + TensorDim + XlaDim> Array<T1, D1> {
         unsafe { out.assume_init() }
     }
 
+    /// Retrieves a specific element from the array based on an index, effectively slicing the array.
     pub fn get(&self, index: usize) -> Array<T1, GetDim<D1>>
     where
         ShapeConstraint: DimGet<D1>,

--- a/libs/nox/src/matrix.rs
+++ b/libs/nox/src/matrix.rs
@@ -1,4 +1,4 @@
-//! Provides functionality for handling matrices in computational tasks, supporting conversion between host and Nox-specific representations, and enabling matrix operations like constant initialization.
+//! Provides a Matrix type alias with convenience functions for converting to various representations.
 use crate::{
     ArrayTy, Buffer, BufferArg, Client, FromHost, Literal, MaybeOwned, Noxpr, Op, Tensor, ToHost,
 };

--- a/libs/nox/src/matrix.rs
+++ b/libs/nox/src/matrix.rs
@@ -1,3 +1,4 @@
+//! Provides functionality for handling matrices in computational tasks, supporting conversion between host and Nox-specific representations, and enabling matrix operations like constant initialization.
 use crate::{
     ArrayTy, Buffer, BufferArg, Client, FromHost, Literal, MaybeOwned, Noxpr, Op, Tensor, ToHost,
 };
@@ -7,6 +8,7 @@ use smallvec::smallvec;
 use std::marker::PhantomData;
 use xla::{ArrayElement, NativeType};
 
+/// Type alias for a tensor that specifically represents a matrix.
 pub type Matrix<T, const R: usize, const C: usize, P = Op> = Tensor<T, (Const<R>, Const<C>), P>;
 
 impl<T, const R: usize, const C: usize> ToHost for Matrix<T, R, C, Buffer>
@@ -37,6 +39,7 @@ where
 }
 
 impl<T: ArrayElement + NativeType, const R: usize, const C: usize> Matrix<T, R, C, Literal> {
+    /// Converts a literal matrix to a constant matrix for operations within Nox.
     pub fn constant(self) -> Matrix<T, R, C, Op> {
         let inner = Noxpr::constant(
             self.inner,
@@ -53,9 +56,15 @@ impl<T: ArrayElement + NativeType, const R: usize, const C: usize> Matrix<T, R, 
     }
 }
 
+/// Extension trait for matrix operations specific to the Nox computational framework.
 pub trait MatrixExt<T: ArrayElement + NativeType, const R: usize, const C: usize> {
+    /// Converts the matrix to a constant matrix representation.
     fn constant(&self) -> Matrix<T, R, C, Op>;
+
+    /// Converts the matrix to a literal matrix representation.
     fn literal(&self) -> Matrix<T, R, C, Literal>;
+
+    /// Converts the matrix to a buffer for device-side operations.
     fn buffer(&self, client: &Client) -> Matrix<T, R, C, Buffer>;
 }
 

--- a/libs/nox/src/matrix.rs
+++ b/libs/nox/src/matrix.rs
@@ -56,7 +56,7 @@ impl<T: ArrayElement + NativeType, const R: usize, const C: usize> Matrix<T, R, 
     }
 }
 
-/// Extension trait for matrix operations specific to the Nox computational framework.
+/// Extension trait to convert between different representations.
 pub trait MatrixExt<T: ArrayElement + NativeType, const R: usize, const C: usize> {
     /// Converts the matrix to a constant matrix representation.
     fn constant(&self) -> Matrix<T, R, C, Op>;
@@ -64,7 +64,7 @@ pub trait MatrixExt<T: ArrayElement + NativeType, const R: usize, const C: usize
     /// Converts the matrix to a literal matrix representation.
     fn literal(&self) -> Matrix<T, R, C, Literal>;
 
-    /// Converts the matrix to a buffer for device-side operations.
+    /// Converts the matrix to a buffer for client-side operations.
     fn buffer(&self, client: &Client) -> Matrix<T, R, C, Buffer>;
 }
 

--- a/libs/nox/src/noxpr.rs
+++ b/libs/nox/src/noxpr.rs
@@ -1,4 +1,4 @@
-//! Provides the data structures and operations for representing and manipulating expression trees (Noxpr).
+//! Provides the data structures and operations for representing and manipulating tensor computations as expression trees (Noxpr).
 use std::{
     collections::HashMap,
     fmt::Display,
@@ -16,7 +16,7 @@ use crate::{
     CompFn, DefaultMap, DefaultMappedDim, Dim, Error, FromOp, IntoOp, MapDim, Tensor, TensorItem,
 };
 
-/// Represents various types of nodes in an expression tree for tensor computations.
+/// Represents various types of nodes in an expression tree (Noxpr) for tensor computations.
 #[derive(Debug)]
 pub enum NoxprNode {
     // Params / Variables
@@ -74,7 +74,7 @@ pub enum NoxprNode {
     Jax(pyo3::PyObject),
 }
 
-/// Represents a constant value within the expression tree.
+/// Represents a constant value within the Noxpr.
 #[derive(Clone)]
 pub struct Constant {
     pub data: xla::Literal, // NOTE: it might make more sense to use the xla independent store below
@@ -88,7 +88,7 @@ impl std::fmt::Debug for Constant {
     }
 }
 
-/// Represents the type of a node in the expression tree, either a tuple or array type.
+/// Represents the type of a node in the Noxpr, either a tuple or array type.
 #[derive(Debug, Clone)]
 pub enum NoxprTy {
     Tuple(Vec<NoxprTy>),
@@ -160,7 +160,7 @@ pub struct Iota {
     pub dim: usize,
 }
 
-/// Represents a binary operation in the expression tree.
+/// Represents a binary operation in the Noxpr.
 #[derive(Debug)]
 pub struct BinaryOp {
     pub lhs: Noxpr,
@@ -358,14 +358,14 @@ impl DotDimensionNums {
     }
 }
 
-/// Stores the details for concatenation operations within the expression tree.
+/// Stores the details for concatenation operations within the Noxpr.
 #[derive(Debug)]
 pub struct Concat {
     pub nodes: Vec<Noxpr>,
     pub dimension: usize,
 }
 
-/// Represents slicing operations within the expression tree.
+/// Represents slicing operations within the Noxpr.
 #[derive(Debug)]
 pub struct Slice {
     pub expr: Noxpr,
@@ -374,7 +374,7 @@ pub struct Slice {
     pub strides: SmallVec<[i64; 4]>,
 }
 
-/// Represents dynamic slicing operations within the expression tree.
+/// Represents dynamic slicing operations within the Noxpr.
 #[derive(Debug)]
 pub struct DynamicSlice {
     pub expr: Noxpr,
@@ -382,14 +382,14 @@ pub struct DynamicSlice {
     pub size_indices: SmallVec<[i64; 4]>,
 }
 
-/// Represents reshaping operations within the expression tree.
+/// Represents reshaping operations within the Noxpr.
 #[derive(Debug)]
 pub struct Reshape {
     pub expr: Noxpr,
     pub new_sizes: SmallVec<[i64; 4]>,
 }
 
-/// Represents a broadcast operation within the expression tree.
+/// Represents a broadcast operation within the Noxpr.
 #[derive(Debug)]
 pub struct Broadcast {
     pub expr: Noxpr,
@@ -404,7 +404,7 @@ pub struct BroadcastInDim {
     pub broadcast_dims: SmallVec<[i64; 4]>,
 }
 
-/// Represents a transpose operation within the expression tree.
+/// Represents a transpose operation within the Noxpr.
 #[derive(Debug)]
 pub struct Transpose {
     pub expr: Noxpr,
@@ -1177,7 +1177,7 @@ impl Deref for Noxpr {
     }
 }
 
-/// Represents a parameter in the expression tree.
+/// Represents a parameter in the Noxpr.
 #[derive(Debug, Clone)]
 pub struct ParamExpr {
     pub number: i64,

--- a/libs/nox/src/noxpr.rs
+++ b/libs/nox/src/noxpr.rs
@@ -319,6 +319,7 @@ impl DotGeneral {
     }
 }
 
+/// Stores dimensions specifications for generalized dot product operations.
 #[derive(Debug, Clone, Default)]
 pub struct DotDimensionNums {
     pub lhs_contracting_dimensions: SmallVec<[i64; 2]>,
@@ -1209,12 +1210,14 @@ impl_binary_op!(Mul, mul, Mul);
 impl_binary_op!(Div, div, Div);
 impl_binary_op!(Sub, sub, Sub);
 
+/// Traces and transforms `Noxpr` expressions into XLA operations.
 pub struct XlaTracer {
     builder: XlaBuilder,
     cache: HashMap<NoxprId, XlaOp>,
 }
 
 impl XlaTracer {
+    /// Constructs a new `XlaTracer` with a specified computation name.
     pub fn new(name: &str) -> Self {
         Self {
             builder: XlaBuilder::new(name),
@@ -1222,6 +1225,7 @@ impl XlaTracer {
         }
     }
 
+    /// Visits a `Noxpr`, recursively compiling it into an `XlaOp` using the XlaBuilder, with caching to prevent redundant computations.
     pub fn visit(&mut self, expr: &Noxpr) -> Result<XlaOp, Error> {
         let id = expr.id();
         if let Some(op) = self.cache.get(&id) {
@@ -1480,6 +1484,7 @@ impl XlaTracer {
         Ok(op)
     }
 
+    /// Helps in visiting and compiling binary operations like Add, Mul into XLA binary operations.
     #[inline]
     fn visit_binary_op(&mut self, op: &BinaryOp) -> Result<(XlaOp, XlaOp), Error> {
         Ok((self.visit(&op.lhs)?, self.visit(&op.rhs)?))

--- a/libs/nox/src/noxpr.rs
+++ b/libs/nox/src/noxpr.rs
@@ -1,3 +1,4 @@
+//! Provides the data structures and operations for representing and manipulating expression trees (Noxpr).
 use std::{
     collections::HashMap,
     fmt::Display,
@@ -15,6 +16,7 @@ use crate::{
     CompFn, DefaultMap, DefaultMappedDim, Dim, Error, FromOp, IntoOp, MapDim, Tensor, TensorItem,
 };
 
+/// Represents various types of nodes in an expression tree for tensor computations.
 #[derive(Debug)]
 pub enum NoxprNode {
     // Params / Variables
@@ -72,6 +74,7 @@ pub enum NoxprNode {
     Jax(pyo3::PyObject),
 }
 
+/// Represents a constant value within the expression tree.
 #[derive(Clone)]
 pub struct Constant {
     pub data: xla::Literal, // NOTE: it might make more sense to use the xla independent store below
@@ -85,6 +88,7 @@ impl std::fmt::Debug for Constant {
     }
 }
 
+/// Represents the type of a node in the expression tree, either a tuple or array type.
 #[derive(Debug, Clone)]
 pub enum NoxprTy {
     Tuple(Vec<NoxprTy>),
@@ -109,6 +113,7 @@ impl NoxprTy {
     }
 }
 
+/// Represents a type of array including its element type and shape.
 #[derive(Debug, Clone)]
 pub struct ArrayTy {
     pub element_type: ElementType,
@@ -146,12 +151,14 @@ impl From<NoxprTy> for xla::Shape {
     }
 }
 
+/// Represents an operation producing an array of sequential integers.
 #[derive(Debug, Clone)]
 pub struct Iota {
     pub shape: ArrayTy,
     pub dim: usize,
 }
 
+/// Represents a binary operation in the expression tree.
 #[derive(Debug)]
 pub struct BinaryOp {
     pub lhs: Noxpr,
@@ -200,6 +207,7 @@ pub(crate) fn broadcast_dims(lhs: &[i64], rhs: &[i64]) -> Option<SmallVec<[i64; 
         .collect()
 }
 
+/// Represents a generalized dot product operation for matrix or tensor multiplication.
 #[derive(Debug)]
 pub struct DotGeneral {
     pub lhs: Noxpr,
@@ -341,12 +349,14 @@ impl DotDimensionNums {
     }
 }
 
+/// Stores the details for concatenation operations within the expression tree.
 #[derive(Debug)]
 pub struct Concat {
     pub nodes: Vec<Noxpr>,
     pub dimension: usize,
 }
 
+/// Represents slicing operations within the expression tree.
 #[derive(Debug)]
 pub struct Slice {
     pub expr: Noxpr,
@@ -355,6 +365,7 @@ pub struct Slice {
     pub strides: SmallVec<[i64; 4]>,
 }
 
+/// Represents dynamic slicing operations within the expression tree.
 #[derive(Debug)]
 pub struct DynamicSlice {
     pub expr: Noxpr,
@@ -362,18 +373,21 @@ pub struct DynamicSlice {
     pub size_indices: SmallVec<[i64; 4]>,
 }
 
+/// Represents reshaping operations within the expression tree.
 #[derive(Debug)]
 pub struct Reshape {
     pub expr: Noxpr,
     pub new_sizes: SmallVec<[i64; 4]>,
 }
 
+/// Represents a broadcast operation within the expression tree.
 #[derive(Debug)]
 pub struct Broadcast {
     pub expr: Noxpr,
     pub sizes: SmallVec<[i64; 4]>,
 }
 
+/// Represents a broadcast operation with specific dimensions.
 #[derive(Debug)]
 pub struct BroadcastInDim {
     pub expr: Noxpr,
@@ -381,12 +395,14 @@ pub struct BroadcastInDim {
     pub broadcast_dims: SmallVec<[i64; 4]>,
 }
 
+/// Represents a transpose operation within the expression tree.
 #[derive(Debug)]
 pub struct Transpose {
     pub expr: Noxpr,
     pub permutation: SmallVec<[i64; 4]>,
 }
 
+/// Represents a gather operation, a form of advanced indexing.
 #[derive(Debug)]
 pub struct Gather {
     pub expr: Noxpr,
@@ -398,6 +414,7 @@ pub struct Gather {
     pub index_vector_dim: i64,
 }
 
+/// Represents a dynamic update slice operation, updating slices of a tensor dynamically.
 #[derive(Debug)]
 pub struct DynamicUpdateSlice {
     pub expr: Noxpr,
@@ -405,6 +422,7 @@ pub struct DynamicUpdateSlice {
     pub update: Noxpr,
 }
 
+/// Represents the operation to extract an element from a tuple.
 #[derive(Debug)]
 pub struct GetTupleElement {
     pub expr: Noxpr,
@@ -418,6 +436,7 @@ pub struct Noxpr {
     pub backtrace: Arc<std::backtrace::Backtrace>,
 }
 
+/// Represents a scan operation, a form of reduction across one dimension.
 #[derive(Debug, Clone)]
 pub struct Scan {
     pub inputs: Vec<Noxpr>,
@@ -1112,6 +1131,7 @@ impl Deref for Noxpr {
     }
 }
 
+/// Represents a parameter in the expression tree.
 #[derive(Debug, Clone)]
 pub struct ParamExpr {
     pub number: i64,

--- a/libs/nox/src/param.rs
+++ b/libs/nox/src/param.rs
@@ -1,3 +1,4 @@
+//! Provides definitions and traits for handling operations on tensor dimensions and data types.
 use std::{
     iter,
     mem::MaybeUninit,
@@ -19,14 +20,17 @@ pub struct Literal;
 
 pub struct Buffer;
 
+/// Defines a trait for dimensions supporting tensor operations, XLA compatibility, and array storage.
 pub trait Dim: ArrayDim + TensorDim + XlaDim {}
 impl<D: ArrayDim + TensorDim + XlaDim> Dim for D {}
 
+/// Represents the interface for data representations in tensor operations.
 pub trait Repr {
     type Inner<T, D: Dim>
     where
         T: Copy;
 
+    /// Performs element-wise addition of two tensors, broadcasting as necessary.
     fn add<T, D1, D2>(
         left: &Self::Inner<T, D1>,
         right: &Self::Inner<T, D2>,
@@ -39,6 +43,8 @@ pub trait Repr {
         <ShapeConstraint as BroadcastDim<D1, D2>>::Output: Dim + ArrayDim,
         <BroadcastedDim<D1, D2> as ArrayDim>::Buf<MaybeUninit<T>>:
             ArrayBufUnit<T, Init = <BroadcastedDim<D1, D2> as ArrayDim>::Buf<T>>;
+
+    /// Performs element-wise subtraction of two tensors, broadcasting as necessary.
     fn sub<T, D1, D2>(
         left: &Self::Inner<T, D1>,
         right: &Self::Inner<T, D2>,
@@ -51,6 +57,8 @@ pub trait Repr {
         <ShapeConstraint as BroadcastDim<D1, D2>>::Output: Dim + ArrayDim,
         <BroadcastedDim<D1, D2> as ArrayDim>::Buf<MaybeUninit<T>>:
             ArrayBufUnit<T, Init = <BroadcastedDim<D1, D2> as ArrayDim>::Buf<T>>;
+
+    /// Performs element-wise multiplication of two tensors, broadcasting as necessary.
     fn mul<T, D1, D2>(
         left: &Self::Inner<T, D1>,
         right: &Self::Inner<T, D2>,
@@ -64,6 +72,7 @@ pub trait Repr {
         <BroadcastedDim<D1, D2> as ArrayDim>::Buf<MaybeUninit<T>>:
             ArrayBufUnit<T, Init = <BroadcastedDim<D1, D2> as ArrayDim>::Buf<T>>;
 
+    /// Performs element-wise division of two tensors, broadcasting as necessary.
     fn div<T, D1, D2>(
         left: &Self::Inner<T, D1>,
         right: &Self::Inner<T, D2>,
@@ -77,6 +86,7 @@ pub trait Repr {
         <BroadcastedDim<D1, D2> as ArrayDim>::Buf<MaybeUninit<T>>:
             ArrayBufUnit<T, Init = <BroadcastedDim<D1, D2> as ArrayDim>::Buf<T>>;
 
+    /// Computes the dot product of two tensors.
     fn dot<T, D1, D2>(
         left: &Self::Inner<T, D1>,
         right: &Self::Inner<T, D2>,
@@ -90,6 +100,7 @@ pub trait Repr {
         <DottedDim<D1, D2> as ArrayDim>::Buf<MaybeUninit<T>>:
             ArrayBufUnit<T, Init = <DottedDim<D1, D2> as ArrayDim>::Buf<T>>;
 
+    /// Concatenates multiple tensors along a new dimension.
     fn concat_many<T1: Field, D1, const N: usize>(
         args: [&Self::Inner<T1, D1>; N],
     ) -> Self::Inner<T1, ConcatManyDim<D1, N>>
@@ -103,6 +114,7 @@ pub trait Repr {
         <ConcatManyDim<D1, N> as ArrayDim>::Buf<MaybeUninit<T1>>:
             ArrayBufUnit<T1, Init = <ConcatManyDim<D1, N> as ArrayDim>::Buf<T1>>;
 
+    /// Retrieves a specific tensor based on an index within a dimension.
     fn get<T1: Field, D1: Dim>(
         arg: &Self::Inner<T1, D1>,
         index: usize,

--- a/libs/nox/src/param.rs
+++ b/libs/nox/src/param.rs
@@ -14,7 +14,7 @@ use crate::{
     DottedDim, Field, GetDim, MapDim, MulDim, Noxpr, TensorDim, XlaDim,
 };
 
-/// Represents an operand.
+/// Represents a compute operation.
 pub struct Op;
 
 /// Represents a literal value.

--- a/libs/nox/src/param.rs
+++ b/libs/nox/src/param.rs
@@ -14,10 +14,13 @@ use crate::{
     DottedDim, Field, GetDim, MapDim, MulDim, Noxpr, TensorDim, XlaDim,
 };
 
+/// Represents an operand.
 pub struct Op;
 
+/// Represents a literal value.
 pub struct Literal;
 
+/// Represents a memory buffer.
 pub struct Buffer;
 
 /// Defines a trait for dimensions supporting tensor operations, XLA compatibility, and array storage.

--- a/libs/nox/src/quaternion.rs
+++ b/libs/nox/src/quaternion.rs
@@ -62,7 +62,7 @@ impl<T: Field> Quaternion<T> {
         Quaternion(inner)
     }
 
-    /// Creates a quaternion from a 3D axis and an angle.
+    /// Creates a quaternion from an axis and an angle.
     pub fn from_axis_angle(axis: impl Into<Vector<T, 3>>, angle: impl Into<Scalar<T>>) -> Self {
         let axis = axis.into();
         let axis = axis.normalize();

--- a/libs/nox/src/quaternion.rs
+++ b/libs/nox/src/quaternion.rs
@@ -1,3 +1,4 @@
+//! Provides functionality to handle quaternions, which are constructs used to represent and manipulate spatial orientations and rotations in 3D space.
 use std::ops::{Add, Mul};
 
 use nalgebra::{Const, RealField, Scalar as NalgebraScalar};
@@ -10,7 +11,7 @@ use crate::{
     ToHost, Vector,
 };
 
-/// Quaternion is representation of spatial orientation or rotation in 3D space.
+/// Represents a quaternion for spatial orientation or rotation in 3D space.
 pub struct Quaternion<T: TensorItem, P: Repr = Op>(pub Vector<T, 4, P>);
 
 impl<T: TensorItem> Clone for Quaternion<T> {
@@ -38,6 +39,7 @@ impl<T: TensorItem> std::fmt::Debug for Quaternion<T> {
 }
 
 impl<T: Field> Quaternion<T> {
+    /// Constructs a new quaternion from individual scalar components.
     pub fn new(
         w: impl Into<Scalar<T>>,
         x: impl Into<Scalar<T>>,
@@ -52,7 +54,7 @@ impl<T: Field> Quaternion<T> {
         Quaternion(inner)
     }
 
-    /// Create a unit quaternion with no rotation.
+    /// Creates a unit quaternion with no rotation.
     pub fn identity() -> Self {
         let inner = T::zero()
             .broadcast::<Const<3>>()
@@ -60,7 +62,7 @@ impl<T: Field> Quaternion<T> {
         Quaternion(inner)
     }
 
-    /// Create a quaternion from an axis and an angle.
+    /// Creates a quaternion from a 3D axis and an angle.
     pub fn from_axis_angle(axis: impl Into<Vector<T, 3>>, angle: impl Into<Scalar<T>>) -> Self {
         let axis = axis.into();
         let axis = axis.normalize();
@@ -72,23 +74,25 @@ impl<T: Field> Quaternion<T> {
         Quaternion(inner)
     }
 
+    /// Returns the four parts (components) of the quaternion as scalars.
     fn parts(&self) -> [Scalar<T>; 4] {
         let Quaternion(v) = self;
         v.parts()
     }
 
+    /// Returns the conjugate of the quaternion.
     pub fn conjugate(&self) -> Self {
         let [i, j, k, w] = self.parts();
         Quaternion(Vector::from_arr([&-i, &-j, &-k, &w]))
     }
 
-    /// Compute the inverse of the quaternion.
+    /// Computes the inverse of the quaternion.
     pub fn inverse(&self) -> Self {
         // TODO: Check for division by zero
         Quaternion(self.conjugate().0 / self.0.norm_squared())
     }
 
-    /// Normalize to a unit quaternion.
+    /// Normalizes to a unit quaternion.
     pub fn normalize(&self) -> Self {
         Quaternion(self.0.clone() / self.0.norm())
     }

--- a/libs/nox/src/scalar.rs
+++ b/libs/nox/src/scalar.rs
@@ -9,7 +9,7 @@ use nalgebra::Scalar as NalgebraScalar;
 use std::{marker::PhantomData, ops::Add};
 use xla::{ArrayElement, NativeType};
 
-/// Type alias for a scalar tensor with a specified precision type `P`, defaulting to operation type `Op`.
+/// Type alias for a scalar tensor with a specific type `T`, an underlying representation `P`, and defaulting to operation type `Op`.
 pub type Scalar<T, P = Op> = Tensor<T, ScalarDim, P>;
 
 impl<T: NativeType + ArrayElement> ToHost for Scalar<T, Buffer> {

--- a/libs/nox/src/scalar.rs
+++ b/libs/nox/src/scalar.rs
@@ -1,3 +1,4 @@
+//! Provides functionality for managing scalar tensors, including operations and transformations between host and device representations.
 use crate::TensorItem;
 use crate::{
     Buffer, BufferArg, Literal, MaybeOwned, NoxprScalarExt, Op, ScalarDim, Tensor, ToHost,
@@ -8,6 +9,7 @@ use nalgebra::Scalar as NalgebraScalar;
 use std::{marker::PhantomData, ops::Add};
 use xla::{ArrayElement, NativeType};
 
+/// Type alias for a scalar tensor with a specified precision type `P`, defaulting to operation type `Op`.
 pub type Scalar<T, P = Op> = Tensor<T, ScalarDim, P>;
 
 impl<T: NativeType + ArrayElement> ToHost for Scalar<T, Buffer> {
@@ -31,10 +33,14 @@ impl<T: ClosedAdd + ArrayElement + NativeType> Add<T> for Scalar<T, Op> {
     }
 }
 
+/// Extension trait for scalar types, enabling direct conversion into tensor representations.
 pub trait ScalarExt: Sized {
+    /// Converts a scalar value into a literal scalar tensor.
     fn literal(self) -> Scalar<Self, Literal>
     where
         Self: TensorItem;
+
+    /// Converts a scalar value into a constant scalar tensor for computation.
     fn constant(self) -> Scalar<Self, Op>
     where
         Self: TensorItem;

--- a/libs/nox/src/scalar.rs
+++ b/libs/nox/src/scalar.rs
@@ -1,4 +1,4 @@
-//! Provides functionality for managing scalar tensors, including operations and transformations between host and device representations.
+//! Provides functionality for managing scalar tensors, including operations and transformations between host and client representations.
 use crate::TensorItem;
 use crate::{
     Buffer, BufferArg, Literal, MaybeOwned, NoxprScalarExt, Op, ScalarDim, Tensor, ToHost,
@@ -9,7 +9,7 @@ use nalgebra::Scalar as NalgebraScalar;
 use std::{marker::PhantomData, ops::Add};
 use xla::{ArrayElement, NativeType};
 
-/// Type alias for a scalar tensor with a specific type `T`, an underlying representation `P`, and defaulting to operation type `Op`.
+/// Type alias for a scalar tensor with a specific type `T`, an underlying representation `P`.
 pub type Scalar<T, P = Op> = Tensor<T, ScalarDim, P>;
 
 impl<T: NativeType + ArrayElement> ToHost for Scalar<T, Buffer> {

--- a/libs/nox/src/spatial.rs
+++ b/libs/nox/src/spatial.rs
@@ -1,3 +1,4 @@
+//! Provides abstractions for rigid body dynamics in 3D space.
 use crate::Field;
 use crate::FixedSliceExt;
 use crate::Tensor;
@@ -17,6 +18,7 @@ pub struct SpatialTransform<T: TensorItem> {
 }
 
 impl<T: TensorItem + Field> SpatialTransform<T> {
+    /// Constructs a new spatial transform from an angular component (Quaternion) and a linear component (Vector).
     pub fn new(angular: impl Into<Quaternion<T>>, linear: impl Into<Vector<T, 3>>) -> Self {
         let angular = angular.into();
         let linear = linear.into();
@@ -24,32 +26,33 @@ impl<T: TensorItem + Field> SpatialTransform<T> {
         SpatialTransform { inner }
     }
 
-    /// Create a spatial transform from a quaternion
+    /// Creates a spatial transform from a quaternion.
     pub fn from_angular(angular: impl Into<Quaternion<T>>) -> Self {
         let zero = T::zero().broadcast::<Const<3>>();
         SpatialTransform::new(angular, zero)
     }
 
-    /// Create a spatial transform from a linear vector
+    /// Creates a spatial transform from a linear vector.
     pub fn from_linear(linear: impl Into<Vector<T, 3>>) -> Self {
         SpatialTransform::new(Quaternion::identity(), linear)
     }
 
-    /// Create a spatial transform from an axis and angle
+    /// Creates a spatial transform from an axis and angle.
     pub fn from_axis_angle(axis: impl Into<Vector<T, 3>>, angle: impl Into<Scalar<T>>) -> Self {
         Self::from_angular(Quaternion::from_axis_angle(axis, angle))
     }
 
-    /// Get the angular part of the spatial transform as a quaternion
+    /// Gets the angular part of the spatial transform as a quaternion.
     pub fn angular(&self) -> Quaternion<T> {
         Quaternion(self.inner.fixed_slice(&[0]))
     }
 
-    /// Get the linear part of the spatial transform as a vector with shape (3,)
+    /// Gets the linear part of the spatial transform as a vector with shape (3,).
     pub fn linear(&self) -> Vector<T, 3> {
         self.inner.fixed_slice(&[4])
     }
 
+    /// Creates a zero spatial transform.
     pub fn zero() -> Self {
         SpatialTransform {
             inner: Tensor::zeros(),
@@ -74,6 +77,7 @@ pub struct SpatialForce<T: TensorItem> {
 }
 
 impl<T: Field> SpatialForce<T> {
+    /// Constructs a new spatial force from a torque component (Vector) and a force component (Vector).
     pub fn new(torque: impl Into<Vector<T, 3>>, force: impl Into<Vector<T, 3>>) -> Self {
         let torque = torque.into();
         let force = force.into();
@@ -81,7 +85,7 @@ impl<T: Field> SpatialForce<T> {
         SpatialForce { inner }
     }
 
-    /// Create a spatial force from a linear force vector
+    /// Creates a spatial force from a linear force vector.
     pub fn from_linear(force: impl Into<Vector<T, 3>>) -> Self {
         let force = force.into();
         let zero = T::zero().broadcast::<Const<3>>();
@@ -89,7 +93,7 @@ impl<T: Field> SpatialForce<T> {
         SpatialForce { inner }
     }
 
-    /// Create a spatial force from a torque vector
+    /// Creates a spatial force from a torque vector.
     pub fn from_torque(torque: impl Into<Vector<T, 3>>) -> Self {
         let torque = torque.into();
         let zero = T::zero().broadcast::<Const<3>>();
@@ -97,16 +101,17 @@ impl<T: Field> SpatialForce<T> {
         SpatialForce { inner }
     }
 
-    /// Get the torque part of the spatial force as a vector with shape (3,)
+    /// Gets the torque part of the spatial force as a vector with shape (3,).
     pub fn torque(&self) -> Vector<T, 3> {
         self.inner.fixed_slice(&[0])
     }
 
-    /// Get the linear force part of the spatial force as a vector with shape (3,)
+    /// Gets the linear force part of the spatial force as a vector with shape (3,).
     pub fn force(&self) -> Vector<T, 3> {
         self.inner.fixed_slice(&[3])
     }
 
+    /// Creates a zero spatial force.
     pub fn zero() -> Self {
         SpatialForce {
             inner: Tensor::zeros(),
@@ -124,12 +129,14 @@ impl<T: Field> Add for SpatialForce<T> {
     }
 }
 
+/// Represents spatial inertia as a 7D vector.
 #[derive(FromBuilder, IntoOp, Clone, Debug, FromOp)]
 pub struct SpatialInertia<T: TensorItem> {
     pub inner: Vector<T, 7>,
 }
 
 impl<T: TensorItem + Field + NativeType + ArrayElement> SpatialInertia<T> {
+    /// Constructs a new spatial inertia from inertia, momentum, and mass components.
     pub fn new(
         inertia: impl Into<Vector<T, 3>>,
         momentum: impl Into<Vector<T, 3>>,
@@ -142,6 +149,7 @@ impl<T: TensorItem + Field + NativeType + ArrayElement> SpatialInertia<T> {
         SpatialInertia { inner }
     }
 
+    /// Constructs spatial inertia from a mass, assuming inertia and momentum are derived from it.
     pub fn from_mass(mass: impl Into<Scalar<T>>) -> Self {
         let mass = mass.into();
         SpatialInertia::new(
@@ -151,12 +159,17 @@ impl<T: TensorItem + Field + NativeType + ArrayElement> SpatialInertia<T> {
         )
     }
 
+    /// Returns the diagonal inertia as a vector.
     pub fn inertia_diag(&self) -> Vector<T, 3> {
         self.inner.fixed_slice(&[0])
     }
+
+    /// Returns the momentum as a vector.
     pub fn momentum(&self) -> Vector<T, 3> {
         self.inner.fixed_slice(&[3])
     }
+
+    /// Returns the momentum as a vector.
     pub fn mass(&self) -> Scalar<T> {
         self.inner.fixed_slice::<Const<1>>(&[6]).reshape()
     }
@@ -192,6 +205,7 @@ pub struct SpatialMotion<T: TensorItem> {
 }
 
 impl<T: Field> SpatialMotion<T> {
+    /// Constructs a new spatial motion from angular and linear components.
     pub fn new(angular: impl Into<Vector<T, 3>>, linear: impl Into<Vector<T, 3>>) -> Self {
         let angular = angular.into();
         let linear = linear.into();
@@ -199,7 +213,7 @@ impl<T: Field> SpatialMotion<T> {
         SpatialMotion { inner }
     }
 
-    /// Create a spatial motion from a linear vector
+    /// Creates a spatial motion from a linear vector.
     pub fn from_linear(linear: impl Into<Vector<T, 3>>) -> Self {
         let linear = linear.into();
         let zero = T::zero().broadcast::<Const<3>>();
@@ -207,7 +221,7 @@ impl<T: Field> SpatialMotion<T> {
         SpatialMotion { inner }
     }
 
-    /// Create a spatial motion from an angular vector
+    /// Creates a spatial motion from an angular vector.
     pub fn from_angular(angular: impl Into<Vector<T, 3>>) -> Self {
         let angular = angular.into();
         let zero = T::zero().broadcast::<Const<3>>();
@@ -215,34 +229,38 @@ impl<T: Field> SpatialMotion<T> {
         SpatialMotion { inner }
     }
 
-    /// Get the angular part of the spatial motion as a vector with shape (3,)
+    /// Gets the angular part of the spatial motion as a vector with shape (3,).
     pub fn angular(&self) -> Vector<T, 3> {
         self.inner.fixed_slice(&[0])
     }
 
-    /// Get the linear part of the spatial motion as a vector with shape (3,)
+    /// Gets the linear part of the spatial motion as a vector with shape (3,).
     pub fn linear(&self) -> Vector<T, 3> {
         self.inner.fixed_slice(&[3])
     }
 
+    /// Adjusts spatial motion based on the given spatial transform.
     pub fn offset(&self, pos: SpatialTransform<T>) -> Self {
         let ang_vel = pos.angular() * self.angular();
         let vel = pos.angular() * self.linear() + ang_vel.cross(&pos.linear());
         SpatialMotion::new(ang_vel, vel)
     }
 
+    /// Computes the cross product of two spatial motions.
     pub fn cross(&self, other: &Self) -> Self {
         let ang_vel = self.angular().cross(&other.angular());
         let vel = self.angular().cross(&other.linear()) + self.linear().cross(&other.angular());
         SpatialMotion::new(ang_vel, vel)
     }
 
+    /// Computes the dual cross product of spatial motion and spatial force.
     pub fn cross_dual(&self, other: &SpatialForce<T>) -> SpatialForce<T> {
         let force = self.angular().cross(&other.torque()) + self.linear().cross(&other.force());
         let torque = self.angular().cross(&other.force());
         SpatialForce::new(torque, force)
     }
 
+    /// Creates a zero spatial motion.
     pub fn zero() -> Self {
         SpatialMotion {
             inner: Tensor::zeros(),

--- a/libs/nox/src/tensor.rs
+++ b/libs/nox/src/tensor.rs
@@ -187,7 +187,7 @@ impl<const N: usize> NonScalarDim for nalgebra::Const<N> {}
 
 /// Trait for dimensions compatible with XLA computation, defining shape information.
 pub trait XlaDim {
-    /// Returns an empty shape, representing a scalar with no dimensions.
+    /// Returns the shape of the implementing type.
     fn shape() -> SmallVec<[i64; 4]>;
 }
 

--- a/libs/nox/src/tensor.rs
+++ b/libs/nox/src/tensor.rs
@@ -177,6 +177,7 @@ pub trait NonScalarDim {}
 /// Represents constant dimensions, specified at compile-time.
 pub trait ConstDim {}
 
+/// Represents a scalar dimension, which is essentially dimensionless.
 pub type ScalarDim = ();
 impl TensorDim for ScalarDim {}
 impl TensorDim for nalgebra::Dyn {}
@@ -184,7 +185,9 @@ impl NonScalarDim for nalgebra::Dyn {}
 impl<const N: usize> TensorDim for nalgebra::Const<N> {}
 impl<const N: usize> NonScalarDim for nalgebra::Const<N> {}
 
+/// Trait for dimensions compatible with XLA computation, defining shape information.
 pub trait XlaDim {
+    /// Returns an empty shape, representing a scalar with no dimensions.
     fn shape() -> SmallVec<[i64; 4]>;
 }
 
@@ -446,9 +449,12 @@ pub trait MapDim<D> {
     const MAPPED_DIM: usize;
 }
 
+/// Alias for the mapped dimension type of `T` for dimension `D`.
 pub type MappedDim<T, D> = <T as MapDim<D>>::MappedDim;
+/// Alias for the type replacing the mapped dimension `T` for dimension `D` with `R`.
 pub type ReplaceMappedDim<T, D, R> = <T as MapDim<D>>::ReplaceMappedDim<R>;
 
+/// Represents a mapped dimension used for transforming tensor dimensions.
 pub struct Mapped;
 
 impl<D: Dim> MapDim<D> for Mapped {
@@ -468,6 +474,7 @@ where
     type DefaultMapDim: MapDim<Self>;
 }
 
+/// Alias for the default mapped dimension of `D`.
 pub type DefaultMappedDim<D> = <<D as DefaultMap>::DefaultMapDim as MapDim<D>>::MappedDim;
 
 impl DefaultMap for ScalarDim {
@@ -591,6 +598,7 @@ impl<const N: usize> NonTupleDim for Const<N> {}
 //     type Output = (A, B);
 // }
 
+/// Alias for the dimension resulting from concatenating dimensions `A` and `B`.
 pub type ConcatDims<A, B> = <(A, B) as DimConcat<A, B>>::Output;
 
 impl<T: TensorItem, D: Dim> Tensor<T, D> {
@@ -616,6 +624,7 @@ impl<T: TensorItem, D: Dim> Tensor<T, D> {
     }
 }
 
+/// Alias for the result of adding dimensions `A` and `B`.
 pub type AddDim<A, B> = <A as nalgebra::DimAdd<B>>::Output;
 
 #[allow(clippy::type_complexity)]
@@ -673,6 +682,7 @@ pub trait BroadcastDim<D1, D2> {
     type Output: Dim;
 }
 
+/// Alias for the dimension resulting from broadcasting dimensions `D1` and `D2`.
 pub type BroadcastedDim<D1, D2> = <ShapeConstraint as BroadcastDim<D1, D2>>::Output;
 
 impl<const A: usize> BroadcastDim<Const<A>, Const<A>> for ShapeConstraint {
@@ -695,6 +705,7 @@ impl<D: Dim + NotConst1> BroadcastDim<Const<1>, D> for ShapeConstraint {
     type Output = D;
 }
 
+/// Marker trait for dimension types that are not dynamic, typically used for compile-time fixed dimensions.
 pub trait NotDyn {}
 impl<const N: usize> NotDyn for Const<N> {}
 impl NotDyn for ScalarDim {}
@@ -766,6 +777,7 @@ where
     type Output = (Dyn, BroadcastedDim<Const<A2>, Const<B2>>);
 }
 
+/// Trait for determining the resulting dimension type from a dot product between two tensors with specified dimensions.
 pub trait DotDim<D1, D2> {
     type Output: Dim;
 }
@@ -793,6 +805,8 @@ where
 impl DotDim<Dyn, Dyn> for ShapeConstraint {
     type Output = Dyn;
 }
+
+/// Alias for the dimension resulting from the dot product of dimensions `D1` and `D2`.
 pub type DottedDim<D1, D2> = <ShapeConstraint as DotDim<D1, D2>>::Output;
 
 impl<T: Field, D1: Dim, R: Repr> Tensor<T, D1, R> {

--- a/libs/nox/src/transfer.rs
+++ b/libs/nox/src/transfer.rs
@@ -138,18 +138,21 @@ impl_buffer_form!(T1, T2, T3, T4, T5, T6, T7, T9, T10, T11);
 impl_buffer_form!(T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12);
 impl_buffer_form!(T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13);
 
+/// A wrapper to manage ownership of resources, allowing for both owned and borrowed references.
 pub enum MaybeOwned<'a, T> {
     Owned(T),
     Borrowed(&'a T),
 }
 
 impl<'a, T> MaybeOwned<'a, T> {
+    /// Constructs a `MaybeOwned` as a borrowed reference.
     fn borrow(val: &'a T) -> Self {
         MaybeOwned::Borrowed(val)
     }
 }
 
 impl<'a, T> Borrow<T> for MaybeOwned<'a, T> {
+    /// Provides a reference to the owned or borrowed value.
     fn borrow(&self) -> &T {
         match self {
             MaybeOwned::Borrowed(b) => b,

--- a/libs/nox/src/transfer.rs
+++ b/libs/nox/src/transfer.rs
@@ -1,18 +1,26 @@
+//! Traits and implementations for data transfer between host and XLA devices, buffer management, and XLA client operations.
 use std::{borrow::Borrow, ops::Deref};
 
 use crate::{Buffer, Client, Dim, Noxpr, Op, Tensor, TensorItem};
 
+/// Defines a trait for converting host data types into computation graph nodes.
 pub trait FromHost {
+    /// Type of the host data that can be converted.
     type HostTy;
 
+    /// Converts a native host type into an instance of the implementing type, using a provided client.
     fn from_host(client: &Client, native: Self::HostTy) -> Self;
 }
 
+/// Defines a trait for constructing objects from PJRT buffers.
 pub trait FromPjrtBuffer {
+    /// Constructs an object from PJRT buffers.
     fn from_pjrt(pjrt: Vec<xla::PjRtBuffer>) -> Self;
 }
 
+/// Provides a mechanism to retrieve a reference to an underlying PJRT buffer.
 pub trait AsBuffer {
+    /// Returns a reference to an associated PJRT buffer.
     fn as_buffer(&self) -> &xla::PjRtBuffer;
 }
 
@@ -22,11 +30,15 @@ impl<'a, A: AsBuffer> AsBuffer for &'a mut A {
     }
 }
 
+/// A trait for converting computation graph nodes into instances of the implementing type.
 pub trait FromOp {
+    /// Constructs an instance of the implementing type from a computation graph node.
     fn from_op(noxpr: Noxpr) -> Self;
 }
 
+/// A trait for converting instances into computation graph nodes.
 pub trait IntoOp {
+    /// Converts an instance into a computation graph node.
     fn into_op(self) -> Noxpr;
 }
 
@@ -36,17 +48,29 @@ impl IntoOp for () {
     }
 }
 
+/// Defines a trait to represent the buffer form of a type.
 pub trait BufferForm {
+    /// The type of the buffer that represents the data.
     type BufferTy;
 }
 
+/// Defines operations for managing buffer arguments, allowing for checking mutable borrow status and buffer manipulation.
 pub trait BufferArg<BufferTy> {
+    /// Determines if the buffer is currently mutably borrowed.
+    ///
+    /// By default, returns false, indicating no mutable borrow.
     fn is_mut_borrowed() -> bool {
         false
     }
 
+    /// Retrieves the buffer associated with this object, possibly in a borrowed state.
+    ///
+    /// `client`: The client associated with the buffer's lifecycle.
     fn as_buffer(&self, client: &Client) -> MaybeOwned<'_, xla::PjRtBuffer>;
 
+    /// Replaces the current buffer with a new one.
+    ///
+    /// `new_buffer`: The new buffer to set.
     fn replace_buffer(&mut self, _new_buffer: xla::PjRtBuffer) {}
 }
 

--- a/libs/nox/src/vector.rs
+++ b/libs/nox/src/vector.rs
@@ -1,3 +1,4 @@
+//! Provides functionality for handling vectors in computational tasks, supporting conversion between host and Nox-specific representations, and enabling vector operations like extension, normalization, and cross products.
 use nalgebra::{ArrayStorage, Const, DimMul, Scalar as NalgebraScalar, ToTypenum};
 use num_traits::Zero;
 use smallvec::smallvec;
@@ -9,9 +10,11 @@ use crate::{
     FromHost, MaybeOwned, Noxpr, Op, Repr, Scalar, Tensor, TensorItem, ToHost,
 };
 
+/// Type alias for a tensor that specifically represents a vector.
 pub type Vector<T, const N: usize, P = Op> = Tensor<T, Const<N>, P>;
 
 impl<T: NativeType + ArrayElement> Vector<T, 3, Op> {
+    /// Extends a 3-dimensional vector to a 4-dimensional vector by appending a given element.
     pub fn extend(&self, elem: T) -> Vector<T, 4, Op> {
         let elem = elem.literal();
         let constant = Noxpr::constant(elem, ArrayTy::new(T::TY, smallvec![1]));
@@ -69,6 +72,7 @@ where
 }
 
 impl<T: TensorItem + Field, const N: usize, R: Repr> Vector<T, N, R> {
+    /// Creates a vector from an array of scalar references.
     pub fn from_arr(arr: [&Scalar<T, R>; N]) -> Self
     where
         Const<N>: Dim,
@@ -90,6 +94,7 @@ impl<T: TensorItem + Field, const N: usize, R: Repr> Vector<T, N, R> {
 }
 
 impl<T: TensorItem + Field, const N: usize, R: Repr> Vector<T, N, R> {
+    /// Returns the individual scalar components of the vector as an array.
     pub fn parts(&self) -> [Scalar<T, R>; N] {
         let mut i = 0;
         [0; N].map(|_| {
@@ -101,6 +106,7 @@ impl<T: TensorItem + Field, const N: usize, R: Repr> Vector<T, N, R> {
 }
 
 impl<T: Field> Vector<T, 3, Op> {
+    /// Computes the cross product of two 3-dimensional vectors.
     pub fn cross(&self, other: &Self) -> Self {
         let [ax, ay, az] = self.parts();
         let [bx, by, bz] = other.parts();
@@ -112,14 +118,17 @@ impl<T: Field> Vector<T, 3, Op> {
 }
 
 impl<T: Field, const N: usize> Vector<T, N, Op> {
+    /// Computes the norm squared of the vector.
     pub fn norm_squared(&self) -> Scalar<T> {
         self.dot(self)
     }
 
+    /// Computes the norm of the vector, which is the square root of the norm squared.
     pub fn norm(&self) -> Scalar<T> {
         self.dot(self).sqrt()
     }
 
+    /// Normalizes the vector to a unit vector.
     pub fn normalize(&self) -> Self {
         self.clone() / self.norm()
     }


### PR DESCRIPTION
Following the discussion in [issue 11](https://github.com/elodin-sys/elodin/issues/11) and the preliminary test in [PR 12](https://github.com/elodin-sys/elodin/pull/12), here is a PR adding doc comments to the entire Nox codebase. As previously stated, the comments are AI-generated, with the goal of speeding up the documentation of the library (it is easier to improve a bad comment than to write one from scratch).

The PR is best examined by generating the documentation (`cargo doc --open --no-deps --all-features`).
Do not hesitate to comment and criticize; some comments will definitely require manual improvements.

One thing that is still missing, and should probably be done by hand, is a `lib.rs` top comment that serves as a documentation readme (ideally with a small code example[^example] showcasing usage and/or a link to the relevant section of the Elodin doc). You can find an example of one such comment [here](https://github.com/nestordemeure/friedrich/blob/master/src/lib.rs) (rendered [there](https://docs.rs/friedrich/latest/friedrich/)).

[^example]: Overall, code examples are the big thing still missing from a new user's perspective.