### PR TITLE
feat(os): add random suffix to hostname

### DIFF
--- a/images/aleph/README.md
+++ b/images/aleph/README.md
@@ -25,12 +25,20 @@ sudo systemctl restart nix-daemon.service
 
 When you receive Aleph, it comes with NixOS pre-installed. Setting up network connectivity will make development more convenient, though you can also work directly via USB or Ethernet.
 
+### Finding Your Aleph Device
+
+Each Aleph has a unique hostname based on a random suffix (e.g., `aleph-99a2.local`). You can find your device on the network using the included scan script:
+```bash
+./scripts/aleph-scan.sh
+```
+
 ### Connect Aleph to WiFi
 
 1. **Establish Connection**: Connect to Aleph via the right-most USB-C port (which has the Ethernet gadget enabled). This sets up a local network connection between your computer and Aleph over USB.
 
 2. **SSH to Aleph**: Log in to Aleph using SSH. The default root password is `root`.
    ```bash
+   # Access via USB Ethernet (always works regardless of hostname)
    ssh root@aleph.local
    ```
 
@@ -47,7 +55,7 @@ When you receive Aleph, it comes with NixOS pre-installed. Setting up network co
 
 After connecting to WiFi, Aleph will store your network credentials and reconnect automatically on subsequent boots. You can verify the connection with `ping google.com` or by checking the assigned IP address with `ip addr show wlan0`.
 
-Once connected to WiFi, you'll be able to SSH directly to Aleph over your wireless network, which is more convenient for ongoing development. The USB Ethernet connection will remain available as a fallback access method.
+Once connected to WiFi, you'll be able to SSH directly to Aleph over your wireless network using its unique hostname (which you can find with the `scripts/aleph-scan.sh` script). The USB Ethernet connection will remain available as a fallback access method with the consistent name `aleph.local`.
 
 ### User Setup
 
@@ -68,12 +76,14 @@ This is the recommended development workflow for iterating on the NixOS configur
 
 2. Modify the NixOS configuration in `flake.nix`, `kernel/`, or `modules/`.
 
