### PR TITLE
Compress aleph-os sd-image and add zstd support to inscriber

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6313,6 +6313,7 @@ dependencies = [
  "nu-ansi-term 0.49.0",
  "promkit",
  "stellarator",
+ "zstd",
 ]
 
 [[package]]
@@ -12814,9 +12815,9 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
  "zstd-safe",
 ]

--- a/apps/inscriber/Cargo.toml
+++ b/apps/inscriber/Cargo.toml
@@ -9,8 +9,9 @@ publish = false
 # errors
 anyhow = "1"
 
-# async
+# io
 stellarator.path = "../../libs/stellarator"
+zstd = "0.13.2"
 
 # terminal
 promkit.version = "0.9.1"

--- a/apps/inscriber/src/main.rs
+++ b/apps/inscriber/src/main.rs
@@ -206,7 +206,13 @@ impl ExternalDisk {
 
 impl Display for ExternalDisk {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} ({})", self.identifier, self.size)
+        write!(
+            f,
+            "{} {} - ({})",
+            self.identifier,
+            self.name.as_deref().unwrap_or_default(),
+            self.size
+        )
     }
 }
 
@@ -262,7 +268,7 @@ fn list_external_disks() -> anyhow::Result<Vec<ExternalDisk>> {
 #[cfg(target_os = "linux")]
 fn list_external_disks() -> anyhow::Result<Vec<ExternalDisk>> {
     let output = Command::new("lsblk")
-        .args(&["-o", "NAME,SIZE,TYPE,MODEL,MOUNTPOINT", "-d", "-n", "-p"])
+        .args(["-o", "NAME,SIZE,TYPE,MODEL,MOUNTPOINT", "-d", "-n", "-p"])
         .output()?;
 
     if !output.status.success() {
@@ -329,7 +335,7 @@ fn is_external_disk_linux(path: &str) -> anyhow::Result<bool> {
     }
 
     if device_name == "sda" {
-        let output = Command::new("ls").args(&["/sys/block/"]).output()?;
+        let output = Command::new("ls").arg("/sys/block/").output()?;
         let output_str = String::from_utf8_lossy(&output.stdout);
         let disk_count = output_str
             .split_whitespace()

--- a/apps/inscriber/src/main.rs
+++ b/apps/inscriber/src/main.rs
@@ -1,20 +1,22 @@
+use anyhow::anyhow;
 use clap::Parser;
 use kdam::{BarExt, term::Colorizer};
-use nu_ansi_term::Color;
-use nu_ansi_term::Style;
-use std::fmt::Display;
-use std::io;
-use std::io::IsTerminal;
-use std::path::PathBuf;
-use std::sync::OnceLock;
-use stellarator::buf::IoBuf;
-use stellarator::fs;
-use stellarator::rent;
+use nu_ansi_term::{Color, Style};
+use std::{
+    fmt::{self, Display},
+    io::{self, IsTerminal},
+    path::PathBuf,
+    process::Command,
+    sync::OnceLock,
+};
+use stellarator::{buf::IoBuf, fs, rent};
+use zstd::stream::raw::{Decoder, Operation};
 
 #[derive(Parser, Clone)]
 struct Args {
     image: PathBuf,
-    dest: PathBuf,
+    #[arg(short, long)]
+    disk: Option<String>,
 }
 
 fn divider_line(color: Color) -> &'static String {
@@ -59,26 +61,55 @@ fn print_header(text: impl Display, color: Color) {
 
 #[stellarator::main]
 async fn main() -> anyhow::Result<()> {
+    kdam::term::init(io::stderr().is_terminal());
+
     let args = Args::parse();
+
+    let disks = list_external_disks()?;
+    let disk = if let Some(disk) = args.disk {
+        disks
+            .into_iter()
+            .find(|f| f.path == disk)
+            .ok_or_else(|| anyhow!("path selected is not an external drive"))?
+    } else {
+        let mut query =
+            promkit::preset::query_selector::QuerySelector::new(disks.clone(), |query, disks| {
+                disks
+                    .iter()
+                    .filter(|disk| disk.contains(query))
+                    .cloned()
+                    .collect::<Vec<_>>()
+            })
+            .title("Please select an external drive to flash")
+            .listbox_lines(5)
+            .prompt()?;
+        let disk = query.run()?;
+        disks.into_iter().find(|f| f.to_string() == disk).unwrap()
+    };
+    disk.unmount()?;
+
     let image_name = args
         .image
         .file_name()
         .and_then(|i| i.to_str())
-        .ok_or_else(|| anyhow::anyhow!("image does not have name"))?;
+        .ok_or_else(|| anyhow!("image does not have name"))?;
     let image = fs::File::open(&args.image).await?;
     let image_metadata = std::fs::metadata(&args.image)?;
-    let dest = fs::File::open_with(&args.dest, fs::OpenOptions::new().write(true)).await?;
-    let dest_name = args
-        .dest
-        .file_name()
-        .and_then(|i| i.to_str())
-        .ok_or_else(|| anyhow::anyhow!("dest does not have name"))?;
+    let disk_path = PathBuf::from(&disk.path);
+    let dest = fs::File::open_with(&disk_path, fs::OpenOptions::new().write(true)).await?;
+
+    let is_zstd = args.image.extension().is_some_and(|ext| ext == "zst");
 
     let mut buf = vec![0; 1024 * 256];
     let mut cursor = 0;
-    kdam::term::init(io::stderr().is_terminal());
-    print_header(format!("Flashing {image_name} to {dest_name}"), Color::Blue);
+
     println!();
+    print_header(
+        format!("Flashing {image_name} to {}", disk.identifier),
+        Color::Blue,
+    );
+    println!();
+
     let total = image_metadata.len() as usize;
     let mut written = 0.0;
     let mut bar = kdam::tqdm!(
@@ -94,14 +125,219 @@ async fn main() -> anyhow::Result<()> {
         unit_scale = true,
         force_refresh = true
     );
-    while cursor < image_metadata.len() {
-        let read = rent!(image.read_at(buf, cursor).await, buf)?;
-        let mut slice = buf.try_slice(..read).unwrap();
-        rent!(dest.write_at(slice, cursor).await, slice)?;
-        written += read as f64 / 1024.0 / 1024.0;
-        let _ = bar.update_to(written as usize);
-        cursor += read as u64;
-        buf = slice.into_inner();
+    if is_zstd {
+        let mut decoder = Decoder::new()?;
+        let mut out_pos = 0;
+        let mut temp_buf = vec![0; 1024 * 1024 * 2];
+
+        while cursor < image_metadata.len() {
+            let read = rent!(image.read_at(buf, cursor).await, buf)?;
+            if read == 0 {
+                break;
+            }
+
+            let mut in_pos = 0;
+            while in_pos < read {
+                let in_buffer = &buf[in_pos..read];
+
+                let result = decoder.run_on_buffers(in_buffer, &mut temp_buf)?;
+
+                if result.bytes_written > 0 {
+                    let mut write_slice = temp_buf.try_slice(..result.bytes_written).unwrap();
+                    rent!(dest.write_at(write_slice, out_pos).await, write_slice)?;
+                    temp_buf = write_slice.into_inner();
+
+                    out_pos += result.bytes_written as u64;
+                }
+
+                in_pos += result.bytes_read;
+            }
+
+            written += read as f64 / 1024.0 / 1024.0;
+            let _ = bar.update_to(written as usize);
+            cursor += read as u64;
+        }
+    } else {
+        while cursor < image_metadata.len() {
+            let read = rent!(image.read_at(buf, cursor).await, buf)?;
+            let mut slice = buf.try_slice(..read).unwrap();
+            rent!(dest.write_at(slice, cursor).await, slice)?;
+            written += read as f64 / 1024.0 / 1024.0;
+            let _ = bar.update_to(written as usize);
+            cursor += read as u64;
+            buf = slice.into_inner();
+        }
     }
     Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct ExternalDisk {
+    path: String,
+    name: Option<String>,
+    size: String,
+    identifier: String,
+}
+
+impl ExternalDisk {
+    #[cfg(target_os = "macos")]
+    pub fn unmount(&self) -> anyhow::Result<()> {
+        let output = Command::new("diskutil")
+            .arg("unmountDisk")
+            .arg(&self.identifier)
+            .output()?;
+
+        if !output.status.success() {
+            return Err(anyhow::anyhow!("Failed to run diskutil list"));
+        }
+        Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
+    pub fn unmount(&self) -> anyhow::Result<()> {
+        let output = Command::new("umount").arg(&self.path).output()?;
+
+        if !output.status.success() {
+            return Err(anyhow::anyhow!("Failed to run diskutil list"));
+        }
+        Ok(())
+    }
+}
+
+impl Display for ExternalDisk {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} ({})", self.identifier, self.size)
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn list_external_disks() -> anyhow::Result<Vec<ExternalDisk>> {
+    let output = Command::new("diskutil").arg("list").output()?;
+
+    if !output.status.success() {
+        return Err(anyhow::anyhow!("Failed to run diskutil list"));
+    }
+
+    let stdout = String::from_utf8(output.stdout)?;
+
+    let mut disks = Vec::new();
+
+    for line in stdout.lines() {
+        if line.starts_with("/dev/disk") && line.contains("external") {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            let path = parts[0].to_string();
+            let identifier = path.split('/').last().unwrap_or("").to_string();
+
+            disks.push(ExternalDisk {
+                path,
+                name: None,
+                size: String::new(),
+                identifier,
+            });
+        } else if let Some(disk) = &mut disks.last_mut() {
+            let line = line.trim();
+            if !line.contains("0:") {
+                continue;
+            }
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            for (i, part) in parts.iter().enumerate() {
+                if part.ends_with("GB") || part.ends_with("MB") || part.ends_with("TB") {
+                    disk.size = format!("{} {part}", parts[i - 1].replace("*", "")); // size is in the previous chunk
+                    break;
+                }
+            }
+
+            for (i, part) in parts.iter().enumerate() {
+                if *part == "NAME" && i + 1 < parts.len() {
+                    disk.name = Some(parts[i + 1].to_string());
+                    break;
+                }
+            }
+        }
+    }
+
+    Ok(disks.into_iter().filter(|d| !d.path.is_empty()).collect())
+}
+
+#[cfg(target_os = "linux")]
+fn list_external_disks() -> anyhow::Result<Vec<ExternalDisk>> {
+    let output = Command::new("lsblk")
+        .args(&["-o", "NAME,SIZE,TYPE,MODEL,MOUNTPOINT", "-d", "-n", "-p"])
+        .output()?;
+
+    if !output.status.success() {
+        return Err(anyhow::anyhow!("Failed to run lsblk"));
+    }
+
+    let stdout = String::from_utf8(output.stdout)?;
+    let mut disks = Vec::new();
+
+    for line in stdout.lines() {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() >= 3 && parts[2] == "disk" {
+            let path = parts[0].to_string();
+
+            let is_external = is_external_disk_linux(&path)?;
+
+            if is_external {
+                let identifier = path.split('/').last().unwrap_or("").to_string();
+                let size = if parts.len() >= 2 {
+                    parts[1].to_string()
+                } else {
+                    String::new()
+                };
+
+                let name = if parts.len() >= 4 {
+                    Some(parts[3].to_string())
+                } else {
+                    None
+                };
+
+                disks.push(ExternalDisk {
+                    path,
+                    name,
+                    size,
+                    identifier,
+                });
+            }
+        }
+    }
+
+    Ok(disks)
+}
+
+#[cfg(target_os = "linux")]
+fn is_external_disk_linux(path: &str) -> anyhow::Result<bool> {
+    let device_name = path.split('/').last().unwrap_or("");
+    if device_name.is_empty() {
+        return Ok(false);
+    }
+
+    let removable_path = format!("/sys/block/{}/removable", device_name);
+    if let Ok(removable) = std::fs::read_to_string(removable_path) {
+        if removable.trim() == "1" {
+            return Ok(true);
+        }
+    }
+
+    let device_path = format!("/sys/block/{}/device", device_name);
+    if let Ok(real_path) = std::fs::read_link(device_path) {
+        let path_str = real_path.to_string_lossy();
+        if path_str.contains("usb") {
+            return Ok(true);
+        }
+    }
+
+    if device_name == "sda" {
+        let output = Command::new("ls").args(&["/sys/block/"]).output()?;
+        let output_str = String::from_utf8_lossy(&output.stdout);
+        let disk_count = output_str
+            .split_whitespace()
+            .filter(|d| d.starts_with("sd") || d.starts_with("nvme"))
+            .count();
+
+        return Ok(disk_count > 1);
+    }
+
+    Ok(!device_name.starts_with("nvme"))
 }

--- a/images/aleph/deploy.sh
+++ b/images/aleph/deploy.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p gum nix-output-monitor
 set -eu
 
 # Default values
@@ -7,9 +8,9 @@ default_host="aleph.local"
 target=".#nixosConfigurations.default.config.system.build.toplevel"
 no_aleph_builder=false
 
-log_info() { echo -e "\033[1;36m[INFO]\033[0m  $*" >&2; }
-log_warn() { echo -e "\033[1;33m[WARN]\033[0m  $*" >&2; }
-log_error() { echo -e "\033[1;31m[ERROR]\033[0m $*" >&2; }
+log_info() { gum log --level info "$*"; }
+log_warn() { gum log --level warn "$*"; }
+log_error() { gum log --level error "$*"; }
 
 show_usage() {
   echo "Usage: $0 [options]"
@@ -188,11 +189,11 @@ fi
 if [ "$no_aleph_builder" = false ] && ! ( ([ "$(uname -m)" = "aarch64" ] && [ "$(uname)" = "Linux" ]) ||
   ([ -f /etc/nix/machines ] && grep -q 'aarch64-linux' /etc/nix/machines)); then
   log_warn "No aarch64-linux builder found, falling back to building on Aleph (slow)"
-  build_cmd="nix build --accept-flake-config --eval-store auto --store ssh-ng://$user@$host $target --print-out-paths"
+  build_cmd="nom build --accept-flake-config --eval-store auto --store ssh-ng://$user@$host $target --print-out-paths"
   log_info "Running: $build_cmd"
   out_path=$(eval "$build_cmd")
 else
-  build_cmd="nix build --accept-flake-config $target --print-out-paths"
+  build_cmd="nom build --accept-flake-config $target --print-out-paths"
   log_info "Running: $build_cmd"
   out_path=$(eval "$build_cmd")
   copy_cmd="nix copy --no-check-sigs --to ssh-ng://$user@$host $out_path"

--- a/images/aleph/modules/hardware.nix
+++ b/images/aleph/modules/hardware.nix
@@ -57,7 +57,7 @@ in {
       });
     })
   ];
-  sdImage.compressImage = false;
+  sdImage.compressImage = true;
   boot.loader.systemd-boot.enable = true;
   boot.loader.systemd-boot.installDeviceTree = true;
   boot.loader.systemd-boot-dtb.enable = true;


### PR DESCRIPTION
This PR enables compression for sd-images to make easier to distribute. It also adds auto-decompression support to inscriber to make flashing these images easy. 


https://github.com/user-attachments/assets/c2d0fcaa-0963-4212-9e79-b82823548043

