### PR TITLE
chore: add an install script for the editor

### DIFF
--- a/apps/elodin/README.md
+++ b/apps/elodin/README.md
@@ -1,7 +1,25 @@
-
 # Elodin Editor
 
-## How to run locally
+### Install
+
+Install the editor using the standalone installer script:
+
+```sh
+# Install the latest version
+curl -LsSf https://storage.googleapis.com/elodin-releases/install-editor.sh | sh
+
+# Install a specific version (e.g., 0.13.3)
+curl -LsSf https://storage.googleapis.com/elodin-releases/install-editor.sh | sh -s v0.13.3
+```
+
+Alternatively, you can download the latest portable binary for your platform:
+
+- [macOS (arm64)](https://storage.googleapis.com/elodin-releases/latest/elodin-aarch64-apple-darwin.tar.gz)
+- [Linux (x86_64)](https://storage.googleapis.com/elodin-releases/latest/elodin-x86_64-unknown-linux-musl.tar.gz)
+- [Linux (arm64)](https://storage.googleapis.com/elodin-releases/latest/elodin-aarch64-unknown-linux-musl.tar.gz)
+- [Windows (x86_64)](https://storage.googleapis.com/elodin-releases/latest/elodin-x86_64-pc-windows-msvc.zip)
+
+### How to run locally
 
 Install nox-py:
 
@@ -17,7 +35,7 @@ Run `three-body.py` example in the editor:
 
 ```sh
 # run from `libs/nox-py`
-cargo run --manifest-path=../../apps/elodin/Cargo.toml editor examples/three-body.py 
+cargo run --manifest-path=../../apps/elodin/Cargo.toml editor examples/three-body.py
 ```
 
 Run `three-body.py` example while watching for editor code changes (requires [cargo-watch](https://crates.io/crates/cargo-watch)):

--- a/apps/elodin/install-editor.sh
+++ b/apps/elodin/install-editor.sh
@@ -48,17 +48,17 @@ add_local_bin_to_path() {
   esac
 }
 
-install_db() {
+install_editor() {
   os=$1
   arch=$2
   version=$3
 
   if [ "$os" = "Darwin" ] && [ "$arch" = "arm64" ]; then
-    download_url="https://storage.googleapis.com/elodin-releases/$version/elodin-db-aarch64-apple-darwin.tar.gz"
+    download_url="https://storage.googleapis.com/elodin-releases/$version/elodin-aarch64-apple-darwin.tar.gz"
   elif [ "$os" = "Linux" ] && [ "$arch" = "aarch64" ]; then
-    download_url="https://storage.googleapis.com/elodin-releases/$version/elodin-db-aarch64-unknown-linux-musl.tar.gz"
+    download_url="https://storage.googleapis.com/elodin-releases/$version/elodin-aarch64-unknown-linux-musl.tar.gz"
   elif [ "$os" = "Linux" ] && [ "$arch" = "x86_64" ]; then
-    download_url="https://storage.googleapis.com/elodin-releases/$version/elodin-db-x86_64-unknown-linux-musl.tar.gz"
+    download_url="https://storage.googleapis.com/elodin-releases/$version/elodin-x86_64-unknown-linux-musl.tar.gz"
   else
     echo "Unsupported (OS, arch): ($os, $arch)"
     exit 1
@@ -66,10 +66,10 @@ install_db() {
 
   echo "Downloading $download_url"
   curl -L -# "$download_url" | tar xz --strip-components=1 -C "$HOME/.local/bin"
-  version=$("$HOME/.local/bin/elodin-db" --version)
+  version=$("$HOME/.local/bin/elodin" --version)
   echo "Installed $version to \$HOME/.local/bin"
 }
 
 mkdir -p "$HOME/.local/bin"
-install_db "$OS" "$ARCH" "$VERSION"
+install_editor "$OS" "$ARCH" "$VERSION"
 add_local_bin_to_path "$SHELL"

--- a/libs/db/README.md
+++ b/libs/db/README.md
@@ -5,7 +5,11 @@
 Install `elodin-db` using the standalone installer script:
 
 ```sh
+# Install the latest version
 curl -LsSf https://storage.googleapis.com/elodin-releases/install-db.sh | sh
+
+# Install a specific version (e.g., 0.13.3)
+curl -LsSf https://storage.googleapis.com/elodin-releases/install-db.sh | sh -s v0.13.3
 ```
 
 Alternatively, you can download the latest portable binary for your platform:
@@ -33,7 +37,7 @@ cc examples/client.c -lm -o /tmp/client; /tmp/client
 ```
 
 
-### Subscribe to data with C++ 
+### Subscribe to data with C++
 
 [./examples/client.cpp](./examples/client.cpp) includes an example of how to subscribe to data using C++. It can be built and run using:
 


### PR DESCRIPTION
```
curl -LsSf https://storage.googleapis.com/elodin-releases/install-editor.sh | sh
```

Doesn't work Windows, but I still find it useful.