-3. Run `./deploy.sh` to deploy with default settings (current username and "aleph.local"), or specify a custom host/user:
+3. Run `./deploy.sh` to deploy with default settings, or specify a custom host/user:
    ```bash
-   # Deploy using default settings
+   # Deploy using default settings ($USER@aleph.local)
    ./deploy.sh
    # Deploy using custom host and username
-   ./deploy.sh --host fde1:2240:a1ef::1 --user myuser
+   ./deploy.sh --host aleph-99a2.local --user myuser
+   # Deploy using IPv6 address
+   ./deploy.sh --host fde1:2240:a1ef::1
    # Don't use Aleph as a remote builder (uses local machine or configured builders instead)
    ./deploy.sh --no-aleph-builder
    # Show all available options

--- a/images/aleph/deploy.sh
+++ b/images/aleph/deploy.sh
@@ -3,7 +3,7 @@ set -eu
 
 # Default values
 default_user="${USER}"
-default_host="aleph.local"
+default_host="aleph-99a2.local"
 target=".#nixosConfigurations.default.config.system.build.toplevel"
 no_aleph_builder=false
 

--- a/images/aleph/flake.nix
+++ b/images/aleph/flake.nix
@@ -76,7 +76,24 @@
       '';
       security.sudo.wheelNeedsPassword = false;
       users.users.root.password = "root";
-      networking.hostName = "aleph";
+      networking.hostName = lib.mkForce "";
+      systemd.services.set-hostname = {
+        description = "Set hostname from /etc/machine-id";
+        after = ["network.target"];
+        before = ["systemd-hostnamed.service"];
+        serviceConfig = {
+          User = "root";
+          Group = "root";
+          Type = "oneshot";
+          RemainAfterExit = true;
+        };
+        script = ''
+          ID_PREFIX=$(head -c 4 /etc/machine-id)
+          echo "aleph-$ID_PREFIX" > /etc/hostname
+          echo "Hostname set to aleph-$ID_PREFIX"
+        '';
+        wantedBy = ["multi-user.target"];
+      };
       networking.dhcpcd.enable = true;
       networking.wireless.iwd = {
         enable = true;

--- a/images/aleph/modules/aleph-dev.nix
+++ b/images/aleph/modules/aleph-dev.nix
@@ -90,6 +90,7 @@ in {
     # Utilities for interfacing with the MCU
     (writeShellScriptBin "reset-mcu" (builtins.readFile ../scripts/reset-mcu.sh))
     (writeShellScriptBin "flash-mcu" (builtins.readFile ../scripts/flash-mcu.sh))
+    (writeShellScriptBin "aleph-scan" (builtins.readFile ../scripts/aleph-scan.sh))
     aleph-status
   ];
   programs.fish.enable = true;

--- a/images/aleph/modules/usb-eth.nix
+++ b/images/aleph/modules/usb-eth.nix
@@ -5,6 +5,7 @@
   ];
   networking.firewall.enable = false;
   networking.interfaces.usb0.useDHCP = false;
+  networking.interfaces.dummy0.useDHCP = false;
   networking.interfaces.usb0.ipv4.addresses = [
     {
       address = "10.224.0.1";
@@ -33,12 +34,19 @@
     '';
   };
   boot.kernel.sysctl = {"net.ipv6.conf.all.forwarding" = true;};
+  environment.etc."avahi/hosts".text = ''
+    fde1:2240:a1ef::1 aleph.local
+  '';
   services.avahi = {
     enable = true;
+    nssmdns4 = true;
+    denyInterfaces = ["dummy0" "lo" "usb0"];
     publish = {
       enable = true;
       userServices = true;
       addresses = true;
+      workstation = true;
+      hinfo = true;
     };
   };
 }

--- a/images/aleph/scripts/aleph-scan.sh
+++ b/images/aleph/scripts/aleph-scan.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+# Script to scan for Aleph devices on the network using mDNS
+
+set -e
+
+show_help() {
+  echo "Usage: $0 [OPTIONS] [DURATION]"
+  echo "  DURATION: Scan duration in seconds (default: 0.5)"
+  echo ""
+  echo "Options:"
+  echo "  -f, --first     Exit after finding the first device"
+  echo "  -h, --help      Show this help message"
+  exit 0
+}
+
+# Parse arguments
+FIRST_ONLY=false
+SCAN_DURATION=0.5
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -f|--first) FIRST_ONLY=true; shift ;;
+    -h|--help) show_help ;;
+    *)
+      if [[ "$1" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+        SCAN_DURATION="$1"
+      else
+        echo "Unknown option: $1"; show_help
+      fi
+      shift ;;
+  esac
+done
+
+# Detect operating system
+OS="$(uname -s)"
+
+# Function to clean up hostname - extracts base hostname and handles null bytes
+clean_hostname() {
+  local raw_host="$1"
+  # Remove null bytes first to avoid warnings
+  raw_host=$(tr -d '\0' <<< "$raw_host")
+  # Process escape sequences and extract base hostname
+  printf "%b" "$raw_host" | sed -E 's/^(aleph-[0-9a-zA-Z]+).*/\1/'
+}
+
+# Scan using avahi-browse on Linux
+scan_with_avahi() {
+  if [ "$FIRST_ONLY" = true ]; then
+    avahi-browse -t -a --resolve --parsable 2>/dev/null |
+    while read -r line; do
+      echo "$line" | grep -qi "aleph" || continue
+      echo "$line" | grep -q "=" || continue
+      hostname=$(echo "$line" | tr -d '\0' | awk -F';' '{print $4}' | grep "^aleph" | head -1)
+      if [ -n "$hostname" ]; then
+        echo "$(clean_hostname "$hostname").local"
+        exit 0
+      fi
+    done
+  else
+    TMP_FILE=$(mktemp)
+    trap 'rm -f "$TMP_FILE"' EXIT
+    timeout "$SCAN_DURATION" avahi-browse -t -a --resolve --parsable 2>/dev/null > "$TMP_FILE" || true
+    grep -i "aleph" "$TMP_FILE" | grep "=" | tr -d '\0' | awk -F';' '{print $4}' | grep "^aleph" | sort -u |
+    while read -r host; do
+      echo "$(clean_hostname "$host").local"
+    done
+  fi
+}
+
+# Scan using dns-sd on macOS
+scan_with_dns_sd() {
+  TMP_FILE=$(mktemp)
+  trap 'rm -f "$TMP_FILE"' EXIT
+
+  {
+    dns-sd -B _workstation._tcp local > "$TMP_FILE" &
+    DNS_PID=$!
+
+    if [ "$FIRST_ONLY" = true ]; then
+      # First-only mode: check frequently and exit as soon as we find something
+      while [ "$(date +%s)" -lt "$END_TIME" ]; do
+        if grep -q "aleph" "$TMP_FILE" 2>/dev/null; then
+          hostname=$(grep "aleph" "$TMP_FILE" 2>/dev/null | awk '{print $7}' | grep "^aleph" | head -1)
+          if [ -n "$hostname" ]; then
+            echo "${hostname}.local"
+            break
+          fi
+        fi
+        sleep 0.1
+      done
+    else
+      sleep "$SCAN_DURATION"
+    fi
+
+    kill $DNS_PID 2>/dev/null || true
+    wait $DNS_PID 2>/dev/null || true
+
+    # For regular mode, output all devices
+    if [ "$FIRST_ONLY" = false ]; then
+      grep -i "aleph" "$TMP_FILE" 2>/dev/null | awk '{print $7}' | grep "^aleph" | sort -u |
+      while read -r host; do
+        echo "${host}.local"
+      done
+    fi
+  } 2>/dev/null
+}
+
+# Start time and end time calculation
+START_TIME=$(date +%s)
+INT_DURATION=$(printf "%.0f" "$(echo "$SCAN_DURATION" | awk '{print int($1+0.5)}')")
+END_TIME=$((START_TIME + INT_DURATION))
+
+# Run the appropriate scanner
+if [ "$OS" = "Linux" ]; then
+  if command -v avahi-browse >/dev/null 2>&1; then
+    scan_with_avahi
+  else
+    >&2 echo "Avahi tools not found. Please install avahi-utils package."
+    exit 1
+  fi
+elif [ "$OS" = "Darwin" ]; then
+  scan_with_dns_sd
+else
+  >&2 echo "Unsupported operating system."
+  exit 1
+fi


### PR DESCRIPTION
aleph.local still works for usb eth. Unfortunately, it's not really possible to associate multiple hostnames to a single IP. So, I couldn't setup aleph.local and aleph-abcd.local to point to the WiFi IP. To mitigate this, I added aleph-scan.sh, which should work on macOS and Linux. During initial setup, you can scan for any aleph hostnames on the network. After that point, you can just refer to your specific Aleph directly by unique hostname (or aleph.local if connected via USB).