### PR TITLE
feat(os): use hardware serial-number to generate hostname

### DIFF
--- a/docs/public/content/home/aleph/setup.md
+++ b/docs/public/content/home/aleph/setup.md
@@ -136,7 +136,7 @@ ping fde1:2240:a1ef::1
 
 {% alert(kind="notice") %}
 Wait approximately 30 seconds for the carrier board to boot up before attempting to connect via SSH.
-The Aleph connection will be a new local network connection broadcasting as `aleph.local`.
+The Aleph connection will be a new local network connection broadcasting as `aleph-<random suffix>.local`.
 {% end %}
 
 The carrier board runs a custom Linux distribution with a pre-installed SSH server. You can connect to the carrier board via SSH using the following command:
@@ -149,7 +149,7 @@ ssh root@fde1:2240:a1ef::1
 
 First install Elodin Editor using the instructions in [Quick Start](/home/quickstart#install)
 
-Next launch Elodin. You should be greeted with a startup window. You can connect to Aleph by selecting the "Connect to IP Address" option from the menu and entering `aleph.local:2240` in the IP address field.
+Next launch Elodin. You should be greeted with a startup window. You can connect to Aleph by selecting the "Connect to IP Address" option from the menu and entering `[fde1:2240:a1ef::1]:2240` in the IP address field.
 
 
 <img src="/assets/aleph-connect.png" alt="screenshot of editor connecting to aleph"/>

--- a/images/aleph/README.md
+++ b/images/aleph/README.md
@@ -30,15 +30,9 @@ When you receive Aleph, it comes with NixOS pre-installed. On first login you wi
 ### Connect Aleph to WiFi
 First connect to Aleph with right-most USB-C port. This port has an Ethernet gadget enabled that will allow you to SSH into Aleph.
 
-Run `ssh root@aleph.local`. The default password is `root`. Once logged in you will be guided through the setup. If the setup does not start, you can manually start it by running `aleph-setup`.
+Run `ssh root@fde1:2240:a1ef::1`. The default password is `root`. Once logged in you will be guided through the setup. If the setup does not start, you can manually start it by running `aleph-setup`.
 
 2. **SSH to Aleph**: Log in to Aleph using SSH. The default root password is `root`.
-   ```bash
-   # Access via USB Ethernet (always works regardless of hostname)
-   ssh root@aleph.local
-   ```
-
-   If mDNS resolution fails (common on some networks or operating systems), use the static IPv6 address instead:
    ```bash
    ssh root@fde1:2240:a1ef::1
    ```
@@ -51,7 +45,7 @@ Run `ssh root@aleph.local`. The default password is `root`. Once logged in you w
 
 After connecting to WiFi, Aleph will store your network credentials and reconnect automatically on subsequent boots. You can verify the connection with `ping google.com` or by checking the assigned IP address with `ip addr show wlan0`.
 
-Once connected to WiFi, you'll be able to SSH directly to Aleph over your wireless network using its unique hostname (which you can find with the `scripts/aleph-scan.sh` script). The USB Ethernet connection will remain available as a fallback access method with the consistent name `aleph.local`.
+Once connected to WiFi, you'll be able to SSH directly to Aleph over your wireless network using its unique hostname (which you can find with the `scripts/aleph-scan.sh` script). The USB Ethernet connection will remain available as a fallback access method with `fde1:2240:a1ef::1` as the static IPv6 address.
 
 [![asciicast](https://asciinema.org/a/716409.svg)](https://asciinema.org/a/716409)
 
@@ -72,7 +66,7 @@ This is the recommended development workflow for iterating on the NixOS configur
 
 3. Run `./deploy.sh` to deploy with default settings, or specify a custom host/user:
    ```bash
-   # Deploy using default settings ($USER@aleph.local)
+   # Deploy using default settings ($USER@fde1:2240:a1ef::1)
    ./deploy.sh
    # Deploy using custom host and username
    ./deploy.sh --host aleph-99a2.local --user myuser
@@ -115,11 +109,6 @@ This method requires a USB flash drive or SD card with at least 8GB of space. Th
 1. **Establish Connection**: Connect to Aleph via the right-most USB-C port (which has the Ethernet gadget enabled). This sets up a local network connection between your computer and Aleph over USB.
 
 2. **SSH to Aleph**: Log in to Aleph using SSH. The default root password is `root`.
-   ```bash
-   ssh root@aleph.local
-   ```
-
-   If mDNS resolution fails (common on some networks or operating systems), use the static IPv6 address instead:
    ```bash
    ssh root@fde1:2240:a1ef::1
    ```

--- a/images/aleph/deploy.sh
+++ b/images/aleph/deploy.sh
@@ -4,7 +4,7 @@ set -eu
 
 # Default values
 default_user="${USER}"
-default_host="aleph.local"
+default_host="fde1:2240:a1ef::1"
 target=".#nixosConfigurations.default.config.system.build.toplevel"
 no_aleph_builder=false
 

--- a/images/aleph/modules/aleph-dev.nix
+++ b/images/aleph/modules/aleph-dev.nix
@@ -110,7 +110,7 @@ in {
     aleph-status
   ];
   programs.fish.enable = true;
-  nix.settings.trusted-users = ["root" "@wheel"];
+  nix.settings.trusted-users = ["@wheel"];
   security.pam.loginLimits = [
     {
       domain = "*";

--- a/images/aleph/modules/usb-eth.nix
+++ b/images/aleph/modules/usb-eth.nix
@@ -34,9 +34,6 @@
     '';
   };
   boot.kernel.sysctl = {"net.ipv6.conf.all.forwarding" = true;};
-  environment.etc."avahi/hosts".text = ''
-    fde1:2240:a1ef::1 aleph.local
-  '';
   services.avahi = {
     enable = true;
     nssmdns4 = true;

--- a/images/aleph/modules/wifi.nix
+++ b/images/aleph/modules/wifi.nix
@@ -1,8 +1,7 @@
 {lib, ...}: {
   networking.hostName = lib.mkForce "";
   systemd.services.set-hostname = {
-    description = "Set hostname from /etc/machine-id";
-    after = ["network.target"];
+    description = "Set hostname from /proc/device-tree/serial-number";
     before = ["systemd-hostnamed.service"];
     serviceConfig = {
       User = "root";
@@ -11,11 +10,11 @@
       RemainAfterExit = true;
     };
     script = ''
-      ID_PREFIX=$(head -c 4 /etc/machine-id)
-      echo "aleph-$ID_PREFIX" > /etc/hostname
-      echo "Hostname set to aleph-$ID_PREFIX"
+      SERIAL_SUFFIX=$(cat /proc/device-tree/serial-number | tr -d '\0' | xargs printf '%x' | tail -c 4)
+      echo "aleph-$SERIAL_SUFFIX" > /etc/hostname
+      echo "Hostname set to aleph-$SERIAL_SUFFIX"
     '';
-    wantedBy = ["multi-user.target"];
+    wantedBy = ["sysinit.target"];
   };
   networking.dhcpcd.enable = true;
   networking.wireless.iwd = {

--- a/images/aleph/template/flake.nix
+++ b/images/aleph/template/flake.nix
@@ -61,7 +61,7 @@
         PermitRootLogin = "yes";
       };
       security.sudo.wheelNeedsPassword = false;
-      nix.settings.trusted-users = ["root" "@wheel"];
+      nix.settings.trusted-users = ["@wheel"];
     };
     # sets up two different nixos systems default and installer
     # installer is setup to be flashed to a usb drive, and contains the


### PR DESCRIPTION
Also, use fde1:2240:a1ef::1 instead of aleph.local. mDNS seems even more unreliable for the IPv6 ethernet gadget connection. Tried on 2 Linux systems and it didn't work OOTB. It's also very flaky on macOS. I think the more standard network interfaces (wifi, ethernet) are a bit more reliable with hostname resolution because they advertise their hostnames when requesting an IP over DHCP and the router is advertising the hostname. So, you can rely on router to help out in case mDNS isn't working.