### PR TITLE
Add auto-tick advancement to JaxSim

### DIFF
--- a/libs/nox-py/python/elodin/__init__.py
+++ b/libs/nox-py/python/elodin/__init__.py
@@ -432,7 +432,6 @@ class World(WorldBuilder):
         run_time_step: Optional[float] = None,
         default_playback_speed: float = 1.0,
         max_ticks: Optional[int] = None,
-        auto_manage_tick: bool = True,
     ) -> object:
         obj, ins, outs, state, dictionary, entity_dict, component_entity_dict = super().to_jax_func(
             system, sim_time_step, run_time_step, default_playback_speed, max_ticks
@@ -445,6 +444,5 @@ class World(WorldBuilder):
             dictionary,
             entity_dict,
             component_entity_dict,
-            auto_manage_tick=auto_manage_tick,
         )
         return sim_object

--- a/libs/nox-py/python/elodin/__init__.py
+++ b/libs/nox-py/python/elodin/__init__.py
@@ -432,11 +432,13 @@ class World(WorldBuilder):
         run_time_step: Optional[float] = None,
         default_playback_speed: float = 1.0,
         max_ticks: Optional[int] = None,
+        auto_manage_tick: bool = True,
     ) -> object:
         obj, ins, outs, state, dictionary, entity_dict, component_entity_dict = super().to_jax_func(
             system, sim_time_step, run_time_step, default_playback_speed, max_ticks
         )
         sim_object = jaxsim.JaxSim(
-            obj, ins, outs, state, dictionary, entity_dict, component_entity_dict
+            obj, ins, outs, state, dictionary, entity_dict, component_entity_dict,
+            auto_manage_tick=auto_manage_tick
         )
         return sim_object

--- a/libs/nox-py/python/elodin/__init__.py
+++ b/libs/nox-py/python/elodin/__init__.py
@@ -438,7 +438,13 @@ class World(WorldBuilder):
             system, sim_time_step, run_time_step, default_playback_speed, max_ticks
         )
         sim_object = jaxsim.JaxSim(
-            obj, ins, outs, state, dictionary, entity_dict, component_entity_dict,
-            auto_manage_tick=auto_manage_tick
+            obj,
+            ins,
+            outs,
+            state,
+            dictionary,
+            entity_dict,
+            component_entity_dict,
+            auto_manage_tick=auto_manage_tick,
         )
         return sim_object

--- a/libs/nox-py/python/elodin/jaxsim.py
+++ b/libs/nox-py/python/elodin/jaxsim.py
@@ -35,6 +35,7 @@ class JaxSim:
         entity_dict,
         component_entity_dict,
         map=None,
+        auto_manage_tick=True,
     ):
         """
         Initializes the JaxSim class with a world, a system, and a simulation time step.
@@ -54,6 +55,11 @@ class JaxSim:
             A dictionary mapping entity names to their IDs.
         component_entity_dict : dict
             A dictionary mapping component names to a list of their entity IDs.
+        map : list, optional
+            An index map for ordering inputs and outputs.
+        auto_manage_tick : bool, optional
+            If True (default), automatically increment SimulationTick on each step.
+            This ensures time-based systems work correctly in JaxSim mode.
         """
 
         self.py_sim = sim_obj
@@ -67,6 +73,18 @@ class JaxSim:
             self.map = self.generate_index_map(self.inputs, self.outputs)
         else:
             self.map = map
+        
+        # Auto-tick management configuration
+        self.auto_manage_tick = auto_manage_tick
+        self._tick_steps = 0  # Track total steps taken
+        
+        # Find tick component location (it's always present when SimulationTick is used)
+        self._tick_index = None
+        if self.auto_manage_tick:
+            for c_p, d_p, name in self.map:
+                if name == "tick":
+                    self._tick_index = d_p
+                    break
 
     def generate_index_map(self, desired_order, current_order):
         """
@@ -117,6 +135,13 @@ class JaxSim:
             The maximum number of steps to simulate.
         """
         for steps in range(max_steps):
+            # Auto-increment tick if enabled
+            if self.auto_manage_tick and self._tick_index is not None:
+                # SimulationTick is always F64, just increment it
+                self.state[self._tick_index] = self.state[self._tick_index] + 1.0
+                self._tick_steps += 1
+            
+            # Call the simulation function  
             self.state = self.py_sim(*self.state)
             self.state = self.order_array(self.state)
 
