### PR TITLE
Initiate a README for noxpr

### DIFF
--- a/libs/nox/src/doctest.rs
+++ b/libs/nox/src/doctest.rs
@@ -1,0 +1,26 @@
+#[cfg(feature = "noxpr")]
+pub mod noxpr {
+    use crate::{Noxpr, NoxprFn, ArrayTy, NoxprTy, NoxprScalarExt};
+    use smallvec::smallvec;
+    use xla::ElementType;
+
+    pub fn example_function() -> NoxprFn {
+        // Parameters
+        let a = Noxpr::parameter(
+            0,
+            NoxprTy::ArrayTy(ArrayTy::new(ElementType::F32, smallvec![3])),
+            "a".into()
+        );
+        let b = Noxpr::parameter(
+            1,
+            NoxprTy::ArrayTy(ArrayTy::new(ElementType::F32, smallvec![3])),
+            "b".into()
+        );
+
+        // ((a + 1) * b).dot(a)
+        let expr = ((a.clone() + 1.0f32.constant()) * b.clone()).dot(&a);
+
+        // Function wrapper (for compile / pretty-print / etc.)
+        NoxprFn::new(vec![a, b], expr)
+    }
+}

--- a/libs/nox/src/doctest.rs
+++ b/libs/nox/src/doctest.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "noxpr")]
 pub mod noxpr {
-    use crate::{Noxpr, NoxprFn, ArrayTy, NoxprTy, NoxprScalarExt};
+    use crate::{ArrayTy, Noxpr, NoxprFn, NoxprScalarExt, NoxprTy};
     use smallvec::smallvec;
     use xla::ElementType;
 
@@ -9,12 +9,12 @@ pub mod noxpr {
         let a = Noxpr::parameter(
             0,
             NoxprTy::ArrayTy(ArrayTy::new(ElementType::F32, smallvec![3])),
-            "a".into()
+            "a".into(),
         );
         let b = Noxpr::parameter(
             1,
             NoxprTy::ArrayTy(ArrayTy::new(ElementType::F32, smallvec![3])),
-            "b".into()
+            "b".into(),
         );
 
         // ((a + 1) * b).dot(a)

--- a/libs/nox/src/lib.rs
+++ b/libs/nox/src/lib.rs
@@ -43,6 +43,13 @@ mod noxpr;
 #[cfg(feature = "noxpr")]
 pub use noxpr::*;
 
+// NOTE(shane): I would like to gate this behind `doctest` since that is all it
+// is used for. However, I can't at least not for the tests present in the
+// README. As a substitute I am making it hidden.
+#[doc(hidden)]
+// #[cfg(doctest)]
+pub mod doctest;
+
 #[cfg(feature = "xla")]
 pub use xla;
 

--- a/libs/nox/src/noxpr/README.md
+++ b/libs/nox/src/noxpr/README.md
@@ -1,0 +1,148 @@
+# noxpr — Tensor Expression IR & XLA Tracer
+
+## Description
+`noxpr` lets you build tensor compute graphs in Rust and run them fast with XLA (Accelerated Linear Algebra).  
+It is a subsystem of **Nox** (not a standalone crate) and lives in `libs/nox/src/noxpr/`.
+
+## Features
+
+1. **Build compute graphs in Rust** — Create expressions with Rust types and methods (no text parsing).  
+   Use `Scalar`, `Vector`, `Matrix`, and `Tensor<_, _, Op>` to build a graph (`Noxpr` / `NoxprNode`). 
+
+2. **Compile to XLA (Accelerated Linear Algebra)** — `XlaTracer` lowers the graph to an `xla::XlaComputation`.  
+   You can also dump **HLO** (High Level Optimizer) text to see what will run.  
+   
+3. **Run on CPU/GPU via PJRT (Portable Just‑In‑Time Runtime)** — The `Client` compiles and executes on CPU (Central Processing Unit) and, if enabled, GPU (Graphics Processing Unit).  
+   
+4. **Rich, typed ops** — Elementwise math, linear algebra (`dot`, `dot_general`), shape transforms (`reshape`, `transpose`, `broadcast`), indexing (`slice`, `gather`, `dynamic_slice`), control flow (`scan`, `select`), type casts (`convert`), and `cholesky`.  
+
+5. **Optional JAX bridge** — With the `jax` feature, interoperate with **JAX** (Python numerical library). Handy for mixing ecosystems or debugging.
+
+## Snippets
+All snippets are supposed to be within the `nox` crate (or its internal modules), since `noxpr` is not publicly exported.
+
+---
+
+###  Build a graph in Rust
+
+> Example: define `a`, `b` (f32 vectors of length 3), then `expr = dot(((a + 1) * b), a)` and wrap it in a `NoxprFn`.
+
+```rust
+use crate::noxpr::{Noxpr, NoxprFn, ArrayTy, NoxprTy, NoxprScalarExt};
+use smallvec::smallvec;
+use xla::ElementType;
+
+// Parameters
+let a = Noxpr::parameter(
+    0,
+    NoxprTy::ArrayTy(ArrayTy::new(ElementType::F32, smallvec![3])),
+    "a".into()
+);
+let b = Noxpr::parameter(
+    1,
+    NoxprTy::ArrayTy(ArrayTy::new(ElementType::F32, smallvec![3])),
+    "b".into()
+);
+
+// ((a + 1) * b).dot(a)
+let expr = ((a.clone() + 1.0f32.constant()) * b.clone()).dot(&a);
+
+// Function wrapper (for compile / pretty-print / etc.)
+let f = NoxprFn::new(vec![a, b], expr);
+
+// Human-readable IR preview (see also “Debug” section below)
+println!("{}", f);
+```
+
+---
+
+### Lower to XLA + peek at HLO
+
+> Starting from a `NoxprFn`, produce an `xla::XlaOp` then an `xla::XlaComputation`.  
+
+```rust
+use crate::noxpr::NoxprFn;
+
+let xla_op = f.build("feat1_example")?;   // Built via XlaTracer
+let comp   = xla_op.build()?;             // xla::XlaComputation
+println!("{}", comp.to_hlo_text()?);
+```
+
+---
+
+### Run via PJRT (CPU/GPU)
+
+> Minimal execution skeleton with `Client` (CPU by default, GPU if enabled).  
+> *Note:* input types/shapes must match the XLA signature.
+
+```rust
+use crate::{Client, tensor};
+
+let client = Client::cpu()?;
+let exec   = comp.compile(&client)?;
+
+let input  = tensor![1.0f32, 2.0, 3.0];
+let out    = exec.run(&client, input)?.to_host();
+```
+
+---
+
+### Typed ops (reshape/transpose/slice/gather/dot_general/select/cholesky)
+
+> Tiny recipes around typed operators. All start from `Noxpr`.
+
+```rust
+use crate::noxpr::{Noxpr, ArrayTy, NoxprTy};
+use smallvec::smallvec;
+use xla::ElementType;
+
+// x: f32[3, 1]
+let x = Noxpr::parameter(
+    0,
+    NoxprTy::ArrayTy(ArrayTy::new(ElementType::F32, smallvec![3, 1])),
+    "x".into()
+);
+
+// Broadcast (3,1) -> (3,4) along dim 1
+let y = x.clone().broadcast_in_dim(smallvec![3, 4], smallvec![0, 1]);
+
+// Transpose (2D)
+let y_t = y.transpose(smallvec![1, 0]);
+
+// Reshape (example) to (12,)
+let z = y_t.reshape(smallvec![12]);
+```
+
+### Feature 5 — JAX bridge (optional)
+
+> Available when the `jax` feature is enabled. Handy for quick prototyping/debugging from Python.
+
+```rust
+#[cfg(feature = "jax")]
+{
+    use crate::noxpr::Noxpr;
+    use pyo3::prelude::*;
+
+    Python::with_gil(|py| {
+        let jnp = py.import("jax.numpy").unwrap();
+        let arr = jnp.call_method1("arange", (6,)).unwrap()
+                     .call_method1("reshape", (2, 3)).unwrap();
+        // Inject a JAX array into noxpr
+        let x = Noxpr::jax(arr.into_py(py));
+        let y = x.sin().log(); // freely compose noxpr ops
+        println!("y shape: {:?}", y.shape());
+    });
+}
+```
+### Debug & helpers
+
+> Pretty-print the graph (human-readable IR)
+
+```rust
+use crate::noxpr::PrettyPrintTracer;
+
+let mut pp = PrettyPrintTracer::default();
+let mut s = String::new();
+pp.visit(&f.inner, &mut s).unwrap();
+println!("{s}");
+```

--- a/libs/nox/src/noxpr/README.md
+++ b/libs/nox/src/noxpr/README.md
@@ -113,27 +113,6 @@ let y_t = y.transpose(smallvec![1, 0]);
 let z = y_t.reshape(smallvec![12]);
 ```
 
-### Feature 5 — JAX bridge (optional)
-
-> Available when the `jax` feature is enabled. Handy for quick prototyping/debugging from Python.
-
-```rust
-#[cfg(feature = "jax")]
-{
-    use crate::noxpr::Noxpr;
-    use pyo3::prelude::*;
-
-    Python::with_gil(|py| {
-        let jnp = py.import("jax.numpy").unwrap();
-        let arr = jnp.call_method1("arange", (6,)).unwrap()
-                     .call_method1("reshape", (2, 3)).unwrap();
-        // Inject a JAX array into noxpr
-        let x = Noxpr::jax(arr.into_py(py));
-        let y = x.sin().log(); // freely compose noxpr ops
-        println!("y shape: {:?}", y.shape());
-    });
-}
-```
 ### Debug & helpers
 
 > Pretty-print the graph (human-readable IR)

--- a/libs/nox/src/noxpr/README.md
+++ b/libs/nox/src/noxpr/README.md
@@ -28,7 +28,7 @@ All snippets are supposed to be within the `nox` crate (or its internal modules)
 > Example: define `a`, `b` (f32 vectors of length 3), then `expr = dot(((a + 1) * b), a)` and wrap it in a `NoxprFn`.
 
 ```rust
-use crate::noxpr::{Noxpr, NoxprFn, ArrayTy, NoxprTy, NoxprScalarExt};
+use crate::nox::{Noxpr, NoxprFn, ArrayTy, NoxprTy, NoxprScalarExt};
 use smallvec::smallvec;
 use xla::ElementType;
 
@@ -61,11 +61,16 @@ println!("{}", f);
 > Starting from a `NoxprFn`, produce an `xla::XlaOp` then an `xla::XlaComputation`.  
 
 ```rust
-use crate::noxpr::NoxprFn;
+use nox::NoxprFn;
+
+# fn main() -> Result<(), nox::Error> {
+# let f = nox::doctest::noxpr::example_function();
 
 let xla_op = f.build("feat1_example")?;   // Built via XlaTracer
 let comp   = xla_op.build()?;             // xla::XlaComputation
 println!("{}", comp.to_hlo_text()?);
+# Ok(())
+# }
 ```
 
 ---
@@ -76,13 +81,20 @@ println!("{}", comp.to_hlo_text()?);
 > *Note:* input types/shapes must match the XLA signature.
 
 ```rust
-use crate::{Client, tensor};
-
+use nox::{Client, tensor};
+use xla::XlaComputation;
+# fn main() -> Result<(), nox::Error> {
 let client = Client::cpu()?;
-let exec   = comp.compile(&client)?;
 
+# let f = nox::doctest::noxpr::example_function();
+# let xla_op = f.build("feat1_example")?;   // Built via XlaTracer
+# let comp   = xla_op.build()?;             // xla::XlaComputation
+
+let exec   = comp.compile(&client)?;
 let input  = tensor![1.0f32, 2.0, 3.0];
 let out    = exec.run(&client, input)?.to_host();
+# Ok(())
+# }
 ```
 
 ---
@@ -92,7 +104,7 @@ let out    = exec.run(&client, input)?.to_host();
 > Tiny recipes around typed operators. All start from `Noxpr`.
 
 ```rust
-use crate::noxpr::{Noxpr, ArrayTy, NoxprTy};
+use nox::{Noxpr, ArrayTy, NoxprTy};
 use smallvec::smallvec;
 use xla::ElementType;
 
@@ -118,10 +130,11 @@ let z = y_t.reshape(smallvec![12]);
 > Pretty-print the graph (human-readable IR)
 
 ```rust
-use crate::noxpr::PrettyPrintTracer;
+use nox::PrettyPrintTracer;
 
 let mut pp = PrettyPrintTracer::default();
 let mut s = String::new();
+let f = nox::doctest::noxpr::example_function();
 pp.visit(&f.inner, &mut s).unwrap();
 println!("{s}");
 ```

--- a/libs/nox/src/noxpr/README.md
+++ b/libs/nox/src/noxpr/README.md
@@ -102,7 +102,7 @@ let mut args = BufferArgsRef::default();
 
 // Convert tensor arguments to typed buffers.
 let typed_buffer_a = a.as_typed_buffer(&client)?;
-let typed_buffer_b = a.as_typed_buffer(&client)?;
+let typed_buffer_b = b.as_typed_buffer(&client)?;
 args.push(&typed_buffer_a.as_ref().buffer);
 args.push(&typed_buffer_b.as_ref().buffer);
 
@@ -113,7 +113,7 @@ let mut out = exec.execute_buffers(args)?;
 let tensor_out = Tensor::from_typed_buffers(&Tensor::from_pjrt_buffers(&mut out))?;
 
 // Check the result.
-assert_eq!(tensor_out, tensor![50.0f32]);
+assert_eq!(tensor_out, tensor![110.0f32]);
 # Ok(())
 # }
 ```

--- a/libs/nox/src/noxpr/README.md
+++ b/libs/nox/src/noxpr/README.md
@@ -82,7 +82,6 @@ println!("{}", comp.to_hlo_text()?);
 
 ```rust
 use nox::{Client, tensor};
-use xla::XlaComputation;
 # fn main() -> Result<(), nox::Error> {
 let client = Client::cpu()?;
 
@@ -90,9 +89,9 @@ let client = Client::cpu()?;
 # let xla_op = f.build("feat1_example")?;   // Built via XlaTracer
 # let comp   = xla_op.build()?;             // xla::XlaComputation
 
-let exec   = comp.compile(&client)?;
+let exec   = client.compile(&comp)?;
 let input  = tensor![1.0f32, 2.0, 3.0];
-let out    = exec.run(&client, input)?.to_host();
+let out    = exec.execute_buffers(input)?.to_host();
 # Ok(())
 # }
 ```

--- a/libs/nox/src/noxpr/mod.rs
+++ b/libs/nox/src/noxpr/mod.rs
@@ -1,3 +1,4 @@
+#![doc = include_str!("README.md")]
 mod batch;
 mod builder;
 mod client;

--- a/libs/nox/src/noxpr/node.rs
+++ b/libs/nox/src/noxpr/node.rs
@@ -2048,7 +2048,7 @@ impl PrettyPrintTracer {
     }
 
     /// Visits a `Noxpr` and prints it in a readable format.
-    fn visit<W: std::fmt::Write>(
+    pub fn visit<W: std::fmt::Write>(
         &mut self,
         expr: &Noxpr,
         writer: &mut W,


### PR DESCRIPTION
`noxpr` is not publicly exposed. In `libs/nox/src/lib.rs`, it’s declared as a private module:
```rust
#[cfg(feature = "noxpr")]
mod noxpr; // not public (no `pub`)
```
- As a result, I could'nt include externally tested examples that would import `nox::noxpr` from another crate; it wouldn’t compile.
- Instead, I added snippets inspired by noxpr’s unit tests (from `noxpr/node.rs`). These are meant as small recipes to reuse from inside the nox crate (or its internal modules), not as standalone, executable examples.