### PR TITLE
Save elodin-db from UI [abandoned]

### DIFF
--- a/libs/impeller2/wkt/src/msgs.rs
+++ b/libs/impeller2/wkt/src/msgs.rs
@@ -519,6 +519,20 @@ impl Request for SaveArchive {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, postcard_schema::Schema)]
+pub struct SaveNative {
+    pub path: PathBuf,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, postcard_schema::Schema)]
+pub struct NativeSaved {
+    pub path: PathBuf,
+}
+
+impl Request for SaveNative {
+    type Reply<B: IoBuf + Clone> = NativeSaved;
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, postcard_schema::Schema)]
 #[serde(rename_all = "snake_case")]
 pub enum ArchiveFormat {
     ArrowIpc,


### PR DESCRIPTION
## Description

Description in this issue https://github.com/elodin-sys/elodin/issues/167, which outlines the feature both in the Command Palette (UI) and from the Elodin CLI (programmatically). _This PR covers only “Save from UI”._

---

### Allowed Save Locations

- Relative subdirectory of the current working directory (workspace) that does not yet exist, for example: `run-2024`
- Nested path under the current working directory, as long as it stays within that tree, e.g., `exports/dbs/session_01`
-  Absolute paths (`/tmp/foo`, `C:\foo`) and upward-traversing paths (`../foo`) are not accepted.
- The final folder name must not be `db`.

### How-to test

- Run the drone example: `cargo run --manifest-path=apps/elodin/Cargo.toml editor examples/drone/main.py`
- CMD+P
- `Save DB…`
- Enter "current_run" as directory name.
- Check the content of this new directory.