@@ -207,6 +232,28 @@ class JaxSim:
                             shape = self.state[d_p][entity_index].shape
                             entity_names_shapes.append(f"{name} (shape: {shape})")
             print(f"{component_name}: {', '.join(entity_names_shapes)}")
+    
+    def disable_auto_tick(self):
+        """Disable automatic tick management.
+        
+        Useful for advanced users who need manual tick control.
+        """
+        self.auto_manage_tick = False
+    
+    def enable_auto_tick(self):
+        """Enable automatic tick management.
+        
+        Re-enables auto-tick if it was disabled.
+        """
+        self.auto_manage_tick = True
+    
+    def get_tick_count(self):
+        """Get the total number of steps taken with auto-tick management.
+        
+        Returns:
+            Number of steps taken since initialization or last reset
+        """
+        return self._tick_steps
 
     def sim_flatten(self):
         """Flatten the JaxSim object for JAX.
@@ -241,7 +288,8 @@ class JaxSim:
         py_sim, inputs, outputs, dictionary, entity_dict, component_entity_dict, map = aux_data
 
         return JaxSim(
-            py_sim, inputs, outputs, cls, dictionary, entity_dict, component_entity_dict, map
+            py_sim, inputs, outputs, cls, dictionary, entity_dict, component_entity_dict, map, 
+            auto_manage_tick=True  # Default to auto-manage tick for reconstructed objects
         )
 
 

--- a/libs/nox-py/python/elodin/jaxsim.py
+++ b/libs/nox-py/python/elodin/jaxsim.py
@@ -73,11 +73,11 @@ class JaxSim:
             self.map = self.generate_index_map(self.inputs, self.outputs)
         else:
             self.map = map
-        
+
         # Auto-tick management configuration
         self.auto_manage_tick = auto_manage_tick
         self._tick_steps = 0  # Track total steps taken
-        
+
         # Find tick component location (it's always present when SimulationTick is used)
         self._tick_index = None
         if self.auto_manage_tick:
@@ -140,8 +140,8 @@ class JaxSim:
                 # SimulationTick is always F64, just increment it
                 self.state[self._tick_index] = self.state[self._tick_index] + 1.0
                 self._tick_steps += 1
-            
-            # Call the simulation function  
+
+            # Call the simulation function
             self.state = self.py_sim(*self.state)
             self.state = self.order_array(self.state)
 
@@ -232,24 +232,24 @@ class JaxSim:
                             shape = self.state[d_p][entity_index].shape
                             entity_names_shapes.append(f"{name} (shape: {shape})")
             print(f"{component_name}: {', '.join(entity_names_shapes)}")
-    
+
     def disable_auto_tick(self):
         """Disable automatic tick management.
-        
+
         Useful for advanced users who need manual tick control.
         """
         self.auto_manage_tick = False
-    
+
     def enable_auto_tick(self):
         """Enable automatic tick management.
-        
+
         Re-enables auto-tick if it was disabled.
         """
         self.auto_manage_tick = True
-    
+
     def get_tick_count(self):
         """Get the total number of steps taken with auto-tick management.
-        
+
         Returns:
             Number of steps taken since initialization or last reset
         """
@@ -288,8 +288,15 @@ class JaxSim:
         py_sim, inputs, outputs, dictionary, entity_dict, component_entity_dict, map = aux_data
 
         return JaxSim(
-            py_sim, inputs, outputs, cls, dictionary, entity_dict, component_entity_dict, map, 
-            auto_manage_tick=True  # Default to auto-manage tick for reconstructed objects
+            py_sim,
+            inputs,
+            outputs,
+            cls,
+            dictionary,
+            entity_dict,
+            component_entity_dict,
+            map,
+            auto_manage_tick=True,  # Default to auto-manage tick for reconstructed objects
         )
 
 

--- a/libs/nox-py/python/elodin/jaxsim.py
+++ b/libs/nox-py/python/elodin/jaxsim.py
@@ -35,7 +35,6 @@ class JaxSim:
         entity_dict,
         component_entity_dict,
         map=None,
-        auto_manage_tick=True,
     ):
         """
         Initializes the JaxSim class with a world, a system, and a simulation time step.
