### PR TITLE
Better support for remote + offline builds, deploy.sh args

### DIFF
--- a/.buildkite/pipeline.py
+++ b/.buildkite/pipeline.py
@@ -157,11 +157,23 @@ test_steps = [
         key="elodin-cli",
         command="nix build .#elodin-cli",
     ),
-    step(
-        label=":nix: aleph-os",
-        key="aleph-os",
-        command="cd images/aleph; nix build --accept-flake-config .#nixosConfigurations.default.config.system.build.toplevel",
-        agents={"queue": "nixos-arm"},
+    group(
+        name=":nix: aleph-os",
+        steps=[
+            step(
+                label=":nix: toplevel",
+                key="toplevel",
+                command="cd images/aleph; nix build --accept-flake-config .#toplevel",
+                agents={"queue": "nixos-arm"},
+            ),
+            step(
+                label=":nix: sdimage",
+                key="sdimage",
+                command="cd images/aleph; nix build --accept-flake-config .#sdimage",
+                depends_on="toplevel",
+                agents={"queue": "nixos-arm"},
+            ),
+        ],
     ),
 ]
 

--- a/docs/public/content/home/aleph/setup.md
+++ b/docs/public/content/home/aleph/setup.md
@@ -116,9 +116,9 @@ Aleph comes with a variety of sensors pre-installed. The simplest way to access 
 # stream accel data
 curl localhost:2248/component/stream/accel/1
 #
-curl localhost:2248/component/gyro/accel/1
+curl localhost:2248/component/stream/gyro/1
 # terminal 3
