### PR TITLE
Simplify the getting started process

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,8 @@
 Elodin is a platform for rapid design, testing, and simulation of
 drones, satellites, and aerospace control systems.
 
-Quick Demo: https://app.elodin.systems/sandbox/hn/cube-sat
-
-Sandbox Alpha: https://app.elodin.systems
-Docs (WIP): https://docs.elodin.systems
+Sandbox: https://app.elodin.systems  
+Docs: https://docs.elodin.systems
 
 This repository is a collection of core libraries:
 
@@ -30,68 +28,22 @@ Join us on Discord: https://discord.gg/agvGJaZXy5!
 
 ## Getting Started
 
-1. Install Rust using https://rustup.rs
-2. Setup a new venv with:
+1. Setup a new venv with:
 
 ```fish
 python3 -m venv .venv
  . .venv/bin/activate.fish # or activate.sh if you do not use fish
 ```
-3. Install `elodin`, and `matplotlib` with
+2. Install `elodin`, and `matplotlib` with
 
 ``` fish
-pip install libs/nox-py
-pip install matplotlib
+pip install -U elodin matplotlib
 ```
 
-4. Try running the following code
+3. Try running the bouncing ball example with:
 
 ```python
-import matplotlib.pyplot as plt
-import jax
-import jax.numpy as jnp
-import elodin as el
-
-
-@el.map
-def gravity(f: el.Force, inertia: el.Inertia) -> el.Force:
-    return f + el.SpatialForce.from_linear(
-        jnp.array([0.0, inertia.mass() * -9.81, 0.0])
-    )
-
-
-@el.map
-def bounce(p: el.WorldPos, v: el.WorldVel) -> el.WorldVel:
-    return jax.lax.cond(
-        jax.lax.max(p.linear()[1], v.linear()[1]) < 0.0,
-        lambda _: el.SpatialMotion.from_linear(
-            v.linear() * jnp.array([1.0, -1.0, 1.0]) * 0.85
-        ),
-        lambda _: v,
-        operand=None,
-    )
-
-
-world = el.World()
-world.spawn(
-    el.Body(
-        world_pos=el.SpatialTransform.from_linear(jnp.array([0.0, 10.0, 0.0])),
-        world_vel=el.SpatialMotion.from_linear(jnp.array([0.0, 0.0, 0.0])),
-        inertia=el.SpatialInertia.from_mass(1.0),
-    )
-)
-client = el.Client.cpu()
-sys = bounce.pipe(el.six_dof(1.0 / 60.0, gravity))
-exec = world.build(sys)
-t = range(500)
-pos = []
-for _ in t:
-    exec.run(client)
-    y = exec.column_array("world_pos")[0, 5]
-    pos.append(y)
-fig, ax = plt.subplots()
-ax.plot(t, pos)
-plt.show()
+python examples/ball/plot.py
 ```
 
 


### PR DESCRIPTION
Recommend installing the pre-built wheels from PyPi. Also, use one of the in-repo examples as it'll be maintained. The README was consistently out of date, and having multiple different documentation sources is a maintenance burden.