### PR TITLE
Add "Clear Schematic" command to Command Palette

### DIFF
--- a/libs/elodin-editor/src/ui/command_palette/palette_items.rs
+++ b/libs/elodin-editor/src/ui/command_palette/palette_items.rs
@@ -894,8 +894,6 @@ pub fn clear_schematic() -> PaletteItem {
         "Clear Schematic",
         PRESETS_LABEL,
         |_: In<String>, mut params: LoadSchematicParams, mut rx: ResMut<SchematicLiveReloadRx>| {
-            // Load an empty schematic in-memory and disable live reload
-            // to avoid reloading a previously watched file.
             params.load_schematic(&impeller2_wkt::Schematic::default());
             rx.0 = None;
             PaletteEvent::Exit


### PR DESCRIPTION
## PR Objective
Add the “Clear Schematic” command to the Command Palette to reset the editor by loading an empty KDL (closes https://github.com/elodin-sys/elodin/issues/162).

## How to test
- Run the editor with any example: 
```
cargo run --manifest-path=apps/elodin/Cargo.toml editor examples/ball/main.py
```
- Open the Command Palette and run "Clear Schematic".

Expected: all tiles/panels disappear and the viewport/grid objects are cleared; this screen is then displayed:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/4392ff2f-d1f2-47af-b281-f3da31d67adf" />

