### PR TITLE
fix: Add `None` as second arg.

### DIFF
--- a/libs/elodin-editor/src/ui/command_palette/palette_items.rs
+++ b/libs/elodin-editor/src/ui/command_palette/palette_items.rs
@@ -914,7 +914,7 @@ pub fn clear_schematic() -> PaletteItem {
         "Clear Schematic",
         PRESETS_LABEL,
         |_: In<String>, mut params: LoadSchematicParams, mut rx: ResMut<SchematicLiveReloadRx>| {
-            params.load_schematic(&impeller2_wkt::Schematic::default());
+            params.load_schematic(&impeller2_wkt::Schematic::default(), None);
             rx.0 = None;
             PaletteEvent::Exit
         },


### PR DESCRIPTION
Small correction.