### PR TITLE
docs: fix typo 'simulaton' → 'simulation' in CLI reference

### DIFF
--- a/docs/public/content/reference/elodin-cli.md
+++ b/docs/public/content/reference/elodin-cli.md
@@ -29,7 +29,7 @@ This document contains the help content for the `elodin` command-line program.
 ###### **Subcommands:**
 
 * `editor` — Launch the Elodin editor (default)
-* `run` — Run an Elodin simulaton in headless mode
+* `run` — Run an Elodin simulation in headless mode
 
 ###### **Options:**
 
@@ -55,7 +55,7 @@ Launch the Elodin editor (default)
 
 ## `elodin run`
 
-Run an Elodin simulaton in headless mode
+Run an Elodin simulation in headless mode
 
 **Usage:** `elodin run [addr/path]`
 


### PR DESCRIPTION
## Summary
Fixes typo in the Elodin CLI documentation where "simulaton" appeared twice instead of the correct spelling "simulation".

## Changes
- Fixed typo on line 32: "Run an Elodin simulaton" → "Run an Elodin simulation"
- Fixed typo on line 58: "Run an Elodin simulaton" → "Run an Elodin simulation"

Fixes #234