### PR TITLE
Fix nix develop failure for nox-py by adding lapack dependencies

### DIFF
--- a/nix/pkgs/elodin-py.nix
+++ b/nix/pkgs/elodin-py.nix
@@ -70,6 +70,8 @@
       [
         python
         openssl
+        lapack
+        openblas
         gfortran.cc.lib # Fortran runtime library for linking
         xla_ext
       ]


### PR DESCRIPTION
## Summary
- add lapack and openblas system libraries to the elodin-py build inputs so the nox-py crate can link successfully

## Testing
- nix develop *(fails in this environment because the `nix` command is unavailable)*

------
https://chatgpt.com/codex/tasks/task_b_68ee5eea62f48327b4fc131843a2266c