### PR TITLE
Add a bunch of small missing features to the editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - **(feat)** Add new two plot types: point and bar. You can change the plot type by selecting the graph, and modifying the plot type in the inspector panel.
 - **(fix)** Fix problem with Ctrl-Tab shortcut moving too fast
-- **(feat)** Add right click menu to plots that sets the plot's visibile time range as the editor's time range
+- **(feat)** Add right click menu to plots that sets the plot's visible time range as the editor's time range
 - **(feat)** Add command palette action that sets the time range of the editor
 - **(feat)** Allow user's to rename the graph's title in the inspector
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## unreleased
 
+- **(feat)** Add new two plot types: point and bar. You can change the plot type by selecting the graph, and modifying the plot type in the inspector panel.
+- **(fix)** Fix problem with Ctrl-Tab shortcut moving too fast
+- **(feat)** Add right click menu to plots that sets the plot's visibile time range as the editor's time range
+- **(feat)** Add command palette action that sets the time range of the editor
+- **(feat)** Allow user's to rename the graph's title in the inspector
+
 ## v0.14
 
 - **(breaking)** Switch vtables to use a new bytecode based format. This changes makes vtables simpler and more flexible. This change also effects the Lua format. You can now formulate a vtable with the `vtable_msg` function:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4583,11 +4583,13 @@ dependencies = [
  "impeller2-cli",
  "impeller2-wkt",
  "itertools 0.12.1",
+ "jiff",
  "miette",
  "nodit",
  "nox",
  "objc",
  "opener",
+ "peg",
  "postcard",
  "raw-window-handle 0.5.2",
  "reqwest",
@@ -6661,6 +6663,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jiff"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02000660d30638906021176af16b17498bd0d12813dbfe7b276d8bc7f3c0806"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c30758ddd7188629c6713fc45d1188af4f44c90582311d0c8d8c9907f60c48"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8580,6 +8623,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
+name = "peg"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9928cfca101b36ec5163e70049ee5368a8a1c3c6efc9ca9c5f9cc2f816152477"
+dependencies = [
+ "peg-macros",
+ "peg-runtime",
+]
+
+[[package]]
+name = "peg-macros"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6298ab04c202fa5b5d52ba03269fb7b74550b150323038878fe6c372d8280f71"
+dependencies = [
+ "peg-runtime",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "peg-runtime"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "132dca9b868d927b35b5dd728167b2dee150eb1ad686008fc71ccb298b776fca"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8778,9 +8848,9 @@ checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
 name = "portable-atomic"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 dependencies = [
  "critical-section",
 ]

--- a/libs/elodin-editor/Cargo.toml
+++ b/libs/elodin-editor/Cargo.toml
@@ -23,7 +23,7 @@ bevy_egui.version = "0.34.0-rc.2"
 egui.version = "0.31"
 egui.features = ["rayon"]
 egui_tiles = "0.12"
-egui_table.version = "0.3"
+egui_table = "0.3"
 winit.version = "0.30"
 winit.features = ["rwh_05"]
 raw-window-handle = "0.5"
@@ -89,6 +89,10 @@ impeller2-cli.path = "../db/cli"
 
 # channels
 flume = "0.11.1"
+
+# parsing
+jiff = "0.2"
+peg = "0.8.5"
 
 
 [target.'cfg(target_family = "wasm")'.dependencies]

--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -922,7 +922,6 @@ pub struct TimeRangeBehavior {
 enum Offset {
     Earliest(Duration),
     Latest(Duration),
-    #[allow(unused)]
     Fixed(Timestamp),
 }
 

--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -920,7 +920,7 @@ pub struct TimeRangeBehavior {
     end: Offset,
 }
 
-#[derive(Resource, PartialEq, Eq, Clone, Copy)]
+#[derive(Resource, PartialEq, Eq, Clone, Copy, Debug)]
 enum Offset {
     Earliest(Duration),
     Latest(Duration),
@@ -961,7 +961,7 @@ impl std::fmt::Display for TimeRangeBehavior {
                 write!(f, "LAST {start}")
             }
             (start, end) => {
-                write!(f, "{start} — {end}")
+                write!(f, "{start} ↔ {end}")
             }
         }
     }

--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -176,7 +176,7 @@ impl Plugin for EditorPlugin {
             .add_plugins(crate::plugins::LogicalKeyPlugin)
             .add_systems(Startup, setup_floating_origin)
             .add_systems(Startup, setup_window_icon)
-            .add_systems(Startup, spawn_clear_bg)
+            //.add_systems(Startup, spawn_clear_bg)
             .add_systems(Startup, setup_clear_state)
             .add_systems(Update, setup_egui_context)
             //.add_systems(Update, make_entities_selectable)
@@ -196,7 +196,7 @@ impl Plugin for EditorPlugin {
                 default_color: Color::WHITE,
             })
             .init_resource::<SyncedGlbs>()
-            .insert_resource(ClearColor(Color::NONE))
+            .insert_resource(ClearColor(Color::Srgba(Srgba::hex("#0C0C0C").unwrap())))
             .insert_resource(TimeRangeBehavior::default())
             .insert_resource(SelectedTimeRange(Timestamp(i64::MIN)..Timestamp(i64::MAX)));
         if cfg!(target_os = "windows") {
@@ -242,38 +242,41 @@ fn setup_floating_origin(mut commands: Commands) {
     ));
 }
 
-fn spawn_clear_bg(mut commands: Commands) {
-    commands.spawn((Camera2d, IsDefaultUiCamera));
-    let bg_color = Color::Srgba(Srgba::hex("#0C0C0C").unwrap());
-    // root node
-    commands
-        .spawn(Node {
-            width: Val::Percent(100.0),
-            height: Val::Percent(100.0),
-            justify_content: JustifyContent::Stretch,
-            flex_direction: FlexDirection::Column,
-            ..default()
-        })
-        .with_children(|parent| {
-            parent
-                .spawn(Node {
-                    height: Val::Px(56.0),
-                    ..default()
-                })
-                .insert(BackgroundColor(if cfg!(target_os = "macos") {
-                    Color::NONE
-                } else {
-                    bg_color
-                }));
+// NOTE(sphw): enabling this causes weird flickering issues when spawning too many 2d cameras
+// This issue (https://github.com/bevyengine/bevy/issues/18897) looks to be the same thing
+//
+// fn spawn_clear_bg(mut commands: Commands) {
+//     commands.spawn((Camera2d, IsDefaultUiCamera));
+//     let bg_color = Color::Srgba(Srgba::hex("#0C0C0C").unwrap());
+//     // root node
+//     commands
+//         .spawn(Node {
+//             width: Val::Percent(100.0),
+//             height: Val::Percent(100.0),
+//             justify_content: JustifyContent::Stretch,
+//             flex_direction: FlexDirection::Column,
+//             ..default()
+//         })
+//         .with_children(|parent| {
+//             parent
+//                 .spawn(Node {
+//                     height: Val::Px(56.0),
+//                     ..default()
+//                 })
+//                 .insert(BackgroundColor(if cfg!(target_os = "macos") {
+//                     Color::NONE
+//                 } else {
+//                     bg_color
+//                 }));
 
-            parent
-                .spawn(Node {
-                    height: Val::Percent(100.0),
-                    ..default()
-                })
-                .insert(BackgroundColor(bg_color));
-        });
-}
+//             parent
+//                 .spawn(Node {
+//                     height: Val::Percent(100.0),
+//                     ..default()
+//                 })
+//                 .insert(BackgroundColor(bg_color));
+//         });
+// }
 
 fn spawn_main_camera(
     commands: &mut Commands,
@@ -319,7 +322,7 @@ fn spawn_main_camera(
         Camera3d::default(),
         Camera {
             hdr: false,
-            clear_color: ClearColorConfig::None,
+            clear_color: ClearColorConfig::Default,
             order: 1,
             ..Default::default()
         },

--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -37,10 +37,12 @@ use plugins::navigation_gizmo::{NavigationGizmoPlugin, RenderLayerAlloc, spawn_g
 use ui::{
     SelectedObject,
     tiles::{self, TileState},
+    utils::FriendlyEpoch,
     widgets::plot::{CollectedGraphData, gpu::LineHandle},
 };
 
 pub mod chunks;
+mod offset_parse;
 mod plugins;
 pub mod ui;
 
@@ -941,7 +943,7 @@ impl std::fmt::Display for Offset {
                 write!(f, "-{d}")
             }
             Offset::Fixed(timestamp) => {
-                let timestamp = hifitime::Epoch::from(*timestamp);
+                let timestamp = FriendlyEpoch(hifitime::Epoch::from(*timestamp));
                 write!(f, "{timestamp}")
             }
         }
@@ -959,7 +961,7 @@ impl std::fmt::Display for TimeRangeBehavior {
                 write!(f, "LAST {start}")
             }
             (start, end) => {
-                write!(f, "{start}..{end}")
+                write!(f, "{start} — {end}")
             }
         }
     }

--- a/libs/elodin-editor/src/offset_parse.rs
+++ b/libs/elodin-editor/src/offset_parse.rs
@@ -1,0 +1,66 @@
+use std::{str::FromStr, time::Duration};
+
+use crate::Offset;
+use impeller2::types::Timestamp;
+use jiff::Span;
+
+peg::parser! {
+    grammar offset_parser() for str {
+
+        rule _ = quiet!{[' ' | '\n' | '\t']*}
+        rule parse_span() -> Span
+            = str:$([_]+) {? str.parse().or(Err("invalid duration")) }
+
+        rule zero() -> Span
+            = "0" ['s'|'m'|'h']? { Span::new() }
+
+        rule span() -> Span
+            = zero() / parse_span()
+
+        rule epoch() -> hifitime::Epoch
+            = str:$([_]+) {? str.parse().or(Err("invalid epoch")) }
+
+        rule sign() -> i64
+            = "+" { 1 }
+            / "-" { -1 }
+        rule start() -> Offset
+            = "+" _  span:span()  {? span_to_duration(span).map(Offset::Earliest).or(Err("invalid duration")) }
+        rule end() -> Offset
+            = "-" _ span:span()  {? span_to_duration(span).map(Offset::Latest).or(Err("invalid duration")) }
+
+        rule fixed() -> Offset
+            = "=" _ epoch:epoch()  { Offset::Fixed(Timestamp::from(epoch)) }
+
+        pub rule offset() -> Offset
+            = start() / end() / fixed()
+    }
+}
+
+impl FromStr for Offset {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        offset_parser::offset(s).map_err(|_| ())
+    }
+}
+
+fn span_to_duration(span: Span) -> Result<Duration, jiff::Error> {
+    Ok(Duration::from_nanos(
+        span.total(jiff::Unit::Nanosecond)? as u64
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_offset_parse() {
+        let o: Offset = "+ 0s".parse().unwrap();
+        assert_eq!(o, Offset::Earliest(Duration::from_secs(0)));
+        let o: Offset = "+ 20s".parse().unwrap();
+        assert_eq!(o, Offset::Earliest(Duration::from_secs(20)));
+        let o: Offset = "- 20s".parse().unwrap();
+        assert_eq!(o, Offset::Latest(Duration::from_secs(20)))
+    }
+}

--- a/libs/elodin-editor/src/plugins/navigation_gizmo.rs
+++ b/libs/elodin-editor/src/plugins/navigation_gizmo.rs
@@ -122,7 +122,7 @@ impl RenderLayerAlloc {
     }
 
     pub fn free_all(&mut self) {
-        self.0 = !1;
+        self.0 = !0;
     }
 }
 

--- a/libs/elodin-editor/src/ui/preset.rs
+++ b/libs/elodin-editor/src/ui/preset.rs
@@ -78,7 +78,7 @@ pub fn tile_to_panel(
                 let entities = entities.into_values().collect();
                 Some(Panel::Graph(impeller2_wkt::Graph {
                     entities,
-                    name: Some(graph.label.clone()),
+                    name: Some(graph_state.label.clone()),
                 }))
             }
             Pane::Monitor(monitor) => Some(Panel::ComponentMonitor(ComponentMonitor {

--- a/libs/elodin-editor/src/ui/preset.rs
+++ b/libs/elodin-editor/src/ui/preset.rs
@@ -79,6 +79,7 @@ pub fn tile_to_panel(
                 Some(Panel::Graph(impeller2_wkt::Graph {
                     entities,
                     name: Some(graph_state.label.clone()),
+                    graph_type: graph_state.graph_type,
                 }))
             }
             Pane::Monitor(monitor) => Some(Panel::ComponentMonitor(ComponentMonitor {

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -29,7 +29,7 @@ use super::{
         WidgetSystem, WidgetSystemExt,
         button::{EImageButton, ETileButton},
         command_palette::{CommandPaletteState, palette_items},
-        plot::{self, GraphBundle, PlotWidget},
+        plot::{self, GraphBundle, GraphState, PlotWidget},
     },
 };
 use crate::{
@@ -190,13 +190,18 @@ pub enum Pane {
 }
 
 impl Pane {
-    fn title(&self) -> &str {
+    fn title(&self, graph_states: &Query<&GraphState>) -> String {
         match self {
-            Pane::Graph(pane) => &pane.label,
-            Pane::Viewport(viewport) => &viewport.label,
-            Pane::Monitor(monitor) => &monitor.label,
-            Pane::SQLTable(..) => "SQL",
-            Pane::ActionTile(action) => &action.label,
+            Pane::Graph(pane) => {
+                if let Ok(graph_state) = graph_states.get(pane.id) {
+                    return graph_state.label.to_string();
+                }
+                pane.label.to_string()
+            }
+            Pane::Viewport(viewport) => viewport.label.to_string(),
+            Pane::Monitor(monitor) => monitor.label.to_string(),
+            Pane::SQLTable(..) => "SQL".to_string(),
+            Pane::ActionTile(action) => action.label.to_string(),
         }
     }
 
@@ -341,7 +346,9 @@ impl egui_tiles::Behavior<Pane> for TreeBehavior<'_> {
     }
 
     fn tab_title_for_pane(&mut self, pane: &Pane) -> egui::WidgetText {
-        pane.title().into()
+        let mut query = SystemState::<Query<&GraphState>>::new(self.world);
+        let query = query.get(self.world);
+        pane.title(&query).into()
     }
 
     fn pane_ui(
@@ -818,19 +825,24 @@ impl WidgetSystem for TileLayout<'_, '_> {
                         }
                     }
                     TreeAction::AddGraph(parent_tile_id, graph_bundle) => {
-                        let graph_bundle = if let Some(graph_bundle) = graph_bundle {
-                            graph_bundle
-                        } else {
-                            GraphBundle::new(&mut state_mut.render_layer_alloc, BTreeMap::default())
-                        };
-                        let graph_id = state_mut.commands.spawn(graph_bundle).id();
-
                         let graph_label = graph_label(
                             &Graph::default(),
                             &state_mut.entity_map,
                             &state_mut.entity_metadata,
                             &state_mut.metadata_store,
                         );
+
+                        let graph_bundle = if let Some(graph_bundle) = graph_bundle {
+                            graph_bundle
+                        } else {
+                            GraphBundle::new(
+                                &mut state_mut.render_layer_alloc,
+                                BTreeMap::default(),
+                                graph_label.clone(),
+                            )
+                        };
+                        let graph_id = state_mut.commands.spawn(graph_bundle).id();
+
                         let graph = GraphPane::new(graph_id, graph_label.clone());
                         let pane = Pane::Graph(graph);
 
@@ -1139,10 +1151,14 @@ pub fn spawn_panel(
                 entities.insert(entity.entity_id, components);
             }
 
-            let graph_id = commands
-                .spawn(GraphBundle::new(render_layer_alloc, entities))
-                .id();
             let graph_label = graph_label(graph, entity_map, entity_metadata, metadata_store);
+            let graph_id = commands
+                .spawn(GraphBundle::new(
+                    render_layer_alloc,
+                    entities,
+                    graph_label.clone(),
+                ))
+                .id();
             let graph = GraphPane::new(graph_id, graph_label);
             ui_state.insert_tile(Tile::Pane(Pane::Graph(graph)), parent_id, false)
         }

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -1186,7 +1186,7 @@ pub fn spawn_panel(
 
 pub fn shortcuts(key_state: Res<LogicalKeyState>, mut ui_state: ResMut<TileState>) {
     // tab switching
-    if key_state.pressed(&Key::Control) && key_state.pressed(&Key::Tab) {
+    if key_state.pressed(&Key::Control) && key_state.just_pressed(&Key::Tab) {
         // TODO(sphw): we should have a more intelligent focus system
         let Some(tile_id) = ui_state.tree.root() else {
             return;

--- a/libs/elodin-editor/src/ui/utils.rs
+++ b/libs/elodin-editor/src/ui/utils.rs
@@ -1,4 +1,5 @@
 use bevy_egui::egui;
+use hifitime::Epoch;
 
 pub fn get_galley_layout_job(
     text: impl ToString,
@@ -25,6 +26,16 @@ pub fn time_label_ms(time: f64) -> String {
     let minutes = (time_in_seconds / 60) % 60;
 
     format!("{minutes:0>2}:{seconds:0>2}.{milliseconds:0>3.0}")
+}
+
+pub struct FriendlyEpoch(pub Epoch);
+
+impl std::fmt::Display for FriendlyEpoch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let (y, month, day, hour, min, sec, ns) = self.0.to_gregorian_utc();
+        let sec = (sec as f64) + (ns as f64) * 1e-9;
+        write!(f, "{y}-{month}-{day}T{hour}:{min}:{sec:0.3}")
+    }
 }
 
 pub fn get_rects_from_relative_width(

--- a/libs/elodin-editor/src/ui/widgets/command_palette/mod.rs
+++ b/libs/elodin-editor/src/ui/widgets/command_palette/mod.rs
@@ -33,6 +33,7 @@ pub struct CommandPaletteState {
     pub page_stack: Vec<PalettePage>,
     pub selected_index: usize,
     pub auto_open_item: Option<PaletteItem>,
+    pub error: Option<String>,
 }
 
 impl CommandPaletteState {
@@ -49,6 +50,7 @@ impl CommandPaletteState {
     pub fn handle_event(&mut self, event: PaletteEvent) {
         match event {
             PaletteEvent::Exit => {
+                self.error = None;
                 self.show = false;
                 self.selected_index = 0;
             }
@@ -56,6 +58,7 @@ impl CommandPaletteState {
                 next_page,
                 prev_page_label,
             } => {
+                self.error = None;
                 self.filter = "".to_string();
                 if let Some(prev_page_label) = prev_page_label {
                     self.page_stack.last_mut().expect("unreachable").label = Some(prev_page_label);
@@ -63,6 +66,9 @@ impl CommandPaletteState {
                 self.page_stack.push(next_page);
                 self.input_focus = true;
                 self.selected_index = 0;
+            }
+            PaletteEvent::Error(err) => {
+                self.error = Some(err);
             }
         }
     }
@@ -355,6 +361,7 @@ impl WidgetSystem for PaletteItems<'_> {
         let mut selected_index = command_palette_state.selected_index;
         let hit_enter = kbd.just_pressed(&Key::Enter);
         let filter = command_palette_state.filter.clone();
+        let error = command_palette_state.error.clone();
 
         if command_palette_state.page_stack.is_empty() {
             command_palette_state
@@ -378,7 +385,6 @@ impl WidgetSystem for PaletteItems<'_> {
         if max_visible_rows > 0 {
             let res = egui::ScrollArea::vertical()
                 .scroll_bar_visibility(egui::scroll_area::ScrollBarVisibility::VisibleWhenNeeded)
-                //.max_height(ui.max_rect().height() - 64.0)
                 .show_rows(ui, row_height, max_visible_rows, |ui, row_range| {
                     let mut current_heading: Option<String> = None;
                     for (
@@ -421,12 +427,17 @@ impl WidgetSystem for PaletteItems<'_> {
                     }
                     None
                 });
+            if let Some(err_msg) = &error {
+                ui.add_space(row_height * 0.5);
+                ui.colored_label(colors::REDDISH_DEFAULT, format!("Error: {}", err_msg));
+            }
             let mut state_mut = state.get_mut(world);
-            state_mut.command_palette_state.page_stack.push(page);
             if let Some(event) = res.inner {
+                state_mut.command_palette_state.page_stack.push(page);
                 state_mut.command_palette_state.handle_event(event);
             } else {
                 state_mut.command_palette_state.selected_index = selected_index;
+                state_mut.command_palette_state.page_stack.push(page);
             }
         } else {
             let mut state_mut = state.get_mut(world);

--- a/libs/elodin-editor/src/ui/widgets/command_palette/mod.rs
+++ b/libs/elodin-editor/src/ui/widgets/command_palette/mod.rs
@@ -432,12 +432,11 @@ impl WidgetSystem for PaletteItems<'_> {
                 ui.colored_label(colors::REDDISH_DEFAULT, format!("Error: {}", err_msg));
             }
             let mut state_mut = state.get_mut(world);
+            state_mut.command_palette_state.page_stack.push(page);
             if let Some(event) = res.inner {
-                state_mut.command_palette_state.page_stack.push(page);
                 state_mut.command_palette_state.handle_event(event);
             } else {
                 state_mut.command_palette_state.selected_index = selected_index;
-                state_mut.command_palette_state.page_stack.push(page);
             }
         } else {
             let mut state_mut = state.get_mut(world);

--- a/libs/elodin-editor/src/ui/widgets/command_palette/palette_items.rs
+++ b/libs/elodin-editor/src/ui/widgets/command_palette/palette_items.rs
@@ -327,7 +327,11 @@ fn graph_entity_item(
                                     values.clone(),
                                 ))),
                             )));
-                            let bundle = GraphBundle::new(&mut render_layer_alloc, entities);
+                            let bundle = GraphBundle::new(
+                                &mut render_layer_alloc,
+                                entities,
+                                "Graph".to_string(),
+                            );
                             tile_state.create_graph_tile(tile_id, bundle);
                             PaletteEvent::Exit
                         },
@@ -552,14 +556,11 @@ fn set_time_range_behavior() -> PaletteItem {
                 ),
                 "Start Offset",
                 move |start_str: In<String>| {
-                    let start_offset = match Offset::from_str(&start_str.0) {
-                        Ok(offset) => offset,
-                        Err(_) => {
-                            return PaletteEvent::Error(format!(
-                                "Invalid start offset format: {}",
-                                start_str.0
-                            ));
-                        }
+                    let Ok(start_offset) = Offset::from_str(&start_str.0) else {
+                        return PaletteEvent::Error(format!(
+                            "Invalid start offset format: {}",
+                            start_str.0
+                        ));
                     };
 
                     PalettePage::new(vec![
@@ -569,17 +570,14 @@ fn set_time_range_behavior() -> PaletteItem {
                             ),
                             "End Offset",
                             move |end_str: In<String>, mut behavior: ResMut<TimeRangeBehavior>| {
-                                let end_offset = match Offset::from_str(&end_str.0) {
-                                    Ok(offset) => offset,
-                                    Err(_) => {
-                                        return PaletteEvent::Error(format!(
-                                            "Invalid end offset format: {}",
-                                            end_str.0
-                                        ));
-                                    }
+                                let Ok(end_offset) = Offset::from_str(&end_str.0) else {
+                                    return PaletteEvent::Error(format!(
+                                        "Invalid end offset format: {}",
+                                        end_str.0
+                                    ));
                                 };
 
-                                behavior.start = start_offset.clone();
+                                behavior.start = start_offset;
                                 behavior.end = end_offset;
                                 PaletteEvent::Exit
                             },

--- a/libs/elodin-editor/src/ui/widgets/command_palette/palette_items.rs
+++ b/libs/elodin-editor/src/ui/widgets/command_palette/palette_items.rs
@@ -683,6 +683,7 @@ pub fn load_preset_inner(name: String) -> PaletteItem {
                         schema_reg,
                         ..
                     } = params;
+                    render_layer_alloc.free_all();
                     tile_state.clear(&mut commands, &mut selected_object);
                     tiles::spawn_panel(
                         &panel,

--- a/libs/elodin-editor/src/ui/widgets/command_palette/palette_items.rs
+++ b/libs/elodin-editor/src/ui/widgets/command_palette/palette_items.rs
@@ -19,6 +19,7 @@ use impeller2_bevy::{ComponentMetadataRegistry, CurrentStreamId, PacketTx};
 use impeller2_wkt::{BodyAxes, EntityMetadata, IsRecording, SetDbSettings, SetStreamState};
 
 use crate::{
+    Offset, SelectedTimeRange, TimeRangeBehavior,
     plugins::navigation_gizmo::RenderLayerAlloc,
     ui::{
         self, EntityData, HdrEnabled,
@@ -526,6 +527,20 @@ fn set_playback_speed() -> PaletteItem {
     })
 }
 
+fn fix_current_time_range() -> PaletteItem {
+    PaletteItem::new(
+        "Fix Current Time Range",
+        SIMULATION_LABEL,
+        |_: In<String>,
+         selected_range: Res<SelectedTimeRange>,
+         mut behavior: ResMut<TimeRangeBehavior>| {
+            behavior.start = Offset::Fixed(selected_range.0.start);
+            behavior.end = Offset::Fixed(selected_range.0.end);
+            PaletteEvent::Exit
+        },
+    )
+}
+
 pub fn save_preset() -> PaletteItem {
     PaletteItem::new("Save Preset", PRESETS_LABEL, |_name: In<String>| {
         PalettePage::new(vec![save_preset_inner()]).into()
@@ -700,6 +715,7 @@ impl Default for PalettePage {
                 },
             ),
             set_playback_speed(),
+            fix_current_time_range(),
             create_graph(None),
             create_action(None),
             create_monitor(None),

--- a/libs/elodin-editor/src/ui/widgets/inspector/entity.rs
+++ b/libs/elodin-editor/src/ui/widgets/inspector/entity.rs
@@ -160,7 +160,8 @@ impl WidgetSystem for InspectorEntity<'_, '_> {
                     entity_id,
                     BTreeMap::from_iter(std::iter::once((component_id, values.clone()))),
                 )));
-                let bundle = GraphBundle::new(&mut render_layer_alloc, entities);
+                let bundle =
+                    GraphBundle::new(&mut render_layer_alloc, entities, metadata.name.clone());
                 tile_state.create_graph_tile(None, bundle);
             }
         }

--- a/libs/elodin-editor/src/ui/widgets/inspector/graph.rs
+++ b/libs/elodin-editor/src/ui/widgets/inspector/graph.rs
@@ -4,6 +4,7 @@ use bevy::ecs::{
     world::World,
 };
 use bevy_egui::egui;
+use impeller2_wkt::GraphType;
 use smallvec::SmallVec;
 
 use egui::Align;
@@ -19,7 +20,7 @@ use crate::ui::{
         WidgetSystem,
         button::ECheckboxButton,
         label::{self, label_with_buttons},
-        plot::{GraphState, gpu::LineType},
+        plot::GraphState,
     },
 };
 
@@ -76,7 +77,7 @@ impl WidgetSystem for InspectorGraph<'_, '_> {
             .show(ui, |ui| {
                 ui.horizontal(|ui| {
                     ui.label(
-                        egui::RichText::new("LINE WIDTH")
+                        egui::RichText::new("WIDTH")
                             .color(with_opacity(colors::PRIMARY_CREAME, 0.6)),
                     );
                     ui.with_layout(egui::Layout::right_to_left(Align::Min), |ui| {
@@ -93,23 +94,23 @@ impl WidgetSystem for InspectorGraph<'_, '_> {
             .inner_margin(egui::Margin::symmetric(0, 8))
             .show(ui, |ui| {
                 ui.label(
-                    egui::RichText::new("LINE TYPE")
+                    egui::RichText::new("GRAPH TYPE")
                         .color(with_opacity(colors::PRIMARY_CREAME, 0.6)),
                 );
                 ui.add_space(8.0);
                 theme::configure_combo_box(ui.style_mut());
                 ui.style_mut().spacing.combo_width = ui.available_size().x;
-                egui::ComboBox::from_id_salt("LINE_TYPE")
-                    .selected_text(match graph_state.line_type {
-                        LineType::Line => "Line",
-                        LineType::Points => "Points",
-                        LineType::Bars => "Bars",
+                egui::ComboBox::from_id_salt("graph_type")
+                    .selected_text(match graph_state.graph_type {
+                        GraphType::Line => "Line",
+                        GraphType::Point => "Point",
+                        GraphType::Bar => "Bar",
                     })
                     .show_ui(ui, |ui| {
                         theme::configure_combo_item(ui.style_mut());
-                        ui.selectable_value(&mut graph_state.line_type, LineType::Line, "Line");
-                        ui.selectable_value(&mut graph_state.line_type, LineType::Points, "Points");
-                        ui.selectable_value(&mut graph_state.line_type, LineType::Bars, "Bars");
+                        ui.selectable_value(&mut graph_state.graph_type, GraphType::Line, "Line");
+                        ui.selectable_value(&mut graph_state.graph_type, GraphType::Point, "Point");
+                        ui.selectable_value(&mut graph_state.graph_type, GraphType::Bar, "Bar");
                     });
             });
 

--- a/libs/elodin-editor/src/ui/widgets/inspector/graph.rs
+++ b/libs/elodin-editor/src/ui/widgets/inspector/graph.rs
@@ -93,22 +93,25 @@ impl WidgetSystem for InspectorGraph<'_, '_> {
         egui::Frame::NONE
             .inner_margin(egui::Margin::symmetric(8, 8))
             .show(ui, |ui| {
-                ui.horizontal(|ui| {
-                    ui.label(
-                        egui::RichText::new("SHOW POINTS")
-                            .color(with_opacity(colors::PRIMARY_CREAME, 0.6)),
-                    );
-                    ui.with_layout(egui::Layout::right_to_left(Align::Min), |ui| {
-                        let mut use_points = graph_state.line_type == LineType::Points;
-                        theme::configure_input_with_border(ui.style_mut());
-                        ui.checkbox(&mut use_points, "");
-                        graph_state.line_type = if use_points {
-                            LineType::Points
-                        } else {
-                            LineType::Line
-                        };
+                ui.label(
+                    egui::RichText::new("LINE TYPE")
+                        .color(with_opacity(colors::PRIMARY_CREAME, 0.6)),
+                );
+                ui.add_space(8.0);
+                theme::configure_combo_box(ui.style_mut());
+                ui.style_mut().spacing.combo_width = ui.available_size().x;
+                egui::ComboBox::from_id_salt("LINE_TYPE")
+                    .selected_text(match graph_state.line_type {
+                        LineType::Line => "Line",
+                        LineType::Points => "Points",
+                        LineType::Bars => "Bars",
+                    })
+                    .show_ui(ui, |ui| {
+                        theme::configure_combo_item(ui.style_mut());
+                        ui.selectable_value(&mut graph_state.line_type, LineType::Line, "Line");
+                        ui.selectable_value(&mut graph_state.line_type, LineType::Points, "Points");
+                        ui.selectable_value(&mut graph_state.line_type, LineType::Bars, "Bars");
                     });
-                });
             });
 
         let mut remove_list: SmallVec<[(EntityId, ComponentId); 1]> = SmallVec::new();

--- a/libs/elodin-editor/src/ui/widgets/inspector/graph.rs
+++ b/libs/elodin-editor/src/ui/widgets/inspector/graph.rs
@@ -13,8 +13,14 @@ use impeller2_bevy::ComponentMetadataRegistry;
 use crate::ui::{
     EntityData, SettingModal, SettingModalState,
     colors::{self, with_opacity},
+    theme,
     utils::MarginSides,
-    widgets::{WidgetSystem, button::ECheckboxButton, label::label_with_buttons, plot::GraphState},
+    widgets::{
+        WidgetSystem,
+        button::ECheckboxButton,
+        label::label_with_buttons,
+        plot::{GraphState, gpu::LineType},
+    },
 };
 
 use super::InspectorIcons;
@@ -83,6 +89,26 @@ impl WidgetSystem for InspectorGraph<'_, '_> {
                 ui.style_mut().spacing.slider_width = ui.available_size().x;
                 ui.style_mut().visuals.widgets.inactive.bg_fill = colors::PRIMARY_ONYX_8;
                 ui.add(egui::Slider::new(&mut graph_state.line_width, 1.0..=15.0).show_value(false))
+            });
+        egui::Frame::NONE
+            .inner_margin(egui::Margin::symmetric(8, 8))
+            .show(ui, |ui| {
+                ui.horizontal(|ui| {
+                    ui.label(
+                        egui::RichText::new("SHOW POINTS")
+                            .color(with_opacity(colors::PRIMARY_CREAME, 0.6)),
+                    );
+                    ui.with_layout(egui::Layout::right_to_left(Align::Min), |ui| {
+                        let mut use_points = graph_state.line_type == LineType::Points;
+                        theme::configure_input_with_border(ui.style_mut());
+                        ui.checkbox(&mut use_points, "");
+                        graph_state.line_type = if use_points {
+                            LineType::Points
+                        } else {
+                            LineType::Line
+                        };
+                    });
+                });
             });
 
         let mut remove_list: SmallVec<[(EntityId, ComponentId); 1]> = SmallVec::new();

--- a/libs/elodin-editor/src/ui/widgets/inspector/graph.rs
+++ b/libs/elodin-editor/src/ui/widgets/inspector/graph.rs
@@ -18,7 +18,7 @@ use crate::ui::{
     widgets::{
         WidgetSystem,
         button::ECheckboxButton,
-        label::label_with_buttons,
+        label::{self, label_with_buttons},
         plot::{GraphState, gpu::LineType},
     },
 };
@@ -34,7 +34,7 @@ pub struct InspectorGraph<'w, 's> {
 }
 
 impl WidgetSystem for InspectorGraph<'_, '_> {
-    type Args = (InspectorIcons, Entity, String);
+    type Args = (InspectorIcons, Entity);
     type Output = ();
 
     fn ui_system(
@@ -45,7 +45,7 @@ impl WidgetSystem for InspectorGraph<'_, '_> {
     ) {
         let state_mut = state.get_mut(world);
 
-        let (icons, graph_id, label) = args;
+        let (icons, graph_id) = args;
 
         let InspectorGraph {
             entities,
@@ -55,10 +55,14 @@ impl WidgetSystem for InspectorGraph<'_, '_> {
         } = state_mut;
 
         let graph_label_margin = egui::Margin::same(0).top(10.0).bottom(14.0);
-        let [add_clicked] = label_with_buttons(
+        let Ok(mut graph_state) = graph_states.get_mut(graph_id) else {
+            return;
+        };
+
+        let [add_clicked] = label::editable_label_with_buttons(
             ui,
             [icons.add],
-            label,
+            &mut graph_state.label,
             colors::PRIMARY_CREAME,
             graph_label_margin,
         );
@@ -67,13 +71,8 @@ impl WidgetSystem for InspectorGraph<'_, '_> {
         }
 
         ui.separator();
-
-        let Ok(mut graph_state) = graph_states.get_mut(graph_id) else {
-            return;
-        };
-
         egui::Frame::NONE
-            .inner_margin(egui::Margin::symmetric(8, 8))
+            .inner_margin(egui::Margin::symmetric(0, 8))
             .show(ui, |ui| {
                 ui.horizontal(|ui| {
                     ui.label(
@@ -91,7 +90,7 @@ impl WidgetSystem for InspectorGraph<'_, '_> {
                 ui.add(egui::Slider::new(&mut graph_state.line_width, 1.0..=15.0).show_value(false))
             });
         egui::Frame::NONE
-            .inner_margin(egui::Margin::symmetric(8, 8))
+            .inner_margin(egui::Margin::symmetric(0, 8))
             .show(ui, |ui| {
                 ui.label(
                     egui::RichText::new("LINE TYPE")

--- a/libs/elodin-editor/src/ui/widgets/inspector/mod.rs
+++ b/libs/elodin-editor/src/ui/widgets/inspector/mod.rs
@@ -152,13 +152,11 @@ impl WidgetSystem for InspectorContent<'_> {
                                     (icons, camera),
                                 );
                             }
-                            SelectedObject::Graph {
-                                label, graph_id, ..
-                            } => {
+                            SelectedObject::Graph { graph_id, .. } => {
                                 ui.add_widget_with::<InspectorGraph>(
                                     world,
                                     "inspector_graph",
-                                    (icons, graph_id, label),
+                                    (icons, graph_id),
                                 );
                             }
                             SelectedObject::Action { action_id, .. } => {

--- a/libs/elodin-editor/src/ui/widgets/label.rs
+++ b/libs/elodin-editor/src/ui/widgets/label.rs
@@ -112,6 +112,53 @@ impl egui::Widget for ELabel {
     }
 }
 
+pub fn editable_label_with_buttons<const N: usize>(
+    ui: &mut egui::Ui,
+    btn_icons: [egui::TextureId; N],
+    label: &mut String,
+    color: egui::Color32,
+    margin: egui::Margin,
+) -> [bool; N] {
+    let mut clicked = [false; N];
+
+    egui::Frame::NONE.inner_margin(margin).show(ui, |ui| {
+        ui.horizontal(|ui| {
+            let (label_rect, btn_rect) = utils::get_rects_from_relative_width(
+                ui.max_rect(),
+                0.8,
+                ui.spacing().interact_size.y,
+            );
+
+            ui.allocate_new_ui(UiBuilder::new().max_rect(label_rect), |ui| {
+                ui.with_layout(egui::Layout::left_to_right(egui::Align::Center), |ui| {
+                    ui.text_edit_singleline(label);
+                    // let text = egui::RichText::new(label.to_string()).color(color);
+                    // ui.add(egui::Label::new(text));
+                });
+            });
+
+            ui.allocate_new_ui(UiBuilder::new().max_rect(btn_rect), |ui| {
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    for (i, btn_icon) in btn_icons.iter().enumerate() {
+                        let btn = ui.add(
+                            EImageButton::new(*btn_icon)
+                                .scale(1.2, 1.2)
+                                .image_tint(color)
+                                .bg_color(colors::TRANSPARENT),
+                        );
+
+                        if btn.clicked() {
+                            clicked[i] = true;
+                        }
+                    }
+                });
+            });
+        });
+    });
+
+    clicked
+}
+
 pub fn label_with_buttons<const N: usize>(
     ui: &mut egui::Ui,
     btn_icons: [egui::TextureId; N],

--- a/libs/elodin-editor/src/ui/widgets/plot/bars.wgsl
+++ b/libs/elodin-editor/src/ui/widgets/plot/bars.wgsl
@@ -1,0 +1,74 @@
+#import bevy_render::view::View
+
+@group(0) @binding(0) var<uniform> view : View;
+
+struct LineUniform {
+    line_width : f32,
+                 color : vec4<f32>,
+                         chunk_size : f32,
+#ifdef SIXTEEN_BYTE_ALIGNMENT
+                                      // WebGL2 structs must be 16 byte aligned.
+                                      _padding : vec2<f32>,
+#endif
+}
+
+@group(1) @binding(0) var<uniform> line_uniform : LineUniform;
+
+@group(2) @binding(0) var<storage> x_values : array<f32>;
+@group(2) @binding(1) var<storage> y_values : array<f32>;
+@group(2) @binding(2) var<storage> index_buffer : array<u32>;
+
+struct VertexInput {
+    @builtin(vertex_index) vertex_index : u32,
+                                          @builtin(instance_index) instance_index : u32,
+};
+
+struct VertexOutput {
+    @builtin(position) clip_position : vec4<f32>,
+                                       @location(0) color : vec4<f32>,
+};
+
+@vertex fn vertex(vertex : VertexInput) -> VertexOutput
+{
+    var positions = array<vec2<f32>, 4>(
+        vec2(0.0, 0.0), // bottom-left
+        vec2(0.0, 1.0), // top-left
+        vec2(1.0, 0.0), // bottom-right
+        vec2(1.0, 1.0) // top-right
+    );
+
+    let position = positions[vertex.vertex_index];
+    let resolution = view.viewport.zw;
+    let bar_width = line_uniform.line_width / resolution.x;
+
+    let index = index_buffer[vertex.instance_index];
+    let time = x_values[index];
+    let data = y_values[index];
+
+    let zero_point = (view.clip_from_view * vec4(time, 0.0, 0.0, 1.0)).xy;
+    let data_point = (view.clip_from_view * vec4(time, data, 0.0, 1.0)).xy;
+
+    let bar_half_width = bar_width * 4.0;
+    let bar_left = zero_point.x - bar_half_width;
+    let bar_right = zero_point.x + bar_half_width;
+
+    let x = mix(bar_left, bar_right, position.x);
+    let y = mix(zero_point.y, data_point.y, position.y);
+
+    let clip_position = vec4(x, y, 0.0, 1.0);
+    return VertexOutput(clip_position, line_uniform.color);
+}
+
+struct FragmentInput {
+    @builtin(position) position : vec4<f32>,
+              @location(0) color : vec4<f32>,
+};
+
+struct FragmentOutput {
+    @location(0) color : vec4<f32>,
+};
+
+@fragment fn fragment(in : FragmentInput) -> FragmentOutput
+{
+    return FragmentOutput(in.color);
+}

--- a/libs/elodin-editor/src/ui/widgets/plot/data.rs
+++ b/libs/elodin-editor/src/ui/widgets/plot/data.rs
@@ -425,6 +425,9 @@ pub fn queue_timestamp_read(
     mut graph_data: ResMut<CollectedGraphData>,
     mut lines: ResMut<Assets<Line>>,
 ) {
+    if selected_range.0.end.0 == i64::MIN || selected_range.0.start.0 == i64::MAX {
+        return;
+    }
     for (&entity_id, entity) in graph_data.entities.iter_mut() {
         for (&component_id, component) in entity.components.iter_mut() {
             let mut line = component

--- a/libs/elodin-editor/src/ui/widgets/plot/gpu.rs
+++ b/libs/elodin-editor/src/ui/widgets/plot/gpu.rs
@@ -48,6 +48,7 @@ use crate::ui::widgets::plot::{CHUNK_COUNT, CHUNK_LEN, Line};
 
 const LINE_SHADER_HANDLE: Handle<Shader> = weak_handle!("e44f3b60-cb86-42a2-b7d8-d8dbf1f0299a");
 const POINT_SHADER_HANDLE: Handle<Shader> = weak_handle!("4f1aa57d-aacd-4d17-859f-0dad0ee3890f");
+const BAR_SHADER_HANDLE: Handle<Shader> = weak_handle!("091989F7-D5B1-4C6C-B9C1-EDD5EE51F1B1");
 
 pub const VALUE_BUFFER_SIZE: NonZeroU64 =
     NonZeroU64::new((CHUNK_COUNT * CHUNK_LEN * size_of::<f32>()) as u64).unwrap();
@@ -69,6 +70,7 @@ impl Plugin for PlotGpuPlugin {
 
         load_internal_asset!(app, LINE_SHADER_HANDLE, "./line.wgsl", Shader::from_wgsl);
         load_internal_asset!(app, POINT_SHADER_HANDLE, "./points.wgsl", Shader::from_wgsl);
+        load_internal_asset!(app, BAR_SHADER_HANDLE, "./bars.wgsl", Shader::from_wgsl);
         let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;
         };
@@ -249,6 +251,7 @@ impl SpecializedRenderPipeline for LinePipeline {
         let shader = match key.line_type {
             LineType::Line => LINE_SHADER_HANDLE,
             LineType::Points => POINT_SHADER_HANDLE,
+            LineType::Bars => BAR_SHADER_HANDLE,
         };
 
         RenderPipelineDescriptor {
@@ -318,6 +321,7 @@ pub struct LineWidgetWidth(pub usize);
 pub enum LineType {
     Line,
     Points,
+    Bars,
 }
 
 #[derive(Clone, Component, ExtractComponent)]

--- a/libs/elodin-editor/src/ui/widgets/plot/gpu.rs
+++ b/libs/elodin-editor/src/ui/widgets/plot/gpu.rs
@@ -47,6 +47,7 @@ use std::ops::Range;
 use crate::ui::widgets::plot::{CHUNK_COUNT, CHUNK_LEN, Line};
 
 const LINE_SHADER_HANDLE: Handle<Shader> = weak_handle!("e44f3b60-cb86-42a2-b7d8-d8dbf1f0299a");
+const POINT_SHADER_HANDLE: Handle<Shader> = weak_handle!("4f1aa57d-aacd-4d17-859f-0dad0ee3890f");
 
 pub const VALUE_BUFFER_SIZE: NonZeroU64 =
     NonZeroU64::new((CHUNK_COUNT * CHUNK_LEN * size_of::<f32>()) as u64).unwrap();
@@ -67,6 +68,7 @@ impl Plugin for PlotGpuPlugin {
             .init_asset::<Line>();
 
         load_internal_asset!(app, LINE_SHADER_HANDLE, "./line.wgsl", Shader::from_wgsl);
+        load_internal_asset!(app, POINT_SHADER_HANDLE, "./points.wgsl", Shader::from_wgsl);
         let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;
         };
@@ -140,6 +142,7 @@ pub struct LineBundle {
     pub uniform: LineUniform,
     pub config: LineConfig,
     pub line_visible_range: LineVisibleRange,
+    pub line_type: LineType,
 }
 
 #[derive(Component, ShaderType, Clone, Copy, ExtractComponent)]
@@ -215,6 +218,7 @@ impl FromWorld for LinePipeline {
 #[derive(PartialEq, Eq, Hash, Clone)]
 pub struct LinePipelineKey {
     view_key: Mesh2dPipelineKey,
+    line_type: LineType,
 }
 
 impl SpecializedRenderPipeline for LinePipeline {
@@ -242,16 +246,20 @@ impl SpecializedRenderPipeline for LinePipeline {
         } else {
             TextureFormat::bevy_default()
         };
+        let shader = match key.line_type {
+            LineType::Line => LINE_SHADER_HANDLE,
+            LineType::Points => POINT_SHADER_HANDLE,
+        };
 
         RenderPipelineDescriptor {
             vertex: VertexState {
-                shader: LINE_SHADER_HANDLE,
+                shader: shader.clone(),
                 entry_point: "vertex".into(),
                 shader_defs: shader_defs.clone(),
                 buffers: line_vertex_buffer_layouts(),
             },
             fragment: Some(FragmentState {
-                shader: LINE_SHADER_HANDLE,
+                shader,
                 shader_defs,
                 entry_point: "fragment".into(),
                 targets: vec![Some(ColorTargetState {
@@ -305,6 +313,12 @@ pub struct LineConfig {
 
 #[derive(Component, Clone, ExtractComponent)]
 pub struct LineWidgetWidth(pub usize);
+
+#[derive(Component, Clone, Copy, ExtractComponent, Hash, PartialEq, Eq, Debug)]
+pub enum LineType {
+    Line,
+    Points,
+}
 
 #[derive(Clone, Component, ExtractComponent)]
 pub struct GpuLine {
@@ -379,6 +393,7 @@ type LineQueryMut = (
     &'static mut LineUniform,
     &'static mut LineVisibleRange,
     &'static mut LineWidgetWidth,
+    &'static mut LineType,
     Option<&'static mut GpuLine>,
 );
 
@@ -394,7 +409,7 @@ fn extract_lines(
         ResMut<'static, Assets<Line>>,
     )>::new(&mut main_world);
     let (mut lines, mut line_assets) = state.get_mut(&mut main_world);
-    for (entity, line_handle, config, uniform, line_visible_range, width, gpu_line) in
+    for (entity, line_handle, config, uniform, line_visible_range, width, line_type, gpu_line) in
         lines.iter_mut()
     {
         let Some(line) = line_assets.get_mut(&line_handle.0) else {
@@ -475,6 +490,7 @@ fn extract_lines(
                 config: config.clone(),
                 uniform: *uniform,
                 line_visible_range: line_visible_range.clone(),
+                line_type: *line_type,
             },
             gpu_line,
             TemporaryRenderEntity,
@@ -488,7 +504,7 @@ fn queue_line(
     pipeline: Res<LinePipeline>,
     mut pipelines: ResMut<SpecializedRenderPipelines<LinePipeline>>,
     pipeline_cache: Res<PipelineCache>,
-    lines: Query<(Entity, &MainEntity, &LineConfig)>,
+    lines: Query<(Entity, &MainEntity, &LineConfig, &LineType)>,
     mut transparent_render_phases: ResMut<ViewSortedRenderPhases<Transparent2d>>,
     mut views: Query<(&ExtractedView, &Msaa, Option<&RenderLayers>)>,
 ) {
@@ -504,7 +520,7 @@ fn queue_line(
             | Mesh2dPipelineKey::from_hdr(view.hdr);
 
         let render_layers = render_layers.unwrap_or_default();
-        for (entity, main_entity, config) in &lines {
+        for (entity, main_entity, config, line_type) in &lines {
             if !config.render_layers.intersects(render_layers) {
                 continue;
             }
@@ -512,7 +528,10 @@ fn queue_line(
             let pipeline = pipelines.specialize(
                 &pipeline_cache,
                 &pipeline,
-                LinePipelineKey { view_key: mesh_key },
+                LinePipelineKey {
+                    view_key: mesh_key,
+                    line_type: *line_type,
+                },
             );
 
             transparent_phase.add(Transparent2d {

--- a/libs/elodin-editor/src/ui/widgets/plot/points.wgsl
+++ b/libs/elodin-editor/src/ui/widgets/plot/points.wgsl
@@ -1,0 +1,66 @@
+#import bevy_render::view::View
+
+@group(0) @binding(0) var<uniform> view : View;
+
+struct LineUniform {
+    line_width : f32,
+                 color : vec4<f32>,
+                         chunk_size : f32,
+#ifdef SIXTEEN_BYTE_ALIGNMENT
+                                      // WebGL2 structs must be 16 byte aligned.
+                                      _padding : vec2<f32>,
+#endif
+}
+
+@group(1) @binding(0) var<uniform> line_uniform : LineUniform;
+
+@group(2) @binding(0) var<storage> x_values : array<f32>;
+@group(2) @binding(1) var<storage> y_values : array<f32>;
+@group(2) @binding(2) var<storage> index_buffer : array<u32>;
+
+struct VertexInput {
+
+    @builtin(vertex_index) vertex_index : u32,
+                                          @builtin(instance_index) instance_index : u32,
+};
+
+struct VertexOutput {
+
+    @builtin(position) position : vec4<f32>,
+                                  @location(0) point : vec2<f32>,
+                                                       @location(1) center : vec2<f32>,
+                                                                             @location(2) width : vec2<f32>,
+                                                                                                  @location(3) color : vec4<f32>,
+};
+
+@vertex fn vertex(vertex : VertexInput) -> VertexOutput
+{
+    var positions = array<vec2<f32>, 4>(vec2(-1.0, -1.0), // bottom-left
+        vec2(-1.0, 1.), // top-left
+        vec2(1.0, -1.0), // bottom-right
+        vec2(1.0, 1.)); // top-right
+    let position = positions[vertex.vertex_index];
+    let resolution = view.viewport.zw;
+    let width = line_uniform.line_width / resolution;
+    let index = index_buffer[vertex.instance_index];
+    let time = x_values[index];
+    let data = y_values[index];
+
+    let pos = vec2(time, data);
+    let clip = (view.clip_from_view * vec4(pos, 0.0, 1.0)).xy;
+    let point = position * width * 3.0 + clip;
+    let clip_position = vec4(point, 0, 1.0);
+    return VertexOutput(clip_position, point, clip, width, line_uniform.color);
+}
+
+struct FragmentOutput {
+    @location(0) color : vec4<f32>,
+};
+
+@fragment fn fragment(in : VertexOutput) -> FragmentOutput
+{
+    let dist = length((in.point - in.center) / in.width / 2);
+    let alpha = 1.0 - smoothstep(0.82, 1.0, dist);
+    let color = vec4(in.color.xyz, alpha);
+    return FragmentOutput(color);
+}

--- a/libs/elodin-editor/src/ui/widgets/plot/state.rs
+++ b/libs/elodin-editor/src/ui/widgets/plot/state.rs
@@ -15,6 +15,8 @@ use crate::MainCamera;
 use crate::plugins::navigation_gizmo::RenderLayerAlloc;
 use crate::ui::{ViewportRect, colors};
 
+use super::gpu::LineType;
+
 pub type GraphStateComponent = Vec<(bool, egui::Color32)>;
 pub type GraphStateEntity = BTreeMap<ComponentId, GraphStateComponent>;
 
@@ -38,6 +40,7 @@ pub struct GraphState {
     pub line_width: f32,
     pub zoom_factor: Vec2,
     pub pan_offset: Vec2,
+    pub line_type: LineType,
 }
 
 impl GraphBundle {
@@ -56,6 +59,7 @@ impl GraphBundle {
             line_width: 2.0,
             zoom_factor: Vec2::ONE,
             pan_offset: Vec2::ZERO,
+            line_type: LineType::Line,
         };
         GraphBundle {
             camera: Camera {

--- a/libs/elodin-editor/src/ui/widgets/plot/state.rs
+++ b/libs/elodin-editor/src/ui/widgets/plot/state.rs
@@ -10,12 +10,11 @@ use bevy_egui::egui::{self, Color32};
 
 use impeller2::types::{ComponentId, EntityId};
 use impeller2_bevy::ComponentValue;
+use impeller2_wkt::GraphType;
 
 use crate::MainCamera;
 use crate::plugins::navigation_gizmo::RenderLayerAlloc;
 use crate::ui::{ViewportRect, colors};
-
-use super::gpu::LineType;
 
 pub type GraphStateComponent = Vec<(bool, egui::Color32)>;
 pub type GraphStateEntity = BTreeMap<ComponentId, GraphStateComponent>;
@@ -40,7 +39,7 @@ pub struct GraphState {
     pub line_width: f32,
     pub zoom_factor: Vec2,
     pub pan_offset: Vec2,
-    pub line_type: LineType,
+    pub graph_type: GraphType,
     pub label: String,
 }
 
@@ -61,7 +60,7 @@ impl GraphBundle {
             line_width: 2.0,
             zoom_factor: Vec2::ONE,
             pan_offset: Vec2::ZERO,
-            line_type: LineType::Line,
+            graph_type: GraphType::Line,
             label,
         };
         GraphBundle {

--- a/libs/elodin-editor/src/ui/widgets/plot/state.rs
+++ b/libs/elodin-editor/src/ui/widgets/plot/state.rs
@@ -41,12 +41,14 @@ pub struct GraphState {
     pub zoom_factor: Vec2,
     pub pan_offset: Vec2,
     pub line_type: LineType,
+    pub label: String,
 }
 
 impl GraphBundle {
     pub fn new(
         render_layer_alloc: &mut RenderLayerAlloc,
         entities: BTreeMap<EntityId, GraphStateEntity>,
+        label: String,
     ) -> Self {
         let Some(layer) = render_layer_alloc.alloc() else {
             todo!("ran out of layers")
@@ -60,6 +62,7 @@ impl GraphBundle {
             zoom_factor: Vec2::ONE,
             pan_offset: Vec2::ZERO,
             line_type: LineType::Line,
+            label,
         };
         GraphBundle {
             camera: Camera {

--- a/libs/elodin-editor/src/ui/widgets/plot/widget.rs
+++ b/libs/elodin-editor/src/ui/widgets/plot/widget.rs
@@ -725,6 +725,7 @@ impl Plot {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn render(
         &self,
         ui: &mut egui::Ui,

--- a/libs/elodin-editor/src/ui/widgets/plot/widget.rs
+++ b/libs/elodin-editor/src/ui/widgets/plot/widget.rs
@@ -358,7 +358,7 @@ impl Plot {
                                     line_visible_range: LineVisibleRange(
                                         line_visible_range.clone(),
                                     ),
-                                    line_type: graph_state.line_type,
+                                    graph_type: graph_state.graph_type,
                                 })
                                 .insert(LineWidgetWidth(ui.max_rect().width() as usize))
                                 .id();
@@ -381,7 +381,7 @@ impl Plot {
                                     graph_state.line_width,
                                     color.into_bevy(),
                                 ))
-                                .try_insert(graph_state.line_type)
+                                .try_insert(graph_state.graph_type)
                                 .try_insert(LineWidgetWidth(ui.max_rect().width() as usize))
                                 .try_insert(LineVisibleRange(line_visible_range.clone()));
                         }

--- a/libs/elodin-editor/src/ui/widgets/plot/widget.rs
+++ b/libs/elodin-editor/src/ui/widgets/plot/widget.rs
@@ -356,6 +356,7 @@ impl Plot {
                                     line_visible_range: LineVisibleRange(
                                         line_visible_range.clone(),
                                     ),
+                                    line_type: graph_state.line_type,
                                 })
                                 .insert(LineWidgetWidth(ui.max_rect().width() as usize))
                                 .id();
@@ -378,6 +379,7 @@ impl Plot {
                                     graph_state.line_width,
                                     color.into_bevy(),
                                 ))
+                                .try_insert(graph_state.line_type)
                                 .try_insert(LineWidgetWidth(ui.max_rect().width() as usize))
                                 .try_insert(LineVisibleRange(line_visible_range.clone()));
                         }

--- a/libs/elodin-editor/src/ui/widgets/timeline/timeline_controls.rs
+++ b/libs/elodin-editor/src/ui/widgets/timeline/timeline_controls.rs
@@ -184,8 +184,10 @@ fn time_range_selector_button(
     behavior: &mut TimeRangeBehavior,
 ) -> impl FnOnce(&mut Ui) -> egui::Response + '_ {
     move |ui| {
+        let behavior_string = behavior.to_string();
+        let width = behavior_string.len() as f32 * 7.5;
         ui.allocate_ui_with_layout(
-            egui::vec2(215.0, 34.0),
+            egui::vec2(width + 50.0, 34.0),
             egui::Layout::centered_and_justified(egui::Direction::LeftToRight),
             |ui| {
                 let font_id = egui::TextStyle::Button.resolve(ui.style());
@@ -206,7 +208,7 @@ fn time_range_selector_button(
                 ui.painter().text(
                     ui.max_rect().left_center() + egui::vec2(8.0, 0.0),
                     egui::Align2::LEFT_CENTER,
-                    behavior.to_string(),
+                    behavior_string,
                     font_id,
                     colors::PRIMARY_CREAME,
                 );

--- a/libs/impeller2/src/types.rs
+++ b/libs/impeller2/src/types.rs
@@ -863,6 +863,7 @@ impl From<Timestamp> for hifitime::Epoch {
     }
 }
 
+#[cfg(feature = "hifitime")]
 impl From<hifitime::Epoch> for Timestamp {
     fn from(epoch: hifitime::Epoch) -> Self {
         Timestamp((epoch.to_unix_milliseconds() * 1000.0) as i64)

--- a/libs/impeller2/src/types.rs
+++ b/libs/impeller2/src/types.rs
@@ -863,6 +863,12 @@ impl From<Timestamp> for hifitime::Epoch {
     }
 }
 
+impl From<hifitime::Epoch> for Timestamp {
+    fn from(epoch: hifitime::Epoch) -> Self {
+        Timestamp((epoch.to_unix_milliseconds() * 1000.0) as i64)
+    }
+}
+
 impl Timestamp {
     pub const EPOCH: Timestamp = Timestamp(0);
 

--- a/libs/impeller2/wkt/src/gui/mod.rs
+++ b/libs/impeller2/wkt/src/gui/mod.rs
@@ -76,6 +76,8 @@ impl Asset for Panel {
 pub struct Graph {
     pub entities: Vec<GraphEntity>,
     pub name: Option<String>,
+    #[serde(default)]
+    pub graph_type: GraphType,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -88,6 +90,15 @@ pub struct GraphEntity {
 pub struct GraphComponent {
     pub component_id: ComponentId,
     pub indexes: Vec<usize>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy, Hash, PartialEq, Eq, Debug, Default)]
+#[cfg_attr(feature = "bevy", derive(bevy::prelude::Component))]
+pub enum GraphType {
+    #[default]
+    Line,
+    Point,
+    Bar,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/libs/nox-py/src/well_known/gui.rs
+++ b/libs/nox-py/src/well_known/gui.rs
@@ -1,7 +1,7 @@
 use crate::*;
 
 use impeller2::component::Asset;
-use impeller2_wkt::{Graph, GraphComponent, Split};
+use impeller2_wkt::{Graph, GraphComponent, GraphType, Split};
 use nox_ecs::nox::Vector3;
 use numpy::PyArrayLike1;
 use pyo3::exceptions::PyValueError;
@@ -97,8 +97,22 @@ impl Panel {
     }
 
     #[staticmethod]
-    #[pyo3(signature = (*entities, name = None))]
-    pub fn graph(entities: Vec<GraphEntity>, name: Option<String>) -> PyResult<Self> {
+    #[pyo3(signature = (*entities, name = None, ty = None))]
+    pub fn graph(
+        entities: Vec<GraphEntity>,
+        name: Option<String>,
+        ty: Option<String>,
+    ) -> PyResult<Self> {
+        let graph_type = match ty.as_deref() {
+            None | Some("line") => GraphType::Line,
+            Some("bar") => GraphType::Bar,
+            Some("point") => GraphType::Point,
+            _ => {
+                return Err(PyValueError::new_err(
+                    "invalid graph type please select either: line, point, or bar",
+                ));
+            }
+        };
         let entities = entities
             .into_iter()
             .map(|x| impeller2_wkt::GraphEntity {
@@ -107,7 +121,11 @@ impl Panel {
             })
             .collect();
         Ok(Self {
-            inner: impeller2_wkt::Panel::Graph(Graph { name, entities }),
+            inner: impeller2_wkt::Panel::Graph(Graph {
+                name,
+                entities,
+                graph_type,
+            }),
         })
     }
 }


### PR DESCRIPTION
**Add Point + Bar Plotting**
I added two new line types to the editor, point, and bar. This is done by adding two new shaders, and then using shader specialization to determine which to use at runtime

<img width="1925" alt="Screenshot 2025-05-06 at 12 48 06 PM" src="https://github.com/user-attachments/assets/d5caa8d4-a708-418f-8436-50c4a350cdb7" />

![Screenshot 2025-05-06 at 12 47 18 PM](https://github.com/user-attachments/assets/15ff262e-30bc-4ae9-8477-e599343180b6)

**Fix tab switching shortcut**
Previously if you used ctrl-tab it would move too fast to be useful. It now uses just_pressed so the user can move a single tab at a time

**Add right click menu to set current graph range as editor time range**

https://github.com/user-attachments/assets/866a4e61-4b6a-4b95-8059-e80ae39ffa51

**Add a command palette action to set the time range to a custom region**


https://github.com/user-attachments/assets/ae49d611-626e-4676-8b9e-f372bc4761f8

**Allow renaming graph panels**

https://github.com/user-attachments/assets/cd439dd9-d363-4e96-bda2-6373b1cb9f08

