### PR TITLE
chore(aleph): re-enable aleph-dev, bump jetpack-nixos

### DIFF
--- a/aleph/flake.lock
+++ b/aleph/flake.lock
@@ -94,17 +94,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1746820677,
-        "narHash": "sha256-qmeJxkpSecAc3evuTvqh9uP9bVZbe0DXXEnIXGYGW7w=",
+        "lastModified": 1750793833,
+        "narHash": "sha256-DXi3/LpWYyBdrI5dLRJ26g+nnVficdcRGJNuSuY/eEA=",
         "owner": "anduril",
         "repo": "jetpack-nixos",
-        "rev": "eb413a5739515086f33c611376075bd869574f4f",
+        "rev": "de01bba154f27a96b40c7f406f1f84517ee11780",
         "type": "github"
       },
       "original": {
         "owner": "anduril",
         "repo": "jetpack-nixos",
-        "rev": "eb413a5739515086f33c611376075bd869574f4f",
+        "rev": "de01bba154f27a96b40c7f406f1f84517ee11780",
         "type": "github"
       }
     },

--- a/aleph/flake.nix
+++ b/aleph/flake.nix
@@ -9,8 +9,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
-    # Pin to version before kernelPackages.devicetree was removed
-    jetpack.url = "github:anduril/jetpack-nixos/eb413a5739515086f33c611376075bd869574f4f";
+    jetpack.url = "github:anduril/jetpack-nixos/de01bba154f27a96b40c7f406f1f84517ee11780";
     rust-overlay.url = "github:oxalica/rust-overlay";
     flake-utils.url = "github:numtide/flake-utils";
     agenix.url = "github:ryantm/agenix";
@@ -64,7 +63,7 @@
     };
     devModules = {
       # Temporarily disabled for nixpkgs 25.05 compatibility (CUDA issues)
-      # aleph-dev = ./modules/aleph-dev.nix;
+      aleph-dev = ./modules/aleph-dev.nix;
     };
     defaultModule = {config, ...}: {
       imports = [

--- a/aleph/modules/aleph-dev.nix
+++ b/aleph/modules/aleph-dev.nix
@@ -49,8 +49,9 @@ in {
       stdenv.cc.cc.lib
       cudaPackages.cudatoolkit
       cudaPackages.cudnn
-      cudaPackages.tensorrt
-      cudaPackages.vpi2
+      # For 25.05, tensorRT requires manual intervention
+      # see: https://github.com/NixOS/nixpkgs/blob/ee9ca432c02483222ce2fd7993582e1e61b77a4d/pkgs/development/cuda-modules/_cuda/fixups/tensorrt.nix#L54
+      # cudaPackages.tensorrt
       gst_all_1.gstreamer
       nvidia-jetpack.l4t-cuda
       nvidia-jetpack.l4t-gstreamer
@@ -58,7 +59,6 @@ in {
       nvidia-jetpack.l4t-camera
     ];
     NVCC_PREPEND_FLAGS = "--compiler-bindir ${pkgs.gcc11}/bin/gcc";
-    NVCC_APPEND_FLAGS = "-I${pkgs.cudaPackages.cuda_cudart.include}/include";
     CONTAINER_HOST = "unix:///run/podman/podman.sock";
     GST_PLUGIN_PATH = lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" [
       gst_all_1.gstreamer

--- a/aleph/pkgs/deepstreamer.nix
+++ b/aleph/pkgs/deepstreamer.nix
@@ -27,8 +27,9 @@ stdenv.mkDerivation {
   buildInputs = [
     cudaPackages.cudatoolkit
     cudaPackages.cudnn
-    cudaPackages.tensorrt
-    cudaPackages.vpi2
+    # For 25.05, TensorRT requires manual intervention
+    # see: https://github.com/NixOS/nixpkgs/blob/ee9ca432c02483222ce2fd7993582e1e61b77a4d/pkgs/development/cuda-modules/_cuda/fixups/tensorrt.nix#L54
+    # cudaPackages.tensorrt
     stdenv.cc.cc.lib
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
@@ -45,6 +46,9 @@ stdenv.mkDerivation {
   unpackCmd = "dpkg-deb -x $src source";
 
   autoPatchelfIgnoreMissingDeps = true;
+  # FIXME: 25.05 change (https://nixos.org/manual/nixpkgs/unstable/#no-broken-symlinks.sh)
+  # see: https://github.com/NixOS/nixpkgs/pull/370750
+  dontCheckForBrokenSymlinks = true;
 
   preBuild = ''
     addAutoPatchelfSearchPath ${yaml-cpp}/lib/


### PR DESCRIPTION
This re-enables the aleph-dev module, while leaving TensorRT unpackaged temporarily

> nix: bump jetpack-nixos flake to for nixos 25.05 support (2025-06-24) nix: re-enable aleph-dev module. disable tensorRT due to changes in how the upstream is distributed
> nix: disable brokensymlink checking in deepstreamer package in order to restore build. fixing the packaging is a separate issue