### PR TITLE
fix: Make `pytest libs/nox-py` work again.

### DIFF
--- a/libs/nox-py/pyproject.toml
+++ b/libs/nox-py/pyproject.toml
@@ -28,5 +28,10 @@ dynamic = []
 python-source = "python"
 features = ["publish"]
 
+[tool.pytest.ini_options]
+pythonpath = [
+  "python",
+]
+
 [project.entry-points.pytest11]
 elodin = "elodin"


### PR DESCRIPTION
Make pytest work from root.

```sh
cd elodin
. .venv/bin/activate # with regular maturin setup as specified in README
pytest libs/nox-py
```

# Workaround

```sh
cd elodin
PYTHONPATH=libs/nox-py/python pytest libs/nox-p
```