### PR TITLE
Restore missing assets

### DIFF
--- a/assets/earth.glb
+++ b/assets/earth.glb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd9b531838704a41ff00dc6c1f8dc32e9dd0f7b15579795ce4480d95ad50ca42
+size 12916540

--- a/assets/rocket.glb
+++ b/assets/rocket.glb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24b04f521a9e7d18ad189f37aeb6160fbee89e0822353158be6607cdee98913c
+size 3959812

--- a/examples/cube-sat/main.py
+++ b/examples/cube-sat/main.py
@@ -644,11 +644,11 @@ w.schematic(
         graph "ore_sat.att_est" Name=Att
     }
     object_3d earth.world_pos {
-        glb path="https://storage.googleapis.com/elodin-assets/earth.glb"
+        glb path="earth.glb"
     }
 
     object_3d ore_sat.world_pos {
-        glb path="https://storage.googleapis.com/elodin-assets/oresat-low.glb"
+        glb path="oresat-low.glb"
     }
     line_3d ore_sat.world_pos line_width=10.0 perspective=#false
 """,

--- a/examples/rocket/main.py
+++ b/examples/rocket/main.py
@@ -499,7 +499,7 @@ w.schematic(
         glb path="compass.glb"
     }
     object_3d rocket.world_pos {
-        glb path="https://storage.googleapis.com/elodin-assets/rocket.glb"
+        glb path="rocket.glb"
     }
     line_3d rocket.world_pos line_width=11.0 perspective=#false {
         color yolk


### PR DESCRIPTION
We shut down google cloud and these assets went with it, restoring with local assets

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add local `earth.glb` and `rocket.glb` assets and update cube-sat and rocket examples to load these instead of external URLs.
> 
> - **Assets**:
>   - Add `assets/earth.glb` and `assets/rocket.glb` (Git LFS).
> - **Examples**:
>   - **cube-sat** (`examples/cube-sat/main.py`): point `object_3d` to local `earth.glb` and `oresat-low.glb`.
>   - **rocket** (`examples/rocket/main.py`): point `object_3d` to local `rocket.glb`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e46dd7034248eaa1ee79c2f49b3bec2ac02fde2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->