### PR TITLE
Ensure netlib-src is a direct dependency for nox-py

### DIFF
--- a/libs/nox-py/Cargo.toml
+++ b/libs/nox-py/Cargo.toml
@@ -81,3 +81,6 @@ convert_case = "0.8.0"
 
 [build-dependencies]
 pkg-config = "0.3"
+
+[target.'cfg(target_os = "linux")'.build-dependencies]
+netlib-src = { version = "0.9", features = ["static"] }


### PR DESCRIPTION
## Summary
- make netlib-src a Linux-only build dependency of nox-py so its build script exposes the BLAS installation path needed during publishing builds

## Testing
- not run (platform-specific build dependency change only)


------
https://chatgpt.com/codex/tasks/task_b_68ee5c4e722c832785c04c914c10aaf8