### PR TITLE
feature: Sort the components in UI.

### DIFF
--- a/libs/db/eql/src/lib.rs
+++ b/libs/db/eql/src/lib.rs
@@ -1,7 +1,7 @@
 use convert_case::Casing;
 use std::{
     borrow::Cow,
-    collections::{BTreeSet, HashMap},
+    collections::{BTreeSet, BTreeMap},
     str::FromStr,
     sync::Arc,
 };
@@ -351,7 +351,7 @@ pub struct ComponentPart {
     pub name: String,
     pub id: ComponentId,
     pub component: Option<Arc<Component>>,
-    pub children: HashMap<String, ComponentPart>,
+    pub children: BTreeMap<String, ComponentPart>,
 }
 
 #[derive(Clone, Debug)]
@@ -398,7 +398,7 @@ fn default_element_names(shape: &[u64]) -> Vec<String> {
 
 #[derive(Debug)]
 pub struct Context {
-    pub component_parts: HashMap<String, ComponentPart>,
+    pub component_parts: BTreeMap<String, ComponentPart>,
     pub earliest_timestamp: Timestamp,
     pub last_timestamp: Timestamp,
 }
@@ -406,7 +406,7 @@ pub struct Context {
 impl Default for Context {
     fn default() -> Self {
         Context {
-            component_parts: HashMap::new(),
+            component_parts: BTreeMap::new(),
             earliest_timestamp: Timestamp(i64::MIN),
             last_timestamp: Timestamp(i64::MAX),
         }
@@ -419,7 +419,7 @@ impl Context {
         earliest_timestamp: Timestamp,
         last_timestamp: Timestamp,
     ) -> Self {
-        let mut component_parts = HashMap::new();
+        let mut component_parts = BTreeMap::new();
         for component in components.into_iter() {
             let path = ComponentPath::from_name(&component.name);
             let nodes = component.name.split('.');
@@ -435,7 +435,7 @@ impl Context {
                     .or_insert_with(|| ComponentPart {
                         id: part.id,
                         name: part.name.to_string(),
-                        children: HashMap::new(),
+                        children: BTreeMap::new(),
                         component: None,
                     });
                 component_parts = &mut part.children;
@@ -446,12 +446,12 @@ impl Context {
                 ComponentPart {
                     id: component.id,
                     name: component.name.clone(),
-                    children: HashMap::new(),
+                    children: BTreeMap::new(),
                     component: Some(component),
                 },
             );
         }
-        // let mut component_parts = HashMap::new();
+        // let mut component_parts = BTreeMap::new();
         // for component in components {
         //     component_parts.insert(component.name.clone(), component);
         // }
@@ -463,7 +463,7 @@ impl Context {
     }
 
     pub fn new(
-        component_parts: HashMap<String, ComponentPart>,
+        component_parts: BTreeMap<String, ComponentPart>,
         earliest_timestamp: Timestamp,
         last_timestamp: Timestamp,
     ) -> Self {
@@ -895,7 +895,7 @@ mod tests {
             name: "b.velocity".to_string(),
             id: ComponentId::new("b.velocity"),
             component: Some(component2),
-            children: HashMap::default(),
+            children: BTreeMap::default(),
         });
 
         // Test Tuple with components from different tables
@@ -949,7 +949,7 @@ mod tests {
             name: "b.velocity".to_string(),
             id: ComponentId::new("b.velocity"),
             component: Some(component2),
-            children: HashMap::default(),
+            children: BTreeMap::default(),
         });
 
         let component3 = Arc::new(Component::new(
@@ -962,7 +962,7 @@ mod tests {
             name: "c.acceleration".to_string(),
             id: ComponentId::new("c.acceleration"),
             component: Some(component3),
-            children: HashMap::default(),
+            children: BTreeMap::default(),
         });
 
         let expr = Expr::Tuple(vec![

--- a/libs/db/eql/src/lib.rs
+++ b/libs/db/eql/src/lib.rs
@@ -1,7 +1,7 @@
 use convert_case::Casing;
 use std::{
     borrow::Cow,
-    collections::{BTreeSet, BTreeMap},
+    collections::{BTreeMap, BTreeSet},
     str::FromStr,
     sync::Arc,
 };

--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -981,18 +981,8 @@ pub fn clamp_current_time(
     }
 }
 
-#[derive(Resource)]
+#[derive(Default, Resource)]
 pub struct EqlContext(pub eql::Context);
-
-impl Default for EqlContext {
-    fn default() -> Self {
-        Self(eql::Context::new(
-            HashMap::new(),
-            Timestamp(i64::MIN),
-            Timestamp(i64::MAX),
-        ))
-    }
-}
 
 pub fn update_eql_context(
     component_metadata_registry: Res<ComponentMetadataRegistry>,

--- a/libs/elodin-editor/src/ui/command_palette/palette_items.rs
+++ b/libs/elodin-editor/src/ui/command_palette/palette_items.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::BTreeMap,
     path::{Path, PathBuf},
     str::FromStr,
     time::Duration,
@@ -298,7 +298,7 @@ pub fn create_graph(tile_id: Option<TileId>) -> PaletteItem {
 }
 
 fn graph_parts(
-    parts: &HashMap<String, eql::ComponentPart>,
+    parts: &BTreeMap<String, eql::ComponentPart>,
     tile_id: Option<TileId>,
 ) -> Vec<PaletteItem> {
     parts
@@ -361,7 +361,7 @@ pub fn create_monitor(tile_id: Option<TileId>) -> PaletteItem {
 }
 
 fn monitor_parts(
-    parts: &HashMap<String, eql::ComponentPart>,
+    parts: &BTreeMap<String, eql::ComponentPart>,
     tile_id: Option<TileId>,
 ) -> Vec<PaletteItem> {
     parts

--- a/libs/elodin-editor/src/ui/hierarchy.rs
+++ b/libs/elodin-editor/src/ui/hierarchy.rs
@@ -1,4 +1,5 @@
 use crate::EqlContext;
+use crate::ui::{EntityFilter, EntityPair, SelectedObject, colors::get_scheme};
 use bevy::ecs::{
     system::{ResMut, SystemParam, SystemState},
     world::World,
@@ -8,7 +9,6 @@ use bevy_egui::egui;
 use fuzzy_matcher::{FuzzyMatcher, skim::SkimMatcherV2};
 use impeller2_bevy::EntityMap;
 use std::collections::BTreeMap;
-use crate::ui::{EntityFilter, EntityPair, SelectedObject, colors::get_scheme};
 
 use super::{inspector::search, schematic::Branch, widgets::WidgetSystem};
 

--- a/libs/elodin-editor/src/ui/hierarchy.rs
+++ b/libs/elodin-editor/src/ui/hierarchy.rs
@@ -7,8 +7,7 @@ use bevy::prelude::Res;
 use bevy_egui::egui;
 use fuzzy_matcher::{FuzzyMatcher, skim::SkimMatcherV2};
 use impeller2_bevy::EntityMap;
-use std::collections::HashMap;
-
+use std::collections::BTreeMap;
 use crate::ui::{EntityFilter, EntityPair, SelectedObject, colors::get_scheme};
 
 use super::{inspector::search, schematic::Branch, widgets::WidgetSystem};
@@ -166,7 +165,7 @@ fn component_part(
 }
 
 fn filter_component_parts<'a, 'b>(
-    children: &'b HashMap<String, eql::ComponentPart>,
+    children: &'b BTreeMap<String, eql::ComponentPart>,
     matcher: &SkimMatcherV2,
     str: &'a str,
 ) -> (Vec<(i64, String, &'b eql::ComponentPart)>, &'a str) {


### PR DESCRIPTION
This addresses issue #150: Sorts the components in the UI.

The change is simple. Instead of using a `HashMap` as a backing store for the EQL context, I switched it to a `BTreeMap`, which stores its keys in order. No extra allocations, no on-request sorting required.

I confirmed this by looking at the drones examples and doing a Command-P, "Create Graph", select "drone", and see that all its components are in alphabetical order.

```sh
cd lib/nox-py
cargo run --manifest-path=../../apps/elodin/Cargo.toml editor ../../examples/drone/main.py
```