### PR TITLE
build(aleph) - enable fallback for nix build

### DIFF
--- a/images/aleph/flake.nix
+++ b/images/aleph/flake.nix
@@ -4,6 +4,7 @@
     extra-trusted-public-keys = [
       "builder-cache-1:q7rDGIQgkg1nsxNEg7mHN1kEDuxPmJhQpuIXCCwLj8E="
     ];
+    fallback = true;
   };
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";


### PR DESCRIPTION
If binary caches are are offline, then nix builds will fail unless the flag --fallback is enabled. This also breaks the aleph deploy script if any binary cache is offline. The breakage is limited to the scope of aleph, as only the aleph flakes/scripts use the elodin build cache.

This commit enables the fallback feature by default, so that nix will "fall back" to building from source if a binary cache is missing.

This change will produce a one-time prompt to allow the "fallback" configuration setting and to set it as permanently trusted (in the same vein as the prompts for adding `ci-arm1.elodin.dev` as a build cache).