### PR TITLE
feat(fw): write to uart6 to test debugprobe

### DIFF
--- a/fsw/sensor-fw/src/main.rs
+++ b/fsw/sensor-fw/src/main.rs
@@ -7,6 +7,7 @@ use alloc::boxed::Box;
 use cortex_m::delay::Delay;
 use embedded_hal::delay::DelayNs;
 use embedded_hal_compat::ForwardCompat;
+use embedded_io::Write;
 use fugit::{ExtU32 as _, RateExtU32 as _};
 use hal::{i2c, pac, usart};
 
@@ -74,6 +75,14 @@ fn main() -> ! {
         &clock_cfg,
     )));
     defmt::info!("Configured UART bridge");
+
+    let mut debug_uart = Box::new(healing_usart::HealingUsart::new(usart::Usart::new(
+        dp.USART6,
+        115200,
+        usart::UsartConfig::default(),
+        &clock_cfg,
+    )));
+    defmt::info!("Configured debug UART");
 
     // Generate a 600kHz PWM signal on TIM3
     let pwm_timer = dp.TIM3.timer(600.kHz(), Default::default(), &clock_cfg);
@@ -257,6 +266,7 @@ fn main() -> ! {
                 monitor.data.rtc_vbat,
                 monitor.data.cpu_temp,
             );
+            debug_uart.write_fmt(format_args!("{}\r\n", ts)).unwrap();
         }
         delay.delay_ns(0);
     }


### PR DESCRIPTION
This is just handy to have setup in case we need to do print debug stuff and don't have RTT access. It's also useful for testing the debugprobe firmware + pinout.