### PR TITLE
Fix db connection thread leak

### DIFF
--- a/libs/elodin-editor/src/ui/actions.rs
+++ b/libs/elodin-editor/src/ui/actions.rs
@@ -37,20 +37,18 @@ impl LuaActor {
                 warn!(?err, "error spawning lua client");
                 return;
             }
-            loop {
-                if let Ok((cmd, res_tx)) = cmd_rx.recv() {
-                    match lua.load(&cmd).eval_async::<MultiValue>().await {
-                        Ok(values) => {
-                            let val = values
-                                .iter()
-                                .map(|value| format!("{:#?}", value))
-                                .collect::<Vec<_>>()
-                                .join("\t");
-                            let _ = res_tx.send(Ok(val));
-                        }
-                        Err(err) => {
-                            let _ = res_tx.send(Err(err.to_string()));
-                        }
+            while let Ok((cmd, res_tx)) = cmd_rx.recv() {
+                match lua.load(&cmd).eval_async::<MultiValue>().await {
+                    Ok(values) => {
+                        let val = values
+                            .iter()
+                            .map(|value| format!("{:#?}", value))
+                            .collect::<Vec<_>>()
+                            .join("\t");
+                        let _ = res_tx.send(Ok(val));
+                    }
+                    Err(err) => {
+                        let _ = res_tx.send(Err(err.to_string()));
                     }
                 }
             }


### PR DESCRIPTION
When connected to an elodin-db instance, if the connection is dropped, the thread managing the connection was going into a tight loop. This commit changes it to exit when recv returns an error, which results in the loop breaking and the thread exiting.