### PR TITLE
fix(aleph): macos networking on aleph

### DIFF
--- a/images/aleph/modules/usb-eth.nix
+++ b/images/aleph/modules/usb-eth.nix
@@ -1,7 +1,7 @@
 {...}: {
   boot.kernelParams = [
     "g_ncm.dev_addr=ee:a1:ef:ee:a1:ef"
-    "g_ncm.host_addr=ee:a1:ef:ee:a1:ef"
+    "g_ncm.host_addr=ee:a1:ef:ae:a1:ef"
   ];
   networking.interfaces.usb0.useDHCP = false;
   networking.interfaces.dummy0.useDHCP = false;


### PR DESCRIPTION
Building off of https://github.com/elodin-sys/elodin/pull/95 which broke aleph ethernet networking for macos.

It turns out that identical host/client mac address break NDP/ARP resolution on macos . They need to be unique. There is a difference between how Linux and MacOS handle ARP/NDP the outcome is the difference in this apparent behavior. The exact mechanism of action is left as an exercise for the reader :)