### PR TITLE
Replace ephemeral trusted key with one persisted in 1p

### DIFF
--- a/images/aleph/flake.nix
+++ b/images/aleph/flake.nix
@@ -2,7 +2,7 @@
   nixConfig = {
     extra-substituters = ["http://ci-arm1.elodin.dev:5000"];
     extra-trusted-public-keys = [
-      "builder-cache-1:rEmIQJ4ChX5bopj3to1Ow7McFb7kLnXIQJYqawVlKEs="
+      "builder-cache-1:q7rDGIQgkg1nsxNEg7mHN1kEDuxPmJhQpuIXCCwLj8E="
     ];
   };
   inputs = {
@@ -121,7 +121,7 @@
       nix.settings.experimental-features = ["nix-command" "flakes"];
       nix.settings.trusted-public-keys = [
         "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
-        "builder-cache-1:rEmIQJ4ChX5bopj3to1Ow7McFb7kLnXIQJYqawVlKEs="
+        "builder-cache-1:q7rDGIQgkg1nsxNEg7mHN1kEDuxPmJhQpuIXCCwLj8E="
       ];
       nix.settings.extra-substituters = [
         "https://cache.nixos.org"


### PR DESCRIPTION
The previous key pair would get rotated on every restart of the CI VM. The new key pair is saved in 1p and injected via opnix.