### PR TITLE
feat(docs): Add a means of testing public docs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2984,6 +2984,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmd_lib"
+version = "1.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1af0f9b65935ff457da75535a6b6ff117ac858f03f71191188b3b696f90aec5a"
+dependencies = [
+ "cmd_lib_macros",
+ "env_logger 0.10.2",
+ "faccess",
+ "lazy_static",
+ "log",
+ "os_pipe",
+]
+
+[[package]]
+name = "cmd_lib_macros"
+version = "1.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e69eee115667ccda8b9ed7010bcf13356ad45269fc92aa78534890b42809a64"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "cobs"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4969,6 +4995,19 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
 version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
@@ -5144,6 +5183,17 @@ dependencies = [
  "rayon-core",
  "smallvec",
  "zune-inflate",
+]
+
+[[package]]
+name = "faccess"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ae66425802d6a903e268ae1a08b8c38ba143520f227a205edf4e9c7e3e26d5"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -5748,6 +5798,15 @@ checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
 dependencies = [
  "libc",
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -7619,6 +7678,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
+name = "literate"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2a17cb625f160b06c1626852870e08a22b6e4e365d3ca48dec02031489123b"
+dependencies = [
+ "pulldown-cmark",
+ "regex",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "literate-tests"
+version = "0.15.0"
+dependencies = [
+ "cmd_lib",
+ "literate",
+]
+
+[[package]]
 name = "litrs"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7642,9 +7721,9 @@ checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "loom"
@@ -9323,6 +9402,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db335f4760b14ead6290116f2427bf33a14d4f0617d49f78a246de10c1831224"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10024,6 +10113,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f58e5423e24c18cc840e1c98370b3993c6649cd1678b4d24318bcf0a083cbe88"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
+dependencies = [
+ "bitflags 2.9.0",
+ "getopts",
+ "memchr",
+ "unicase",
 ]
 
 [[package]]
@@ -12691,6 +12792,12 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ members = [
     "libs/db/eql",
     "libs/impeller2/kdl",
     "libs/db/examples/rust_client"
- ]
+ , "docs/literate-tests"]
 exclude = ["fsw/sensor-fw", "fsw/blackbox", "docs/memserve"]
 
 [workspace.package]

--- a/docs/literate-tests/Cargo.toml
+++ b/docs/literate-tests/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "literate-tests"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+
+[dependencies]
+
+[build-dependencies]
+literate = "0.5"
+cmd_lib = "1.9"

--- a/docs/literate-tests/build.rs
+++ b/docs/literate-tests/build.rs
@@ -1,0 +1,94 @@
+// build.rs
+use std::{
+    env,
+    io::{BufReader, BufWriter, Write},
+    fs::File,
+    path::{Path, PathBuf},
+};
+use literate::{LiterateError, CodeMatcher};
+use cmd_lib::run_cmd;
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    process_file("docs/public/content/home/bouncing-ball.md", "bouncing-ball.py", Language::Python);
+    process_file("docs/public/content/home/3-body.md", "3-body.py", Language::Python);
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Language {
+    Rust,
+    Python,
+}
+
+impl Language {
+    fn extension(&self) -> &'static str {
+        match self {
+            Language::Rust => "rs",
+            Language::Python => "py",
+        }
+    }
+
+    fn block(&self) -> &'static str {
+        match self {
+            Language::Rust => "rust",
+            Language::Python => "python",
+        }
+    }
+
+    fn comment(&self) -> &'static str {
+        match self {
+            Language::Rust => "//",
+            Language::Python => "#",
+        }
+    }
+}
+
+/// Provide the path from the root elodin directory.
+fn process_file(source: &str, output_file_name: &str, language: Language) {
+
+    let mut output = PathBuf::from(env::var("OUT_DIR").unwrap());
+    output.push(output_file_name);
+    // Tell Cargo to re-run the build script if the Markdown file changes
+    println!("cargo:rerun-if-changed={}", source);
+
+    let mut input = PathBuf::from("../..");
+    input.push(source);
+    let _ = extract_file(&input, &output, language)
+        .expect("Failed to process literate file");
+
+    match language {
+        Language::Rust => {
+            // These files can now be included in the code.
+        }
+        Language::Python => {
+            // It'd be nice to do a format check here at least.
+            run_cmd!{
+                ruff check ${output}
+            }.expect("Failed python format check");
+        }
+    }
+}
+
+// This will extract code blocks and write them to a new file.
+fn extract_file(source: &Path, target: &Path, language: Language) -> Result<usize, LiterateError> {
+    // Read the source markdown file
+    let input = BufReader::new(File::open(source)?);
+
+    // Create the target directory if it doesn't exist
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    
+    // Create the output file
+    let mut output = BufWriter::new(File::create(target)?);
+
+    let comment_prefix = language.comment();
+    // Write a warning header comment to put the file into read-only mode in Emacs and vim.
+    writeln!(output, r#"{} vim:set ro: -*- buffer-read-only:t -*-
+{} This file was automatically generated from {:?}. Please edit that file."#, comment_prefix, comment_prefix, source)?;
+
+    // Extract Rust code blocks using literate
+    literate::extract(input, output, language.block())
+}
+

--- a/docs/literate-tests/src/lib.rs
+++ b/docs/literate-tests/src/lib.rs
@@ -1,0 +1,5 @@
+// Include generated code from bouncing-ball.md
+#[cfg(test)]
+mod test {
+    // include!(concat!(env!("OUT_DIR"), "/bouncing-ball.rs"));
+}


### PR DESCRIPTION
The public docs are written in a semi-literate programming style. Semi-literate in the sense they aren't written in a Knuth Literate Programming style, which is a complex and comprehensive system for creating multiple program files from multiple document files. The semi-literate programming uses a simpler approach, one markdown file to create one code file, which I think is preferable in this case.

Semi-literate programs differ from doc-tests because code blocks in doc-tests are isolated: one code block has no bearing on another. Instead a semi-literate program blocks are expected to accrue from top to bottom. In a way, it's like writing a program but flipping it from default code and exceptional comments to default comment and exceptional code.

This commit adds a literate-tests crate internal to docs that can be directed to extract Rust or Python code from markdown files and then test, exercise, or check formatting of those of those files. In this way, the aim is to bring the public docs under our regular CI test regime, so that they will be flagged when changes break them.