### PR TITLE
fix(stellar): fix nested reactor access in cleanup

### DIFF
--- a/libs/stellarator/maitake/src/scheduler.rs
+++ b/libs/stellarator/maitake/src/scheduler.rs
@@ -1621,6 +1621,15 @@ feature! {
         pub fn spawner(&self) -> LocalSpawner {
             LocalSpawner(Arc::downgrade(&self.core), Arc::downgrade(&self.waker))
         }
+
+        /// Drains the run queue of all existing tasks
+        pub fn cancel_all(&self) {
+            let run_queue = self.core.run_queue.consume();
+            while let Some(t) = run_queue.dequeue() {
+               drop(t);
+            }
+
+        }
     }
 
     impl Schedule for LocalScheduler{

--- a/libs/stellarator/src/poll/mod.rs
+++ b/libs/stellarator/src/poll/mod.rs
@@ -61,9 +61,8 @@ impl Reactor for PollingReactor {
         Ok(())
     }
 
-    fn finalize_io(&mut self) -> Result<(), crate::Error> {
-        Ok(())
-    }
+    type RemainingIo = ();
+    fn drain_io(&mut self) -> Self::RemainingIo {}
 
     fn waker(&self) -> Waker {
         let poller = self.poller.clone();


### PR DESCRIPTION
This PR fixes a series of issues that occurred when an executor was dropped. There were two primary problems: 

- `finalize_io` was initially designed to prevent the problem of inflight io_uring operations causing memory corruption. Imagine if you had a waiting `Read` op, and the buffer gets de-allocated, the kernel could clobber some random buffer. So `finalize_io` waited for all the inflight IO to complete. The problem is that some inflight io might never complete, like a `read` or `accept` which could leave a thread hanging. Now we explicitly issue `AsyncCancel` request so the kernel won't write into a de-alloced buffer.
- Previously we were de-allocating the reactor by simply taking the Executor, and dropping it. This caused issues because  when dropping tasks they would attempt to access the Executor, and fail to find it. The solution is to first cancel all the tasks in the executor, then cleanup any outstanding io, and then finally remove the executor