### PR TITLE
chore: upload sd image to gcs on main builds

### DIFF
--- a/.buildkite/pipeline.py
+++ b/.buildkite/pipeline.py
@@ -169,14 +169,21 @@ test_steps = [
             step(
                 label=":nix: sdimage",
                 key="sdimage",
-                command="cd images/aleph; nix build --accept-flake-config .#sdimage",
+                command=[
+                    "cd images/aleph",
+                    "nix build --accept-flake-config .#sdimage",
+                    """[[ $BUILDKITE_BRANCH == main ]] && buildkite-agent artifact upload result/sd-image/*.img.zst || echo "Not on main branch, skipping upload." """,
+                ],
                 depends_on="toplevel",
                 agents={"queue": "nixos-arm"},
             ),
             step(
                 label=":nix: flash-uefi",
                 key="flash-uefi",
-                command="cd images/aleph; nix build --accept-flake-config .#flash-uefi",
+                command=[
+                    "cd images/aleph",
+                    "nix build --accept-flake-config .#flash-uefi",
+                ],
             ),
         ],
     ),


### PR DESCRIPTION
We can make this more convenient but with this change, you'll be able to go to the latest main build on buildkite and download the sdimage directly.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/eab7da18-f696-4a43-8c56-c74e4678776f" />