### PR TITLE
feat(aleph) - allow custom save location for db

### DIFF
--- a/images/aleph/modules/elodin-db.nix
+++ b/images/aleph/modules/elodin-db.nix
@@ -21,21 +21,44 @@ in {
         Whether to automatically open the specified ports in the firewall.
       '';
     };
+    dbFolderName = lib.mkOption {
+      type = lib.types.str;
+      default = "/db";
+      description = ''
+        The parent path for the elodin-db output directory.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
-    systemd.services.elodin-db = with pkgs; {
-      wantedBy = ["multi-user.target"];
+    systemd.services."elodin-db@" = with pkgs; {
       after = ["network.target"];
       description = "start elodin-db";
       serviceConfig = {
         Type = "exec";
         User = "root";
-        ExecStart = "${elodin-db}/bin/elodin-db run [::]:2240 --http-addr [::]:2248 /db";
+        ExecStart = "${elodin-db}/bin/elodin-db run [::]:2240 --http-addr [::]:2248 ${cfg.dbFolderName}/%i";
         KillSignal = "SIGINT";
         Environment = "RUST_LOG=info";
       };
     };
+
+    systemd.packages = [
+      (pkgs.runCommandNoCC "elodin-db-default-service" {
+          preferLocalBuild = true;
+          allowSubstitutes = false;
+        } ''
+          mkdir -p $out/etc/systemd/system/
+          ln -s /etc/systemd/system/elodin-db@.service $out/etc/systemd/system/elodin-db@default.service
+        '')
+    ];
+
+    # see: https://github.com/NixOS/nixpkgs/issues/80933
+    systemd.services."elodin-db@default" = {
+      wantedBy = ["multi-user.target"];
+      overrideStrategy = "asDropin";
+    };
+
     environment.systemPackages = [pkgs.elodin-db];
     networking.firewall.allowedTCPPorts = lib.optionals cfg.openFirewall [2240 2248];
   };


### PR DESCRIPTION
In elodin-db module, the database will now be saved as a _sub-folder_ of `/db.` The previous behavior was to save in `/db` directly. The subfolder name is customizable and can be passed as an argument to the service, where:

> `systemctl start elodin-db@NAME.service`

will result in a database saved to` /db/name`. This is useful for test applications where it is desirable to initialize the database in new locations.

Note: the parent folder (`/db`) is also customizable as a variable in the elodin-db nix module.