### PR TITLE
feat(db): add sql stream tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4513,6 +4513,7 @@ dependencies = [
  "miette",
  "nox",
  "parquet",
+ "pin-project",
  "postcard",
  "postcard-c-codegen",
  "postcard-dyn",

--- a/libs/db/Cargo.toml
+++ b/libs/db/Cargo.toml
@@ -49,6 +49,7 @@ memmap2 = "0.9"
 smallvec.version = "1.11.2"
 smallvec.features = ["const_generics", "union", "serde"]
 zerocopy.version = "0.8.2"
+pin-project = "1"
 
 # errors
 thiserror = "2"

--- a/libs/db/src/arrow.rs
+++ b/libs/db/src/arrow.rs
@@ -7,40 +7,83 @@ use arrow::{
     datatypes::*,
 };
 use convert_case::{Case, Casing};
-use datafusion::{datasource::MemTable, parquet, prelude::SessionContext};
-use impeller2::types::PrimType;
+use datafusion::{
+    catalog::streaming::StreamingTable, datasource::MemTable, execution::RecordBatchStream,
+    parquet, physical_plan::streaming::PartitionStream, prelude::SessionContext,
+};
+use futures_lite::{Stream, StreamExt, pin};
+use impeller2::types::{PrimType, Timestamp};
 use impeller2_wkt::ArchiveFormat;
-use std::{fs::File, path::Path, ptr::NonNull, sync::Arc};
+use std::{
+    fs::File,
+    ops::{Bound, RangeBounds},
+    path::Path,
+    pin::Pin,
+    ptr::NonNull,
+    sync::Arc,
+    task::{Context, Poll},
+};
 use zerocopy::{Immutable, IntoBytes};
 
 use crate::{Component, DB, Error, append_log::AppendLog};
 
 impl<T: IntoBytes + Immutable> AppendLog<T> {
-    pub fn as_arrow_buffer(&self) -> Buffer {
+    pub fn as_arrow_buffer(&self, element_size: usize) -> Buffer {
+        self.as_arrow_buffer_range(.., element_size)
+    }
+
+    pub fn as_arrow_buffer_range<R: RangeBounds<usize>>(
+        &self,
+        range: R,
+        element_size: usize,
+    ) -> Buffer {
         let data = self.data();
+        let start = match range.start_bound() {
+            Bound::Included(&n) => n * element_size,
+            Bound::Excluded(&n) => (n + 1) * element_size,
+            Bound::Unbounded => 0,
+        };
+        let end = match range.end_bound() {
+            Bound::Included(&n) => (n + 1) * element_size,
+            Bound::Excluded(&n) => n * element_size,
+            Bound::Unbounded => data.len(),
+        };
+        let start = start.min(data.len());
+        let end = end.min(data.len());
+        let len = end.saturating_sub(start);
+
         unsafe {
-            let ptr = NonNull::new(data.as_ptr() as *mut _).expect("mmap null");
-            Buffer::from_custom_allocation(ptr, data.len(), self.raw_mmap().clone())
+            let ptr = NonNull::new(data.as_ptr().add(start) as *mut _).expect("mmap null");
+            Buffer::from_custom_allocation(ptr, len, self.raw_mmap().clone())
         }
     }
 }
 
 impl Component {
     pub fn as_data_array(&self, name: impl ToString) -> (FieldRef, ArrayRef) {
+        self.as_data_array_range(name, ..)
+    }
+
+    pub fn as_data_array_range<R: RangeBounds<usize>>(
+        &self,
+        name: impl ToString,
+        range: R,
+    ) -> (FieldRef, ArrayRef) {
         let size = self.schema.dim.iter().product::<usize>() as i32;
         let buf = self.time_series.data();
+        let element_size = self.time_series.element_size();
         let array = match self.schema.prim_type {
-            PrimType::F64 => array_ref::<Float64Type, _>(buf),
-            PrimType::F32 => array_ref::<Float32Type, _>(buf),
-            PrimType::U64 => array_ref::<UInt64Type, _>(buf),
-            PrimType::U32 => array_ref::<UInt32Type, _>(buf),
-            PrimType::U16 => array_ref::<UInt16Type, _>(buf),
-            PrimType::U8 => array_ref::<UInt8Type, _>(buf),
-            PrimType::I64 => array_ref::<Int64Type, _>(buf),
-            PrimType::I32 => array_ref::<Int32Type, _>(buf),
-            PrimType::I16 => array_ref::<Int16Type, _>(buf),
-            PrimType::I8 => array_ref::<Int8Type, _>(buf),
-            PrimType::Bool => bool_ref(buf),
+            PrimType::F64 => array_ref::<Float64Type, _>(buf, range, element_size),
+            PrimType::F32 => array_ref::<Float32Type, _>(buf, range, element_size),
+            PrimType::U64 => array_ref::<UInt64Type, _>(buf, range, element_size),
+            PrimType::U32 => array_ref::<UInt32Type, _>(buf, range, element_size),
+            PrimType::U16 => array_ref::<UInt16Type, _>(buf, range, element_size),
+            PrimType::U8 => array_ref::<UInt8Type, _>(buf, range, element_size),
+            PrimType::I64 => array_ref::<Int64Type, _>(buf, range, element_size),
+            PrimType::I32 => array_ref::<Int32Type, _>(buf, range, element_size),
+            PrimType::I16 => array_ref::<Int16Type, _>(buf, range, element_size),
+            PrimType::I8 => array_ref::<Int8Type, _>(buf, range, element_size),
+            PrimType::Bool => bool_ref(buf, range, element_size),
         };
 
         let inner_field = Arc::new(Field::new(
@@ -85,16 +128,29 @@ impl Component {
     }
 
     pub fn as_time_series_array(&self) -> ArrayRef {
+        self.as_time_series_array_range(..)
+    }
+
+    pub fn as_time_series_array_range<R: RangeBounds<usize>>(&self, range: R) -> ArrayRef {
         let buf = self.time_series.index();
-        let array = scalar_buffer::<TimestampMicrosecondType, _>(buf);
+        let array =
+            scalar_buffer::<TimestampMicrosecondType, _>(buf, range, size_of::<Timestamp>());
         let array = TimestampMicrosecondArray::new(array, None);
         Arc::new(array)
     }
 
     pub fn as_record_batch(&self, name: impl ToString) -> RecordBatch {
+        self.as_record_batch_range(name, ..)
+    }
+
+    pub fn as_record_batch_range(
+        &self,
+        name: impl ToString,
+        range: impl RangeBounds<usize> + Clone,
+    ) -> RecordBatch {
         let name = name.to_string();
-        let (data_field, data_array) = self.as_data_array(name.clone());
-        let time_array = self.as_time_series_array();
+        let (data_field, data_array) = self.as_data_array_range(name.clone(), range.clone());
+        let time_array = self.as_time_series_array_range(range);
         let len = data_array.len().min(time_array.len());
         let time_field = Arc::new(Field::new(
             "time",
@@ -106,6 +162,13 @@ impl Component {
 
         RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)
             .expect("record batch params wrong")
+    }
+
+    pub fn as_stream_table(&self, name: impl ToString) -> StreamingTable {
+        let stream = Arc::new(ComponentPartStream::new(name.to_string(), self.clone()));
+        StreamingTable::try_new(stream.schema.clone(), vec![stream])
+            .expect("streaming table create failed")
+            .with_infinite_table(true)
     }
     pub fn as_mem_table(&self, name: impl ToString) -> MemTable {
         let record_batch = self.as_record_batch(name);
@@ -136,8 +199,12 @@ impl DB {
                 let entity_name = entity_metadata.name.to_case(convert_case::Case::Snake);
                 let component_name = component_metadata.name.to_case(convert_case::Case::Snake);
                 let name = format!("{entity_name}_{component_name}");
-                let mem_table = component.as_mem_table(component_name);
+                let mem_table = component.as_mem_table(&component_name);
                 ctx.register_table(name, Arc::new(mem_table))?;
+
+                let stream_name = format!("{entity_name}_{component_name}_stream");
+                let stream_table = component.as_stream_table(component_name);
+                ctx.register_table(stream_name, Arc::new(stream_table))?;
             }
             Ok::<_, datafusion::error::DataFusionError>(())
         })?;
@@ -241,23 +308,129 @@ impl DB {
     }
 }
 
-fn bool_ref<T: IntoBytes + Immutable>(buf: &AppendLog<T>) -> ArrayRef {
-    let buffer = buf.as_arrow_buffer();
+fn bool_ref<T: IntoBytes + Immutable, R: RangeBounds<usize>>(
+    buf: &AppendLog<T>,
+    range: R,
+    element_size: usize,
+) -> ArrayRef {
+    let buffer = buf.as_arrow_buffer_range(range, element_size);
     let len = buffer.len();
     let buf = BooleanBuffer::new(buffer, 0, len);
     Arc::new(BooleanArray::new(buf, None))
 }
 
-fn array_ref<P: ArrowPrimitiveType, T: IntoBytes + Immutable>(buf: &AppendLog<T>) -> ArrayRef {
-    let scalar_buffer = scalar_buffer::<P, T>(buf);
+fn array_ref<P: ArrowPrimitiveType, T: IntoBytes + Immutable>(
+    buf: &AppendLog<T>,
+    range: impl RangeBounds<usize>,
+    element_size: usize,
+) -> ArrayRef {
+    let scalar_buffer = scalar_buffer::<P, T>(buf, range, element_size);
     let array = PrimitiveArray::<P>::new(scalar_buffer, None);
     Arc::new(array)
 }
 
 fn scalar_buffer<P: ArrowPrimitiveType, T: IntoBytes + Immutable>(
     buf: &AppendLog<T>,
+    range: impl RangeBounds<usize>,
+    element_size: usize,
 ) -> ScalarBuffer<P::Native> {
-    let buffer = buf.as_arrow_buffer();
-    let len = buffer.len() / size_of::<P::Native>();
+    let buffer = buf.as_arrow_buffer_range(range, element_size);
+    let len = buffer.len() / std::mem::size_of::<P::Native>();
     ScalarBuffer::<P::Native>::new(buffer, 0, len)
+}
+
+#[pin_project::pin_project]
+pub struct ComponentStream {
+    stream: Pin<
+        Box<
+            dyn Stream<Item = Result<RecordBatch, datafusion::error::DataFusionError>>
+                + Send
+                + Sync,
+        >,
+    >,
+    schema: SchemaRef,
+}
+
+pub struct ComponentPartStream {
+    name: String,
+    component: Component,
+    schema: SchemaRef,
+}
+
+impl ComponentPartStream {
+    pub fn new(name: String, component: Component) -> Self {
+        let record_batch = component.as_record_batch(&name);
+        let schema = record_batch.schema();
+        Self {
+            name,
+            component,
+            schema,
+        }
+    }
+}
+
+impl std::fmt::Debug for ComponentPartStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ComponentPartStream")
+            .field("name", &self.name)
+            .field("schema", &self.schema)
+            .finish()
+    }
+}
+
+impl std::fmt::Debug for ComponentStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ComponentStream").finish()
+    }
+}
+
+pub fn component_stream(
+    component: Component,
+    name: impl ToString,
+) -> impl futures_lite::Stream<Item = Result<RecordBatch, datafusion::error::DataFusionError>> {
+    let name = name.to_string();
+    let current_len = component.time_series.index().len() as usize / size_of::<Timestamp>();
+    futures_lite::stream::unfold(
+        (component, current_len, name),
+        |(component, last_pos, name)| async move {
+            let waiter = component.time_series.waiter();
+            let _ = waiter.wait().await;
+
+            let current_len = component.time_series.index().len() as usize / size_of::<Timestamp>();
+            let record_batch = component.as_record_batch_range(name.clone(), last_pos..current_len);
+
+            Some((Ok(record_batch), (component, current_len, name)))
+        },
+    )
+}
+
+impl Stream for ComponentStream {
+    type Item = Result<RecordBatch, datafusion::error::DataFusionError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        this.stream.poll_next(cx)
+    }
+}
+
+impl RecordBatchStream for ComponentStream {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}
+
+impl PartitionStream for ComponentPartStream {
+    fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    fn execute(
+        &self,
+        _ctx: Arc<datafusion::execution::TaskContext>,
+    ) -> datafusion::execution::SendableRecordBatchStream {
+        Box::pin(ComponentStream {
+            stream: Box::pin(component_stream(self.component.clone(), self.name.clone())),
+            schema: self.schema.clone(),
+        })
+    }
 }

--- a/libs/db/src/time_series.rs
+++ b/libs/db/src/time_series.rs
@@ -59,7 +59,7 @@ impl TimeSeries {
             .expect("mmep unaligned")
     }
 
-    fn element_size(&self) -> usize {
+    pub fn element_size(&self) -> usize {
         *self.data.extra() as usize
     }
 


### PR DESCRIPTION
This PR adds a new new streaming tables to the datafusion session. They allow you to query streaming data as it comes in. I had hoped this would be more useful than it is, and would allow you to do stuff like streaming the average of data. But it seems pretty limited right now. Never the less, this should set us up well for when data fusion adds more features