### PR TITLE
Add GitHub Pages deployment with PR previews

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,224 @@
+# Deploy Documentation to GitHub Pages
+#
+# This workflow builds our Zola-based documentation site and deploys it to GitHub Pages.
+# It runs automatically on pushes to main and pull requests.
+#
+# Features:
+# - Production deployment on main branch pushes
+# - Preview deployments for pull requests
+# - Automatic cleanup of old previews
+#
+# For contributors:
+# - The docs source is in /docs/public
+# - We use Zola static site generator (https://www.getzola.org/)
+# - PRs get preview deployments at: https://docs.elodin.systems/preview/pr-{number}/
+# - Live site: https://docs.elodin.systems
+
+name: Deploy Documentation
+
+on:
+  # Trigger on pushes to main branch
+  push:
+    branches: [ main ]
+    paths:
+      - 'docs/public/**'
+      - '.github/workflows/deploy-docs.yml'
+  
+  # Trigger on pull requests
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    paths:
+      - 'docs/public/**'
+      - '.github/workflows/deploy-docs.yml'
+  
+  # Allow manual trigger from GitHub UI
+  workflow_dispatch:
+    inputs:
+      debug:
+        description: 'Enable debug logging'
+        required: false
+        default: 'false'
+
+# Sets permissions of the GITHUB_TOKEN
+permissions:
+  contents: write  # Needed for gh-pages branch
+  pull-requests: write  # Needed to comment on PRs
+
+# Allow only one concurrent deployment per PR/branch
+concurrency:
+  group: "pages-${{ github.event.pull_request.number || github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  # Build and deploy job
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Zola
+        if: github.event.action != 'closed'
+        uses: taiki-e/install-action@v2
+        with:
+          tool: zola@0.19.2
+
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # For main branch: Build and deploy production
+      - name: Build production site
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          cd docs/public
+          echo "🔨 Building production site..."
+          zola build
+          echo "✅ Build complete!"
+          
+          # Copy to gh-pages root (preserving preview directory)
+          cd ../..
+          rsync -av --delete \
+            --exclude=preview/ \
+            --exclude=.git/ \
+            --exclude=CNAME \
+            docs/public/public/ gh-pages/
+          
+          # Ensure CNAME file exists
+          echo "docs.elodin.systems" > gh-pages/CNAME
+
+      # For PRs: Build and deploy preview
+      - name: Build preview site
+        if: github.event_name == 'pull_request' && github.event.action != 'closed'
+        run: |
+          cd docs/public
+          echo "🔨 Building preview for PR #${{ github.event.pull_request.number }}..."
+          
+          # Build with preview base URL
+          zola build --base-url "https://docs.elodin.systems/preview/pr-${{ github.event.pull_request.number }}"
+          echo "✅ Build complete!"
+          
+          # Deploy to preview directory
+          cd ../..
+          mkdir -p gh-pages/preview/pr-${{ github.event.pull_request.number }}
+          rsync -av --delete docs/public/public/ gh-pages/preview/pr-${{ github.event.pull_request.number }}/
+
+      # For closed PRs: Cleanup preview
+      - name: Cleanup preview
+        if: github.event_name == 'pull_request' && github.event.action == 'closed'
+        run: |
+          echo "🧹 Removing preview for PR #${{ github.event.pull_request.number }}..."
+          rm -rf gh-pages/preview/pr-${{ github.event.pull_request.number }}
+
+      # Commit and push changes
+      - name: Deploy to GitHub Pages
+        if: github.event.action != 'closed' || (github.event_name == 'pull_request' && github.event.action == 'closed')
+        run: |
+          cd gh-pages
+          
+          # Configure git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          # Commit changes
+          git add -A
+          
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            git commit -m "Deploy documentation from ${{ github.sha }}" || echo "No changes to commit"
+          elif [[ "${{ github.event.action }}" == "closed" ]]; then
+            git commit -m "Remove preview for PR #${{ github.event.pull_request.number }}" || echo "No changes to commit"
+          else
+            git commit -m "Deploy preview for PR #${{ github.event.pull_request.number }}" || echo "No changes to commit"
+          fi
+          
+          git push origin gh-pages
+
+      # Comment on PR with preview link
+      - name: Comment PR with preview link
+        if: github.event_name == 'pull_request' && github.event.action != 'closed'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const previewUrl = `https://docs.elodin.systems/preview/pr-${prNumber}/`;
+            
+            // Find existing comment
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            
+            const botComment = comments.find(comment => 
+              comment.user.type === 'Bot' && 
+              comment.body.includes('📚 Documentation Preview')
+            );
+            
+            const body = `📚 **Documentation Preview Ready!**
+            
+            Your documentation changes have been deployed to:
+            🔗 ${previewUrl}
+            
+            This preview will be automatically updated when you push new commits.
+            The preview will be removed when this PR is closed or merged.
+            
+            ---
+            <sub>Preview deployment started at ${new Date().toUTCString()}</sub>`;
+            
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: body
+              });
+            }
+
+      # Comment when preview is removed
+      - name: Comment PR on cleanup
+        if: github.event_name == 'pull_request' && github.event.action == 'closed'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: `🧹 Documentation preview for PR #${prNumber} has been removed.`
+            });
+
+  # Verify deployment (only for production)
+  verify:
+    needs: build-and-deploy
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify deployment
+        run: |
+          echo "🚀 Documentation deployed successfully!"
+          echo "📍 View at: https://docs.elodin.systems"
+          
+          # Wait a bit for deployment to propagate
+          sleep 10
+          
+          # Simple health check
+          response=$(curl -s -o /dev/null -w "%{http_code}" https://docs.elodin.systems)
+          if [ "$response" = "200" ]; then
+            echo "✅ Site is accessible (HTTP $response)"
+          else
+            echo "⚠️ Site returned HTTP $response - may still be propagating"
+          fi

--- a/docs/public/DEPLOYMENT.md
+++ b/docs/public/DEPLOYMENT.md
@@ -1,0 +1,187 @@
+# Documentation Deployment Guide
+
+This guide explains how the Elodin documentation site is built and deployed to GitHub Pages.
+
+## 🚀 Overview
+
+Our documentation is:
+- **Built with:** [Zola](https://www.getzola.org/) static site generator
+- **Hosted on:** GitHub Pages
+- **Domain:** https://docs.elodin.systems
+- **Auto-deployed:** On every push to `main` branch
+- **PR Previews:** Automatic preview deployments for pull requests
+
+## 📁 Project Structure
+
+```
+docs/public/
+├── config.toml        # Zola configuration
+├── content/          # Markdown content files
+├── static/           # Static assets (images, videos, etc.)
+├── sass/            # SCSS stylesheets
+├── templates/       # HTML templates
+└── public/          # Built site (git-ignored)
+```
+
+## 🔧 Local Development
+
+### Prerequisites
+- Install Zola: `brew install zola` (macOS) or see [installation guide](https://www.getzola.org/documentation/getting-started/installation/)
+
+### Running Locally
+```bash
+cd docs/public
+zola serve
+# Visit http://127.0.0.1:1111
+```
+
+### Building Locally
+```bash
+cd docs/public
+zola build
+# Output will be in docs/public/public/
+```
+
+## 🚢 Deployment Process
+
+### Automatic Production Deployment
+The site automatically deploys to production when:
+1. Changes are pushed to `main` branch
+2. Changes affect files in `docs/public/` directory
+3. GitHub Actions workflow completes successfully
+4. Site updates at https://docs.elodin.systems
+
+### Pull Request Previews
+Every pull request automatically gets a preview deployment:
+1. Open a PR with changes to `docs/public/`
+2. GitHub Actions builds the preview
+3. Preview deploys to: `https://docs.elodin.systems/preview/pr-{number}/`
+4. A comment is posted on the PR with the preview link
+5. Preview updates automatically when you push new commits
+6. Preview is removed when PR is closed or merged
+
+### Manual Deployment
+You can manually trigger deployment:
+1. Go to [Actions tab](../../actions)
+2. Select "Deploy Documentation" workflow
+3. Click "Run workflow"
+4. Select `main` branch and click "Run workflow"
+
+### How It Works
+
+The deployment is handled by `.github/workflows/deploy-docs.yml`:
+
+#### Production Deployment (main branch):
+1. **Build Stage:**
+   - Checks out the repository
+   - Installs Zola v0.19.2
+   - Runs `zola build` in `docs/public/`
+   - Deploys to root of `gh-pages` branch
+
+2. **Verify Stage:**
+   - Confirms deployment success
+   - Performs health check on https://docs.elodin.systems
+
+#### PR Preview Deployment:
+1. **Build Stage:**
+   - Checks out the PR code
+   - Builds with preview-specific base URL
+   - Deploys to `gh-pages` branch under `/preview/pr-{number}/`
+
+2. **Comment Stage:**
+   - Posts/updates comment on PR with preview link
+   - Includes deployment timestamp
+
+3. **Cleanup Stage (when PR closes):**
+   - Removes preview directory from `gh-pages` branch
+   - Comments on PR confirming removal
+
+## 📝 Making Changes
+
+### Content Updates
+1. Edit markdown files in `docs/public/content/`
+2. Test locally with `zola serve`
+3. Commit and push to `main`
+4. Deployment happens automatically
+
+### Style Changes
+1. Edit SCSS files in `docs/public/sass/`
+2. Zola automatically compiles SCSS → CSS
+3. Test locally before pushing
+
+### Adding Assets
+1. Place files in `docs/public/static/`
+2. Reference from content as `/path/to/asset`
+3. Keep file sizes reasonable (videos are already optimized)
+
+## 🎥 Video Encoding
+
+For adding new videos, use the provided justfile:
+```bash
+cd docs/public
+just encode path/to/video.mov
+```
+This creates optimized H.264 and AV1 versions.
+
+## 🔍 Troubleshooting
+
+### Build Failures
+- Check [GitHub Actions](../../actions) for error logs
+- Ensure Zola version matches (0.19.2)
+- Validate `config.toml` syntax
+- Check for broken internal links
+
+### Domain Issues
+- DNS is managed through Cloudflare
+- GitHub Pages custom domain is set in repository settings
+- CNAME file is automatically handled by GitHub
+
+### Preview Deployment Issues
+- Ensure PR has write permissions (from repo collaborators)
+- Check that `gh-pages` branch exists
+- Verify GitHub Pages is set to deploy from `gh-pages` branch
+- Preview URLs only work after DNS is properly configured
+
+### Local vs Production Differences
+- Base URL is set to `https://docs.elodin.systems` in config.toml
+- Local development uses `http://127.0.0.1:1111`
+- Zola handles this automatically
+
+## 🤝 Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes in `docs/public/`
+4. Test locally with `zola serve`
+5. Submit a pull request
+6. **Automatic preview deployment:**
+   - Wait ~2 minutes for the preview to build
+   - Find the preview URL in the automated PR comment
+   - Preview URL format: `https://docs.elodin.systems/preview/pr-{number}/`
+   - Preview updates automatically with each push
+   - Share preview link with reviewers for feedback
+
+## 📊 Monitoring
+
+- View deployment status: [GitHub Actions](../../actions)
+- Check site health: https://docs.elodin.systems
+- GitHub Pages status: [Repository Settings → Pages](../../settings/pages)
+
+## 💡 Tips
+
+- Keep content in markdown for easy editing
+- Use relative links between docs pages
+- Optimize images before adding (use WebP when possible)
+- Test responsive design locally
+- Check search functionality after major changes
+
+## 🆘 Getting Help
+
+- Check this guide first
+- Review [Zola documentation](https://www.getzola.org/documentation/)
+- Open an issue for documentation problems
+- Discuss in project Discord/Slack
+
+---
+
+*Last updated: December 2024*

--- a/docs/public/README.md
+++ b/docs/public/README.md
@@ -6,7 +6,6 @@ Elodin Documentation is statically built using:
 [Tera](https://keats.github.io/tera/): Templating engine for Zola
 [AdiDoks](https://adidoks.org/): This was initially built on top of AdiDoks, a modern documentation theme, which is a port of the Hugo theme [Doks](https://github.com/h-enk/doks) for Zola.
 [Bootstrap](https://icons.getbootstrap.com/): AdiDoks is built on Bootstrap
-[memserve](../memserve): Rust-based static web server used when deployed, see the [docs.nix](../../nix/docs.nix) file for usage.
 
 *note: The styles and templates have been heavily modified since AdiDoks, and will not always be recognizable.*
 
@@ -27,3 +26,6 @@ zola serve
 ```sh
 ./justfile <path/to/video>
 ```
+
+### Deployment
+see [DEPLOYMENT.md](./DEPLOYMENT.md)


### PR DESCRIPTION
Moving Docs site generation & hosting to Github Actions/Pages, including preview sites for PRs.