-curl localhost:2248/component/mag/accel/1
+curl localhost:2248/component/stream/mag/1
 ```
 
 ### Connecting via SSH / Ethernet USB

--- a/images/aleph/README.md
+++ b/images/aleph/README.md
@@ -81,12 +81,20 @@ TODO
 This is the recommended development workflow for iterating on the NixOS configuration. It's significantly faster than the fresh install method (described below) and easier to revert in case of mistakes.
 
 1. Ensure you can SSH into Aleph over WiFi (recommended) or via the USB-C port with the Ethernet gadget enabled (right-most USB-C port).
+
 2. Modify the NixOS configuration in `flake.nix`, `kernel/`, or `modules/`.
-3. Run `./deploy.sh`. This copies all necessary store paths to Aleph, activates the new configuration, and creates a new bootloader entry.
 
-If you have a local user module (created with `create_user_module.sh`), the deploy script will automatically use it alongside the repository configuration.
+3. Run `./deploy.sh` to deploy with default settings (current username and "aleph.local"), or specify a custom host/user:
+   ```bash
+   # Deploy using custom host and username
+   ./deploy.sh --host fde1:2240:a1ef::1 --user myuser
+   # Don't use Aleph as a remote builder (uses local machine or configured builders instead)
+   ./deploy.sh --no-aleph-builder
+   # Show all available options
+   ./deploy.sh --help
+   ```
 
-To revert to the previous configuration, reboot and select the previous bootloader entry from the boot menu.
+This copies all necessary store paths to Aleph, activates the new configuration, and creates a new bootloader entry. If you have a local user module (created with `create_user_module.sh`), the deploy script will automatically use it alongside the repository configuration. To revert to the previous configuration, reboot and select the previous bootloader entry from the boot menu.
 
 NOTE: The bootloader can only be accessed via the serial console. So, you'll need to switch the USB-C cable to the debugger port (left-most USB-C port).
 

--- a/images/aleph/deploy.sh
+++ b/images/aleph/deploy.sh
@@ -7,25 +7,51 @@ target=".#nixosConfigurations.default.config.system.build.toplevel"
 
 USER_MODULE_DIR="$HOME/.config/aleph/user-module"
 
-log_info() { echo -e "\033[1;36m[INFO]\033[0m  $*"; }
-log_warn() { echo -e "\033[1;33m[WARN]\033[0m  $*"; }
-log_error() { echo -e "\033[1;31m[ERROR]\033[0m $*"; }
+log_info() { echo -e "\033[1;36m[INFO]\033[0m  $*" >&2; }
+log_warn() { echo -e "\033[1;33m[WARN]\033[0m  $*" >&2; }
+log_error() { echo -e "\033[1;31m[ERROR]\033[0m $*" >&2; }
+
+_ssh_execute() {
+  local ssh_user="$1"
+  local ssh_host="$2"
+  local ssh_command="$3"
+  local ssh_key="${4:-}"
+  local timeout="${5:-5}"
+  local ssh_opts="-o BatchMode=yes -o ConnectTimeout=$timeout -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o PreferredAuthentications=publickey -o PasswordAuthentication=no"
+  if [ -n "$ssh_key" ]; then
+    ssh_opts="$ssh_opts -i $ssh_key"
+  fi
+  ssh -q $ssh_opts "$ssh_user@$ssh_host" "$ssh_command" 2>/dev/null
+  return $?
+}
 
 attempt_ssh() {
-  log_info "Attempting to SSH to $2 as $1 (nopass)"
-  active_store_path=$(ssh -q \
-    -o BatchMode=yes \
-    -o ConnectTimeout=5 \
-    -o StrictHostKeyChecking=no \
-    -o UserKnownHostsFile=/dev/null \
-    -o PreferredAuthentications=publickey \
-    -o PasswordAuthentication=no \
-    "$1@$2" "readlink -f /run/current-system")
-  if [ $? -ne 0 ]; then
+  local test_user="$1"
+  local test_host="$2"
+  log_info "Attempting to SSH to $test_host as $test_user (nopass)"
+  local active_store_path
+  if ! active_store_path=$(_ssh_execute "$test_user" "$test_host" "readlink -f /run/current-system"); then
     return 1
   fi
-  log_info "SSH connectivity test to $2 was successful"
+  log_info "SSH connectivity test to $test_host was successful"
   log_info "Active store path: $active_store_path"
+}
+
+find_working_ssh_key() {
+  local test_user="$1"
+  local test_host="$2"
+  local key_found=""
+  for key_file in ~/.ssh/id_ed25519 ~/.ssh/id_rsa; do
+    if [ -f "$key_file" ]; then
+      if _ssh_execute "$test_user" "$test_host" "echo success > /dev/null" "$key_file"; then
+        key_found=$(realpath "$key_file")
+        echo "$key_found"
+        return 0
+      fi
+    fi
+  done
+  log_error "No working SSH key found"
+  exit 1
 }
 
 # Check for user module and prepare override if needed
@@ -52,20 +78,39 @@ if ! attempt_ssh $user $host; then
   fi
 fi
 
+remote_arg=""
 if ! ( ([ "$(uname -m)" = "aarch64" ] && [ "$(uname)" = "Linux" ]) ||
   ([ -f /etc/nix/machines ] && grep -q 'aarch64-linux' /etc/nix/machines)); then
   log_warn "No aarch64-linux builder found, falling back to building on Aleph (slow)"
-  build_cmd="nix build --accept-flake-config --eval-store auto --store ssh-ng://$user@$host $override_arg $target --print-out-paths"
-  log_info "Running: $build_cmd"
-  out_path=$(${build_cmd})
-else
-  build_cmd="nix build --accept-flake-config $override_arg $target --print-out-paths"
-  log_info "Running: $build_cmd"
-  out_path=$(${build_cmd})
-  copy_cmd="nix copy --no-check-sigs --to ssh-ng://$user@$host $out_path"
-  log_info "Running: $copy_cmd"
-  $(${copy_cmd})
+  ssh_key=$(find_working_ssh_key $user $host)
+  remote_arg="--builders 'ssh://$user@$host aarch64-linux $ssh_key' --option builders-use-substitutes false --max-jobs 0"
 fi
+
+build_cmd="nix build --accept-flake-config $override_arg $remote_arg $target -v --print-out-paths"
+log_info "Running: $build_cmd"
+log_file=$(mktemp)
+log_info "Streaming build logs to: $log_file"
+set +e
+out_path=$(eval "$build_cmd" 2>"$log_file")
+build_status=$?
+set -e
+
+if [ $build_status -ne 0 ]; then
+  if grep -q "Host key verification failed" "$log_file"; then
+    log_error "Build failed due to host key verification issues."
+    log_info "To resolve this, please run SSH into Aleph as root and accept the host key:"
+    log_info "    sudo ssh -o StrictHostKeyChecking=ask $user@$host exit"
+    log_info "After that, run this script again."
+  else
+    log_error "Build failed"
+  fi
+  exit 1
+fi
+
+copy_cmd="nix copy --no-check-sigs --to ssh-ng://$user@$host $out_path"
+log_info "Running: $copy_cmd"
+eval "$copy_cmd"
+
 log_info "Activating $out_path on $user@$host"
 ssh "$user@$host" "sudo nix-env -p /nix/var/nix/profiles/system --set ${out_path} \
   && sudo ${out_path}/bin/switch-to-configuration switch;"

--- a/images/aleph/modules/elodin-db.nix
+++ b/images/aleph/modules/elodin-db.nix
@@ -6,7 +6,7 @@
     serviceConfig = {
       Type = "exec";
       User = "root";
-      ExecStart = "${elodin-db}/bin/elodin-db run [::]:2240 /db";
+      ExecStart = "${elodin-db}/bin/elodin-db run [::]:2240 --http-addr [::]:2248 /db";
       KillSignal = "SIGINT";
       Environment = "RUST_LOG=info";
     };


### PR DESCRIPTION
[support remote offline builds](https://github.com/elodin-sys/elodin/pull/25/commits/db5c1aa8c26e6f88487e0dc6b1a9a16b97468eba)

One annoying issue that people could run into when setting up Aleph is:
remote builds on Aleph currently require access to substituters. So, if
Aleph is offline, the remote builds will fail.

It's easy enough to connect Aleph to WiFi now, but that's only in the
recent OS images. People still have to upgrade their old OS images
somehow.

This change attempts to do remote builds while preventing the builder
(Aleph) from using its susbstituters. The host machine can still
download dependencies and final artifacts from binary caches and copy
them onto Aleph. Unfortunately, nix remote builds are still pretty buggy
and I still see occasional random lockups or cases when the builder
randomly decides to access its substituters and panics.

[add args to deploy.sh](https://github.com/elodin-sys/elodin/pull/25/commits/e2ad4643d9521ca3427780dc94a8d771b10f887f)

Mainly useful for debugging purposes, but they come in handy.