### PR TITLE
Add pycuda, fix libcuda.so not found issue

### DIFF
--- a/fsw/aleph-setup/src/main.rs
+++ b/fsw/aleph-setup/src/main.rs
@@ -173,7 +173,7 @@ async fn create_user() -> anyhow::Result<String> {
         .args([
             "-m",
             "-G",
-            "wheel",
+            "wheel,dialout,video",
             "-s",
             "/run/current-system/sw/bin/bash",
             "-U",

--- a/images/aleph/modules/aleph-dev.nix
+++ b/images/aleph/modules/aleph-dev.nix
@@ -37,7 +37,6 @@ in {
     LD_LIBRARY_PATH = lib.makeLibraryPath [
       stdenv.cc.cc.lib
       cudaPackages.cudatoolkit
-      cudaPackages.cudatoolkit
       cudaPackages.cudnn
       cudaPackages.tensorrt
       cudaPackages.vpi2
@@ -47,6 +46,7 @@ in {
       nvidia-jetpack.l4t-camera
     ];
   };
+  hardware.graphics.enable = true;
   virtualisation.podman = {
     enable = true;
     # TODO: replace with `hardware.nvidia-container-toolkit.enable` when it works (https://github.com/nixos/nixpkgs/issues/344729).

--- a/images/aleph/modules/aleph-dev.nix
+++ b/images/aleph/modules/aleph-dev.nix
@@ -30,6 +30,7 @@
       onnx
       tqdm
       matplotlib
+      pycuda
       (onnxruntime-gpu-wheel ps)
     ];
 in {
@@ -45,6 +46,8 @@ in {
       nvidia-jetpack.l4t-multimedia
       nvidia-jetpack.l4t-camera
     ];
+    NVCC_PREPEND_FLAGS = "--compiler-bindir ${pkgs.gcc11}/bin/gcc";
+    NVCC_APPEND_FLAGS = "-I${pkgs.cudaPackages.cuda_cudart.include}/include";
   };
   hardware.graphics.enable = true;
   virtualisation.podman = {
@@ -79,6 +82,7 @@ in {
     lsof
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
+    cudaPackages.cuda_nvcc
     nvidia-jetpack.samples.cuda-test
     nvidia-jetpack.samples.cudnn-test
     (python311.withPackages pythonPackages)


### PR DESCRIPTION
- Add user to video group to use cuda without sudo.
- Enable `hardware.graphics` to symlink `libcuda.so` to `/run/opengl-driver/lib/`. All nix packages that depend on cuda are patched with an rpath that includes this directory. With this change, setting LD_LIBRARY_PATH is no longer required for native nix packages. It's still needed for python scripts unfortunately.
- Add nvcc, pycuda. nvcc only works with gcc <= 11. Also, it needs to be informed of the header file location. So, I'm setting `NVCC_PREPEND_FLAGS` and `NVCC_APPEND_FLAGS` to address this. I'm not sure if there's a better way.