### PR TITLE
Fix the component monitor KDL

### DIFF
--- a/libs/elodin-editor/src/ui/command_palette/palette_items.rs
+++ b/libs/elodin-editor/src/ui/command_palette/palette_items.rs
@@ -373,7 +373,7 @@ fn monitor_parts(
                 "Component",
                 move |_: In<String>, mut tile_state: ResMut<tiles::TileState>| {
                     if let Some(component) = &part.component {
-                        tile_state.create_monitor_tile(component.id, tile_id);
+                        tile_state.create_monitor_tile(component.name.clone(), tile_id);
                         PaletteEvent::Exit
                     } else {
                         PalettePage::new(monitor_parts(&part.children, tile_id)).into()

--- a/libs/elodin-editor/src/ui/monitor.rs
+++ b/libs/elodin-editor/src/ui/monitor.rs
@@ -10,14 +10,14 @@ use super::{colors::get_scheme, widgets::WidgetSystem};
 #[derive(Clone)]
 pub struct MonitorPane {
     pub label: String,
-    pub eql: String,
+    pub component_name: String,
 }
 
 impl MonitorPane {
-    pub fn new(label: String, eql: String) -> Self {
+    pub fn new(label: String, component_name: String) -> Self {
         Self {
             label,
-            eql,
+            component_name,
         }
     }
 }
@@ -45,7 +45,7 @@ impl WidgetSystem for MonitorWidget<'_, '_> {
             mut component_value_query,
             entity_map,
         } = state.get_mut(world);
-        let component_id = ComponentId::new("world_pos");
+        let component_id = ComponentId::new(&pane.component_name);
         let Some(entity) = entity_map.get(&component_id) else {
             return;
         };

--- a/libs/elodin-editor/src/ui/monitor.rs
+++ b/libs/elodin-editor/src/ui/monitor.rs
@@ -10,14 +10,14 @@ use super::{colors::get_scheme, widgets::WidgetSystem};
 #[derive(Clone)]
 pub struct MonitorPane {
     pub label: String,
-    pub component_id: ComponentId,
+    pub eql: String,
 }
 
 impl MonitorPane {
-    pub fn new(label: String, component_id: ComponentId) -> Self {
+    pub fn new(label: String, eql: String) -> Self {
         Self {
             label,
-            component_id,
+            eql,
         }
     }
 }
@@ -45,10 +45,11 @@ impl WidgetSystem for MonitorWidget<'_, '_> {
             mut component_value_query,
             entity_map,
         } = state.get_mut(world);
-        let Some(entity) = entity_map.get(&pane.component_id) else {
+        let component_id = ComponentId::new("world_pos");
+        let Some(entity) = entity_map.get(&component_id) else {
             return;
         };
-        let Some(metadata) = metadata_store.get_metadata(&pane.component_id) else {
+        let Some(metadata) = metadata_store.get_metadata(&component_id) else {
             return;
         };
 

--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -268,7 +268,7 @@ impl LoadSchematicParams<'_, '_> {
                     .insert_tile(Tile::Pane(Pane::Graph(graph)), parent_id, false)
             }
             Panel::ComponentMonitor(monitor) => {
-                let pane = MonitorPane::new("Monitor".to_string(), monitor.eql.clone());
+                let pane = MonitorPane::new("Monitor".to_string(), monitor.component_name.clone());
                 self.tile_state
                     .insert_tile(Tile::Pane(Pane::Monitor(pane)), parent_id, false)
             }

--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -268,7 +268,7 @@ impl LoadSchematicParams<'_, '_> {
                     .insert_tile(Tile::Pane(Pane::Graph(graph)), parent_id, false)
             }
             Panel::ComponentMonitor(monitor) => {
-                let pane = MonitorPane::new("Monitor".to_string(), monitor.component_id);
+                let pane = MonitorPane::new("Monitor".to_string(), monitor.eql.clone());
                 self.tile_state
                     .insert_tile(Tile::Pane(Pane::Monitor(pane)), parent_id, false)
             }

--- a/libs/elodin-editor/src/ui/schematic/mod.rs
+++ b/libs/elodin-editor/src/ui/schematic/mod.rs
@@ -95,7 +95,7 @@ impl SchematicParam<'_, '_> {
                 }
 
                 Pane::Monitor(monitor) => Some(Panel::ComponentMonitor(ComponentMonitor {
-                    component_id: monitor.component_id,
+                    eql: monitor.eql.clone(),
                 })),
 
                 Pane::QueryTable(query_table) => {

--- a/libs/elodin-editor/src/ui/schematic/mod.rs
+++ b/libs/elodin-editor/src/ui/schematic/mod.rs
@@ -95,7 +95,7 @@ impl SchematicParam<'_, '_> {
                 }
 
                 Pane::Monitor(monitor) => Some(Panel::ComponentMonitor(ComponentMonitor {
-                    eql: monitor.eql.clone(),
+                    component_name: monitor.component_name.clone(),
                 })),
 
                 Pane::QueryTable(query_table) => {

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -15,7 +15,6 @@ use bevy_render::{
 };
 use egui::UiBuilder;
 use egui_tiles::{Container, Tile, TileId, Tiles};
-use impeller2::types::ComponentId;
 use impeller2_wkt::{Dashboard, Graph, Viewport};
 use smallvec::SmallVec;
 use std::collections::{BTreeMap, HashMap};
@@ -155,8 +154,7 @@ impl TileState {
     }
 
     pub fn create_monitor_tile(&mut self, eql: String, tile_id: Option<TileId>) {
-        self.tree_actions
-            .push(TreeAction::AddMonitor(tile_id, eql));
+        self.tree_actions.push(TreeAction::AddMonitor(tile_id, eql));
     }
 
     pub fn create_action_tile(

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -154,9 +154,9 @@ impl TileState {
         self.tree_actions.push(TreeAction::AddViewport(None));
     }
 
-    pub fn create_monitor_tile(&mut self, component_id: ComponentId, tile_id: Option<TileId>) {
+    pub fn create_monitor_tile(&mut self, eql: String, tile_id: Option<TileId>) {
         self.tree_actions
-            .push(TreeAction::AddMonitor(tile_id, component_id));
+            .push(TreeAction::AddMonitor(tile_id, eql));
     }
 
     pub fn create_action_tile(
@@ -633,7 +633,7 @@ struct TreeBehavior<'w> {
 pub enum TreeAction {
     AddViewport(Option<TileId>),
     AddGraph(Option<TileId>, Option<GraphBundle>),
-    AddMonitor(Option<TileId>, ComponentId),
+    AddMonitor(Option<TileId>, String),
     AddQueryTable(Option<TileId>),
     AddQueryPlot(Option<TileId>),
     AddActionTile(Option<TileId>, String, String),
@@ -1242,8 +1242,8 @@ impl WidgetSystem for TileLayout<'_, '_> {
                             ui_state.graphs.insert(tile_id, graph_id);
                         }
                     }
-                    TreeAction::AddMonitor(parent_tile_id, component_id) => {
-                        let monitor = MonitorPane::new("Monitor".to_string(), component_id);
+                    TreeAction::AddMonitor(parent_tile_id, eql) => {
+                        let monitor = MonitorPane::new("Monitor".to_string(), eql);
 
                         let pane = Pane::Monitor(monitor);
                         if let Some(tile_id) =

--- a/libs/impeller2/kdl/src/de.rs
+++ b/libs/impeller2/kdl/src/de.rs
@@ -213,18 +213,17 @@ fn parse_graph(node: &KdlNode, src: &str) -> Result<Panel, KdlSchematicError> {
 }
 
 fn parse_component_monitor(node: &KdlNode, src: &str) -> Result<Panel, KdlSchematicError> {
-    let component_id = node
+    let eql = node
         .get("component_id")
         .and_then(|v| v.as_string())
-        .map(ComponentId::new)
         .ok_or_else(|| KdlSchematicError::MissingProperty {
-            property: "component_id".to_string(),
+            property: "eql".to_string(),
             node: "component_monitor".to_string(),
             src: src.to_string(),
             span: node.span(),
         })?;
 
-    Ok(Panel::ComponentMonitor(ComponentMonitor { component_id }))
+    Ok(Panel::ComponentMonitor(ComponentMonitor { eql: eql.to_string() }))
 }
 
 fn parse_action_pane(node: &KdlNode, src: &str) -> Result<Panel, KdlSchematicError> {

--- a/libs/impeller2/kdl/src/de.rs
+++ b/libs/impeller2/kdl/src/de.rs
@@ -1,4 +1,3 @@
-use impeller2::types::ComponentId;
 use impeller2_wkt::{Color, Schematic, SchematicElem};
 use kdl::{KdlDocument, KdlNode};
 use std::collections::HashMap;
@@ -213,17 +212,17 @@ fn parse_graph(node: &KdlNode, src: &str) -> Result<Panel, KdlSchematicError> {
 }
 
 fn parse_component_monitor(node: &KdlNode, src: &str) -> Result<Panel, KdlSchematicError> {
-    let eql = node
-        .get("component_id")
+    let component_name = node
+        .get("component_name")
         .and_then(|v| v.as_string())
         .ok_or_else(|| KdlSchematicError::MissingProperty {
-            property: "eql".to_string(),
+            property: "component_name".to_string(),
             node: "component_monitor".to_string(),
             src: src.to_string(),
             span: node.span(),
         })?;
 
-    Ok(Panel::ComponentMonitor(ComponentMonitor { eql: eql.to_string() }))
+    Ok(Panel::ComponentMonitor(ComponentMonitor { component_name: component_name.to_string() }))
 }
 
 fn parse_action_pane(node: &KdlNode, src: &str) -> Result<Panel, KdlSchematicError> {
@@ -1140,15 +1139,15 @@ object_3d "a.world_pos" {
 
     #[test]
     fn test_component_monitor() {
-        let kdl = r#"component_monitor component_id="a.world_pos""#;
+        let kdl = r#"component_monitor component_name="a.world_pos""#;
         let schematic = parse_schematic(kdl).unwrap();
 
         assert_eq!(schematic.elems.len(), 1);
 
         if let SchematicElem::Panel(Panel::ComponentMonitor(monitor)) = &schematic.elems[0] {
-            assert_eq!(monitor.component_id, ComponentId::new("a.world_pos"));
+            assert_eq!(monitor.component_name, "a.world_pos");
         } else {
-            panic!("Expected object_3d");
+            panic!("Expected component_monitor");
         }
     }
 

--- a/libs/impeller2/kdl/src/de.rs
+++ b/libs/impeller2/kdl/src/de.rs
@@ -222,7 +222,9 @@ fn parse_component_monitor(node: &KdlNode, src: &str) -> Result<Panel, KdlSchema
             span: node.span(),
         })?;
 
-    Ok(Panel::ComponentMonitor(ComponentMonitor { component_name: component_name.to_string() }))
+    Ok(Panel::ComponentMonitor(ComponentMonitor {
+        component_name: component_name.to_string(),
+    }))
 }
 
 fn parse_action_pane(node: &KdlNode, src: &str) -> Result<Panel, KdlSchematicError> {

--- a/libs/impeller2/kdl/src/ser.rs
+++ b/libs/impeller2/kdl/src/ser.rs
@@ -161,8 +161,8 @@ fn serialize_graph<T>(graph: &Graph<T>) -> KdlNode {
 fn serialize_component_monitor(monitor: &ComponentMonitor) -> KdlNode {
     let mut node = KdlNode::new("component_monitor");
     node.entries_mut().push(KdlEntry::new_prop(
-        "component_id",
-        monitor.component_id.to_string(),
+        "eql",
+        monitor.eql.clone(),
     ));
     node
 }

--- a/libs/impeller2/kdl/src/ser.rs
+++ b/libs/impeller2/kdl/src/ser.rs
@@ -161,8 +161,8 @@ fn serialize_graph<T>(graph: &Graph<T>) -> KdlNode {
 fn serialize_component_monitor(monitor: &ComponentMonitor) -> KdlNode {
     let mut node = KdlNode::new("component_monitor");
     node.entries_mut().push(KdlEntry::new_prop(
-        "eql",
-        monitor.eql.clone(),
+        "component_name",
+        monitor.component_name.clone(),
     ));
     node
 }

--- a/libs/impeller2/wkt/src/gui.rs
+++ b/libs/impeller2/wkt/src/gui.rs
@@ -386,7 +386,7 @@ impl Asset for Object3D {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "bevy", derive(bevy::prelude::Component))]
 pub struct ComponentMonitor {
-    pub component_id: ComponentId,
+    pub eql: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]

--- a/libs/impeller2/wkt/src/gui.rs
+++ b/libs/impeller2/wkt/src/gui.rs
@@ -386,7 +386,11 @@ impl Asset for Object3D {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "bevy", derive(bevy::prelude::Component))]
 pub struct ComponentMonitor {
-    pub eql: String,
+    /// The component name that we are monitoring.
+    ///
+    /// NOTE: It may be nice to allow this to be an EQL expression that we
+    /// monitor, which can be a simple component_name.
+    pub component_name: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]


### PR DESCRIPTION
This PR fixes issue #152. Instead of using the component ID directly, which are not human readable, this serializes the component name. This improves the human readable format and makes monitors that have been serialized work again.

## Testing 

This can be tested by running the following command :

```
cd libs/nox-py
. .venv/bin/activate; # See elodin/README if not present.
cargo run --manifest-path=../../apps/elodin/Cargo.toml editor examples/three-body.py
```

### Save a KDL
Hit Command-P "Create Monitor". Select a component. Observe monitor pane. Hit Command-P "Save Schematic As...", name it "a.kdl". 

### Load a KDL
Restart app. Hit Command-P "Load Schematic" a.kdl and observe monitor is present and working.