### PR TITLE
Remove component ID display from inspector (#164)

### DIFF
--- a/libs/elodin-editor/src/ui/inspector/entity.rs
+++ b/libs/elodin-editor/src/ui/inspector/entity.rs
@@ -68,43 +68,24 @@ impl WidgetSystem for InspectorEntity<'_, '_> {
 
         let (icons, pair) = args;
 
-        let entity_id = pair.impeller;
         let Ok(metadata) = metadata_query.get(pair.bevy) else {
             ui.add(empty_inspector());
             return tree_actions;
         };
 
         let icon_chart = icons.chart;
-
-        let mono_font = egui::TextStyle::Monospace.resolve(ui.style_mut());
         egui::Frame::NONE
             .inner_margin(egui::Margin::ZERO.top(8.0))
             .show(ui, |ui| {
-                ui.horizontal(|ui| {
-                    ui.add(
-                        label::ELabel::new(&metadata.name)
-                            .padding(egui::Margin::same(0).bottom(24.))
-                            .bottom_stroke(egui::Stroke {
-                                width: 1.0,
-                                color: get_scheme().border_primary,
-                            })
-                            .margin(egui::Margin::same(0).bottom(8.)),
-                    );
-
-                    ui.with_layout(egui::Layout::right_to_left(Align::Min), |ui| {
-                        ui.label(
-                            RichText::new(entity_id.0.to_string())
-                                .color(get_scheme().text_primary)
-                                .font(mono_font.clone()),
-                        );
-                        ui.add_space(6.0);
-                        ui.label(
-                            egui::RichText::new("ID")
-                                .color(get_scheme().text_secondary)
-                                .font(mono_font.clone()),
-                        );
-                    });
-                });
+                ui.add(
+                    label::ELabel::new(&metadata.name)
+                        .padding(egui::Margin::same(0).bottom(24.))
+                        .bottom_stroke(egui::Stroke {
+                            width: 1.0,
+                            color: get_scheme().border_primary,
+                        })
+                        .margin(egui::Margin::same(0).bottom(8.)),
+                );
             });
 
         search(ui, &mut filter.0, icons.search);


### PR DESCRIPTION
## Summary
- Remove the component ID label from the inspector header so the inspector no longer shows component IDs