@@ -57,9 +56,6 @@ class JaxSim:
             A dictionary mapping component names to a list of their entity IDs.
         map : list, optional
             An index map for ordering inputs and outputs.
-        auto_manage_tick : bool, optional
-            If True (default), automatically increment SimulationTick on each step.
-            This ensures time-based systems work correctly in JaxSim mode.
         """
 
         self.py_sim = sim_obj
@@ -74,17 +70,14 @@ class JaxSim:
         else:
             self.map = map
 
-        # Auto-tick management configuration
-        self.auto_manage_tick = auto_manage_tick
         self._tick_steps = 0  # Track total steps taken
 
         # Find tick component location (it's always present when SimulationTick is used)
         self._tick_index = None
-        if self.auto_manage_tick:
-            for c_p, d_p, name in self.map:
-                if name == "tick":
-                    self._tick_index = d_p
-                    break
+        for c_p, d_p, name in self.map:
+            if name == "tick":
+                self._tick_index = d_p
+                break
 
     def generate_index_map(self, desired_order, current_order):
         """
@@ -136,7 +129,7 @@ class JaxSim:
         """
         for steps in range(max_steps):
             # Auto-increment tick if enabled
-            if self.auto_manage_tick and self._tick_index is not None:
+            if self._tick_index is not None:
                 # SimulationTick is always F64, just increment it
                 self.state[self._tick_index] = self.state[self._tick_index] + 1.0
                 self._tick_steps += 1
@@ -233,20 +226,6 @@ class JaxSim:
                             entity_names_shapes.append(f"{name} (shape: {shape})")
             print(f"{component_name}: {', '.join(entity_names_shapes)}")
 
-    def disable_auto_tick(self):
-        """Disable automatic tick management.
-
-        Useful for advanced users who need manual tick control.
-        """
-        self.auto_manage_tick = False
-
-    def enable_auto_tick(self):
-        """Enable automatic tick management.
-
-        Re-enables auto-tick if it was disabled.
-        """
-        self.auto_manage_tick = True
-
     def get_tick_count(self):
         """Get the total number of steps taken with auto-tick management.
 
@@ -296,7 +275,6 @@ class JaxSim:
             entity_dict,
             component_entity_dict,
             map,
-            auto_manage_tick=True,  # Default to auto-manage tick for reconstructed objects
         )
 
 


### PR DESCRIPTION
## Problem Summary

When implementing Software In The Loop (SITL) testing using Elodin's JaxSim interface, the simulation tick wasn't advancing automatically, causing:
- Time to remain at 0
- No physics calculations (velocity stayed 0, Mach stayed 0) 
- Missile never launching or moving

## Root Cause

The issue stems from a fundamental difference in how Elodin handles simulation time in different modes:

### 1. Runtime Mode (`world.run()`)
- Elodin's runtime automatically manages `el.SimulationTick`
- The tick increments before each simulation step
- Time progresses naturally via the `set_time` system

### 2. JaxSim Mode (`world.to_jax()`)
- Everything becomes pure JAX functions
- `el.SimulationTick` is treated as regular state, not special
- The tick must be manually managed - it doesn't auto-increment

## Architecture Differences

### Consider a time based simulation that leverages the native SimulationTick (like the rocket.py example)
```python
# Uses Elodin's special tick component
@el.system
def set_time(
    tick: el.Query[el.SimulationTick],
    dt: el.Query[el.SimulationTimeStep],
    q: el.Query[Time],
) -> el.Query[Time, SimTick]:
    return q.map((Time, SimTick), lambda _: (tick[0] * dt[0], tick[0]))
```
- Relies on `el.SimulationTick` for timing
- Many systems depend on `Time` component
- Time drives physics, state transitions, etc.

### Cube-Sat Example
```python
# Uses constant time step directly
SIM_TIME_STEP = 1.0 / 20.0

def propagate_quaternion(q: Quaternion, omega: jax.Array, dt: float) -> Quaternion:
    # dt is passed as parameter, not queried from system
```
- No dependency on `el.SimulationTick`
- Time step passed as function parameter
- Self-contained timing logic

### Conclusion
As a result, the rocket.py would run but would show the same data from step 0, and never be incremented.

These changes introduce a mode for JaxSim to auto-increment the tick component, resulting in correct behavior for the rest of the simulation integration.