### PR TITLE
Handle BLAS lookup fallback for nox-py build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8681,6 +8681,7 @@ dependencies = [
  "nox-ecs-macros",
  "noxla",
  "numpy",
+ "pkg-config",
  "postcard",
  "pyo3",
  "roci-adcs",

--- a/libs/nox-py/Cargo.toml
+++ b/libs/nox-py/Cargo.toml
@@ -78,3 +78,6 @@ s10.path = "../s10"
 zerocopy.version = "0.8.2"
 env_logger = "0.11.8"
 convert_case = "0.8.0"
+
+[build-dependencies]
+pkg-config = "0.3"

--- a/libs/nox-py/build.rs
+++ b/libs/nox-py/build.rs
@@ -5,25 +5,7 @@ fn main() {
         .expect("noxla did not export path to libnoxla_kernels.a");
 
     #[cfg(target_os = "linux")]
-    {
-        let blas_root =
-            env::var("DEP_BLAS_ROOT").expect("netlib-src crate is not a direct dependency!");
-        let lapack_path = format!("{}/lib/liblapack-netlib.a", blas_root);
-        let blas_path = format!("{}/lib/libblas-netlib.a", blas_root);
-
-        println!("cargo:rustc-link-arg=-Wl,--no-as-needed");
-        println!("cargo:rustc-link-arg=-Wl,--whole-archive");
-        println!("cargo:rustc-link-arg={}", kernels_path);
-        println!("cargo:rustc-link-arg=-Wl,--no-whole-archive");
-
-        println!("cargo:rustc-link-arg=-Wl,--start-group");
-        println!("cargo:rustc-link-arg={}", lapack_path);
-        println!("cargo:rustc-link-arg={}", blas_path);
-        println!("cargo:rustc-link-lib=dylib=gfortran");
-        println!("cargo:rustc-link-arg=-Wl,--end-group");
-        // println!("cargo:rustc-link-arg=-Wl,-u,_gfortran_stop_string");
-        println!("cargo:rustc-link-lib=stdc++");
-    }
+    link_linux_libraries(&kernels_path);
 
     #[cfg(target_os = "macos")]
     {
@@ -31,4 +13,54 @@ fn main() {
         println!("cargo:rustc-link-arg=-Wl,-no_dead_strip_inits_and_terms");
         println!("cargo:rustc-link-lib=c++");
     }
+}
+
+#[cfg(target_os = "linux")]
+fn link_linux_libraries(kernels_path: &str) {
+    println!("cargo:rustc-link-arg=-Wl,--no-as-needed");
+    println!("cargo:rustc-link-arg=-Wl,--whole-archive");
+    println!("cargo:rustc-link-arg={}", kernels_path);
+    println!("cargo:rustc-link-arg=-Wl,--no-whole-archive");
+
+    match env::var("DEP_BLAS_ROOT") {
+        Ok(blas_root) => {
+            let lapack_path = format!("{}/lib/liblapack-netlib.a", blas_root);
+            let blas_path = format!("{}/lib/libblas-netlib.a", blas_root);
+
+            println!("cargo:rustc-link-arg=-Wl,--start-group");
+            println!("cargo:rustc-link-arg={}", lapack_path);
+            println!("cargo:rustc-link-arg={}", blas_path);
+            println!("cargo:rustc-link-arg=-Wl,--end-group");
+        }
+        Err(err) => {
+            println!(
+                "cargo:warning=DEP_BLAS_ROOT not provided ({}); falling back to pkg-config lookup for BLAS/LAPACK.",
+                err
+            );
+
+            let mut pkg_errors = Vec::new();
+            let mut found = false;
+            for lib in ["lapack", "openblas"] {
+                match pkg_config::Config::new().probe(lib) {
+                    Ok(_) => {
+                        found = true;
+                        break;
+                    }
+                    Err(probe_err) => {
+                        pkg_errors.push(format!("{lib}: {probe_err}"));
+                    }
+                }
+            }
+
+            if !found {
+                panic!(
+                    "Failed to locate a BLAS/LAPACK implementation. Set DEP_BLAS_ROOT via netlib-src or install lapack/openblas with pkg-config support. Errors: {}",
+                    pkg_errors.join(", ")
+                );
+            }
+        }
+    }
+
+    println!("cargo:rustc-link-lib=dylib=gfortran");
+    println!("cargo:rustc-link-lib=stdc++");
 }


### PR DESCRIPTION
## Summary
- add pkg-config as a build dependency for the nox-py crate
- fall back to pkg-config BLAS/LAPACK discovery when DEP_BLAS_ROOT is missing so nix shells can build

## Testing
- cargo check -p nox-py *(fails: netlib-src build script requires a Fortran compiler in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ee580cd41c8327a60eb90e157a4245