### PR TITLE
feat(plot): Enhanced plot zoom/pan interactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4567,6 +4567,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "egui_material_icons"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8fbdd1ecd47e2308795f3a79fc3b61456191b9276766b0009d9bcff72330ad"
+dependencies = [
+ "egui",
+]
+
+[[package]]
 name = "egui_table"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4714,6 +4723,7 @@ dependencies = [
  "convert_case 0.6.0",
  "directories",
  "egui",
+ "egui_material_icons",
  "egui_table",
  "egui_tiles",
  "eql",

--- a/libs/elodin-editor/Cargo.toml
+++ b/libs/elodin-editor/Cargo.toml
@@ -14,6 +14,7 @@ inspector = ["dep:bevy-inspector-egui"]
 # math
 nox.path = "../nox"
 nox.default-features = false
+egui_material_icons = "0.3"
 
 # bevy
 bevy.version = "0.16"

--- a/libs/elodin-editor/src/ui/plot/mod.rs
+++ b/libs/elodin-editor/src/ui/plot/mod.rs
@@ -8,25 +8,21 @@ pub use state::*;
 
 use bevy::{
     app::{Plugin, PostUpdate, Startup, Update},
-    ecs::schedule::IntoScheduleConfigs, // for `.after(...)`
+    ecs::schedule::IntoScheduleConfigs, 
 };
 
 pub struct PlotPlugin;
 impl Plugin for PlotPlugin {
     fn build(&self, app: &mut bevy::prelude::App) {
         app
-            // Resources
             .init_resource::<CollectedGraphData>()
             .init_resource::<LockedGraphsLeader>()
-            .init_resource::<LockTracker>() // Tracks per-entity lock state edges
-            // Systems
+            .init_resource::<LockTracker>()
             .add_systems(Startup, setup_pkt_handler)
-            // Input/interaction updates
             .add_systems(Update, zoom_graph)
             .add_systems(Update, graph_touch)
             .add_systems(Update, pan_graph)
             .add_systems(Update, reset_graph)
-            // Lock edge tracking must run after interaction updates
             .add_systems(
                 Update,
                 widget::track_lock_toggles
@@ -34,7 +30,6 @@ impl Plugin for PlotPlugin {
                     .after(pan_graph)
                     .after(reset_graph),
             )
-            // Leader-driven X-sync must run after lock edge handling
             .add_systems(
                 Update,
                 widget::sync_locked_graphs
@@ -43,7 +38,6 @@ impl Plugin for PlotPlugin {
                     .after(pan_graph)
                     .after(reset_graph),
             )
-            // Data lifecyle / GPU
             .add_systems(PostUpdate, queue_timestamp_read)
             .add_systems(Update, collect_garbage)
             .add_systems(Update, sync_graphs)

--- a/libs/elodin-editor/src/ui/plot/mod.rs
+++ b/libs/elodin-editor/src/ui/plot/mod.rs
@@ -1,8 +1,4 @@
 pub mod data;
-use bevy::{
-    app::{Plugin, PostUpdate, Startup, Update},
-    ecs::schedule::IntoScheduleConfigs,
-};
 pub use data::*;
 pub mod gpu;
 mod widget;
@@ -10,15 +6,44 @@ pub use widget::*;
 mod state;
 pub use state::*;
 
+use bevy::{
+    app::{Plugin, PostUpdate, Startup, Update},
+    ecs::schedule::IntoScheduleConfigs, // for `.after(...)`
+};
+
 pub struct PlotPlugin;
 impl Plugin for PlotPlugin {
     fn build(&self, app: &mut bevy::prelude::App) {
-        app.init_resource::<CollectedGraphData>()
+        app
+            // Resources
+            .init_resource::<CollectedGraphData>()
+            .init_resource::<LockedGraphsLeader>()
+            .init_resource::<LockTracker>() // Tracks per-entity lock state edges
+            // Systems
             .add_systems(Startup, setup_pkt_handler)
+            // Input/interaction updates
             .add_systems(Update, zoom_graph)
             .add_systems(Update, graph_touch)
             .add_systems(Update, pan_graph)
             .add_systems(Update, reset_graph)
+            // Lock edge tracking must run after interaction updates
+            .add_systems(
+                Update,
+                widget::track_lock_toggles
+                    .after(zoom_graph)
+                    .after(pan_graph)
+                    .after(reset_graph),
+            )
+            // Leader-driven X-sync must run after lock edge handling
+            .add_systems(
+                Update,
+                widget::sync_locked_graphs
+                    .after(widget::track_lock_toggles)
+                    .after(zoom_graph)
+                    .after(pan_graph)
+                    .after(reset_graph),
+            )
+            // Data lifecyle / GPU
             .add_systems(PostUpdate, queue_timestamp_read)
             .add_systems(Update, collect_garbage)
             .add_systems(Update, sync_graphs)

--- a/libs/elodin-editor/src/ui/plot/mod.rs
+++ b/libs/elodin-editor/src/ui/plot/mod.rs
@@ -8,14 +8,13 @@ pub use state::*;
 
 use bevy::{
     app::{Plugin, PostUpdate, Startup, Update},
-    ecs::schedule::IntoScheduleConfigs, 
+    ecs::schedule::IntoScheduleConfigs,
 };
 
 pub struct PlotPlugin;
 impl Plugin for PlotPlugin {
     fn build(&self, app: &mut bevy::prelude::App) {
-        app
-            .init_resource::<CollectedGraphData>()
+        app.init_resource::<CollectedGraphData>()
             .init_resource::<LockedGraphsLeader>()
             .init_resource::<LockTracker>()
             .add_systems(Startup, setup_pkt_handler)

--- a/libs/elodin-editor/src/ui/plot/mod.rs
+++ b/libs/elodin-editor/src/ui/plot/mod.rs
@@ -1,8 +1,24 @@
+use bevy_egui::EguiContexts;
 pub mod data;
-pub use data::*;
+pub use data::{
+    BufferShardAlloc, CHUNK_COUNT, CHUNK_LEN, CollectedGraphData, Line, PlotDataComponent, XYLine,
+    collect_garbage, queue_timestamp_read, setup_pkt_handler,
+};
+
 pub mod gpu;
+pub use gpu::{
+    INDEX_BUFFER_LEN, INDEX_BUFFER_SIZE, LineBundle, LineConfig, LineHandle, LineUniform,
+    LineWidgetWidth, PlotGpuPlugin, VALUE_BUFFER_SIZE,
+};
+
 mod widget;
-pub use widget::*;
+pub use widget::{
+    AXIS_LABEL_MARGIN, LockTracker, NOTCH_LENGTH, PlotBounds, PlotWidget, STEPS_X_WIDTH_DIVISOR,
+    STEPS_Y_HEIGHT_DIVISOR, XSyncClock, auto_y_bounds, draw_borders, draw_y_axis, get_inner_rect,
+    graph_touch, pan_graph, pretty_round, reset_graph, sync_graphs, sync_locked_graphs,
+    track_lock_toggles, zoom_graph,
+};
+
 mod state;
 pub use state::*;
 
@@ -11,28 +27,34 @@ use bevy::{
     ecs::schedule::IntoScheduleConfigs,
 };
 
+fn load_material_icons(mut egui_contexts: EguiContexts) {
+    let ctx = egui_contexts.ctx_mut();
+    egui_material_icons::initialize(ctx);
+}
+
 pub struct PlotPlugin;
 impl Plugin for PlotPlugin {
     fn build(&self, app: &mut bevy::prelude::App) {
         app.init_resource::<CollectedGraphData>()
-            .init_resource::<LockedGraphsLeader>()
             .init_resource::<LockTracker>()
+            .init_resource::<XSyncClock>()
             .add_systems(Startup, setup_pkt_handler)
+            .add_systems(Startup, load_material_icons)
             .add_systems(Update, zoom_graph)
             .add_systems(Update, graph_touch)
             .add_systems(Update, pan_graph)
             .add_systems(Update, reset_graph)
             .add_systems(
                 Update,
-                widget::track_lock_toggles
+                track_lock_toggles
                     .after(zoom_graph)
                     .after(pan_graph)
                     .after(reset_graph),
             )
             .add_systems(
                 Update,
-                widget::sync_locked_graphs
-                    .after(widget::track_lock_toggles)
+                sync_locked_graphs
+                    .after(track_lock_toggles)
                     .after(zoom_graph)
                     .after(pan_graph)
                     .after(reset_graph),
@@ -41,6 +63,6 @@ impl Plugin for PlotPlugin {
             .add_systems(Update, collect_garbage)
             .add_systems(Update, sync_graphs)
             .add_systems(Update, auto_y_bounds.after(sync_graphs))
-            .add_plugins(gpu::PlotGpuPlugin);
+            .add_plugins(PlotGpuPlugin);
     }
 }

--- a/libs/elodin-editor/src/ui/plot/state.rs
+++ b/libs/elodin-editor/src/ui/plot/state.rs
@@ -49,6 +49,7 @@ pub struct GraphState {
     pub x_range: Range<f64>,
     pub widget_width: f64,
     pub visible_range: LineVisibleRange,
+    pub locked: bool,
 }
 
 impl GraphBundle {
@@ -76,6 +77,7 @@ impl GraphBundle {
             auto_x_range: true,
             widget_width: 1920.0,
             visible_range: LineVisibleRange(Timestamp(i64::MIN)..Timestamp(i64::MAX)),
+            locked: false,
         };
         GraphBundle {
             camera: Camera {

--- a/libs/elodin-editor/src/ui/plot/state.rs
+++ b/libs/elodin-editor/src/ui/plot/state.rs
@@ -2,10 +2,8 @@ use std::collections::BTreeMap;
 use std::ops::Range;
 
 use bevy::core_pipeline::tonemapping::Tonemapping;
-
-use bevy::render::camera::ScalingMode;
-
 use bevy::prelude::*;
+use bevy::render::camera::ScalingMode;
 use bevy::render::view::RenderLayers;
 use bevy_egui::egui::{self, Color32};
 
@@ -50,6 +48,10 @@ pub struct GraphState {
     pub widget_width: f64,
     pub visible_range: LineVisibleRange,
     pub locked: bool,
+
+    // peer-ready metadata (not used until widget.rs switches to peers)
+    pub x_rev: u64,
+    pub x_dirty: bool,
 }
 
 impl GraphBundle {
@@ -78,6 +80,8 @@ impl GraphBundle {
             widget_width: 1920.0,
             visible_range: LineVisibleRange(Timestamp(i64::MIN)..Timestamp(i64::MAX)),
             locked: false,
+            x_rev: 0,
+            x_dirty: false,
         };
         GraphBundle {
             camera: Camera {
@@ -109,8 +113,6 @@ impl GraphBundle {
 impl GraphState {
     pub fn remove_component(&mut self, component_path: &ComponentPath) {
         self.components.remove(component_path);
-
-        // Also remove from enabled_lines
         self.enabled_lines
             .retain(|(path, _), _| path != component_path);
     }

--- a/libs/elodin-editor/src/ui/plot/widget.rs
+++ b/libs/elodin-editor/src/ui/plot/widget.rs
@@ -391,37 +391,40 @@ impl TimeseriesPlot {
         // It only toggles `graph_state.locked` (no functional effect yet).
         {
             let lock_size = egui::vec2(20.0, 20.0);
-            let lock_pos  = egui::pos2(
+            let lock_pos = egui::pos2(
                 self.inner_rect.max.x - lock_size.x - 6.0,
                 self.rect.min.y + 6.0,
             );
 
-            egui::Area::new(egui::Id::new(("plot_lock_btn", (graph_state as *const _) as usize)))
-                .order(egui::Order::Foreground)
-                .fixed_pos(lock_pos)
-                .show(ui.ctx(), |ui| {
-                    let (rect, resp) = ui.allocate_exact_size(lock_size, egui::Sense::click());
+            egui::Area::new(egui::Id::new((
+                "plot_lock_btn",
+                (graph_state as *const _) as usize,
+            )))
+            .order(egui::Order::Foreground)
+            .fixed_pos(lock_pos)
+            .show(ui.ctx(), |ui| {
+                let (rect, resp) = ui.allocate_exact_size(lock_size, egui::Sense::click());
 
-                    // subtle hover feedback
-                    if resp.hovered() {
-                        ui.painter().rect_filled(
-                            rect.expand(2.0),
-                            egui::CornerRadius::same(6), // u8 with your egui version
-                            get_scheme().bg_secondary.opacity(0.6),
-                        );
-                    }
+                // subtle hover feedback
+                if resp.hovered() {
+                    ui.painter().rect_filled(
+                        rect.expand(2.0),
+                        egui::CornerRadius::same(6), // u8 with your egui version
+                        get_scheme().bg_secondary.opacity(0.6),
+                    );
+                }
 
-                    // vector lock icon (defined at bottom)
-                    paint_lock_icon(ui, rect, graph_state.locked);
+                // vector lock icon (defined at bottom)
+                paint_lock_icon(ui, rect, graph_state.locked);
 
-                    // callback is intentionally "empty": toggle only
-                    if resp.clicked() {
-                        graph_state.locked = !graph_state.locked;
-                    }
+                // callback is intentionally "empty": toggle only
+                if resp.clicked() {
+                    graph_state.locked = !graph_state.locked;
+                }
 
-                    // tooltip
-                    resp.on_hover_text(if graph_state.locked { "Unlock" } else { "Lock" });
-                });
+                // tooltip
+                resp.on_hover_text(if graph_state.locked { "Unlock" } else { "Lock" });
+            });
         }
 
         response.context_menu(|ui| {
@@ -1326,7 +1329,11 @@ fn paint_lock_icon(ui: &mut egui::Ui, rect: egui::Rect, locked: bool) {
     let cx = body.center().x;
     let base_y = body.top() + 1.0;
     let r = 6.0;
-    let (start_deg, end_deg) = if locked { (210.0_f32, -30.0_f32) } else { (200.0, -10.0) };
+    let (start_deg, end_deg) = if locked {
+        (210.0_f32, -30.0_f32)
+    } else {
+        (200.0, -10.0)
+    };
     let steps = 18;
 
     let mut pts = Vec::with_capacity(steps + 1);
@@ -1349,4 +1356,3 @@ fn paint_lock_icon(ui: &mut egui::Ui, rect: egui::Rect, locked: bool) {
 
     ui.painter().line(pts, stroke);
 }
- 

--- a/libs/elodin-editor/src/ui/plot/widget.rs
+++ b/libs/elodin-editor/src/ui/plot/widget.rs
@@ -707,10 +707,10 @@ pub fn sync_bounds(
     let outer_ratio = (rect.size() / inner_rect.size()).as_dvec2();
     let pan_offset = graph_state.pan_offset.as_dvec2() * DVec2::new(-1.0, 1.0);
     PlotBounds::from_lines(&selected_range, earliest_timestamp, y_min, y_max)
-        .zoom_at(outer_ratio, DVec2::new(1.0, 0.5))
-        .offset_by_norm(pan_offset)
-        .zoom(graph_state.zoom_factor.as_dvec2())
-        .normalize()
+        .zoom_at(outer_ratio, DVec2::new(1.0, 0.5)) // Zoom the bounds out so the graph takes up the entire screen.
+        .offset_by_norm(pan_offset) // Pan the bounds by the amount the cursor has moved.
+        .zoom(graph_state.zoom_factor.as_dvec2()) // Zoom the bounds based on the current zoom factor.
+        .normalize() // Clamp the bounds so max > min.
 }
 
 pub fn auto_y_bounds(
@@ -1326,12 +1326,15 @@ fn sigfig_round(x: f64, mut digits: i32) -> f64 {
 pub fn pretty_round(num: f64) -> f64 {
     let mut multiplier = 1.0;
     let mut n = num;
+    // Handle negative numbers.
     let is_negative = n < 0.0;
     n = n.abs();
+    // Find the appropriate multiplier for the decimal places.
     while n < 1.0 {
         n *= 10.0;
         multiplier *= 10.0;
     }
+    // Round to nearest 5.
     let rounded = (n * 2.0).round() / 2.0;
     let result = rounded / multiplier;
     if is_negative { -result } else { result }

--- a/libs/elodin-editor/src/ui/plot/widget.rs
+++ b/libs/elodin-editor/src/ui/plot/widget.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use std::collections::HashMap; 
+use std::collections::HashMap;
 
 use crate::{
     editor_cam_touch::*,
@@ -873,10 +873,7 @@ pub fn sync_graphs(
 
 #[allow(clippy::type_complexity)]
 pub fn track_lock_toggles(
-    mut sets: ParamSet<(
-        Query<(Entity, &GraphState)>, 
-        Query<&mut GraphState>,      
-    )>,
+    mut sets: ParamSet<(Query<(Entity, &GraphState)>, Query<&mut GraphState>)>,
     mut tracker: ResMut<LockTracker>,
     mut leader_res: ResMut<LockedGraphsLeader>,
 ) {
@@ -904,7 +901,7 @@ pub fn track_lock_toggles(
                 _ => {}
             }
         }
-    } 
+    }
 
     if let Some(old_leader) = leader_unlocked {
         let mut new_leader: Option<Entity> = None;
@@ -945,8 +942,8 @@ pub fn track_lock_toggles(
 #[allow(clippy::type_complexity)]
 pub fn sync_locked_graphs(
     mut sets: ParamSet<(
-        Query<(Entity, &GraphState)>,     
-        Query<(Entity, &mut GraphState)>, 
+        Query<(Entity, &GraphState)>,
+        Query<(Entity, &mut GraphState)>,
     )>,
     leader_res: Res<LockedGraphsLeader>,
 ) {

--- a/libs/elodin-editor/src/ui/plot/widget.rs
+++ b/libs/elodin-editor/src/ui/plot/widget.rs
@@ -1,5 +1,4 @@
 use bevy::prelude::*;
-use bevy_egui::EguiContexts;
 use egui_material_icons::{icon_button, icons::*};
 use std::collections::HashMap;
 
@@ -64,12 +63,6 @@ pub struct LockTracker(pub HashMap<Entity, bool>);
 /// Monotonic revision for X-sync (last-writer-wins)
 #[derive(Resource, Default, Debug, Clone, Copy)]
 pub struct XSyncClock(pub u64);
-
-/// Initialize Material Icons once (call in Startup)
-pub fn load_material_icons(mut egui_contexts: EguiContexts) {
-    let ctx = egui_contexts.ctx_mut();
-    egui_material_icons::initialize(&*ctx);
-}
 
 #[derive(SystemParam)]
 pub struct PlotWidget<'w, 's> {

--- a/libs/elodin-editor/src/ui/plot/widget.rs
+++ b/libs/elodin-editor/src/ui/plot/widget.rs
@@ -870,8 +870,13 @@ pub fn track_lock_toggles(
     for (_e, g) in sets.p0().iter() {
         if g.locked {
             let cand = (g.zoom_factor.x, g.pan_offset.x, g.x_rev);
-            if source.map_or(true, |s| cand.2 > s.2) {
-                source = Some(cand);
+            match source {
+                None => source = Some(cand),
+                Some(s) => {
+                    if cand.2 > s.2 {
+                        source = Some(cand);
+                    }
+                }
             }
         }
     }
@@ -900,8 +905,13 @@ pub fn sync_locked_graphs(
     for (e, gs) in sets.p0().iter() {
         if gs.locked {
             let cand = (e, gs.zoom_factor.x, gs.pan_offset.x, gs.x_rev);
-            if src.map_or(true, |s| cand.3 > s.3) {
-                src = Some(cand);
+            match src {
+                None => src = Some(cand),
+                Some(s) => {
+                    if cand.3 > s.3 {
+                        src = Some(cand);
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
See this issue: https://github.com/elodin-sys/elodin/issues/139

# Feature (lock behavior on plots)
- First lock activated
   - The first plot-graph whose lock is toggled becomes the leader.
   - No visible effect at first, but this plot will serve as the reference for `zoom_x`.
- Second lock (and subsequent ones)
   - When another plot-graph is locked, it automatically synchronizes with the `zoom_x` of the already locked group.
   - As a result, all locked plots share the same `zoom_x` state.
- Propagation of `zoom_x`
   - Whenever a user applies a `zoom_x` (via the UI) on a locked plot, this zoom is transmitted to all other locked plots.
   -This works in a peer-to-peer logic: each locked plot can temporarily become the “leader” while it’s being interacted with.

# `zoom_x` in/out
- On macOS: CMD + mouse wheel

# egui_materials-icons
This branch modifies `elodin-editor/Cargo.toml` to include the following:
```toml
[dependencies]
egui_material_icons = "0.3"
```