### PR TITLE
Add Linux lapack dependencies to nox-py

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8676,6 +8676,8 @@ dependencies = [
  "impeller2",
  "impeller2-wkt",
  "indicatif",
+ "lapack-src",
+ "lapack-sys",
  "miette 7.6.0",
  "nox-ecs",
  "nox-ecs-macros",

--- a/libs/nox-py/Cargo.toml
+++ b/libs/nox-py/Cargo.toml
@@ -82,5 +82,6 @@ convert_case = "0.8.0"
 [build-dependencies]
 pkg-config = "0.3"
 
-[target.'cfg(target_os = "linux")'.build-dependencies]
-netlib-src = { version = "0.9", features = ["static"] }
+[target.'cfg(target_os = "linux")'.dependencies]
+lapack-src = { version = "0.13", features = ["netlib"] }
+lapack-sys = "0.14"


### PR DESCRIPTION
## Summary
- add explicit lapack-src and lapack-sys dependencies for the nox-py crate when building on Linux
- ensure the Cargo.lock reflects the new dependencies so the cdylib links the LAPACK symbols

## Testing
- `cargo check -p nox-py` *(fails: missing Fortran compiler required by netlib-src build script in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ee627d80808327a1048b3bcfbf453f