### PR TITLE
fix(inspector): restore graph inspector on title click to fix regression

### DIFF
--- a/libs/elodin-editor/src/ui/plot/widget.rs
+++ b/libs/elodin-editor/src/ui/plot/widget.rs
@@ -136,7 +136,7 @@ impl WidgetSystem for PlotWidget<'_, '_> {
             &mut graph_state,
             &scrub_icon,
             id,
-            &mut *selected_object,
+            selected_object.as_mut(),
             &mut time_range_behavior,
         );
     }

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -1313,40 +1313,31 @@ impl WidgetSystem for TileLayout<'_, '_> {
                     TreeAction::SelectTile(tile_id) => {
                         ui_state.tree.make_active(|id, _| id == tile_id);
 
-                        if let Some(tile) = ui_state.tree.tiles.get(tile_id) {
-                            if let egui_tiles::Tile::Pane(pane) = tile {
-                                match pane {
-                                    Pane::Graph(graph) => {
-                                        *state_mut.selected_object =
-                                            SelectedObject::Graph { graph_id: graph.id };
-                                        if !ui_state.has_inspector()
-                                            && !ui_state.inspector_pending()
-                                        {
-                                            ui_state
-                                                .tree_actions
-                                                .push(TreeAction::AddInspector(None));
-                                        }
+                        if let Some(egui_tiles::Tile::Pane(pane)) = ui_state.tree.tiles.get(tile_id)
+                        {
+                            match pane {
+                                Pane::Graph(graph) => {
+                                    *state_mut.selected_object =
+                                        SelectedObject::Graph { graph_id: graph.id };
+                                    if !ui_state.has_inspector() && !ui_state.inspector_pending() {
+                                        ui_state.tree_actions.push(TreeAction::AddInspector(None));
                                     }
-                                    Pane::QueryPlot(plot) => {
-                                        *state_mut.selected_object = SelectedObject::Graph {
-                                            graph_id: plot.entity,
-                                        };
-                                        if !ui_state.has_inspector()
-                                            && !ui_state.inspector_pending()
-                                        {
-                                            ui_state
-                                                .tree_actions
-                                                .push(TreeAction::AddInspector(None));
-                                        }
-                                    }
-                                    Pane::Viewport(viewport) => {
-                                        if let Some(camera) = viewport.camera {
-                                            *state_mut.selected_object =
-                                                SelectedObject::Viewport { camera };
-                                        }
-                                    }
-                                    _ => {}
                                 }
+                                Pane::QueryPlot(plot) => {
+                                    *state_mut.selected_object = SelectedObject::Graph {
+                                        graph_id: plot.entity,
+                                    };
+                                    if !ui_state.has_inspector() && !ui_state.inspector_pending() {
+                                        ui_state.tree_actions.push(TreeAction::AddInspector(None));
+                                    }
+                                }
+                                Pane::Viewport(viewport) => {
+                                    if let Some(camera) = viewport.camera {
+                                        *state_mut.selected_object =
+                                            SelectedObject::Viewport { camera };
+                                    }
+                                }
+                                _ => {}
                             }
                         }
                     }


### PR DESCRIPTION
# PR Overview

- Restore 0.14.2 behavior: when selecting a graph tab, the inspector now locks onto that graph again, fixing the regression introduced by the tab-rename changes.
- Improve inspector usability: if the inspector pane was closed earlier in the session, the next graph-tab click respawns it automatically, so the graph’s properties reappear.

# How-to test
https://github.com/user-attachments/assets/878b4f1a-979c-43cf-86ad-3a0b2824fb69

