### PR TITLE
doc: Update change log.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ## v0.15
 
 ### v0.15.0
+- **(feature)** Lock graphs to same x-axis zoom
+- **(feature)** Editable panel titles
+- **(feature)** Components sorted alphabetically
 - **(fix)** Add auto-tick advancement to JaxSim.
 - **(breaking)** Handle UI and object visualization using new schematics format. See [migration guide](/reference/migration/to-0-15).
 - **(fix)** Stop endlessly creating entities for packet handling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - **(fix)** Add auto-tick advancement to JaxSim.
 - **(breaking)** Handle UI and object visualization using new schematics format. See [migration guide](/reference/migration/to-0-15).
 - **(fix)** Stop endlessly creating entities for packet handling.
+- **(breaking)** The entity concept was removed from the DB, breaking previous saves.
 - **(breaking)** Replace `set_component_name` with `set_component_metadata` in C++ API to support setting element names.
 - **(breaking)** `exec.history()` now expects a component name, or a list of component names. If multiple component names are provided, they will be joined on the "time" column.
 - **(fix)** Fix bug where component values for tick 0 (initial component values before simulating) and tick 1 would have the same timestamps.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@
 ## v0.15
 
 ### v0.15.0
-- **(feature)** Lock graphs to same x-axis zoom
-- **(feature)** Editable panel titles
-- **(feature)** Components sorted alphabetically
+- **(feat)** UI: Lock graphs to same x-axis zoom
+- **(feat)** UI: Editable panel titles
+- **(feat)** UI: Sort components alphabetically by name
+- **(feat)** Add DeepStream binary to Aleph
+- **(feat)** Add Rust example: Rocket Trim Client Control
+- **(feat)** Allow custom save location for DB
+- **(feat)** Add component discovery Python command
+- **(doc)** Add READMEs for `nox/noxpr`, `nox_frames`, `nox_array`
 - **(fix)** Add auto-tick advancement to JaxSim.
 - **(breaking)** Handle UI and object visualization using new schematics format. See [migration guide](/reference/migration/to-0-15).
 - **(fix)** Stop endlessly creating entities for packet handling.

--- a/docs/public/content/releases/changelog.md
+++ b/docs/public/content/releases/changelog.md
@@ -16,6 +16,9 @@ order = 1
 ## v0.15
 
 ### v0.15.0
+- **(feature)** Lock graphs to same x-axis zoom
+- **(feature)** Editable panel titles
+- **(feature)** Components sorted alphabetically
 - **(fix)** Add auto-tick advancement to JaxSim.
 - **(breaking)** Handle UI and object visualization using new schematics format. See [migration guide](/reference/migration/to-0-15).
 - **(fix)** Stop endlessly creating entities for packet handling.

--- a/docs/public/content/releases/changelog.md
+++ b/docs/public/content/releases/changelog.md
@@ -16,9 +16,14 @@ order = 1
 ## v0.15
 
 ### v0.15.0
-- **(feature)** Lock graphs to same x-axis zoom
-- **(feature)** Editable panel titles
-- **(feature)** Components sorted alphabetically
+- **(feat)** UI: Lock graphs to same x-axis zoom
+- **(feat)** UI: Editable panel titles
+- **(feat)** UI: Sort components alphabetically by name
+- **(feat)** Add DeepStream binary to Aleph
+- **(feat)** Add Rust example: Rocket Trim Client Control
+- **(feat)** Allow custom save location for DB
+- **(feat)** Add component discovery Python command
+- **(doc)** Add READMEs for `nox/noxpr`, `nox_frames`, `nox_array`
 - **(fix)** Add auto-tick advancement to JaxSim.
 - **(breaking)** Handle UI and object visualization using new schematics format. See [migration guide](/reference/migration/to-0-15).
 - **(fix)** Stop endlessly creating entities for packet handling.


### PR DESCRIPTION
Updated the changelog post-hoc for the v0.15.0 release.

The changelog was not comprehensive when released. (Doh!) I updated it here, and I updated the [github release page](https://github.com/elodin-sys/elodin/releases/tag/v0.15.0) manually.