### PR TITLE
Chore/migrate ci

### DIFF
--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -1,0 +1,151 @@
+# Buildkite CI Setup
+
+This directory contains the configuration for Elodin's Buildkite CI infrastructure, designed for reproducible, ephemeral builds on AWS EC2. The CI system uses self-hosted agents with overlayroot (tmpfs root filesystem) to ensure a clean state on every reboot, preventing build artifacts and state from persisting between jobs. Agents automatically configure themselves based on instance architecture, joining either the `nixos-x86-aws` queue (for most CI tasks) or `nixos-arm-aws` queue (for ARM-specific builds like Aleph-OS). All build environments use Nix for reproducible dependencies, and the entire agent bootstrap process is fully automated via cloud-init—requiring only SSH deploy keys and a Buildkite agent token to be configured once in the user-data script.
+
+## Quick Start
+
+Here's the complete setup in order:
+
+```bash
+# 1. Generate SSH deploy key
+ssh-keygen -t ed25519 -C "buildkite-ci@elodin.systems" -f ~/.ssh/buildkite_deploy_key
+
+# 2. Base64 encode the private key (single line, no wrapping)
+base64 -w 0 ~/.ssh/buildkite_deploy_key
+# Copy the output and paste it into user-data at the SSH_KEY_BASE64 variable
+
+# 3. Add your Buildkite agent token to user-data
+# Get from: Buildkite Dashboard → Organization Settings → Agents → Reveal Agent Token
+# Replace BUILDKITE_AGENT_TOKEN="bkt_your_actual_token_here" in user-data
+
+# 4. Add public key to GitHub
+cat ~/.ssh/buildkite_deploy_key.pub
+# Copy output and add as Deploy Key in GitHub repo settings
+
+# 5. Launch EC2 instances with the updated user-data script
+```
+
+**Note:** If you're on macOS, use `base64 -i ~/.ssh/buildkite_deploy_key` (no `-w` flag).
+
+## Prerequisites
+
+### 1. Generate and Encode SSH Deploy Key
+
+Your Buildkite agents need access to your Git repository. Generate a deploy key and encode it:
+
+```bash
+# Generate a new SSH key (recommended: use a dedicated deploy key)
+ssh-keygen -t ed25519 -C "buildkite-ci@elodin.systems" -f ~/.ssh/buildkite_deploy_key
+
+# Base64 encode the PRIVATE key (no line wrapping)
+# Linux:
+base64 -w 0 ~/.ssh/buildkite_deploy_key
+
+# macOS:
+base64 -i ~/.ssh/buildkite_deploy_key
+
+# Copy the entire base64 output and paste it into user-data at:
+# SSH_KEY_BASE64="paste-here"
+```
+
+**Why base64?** The private key has multiple lines which causes YAML parsing issues in cloud-init. Base64 encoding makes it a single line.
+
+### 2. Add Public Key to GitHub
+
+```bash
+# Display the PUBLIC key
+cat ~/.ssh/buildkite_deploy_key.pub
+# Output looks like: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA...
+```
+
+Add to GitHub:
+1. Go to your repository → Settings → Deploy keys
+2. Click "Add deploy key"
+3. Paste the public key content
+4. Name it "Buildkite CI"
+5. **Do NOT** check "Allow write access" (read-only is safer)
+
+### 3. Add Buildkite Agent Token
+
+Get your agent token from Buildkite:
+- Go to: Buildkite Dashboard → Organization Settings → Agents → Reveal Agent Token
+- Copy the token (starts with `bkt_`)
+- In `user-data`, replace: `BUILDKITE_AGENT_TOKEN="bkt_your_actual_token_here"`
+
+## How It Works
+
+The user-data script uses a two-stage boot process:
+
+### First Boot
+1. Cloud-init installs packages
+2. Writes configuration files (including systemd service)
+3. Configures GRUB and initramfs for overlayroot
+4. **Enables** `buildkite-bootstrap.service` (but doesn't run it yet)
+5. **Reboots** to activate overlayroot
+
+### Second Boot (Automatic)
+1. System boots with overlayroot active (root filesystem is now tmpfs)
+2. `buildkite-bootstrap.service` runs automatically
+3. Installs Nix and Buildkite agent
+4. Creates flag file `/var/lib/buildkite-bootstrap-complete` so it only runs once
+5. Buildkite agent starts and joins the queue
+
+**Why two boots?** Overlayroot needs to be active before installing Nix/Buildkite, otherwise those installations would be on the persistent disk instead of tmpfs.
+
+## Architecture
+
+The user-data script automatically detects the instance architecture using `uname -m` and configures the appropriate queue:
+
+- **x86-64 agents**: Queue `nixos-x86-aws` (default for most steps)
+  - Detected architectures: `x86_64`, `amd64`
+- **ARM64 agents**: Queue `nixos-arm-aws` (for Aleph-OS builds: toplevel, sdimage)
+  - Detected architectures: `aarch64`, `arm64`
+
+This means you can use the same user-data script for both x86 and ARM instances!
+
+## Troubleshooting
+
+### Check bootstrap service status
+
+```bash
+# Check if the bootstrap service ran successfully
+sudo systemctl status buildkite-bootstrap.service
+
+# View bootstrap logs
+sudo journalctl -u buildkite-bootstrap.service
+
+# Check if bootstrap completed
+ls -la /var/lib/buildkite-bootstrap-complete
+# If this file exists, bootstrap ran successfully
+
+# Check if overlayroot is active
+mount | grep overlayroot
+# Should show: overlayroot on / type overlay
+```
+
+### View agent logs
+
+```bash
+sudo journalctl -u buildkite-agent -f
+```
+
+### Manually trigger bootstrap (if needed)
+
+```bash
+# If bootstrap didn't run or you need to re-run it
+sudo rm -f /var/lib/buildkite-bootstrap-complete
+sudo systemctl start buildkite-bootstrap.service
+```
+
+### Verify architecture detection and queue assignment
+
+```bash
+# Check what architecture was detected
+uname -m
+
+# Check the configured agent tags
+grep tags /etc/buildkite-agent/buildkite-agent.cfg
+# Should show: tags="nix=true,os=nixos,arch=x86_64,queue=nixos-x86-aws"
+#          or: tags="nix=true,os=nixos,arch=arm64,queue=nixos-arm-aws"
+```
+

--- a/.buildkite/buildkite.py
+++ b/.buildkite/buildkite.py
@@ -23,5 +23,8 @@ def group(name, is_gha=False, key=None, depends_on=None, steps=[]):
     }
 
 
