### PR TITLE
fix: Resize monitor boxes.

### DIFF
--- a/libs/elodin-editor/src/ui/monitor.rs
+++ b/libs/elodin-editor/src/ui/monitor.rs
@@ -153,13 +153,3 @@ impl WidgetSystem for MonitorWidget<'_, '_> {
             });
     }
 }
-
-#[cfg(test)]
-mod test {
-
-    #[test]
-    fn test_width() {
-        assert_eq!("0.01234568", format!("{:<10.8}", 0.0123456789));
-        assert_eq!("10000.012345678", format!("{:<10.8}", 10000.0123456789));
-    }
-}


### PR DESCRIPTION
They took up a lot of screen real-estate.

# Before

<img width="1428" height="436" alt="Screenshot 2025-11-04 at 5 46 25 PM" src="https://github.com/user-attachments/assets/9e082bb0-20c3-4976-a456-0c8790e7e1f0" />

# After

<img width="1428" height="428" alt="Screenshot 2025-11-04 at 5 45 19 PM" src="https://github.com/user-attachments/assets/bdcee0dd-bc9c-4362-ad8e-2f6c745498ce" />
