### PR TITLE
fix: Avoid subtract overflow.

### DIFF
--- a/justfile
+++ b/justfile
@@ -23,6 +23,7 @@ promote tag:
   #!/usr/bin/env sh
   dir=$(mktemp -d)
   gh release download {{tag}} --pattern 'elodin-*.whl' --dir $dir
+  echo "uv publish \"$dir/*.whl\""
   uv publish "$dir/*.whl"
 
 public-changelog:

--- a/libs/elodin-editor/src/ui/plot/widget.rs
+++ b/libs/elodin-editor/src/ui/plot/widget.rs
@@ -1201,8 +1201,8 @@ impl PlotBounds {
         max_y: f64,
     ) -> Self {
         let (min_x, max_x) = (
-            (baseline.start.0 - earliest_timestamp.0) as f64,
-            (baseline.end.0 - earliest_timestamp.0) as f64,
+            baseline.start.0.saturating_sub(earliest_timestamp.0) as f64,
+            baseline.end.0.saturating_sub(earliest_timestamp.0) as f64,
         );
 
         let min_y = sigfig_round(min_y, 2);


### PR DESCRIPTION
When I ran the rocket example once, I got this:
```
thread 'main' panicked at libs/elodin-editor/src/ui/plot/widget.rs:1204:13:
attempt to subtract with overflow
```
It was not reproducible.

p.s. This PR also has a one-line change to the justfile from doing the release.