-def pipeline(steps=[], env={}):
-    return print(json.dumps({"steps": steps, "env": env}))
+def pipeline(steps=[], env={}, agents={}):
+    result = {"steps": steps, "env": env}
+    if agents:
+        result["agents"] = agents
+    return print(json.dumps(result))

--- a/.buildkite/steps.py
+++ b/.buildkite/steps.py
@@ -55,21 +55,3 @@ EOF"""
         plugins=plugins,
         agents=agents,
     )
-
-
-def rust_step(label, command, env={}, emoji=":crab:"):
-    return nix_step(
-        label=label,
-        emoji=emoji,
-        command=command,
-        env=env,
-    )
-
-
-def c_step(label, command, env={}, emoji=":c:"):
-    return nix_step(
-        label=label,
-        emoji=emoji,
-        command=command,
-        env=env,
-    )

--- a/.buildkite/user-data
+++ b/.buildkite/user-data
@@ -1,0 +1,146 @@
+#cloud-config
+# Buildkite CI Agent Bootstrap Script
+#
+# BEFORE USING:
+# 1. Generate SSH key: ssh-keygen -t ed25519 -f ~/.ssh/buildkite_deploy_key
+# 2. Encode private key: base64 -w 0 ~/.ssh/buildkite_deploy_key (Linux) or base64 -i ~/.ssh/buildkite_deploy_key (macOS)
+# 3. Replace SSH_KEY_BASE64 below with the base64 output
+# 4. Add public key (~/.ssh/buildkite_deploy_key.pub) to GitHub repo as Deploy Key
+# 5. Replace BUILDKITE_AGENT_TOKEN below with your actual token
+#
+package_update: true
+packages:
+  - overlayroot
+  - curl
+  - ca-certificates
+  - gpg
+  - dbus
+  - jq
+  - yq
+  - git
+  - git-lfs
+  - git-filter-repo
+  - pciutils
+  - openssl
+
+write_files:
+  - path: /etc/overlayroot.local.conf
+    permissions: "0644"
+    owner: root:root
+    content: |
+      overlayroot="tmpfs"
+
+  - path: /etc/systemd/system/buildkite-bootstrap.service
+    permissions: "0644"
+    owner: root:root
+    content: |
+      [Unit]
+      Description=Buildkite Agent Bootstrap (runs once after overlayroot is active)
+      After=network-online.target
+      Wants=network-online.target
+      ConditionPathExists=!/var/lib/buildkite-bootstrap-complete
+
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/local/sbin/bootstrap-ci.sh
+      ExecStartPost=/usr/bin/touch /var/lib/buildkite-bootstrap-complete
+      RemainAfterExit=yes
+
+      [Install]
+      WantedBy=multi-user.target
+
+  - path: /usr/local/sbin/bootstrap-ci.sh
+    permissions: "0755"
+    owner: root:root
+    content: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+
+      # --- Determinate Nix (non-interactive) ---
+      curl --proto '=https' --tlsv1.2 -fsSL -L https://install.determinate.systems/nix \
+        | sh -s -- install linux --determinate --no-confirm
+
+      # --- Buildkite Agent (APT) ---
+      install -d -m 0755 /etc/apt/keyrings
+      curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 \
+        | gpg --dearmor -o /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
+
+      echo "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] \
+        https://apt.buildkite.com/buildkite-agent stable main" \
+        | tee /etc/apt/sources.list.d/buildkite-agent.list
+
+      apt-get update -y && apt-get install -y buildkite-agent
+
+      # Allow agent to talk to nix-daemon
+      getent group nix-users >/dev/null || groupadd -r nix-users
+      usermod -aG nix-users buildkite-agent
+      chgrp nix-users /nix/var/nix/daemon-socket || true
+      chmod 770 /nix/var/nix/daemon-socket || true
+
+      # Deploy SSH private key (base64 encoded to avoid YAML parsing issues)
+      SSH_KEY_BASE64="LS0tLS1CRUdJTiBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0K...your-base64-encoded-key-here"
+      
+      mkdir -p /var/lib/buildkite-agent/.ssh
+      echo "$SSH_KEY_BASE64" | base64 -d > /var/lib/buildkite-agent/.ssh/id_ed25519
+      chmod 600 /var/lib/buildkite-agent/.ssh/id_ed25519
+      chown -R buildkite-agent:buildkite-agent /var/lib/buildkite-agent/.ssh
+
+      # Configure SSH to use the key and accept GitHub/GitLab host keys
+      bash -c 'cat > /var/lib/buildkite-agent/.ssh/config << "SSHEOF"
+      Host github.com
+        HostName github.com
+        IdentityFile ~/.ssh/id_ed25519
+        StrictHostKeyChecking accept-new
+      SSHEOF"'
+      chmod 600 /var/lib/buildkite-agent/.ssh/config
+      chown buildkite-agent:buildkite-agent /var/lib/buildkite-agent/.ssh/config
+
+      # Detect architecture and set appropriate queue
+      ARCH=$(uname -m)
+      if [[ "$ARCH" == "aarch64" ]] || [[ "$ARCH" == "arm64" ]]; then
+        AGENT_ARCH="arm64"
+        AGENT_QUEUE="nixos-arm-aws"
+      elif [[ "$ARCH" == "x86_64" ]] || [[ "$ARCH" == "amd64" ]]; then
+        AGENT_ARCH="x86_64"
+        AGENT_QUEUE="nixos-x86-aws"
+      else
+        echo "Unknown architecture: $ARCH"
+        AGENT_ARCH="$ARCH"
+        AGENT_QUEUE="nixos-unknown"
+      fi
+
+      # Configure Buildkite agent token
+      # Get your token from: Buildkite Dashboard → Organization Settings → Agents → Reveal Agent Token
+      BUILDKITE_AGENT_TOKEN="bkt_your_actual_token_here"
+      
+      sed -i "s/xxx/$BUILDKITE_AGENT_TOKEN/g" /etc/buildkite-agent/buildkite-agent.cfg
+      sed -i 's/# spawn=1/spawn=5/' /etc/buildkite-agent/buildkite-agent.cfg
+      sed -i "s/# tags=\"key1=val2,key2=val2\"/tags=\"nix=true,os=nixos,arch=${AGENT_ARCH},queue=${AGENT_QUEUE}\"/" /etc/buildkite-agent/buildkite-agent.cfg
+
+      # Systemd drop-in so the agent has Nix in PATH without sourcing profiles
+      mkdir -p /etc/systemd/system/buildkite-agent.service.d
+      bash -c 'cat > /etc/systemd/system/buildkite-agent.service.d/10-nix-env.conf << "EOF"
+      [Service]
+      Environment=NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+      Environment=NIX_PROFILES=/nix/var/nix/profiles/default
+      Environment=PATH=/nix/var/nix/profiles/default/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+      # Disable eval cache to prevent SQLite contention between spawned agents
+      Environment=NIX_CONFIG="eval-cache = false"
+      EOF"'
+
+      systemctl daemon-reload
+      systemctl enable --now buildkite-agent
+
+runcmd:
+  # Configure GRUB and initramfs for overlayroot
+  - [ bash, -lc, 'sed -i "s/^GRUB_FORCE_PARTUUID/#GRUB_FORCE_PARTUUID/" /etc/default/grub.d/40-force-partuuid.cfg' ]
+  - [ bash, -lc, 'update-grub' ]
+  - [ bash, -lc, 'update-initramfs -u' ]
+  # Enable systemd service to run bootstrap script AFTER reboot
+  - [ systemctl, enable, buildkite-bootstrap.service ]
+
+power_state:
+  # Reboot to activate overlayroot, then buildkite-bootstrap.service will run
+  mode: reboot
+  timeout: 30
+  condition: True


### PR DESCRIPTION
1. Migrate our Buildkite CI to AWS
2. Unlock ridiculous performance with overlayroot tmpfs (100% ram-based file system)
3. Document so I remember how I did this for next time.
4. Have fun with AI generated ASCII art

```
████████╗███╗   ███╗██████╗ ███████╗███████╗    ██████╗  ██████╗ ██╗    ██╗███████╗██████╗ 
╚══██╔══╝████╗ ████║██╔══██╗██╔════╝██╔════╝    ██╔══██╗██╔═══██╗██║    ██║██╔════╝██╔══██╗
   ██║   ██╔████╔██║██████╔╝█████╗  ███████╗    ██████╔╝██║   ██║██║ █╗ ██║█████╗  ██████╔╝
   ██║   ██║╚██╔╝██║██╔═══╝ ██╔══╝  ╚════██║    ██╔═══╝ ██║   ██║██║███╗██║██╔══╝  ██╔══██╗
   ██║   ██║ ╚═╝ ██║██║     ██║     ███████║    ██║     ╚██████╔╝╚███╔███╔╝███████╗██║  ██║
   ╚═╝   ╚═╝     ╚═╝╚═╝     ╚═╝     ╚══════╝    ╚═╝      ╚═════╝  ╚══╝╚══╝ ╚══════╝╚═╝  ╚═╝

                    ⚡⚡⚡ 90% FASTER - 100% EPHEMERAL ⚡⚡⚡

     ██████╗  █████╗ ███╗   ███╗     ██████╗ ███╗   ██╗██╗  ██╗   ██╗
     ██╔══██╗██╔══██╗████╗ ████║    ██╔═══██╗████╗  ██║██║  ╚██╗ ██╔╝
     ██████╔╝███████║██╔████╔██║    ██║   ██║██╔██╗ ██║██║   ╚████╔╝ 
     ██╔══██╗██╔══██║██║╚██╔╝██║    ██║   ██║██║╚██╗██║██║    ╚██╔╝  
     ██║  ██║██║  ██║██║ ╚═╝ ██║    ╚██████╔╝██║ ╚████║███████╗██║   
     ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝     ╚═════╝ ╚═╝  ╚═══╝╚══════╝╚═╝   

  ┌────────────────────────────────────────────────────────────────────┐
  │                                                                    │
  │   "Some move mountains. We move bits at the speed of electricity." │
  │                                                                    │
  │             Disk I/O: 🐌 ~100-300 MB/s                             │
  │              RAM I/O: ⚡ ~20,000 MB/s                               │
  │                                                                    │
  │                  THE MATH CHECKS OUT.                              │
  │                                                                    │
  └────────────────────────────────────────────────────────────────────┘

                         ⚡ OVERLAYROOT + NIX + AWS ⚡
                      No disk. No cache. No compromises.
                         Just pure, unadulterated SPEED.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces AWS-based ephemeral Buildkite agents with overlayroot + Nix, updates pipeline to use architecture-specific queues and nix_step, and adds agent/queue configuration support.
> 
> - **CI Infrastructure (Buildkite on AWS)**
>   - Add `user-data` cloud-init script to provision ephemeral agents using overlayroot (tmpfs), install Nix and Buildkite agent, configure SSH deploy key, and auto-detect architecture to tag queues (`nixos-x86-aws`, `nixos-arm-aws`).
>   - Add `.buildkite/README.md` documenting setup, architecture, and troubleshooting.
> - **Pipeline/Step Changes**
>   - `buildkite.pipeline`: support top-level `agents` in output JSON.
>   - Default pipeline agents set to `{"queue": "nixos-x86-aws"}` in `pipeline.py`.
>   - Switch C/Rust steps to `nix_step`; remove `c_step` and `rust_step` helpers.
>   - Update Aleph-OS build steps to use `agents={"queue": "nixos-arm-aws"}` (was `nixos-arm`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 948a6eae2f9cd0e70f4633f7f2a9515912162455. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->