### PR TITLE
fix(aleph-os): usb gadget mac address to unicast

### DIFF
--- a/images/aleph/modules/usb-eth.nix
+++ b/images/aleph/modules/usb-eth.nix
@@ -1,7 +1,7 @@
 {...}: {
   boot.kernelParams = [
-    "g_ncm.dev_addr=bf:02:bf:e2:b4:90"
-    "g_ncm.host_addr=cf:52:68:62:d9:08"
+    "g_ncm.dev_addr=ee:a1:ef:ee:a1:ef"
+    "g_ncm.host_addr=ee:a1:ef:ee:a1:ef"
   ];
   networking.interfaces.usb0.useDHCP = false;
   networking.interfaces.dummy0.useDHCP = false;


### PR DESCRIPTION
This PR pins the device-side and host-side mac address of the aleph to a valid [unicast mac address](https://en.wikipedia.org/wiki/MAC_address#Ranges_of_group_and_locally_administered_addresses).

The previous value was not a valid individual mac address and the setting was being ignored by the kernel driver. With the previous setting, the configuration on aleph-os would result in a random device-side & host-side mac address being set upon each boot. From a developer-perspective, this resulted in a new NIC device appearing upon each reboot of aleph-os. If you had a device-specific network setting applied (with eg. NetworkManager), then those settings would not be applied on aleph reboots, since a new, unique device would appear after each reboot.

This fix gives aleph-os a static mac address and allows the developer persist device-specific network settings, on the host-side. Hostname generation is [not affected](https://github.com/elodin-sys/elodin/blob/426d71aef50b45a2a66dce38d4a98155d1a0003f/images/aleph/modules/wifi.nix#L6).