### PR TITLE
fix(aleph) disable onyxruntime_gpu pypi wheel

### DIFF
--- a/images/aleph/modules/aleph-dev.nix
+++ b/images/aleph/modules/aleph-dev.nix
@@ -5,9 +5,13 @@
       version = "1.16.3";
       format = "wheel";
 
+      # src = pkgs.fetchurl {
+      #   url = "https://pypi.jetson-ai-lab.dev/jp5/cu114/+f/43e/f0cec5f026159/onnxruntime_gpu-1.16.3-cp311-cp311-linux_aarch64.whl";
+      #   sha256 = "43ef0cec5f026159306e69540138f457ecbc8eb0282d1f7166761e7fbc84288e";
+      # };
       src = pkgs.fetchurl {
-        url = "https://pypi.jetson-ai-lab.dev/jp5/cu114/+f/43e/f0cec5f026159/onnxruntime_gpu-1.16.3-cp311-cp311-linux_aarch64.whl";
-        sha256 = "43ef0cec5f026159306e69540138f457ecbc8eb0282d1f7166761e7fbc84288e";
+        url = "https://pypi.jetson-ai-lab.io/jp5/cu114/+f/38f/9120323ff84c2/onnxruntime_gpu-1.16.0-cp38-cp38-linux_aarch64.whl";
+        sha256 = "38f9120323ff84c264edf73eb41760aa71304c134c109d4fbf41090987b85d42";
       };
 
       propagatedBuildInputs = with ps; [
@@ -31,7 +35,7 @@
       tqdm
       matplotlib
       pycuda
-      (onnxruntime-gpu-wheel ps)
+      # (onnxruntime-gpu-wheel ps)
     ];
 in {
   nixpkgs.config = {


### PR DESCRIPTION
Via  https://forums.developer.nvidia.com/t/pypi-jetson-ai-lab-dev-is-down-again/338358/45
Nvidia upstream is using a new server and URL for pypi.

Via https://forums.developer.nvidia.com/t/jp5-missing-from-https-pypi-jetson-ai-lab-io/340776 
Nvidia is dropping support for Jetpack 5 wheels in their new repository server.

As of 2025-09-09, the wheels for `onnxruntime_gpu` were removed. Either way, this is a bit of a moving target, so this PR disables the repository for now until the Jetpack 6 transition and/or until it can be packaged for building from source.

Of course, packaging from a source build is the more robust, permanent solution, but for now the missing source breaks building aleph sdimage, so this PR will unbreak the build process.