### PR TITLE
Fix nix cache upload command

### DIFF
--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -156,8 +156,6 @@ The user-data script uses a two-stage boot process:
 
 **Why two boots?** Overlayroot needs to be active before installing Nix/Buildkite, otherwise those installations would be on the persistent disk instead of tmpfs.
 
-**Note on Nix installation:** We use the Determinate Systems installer but without the `--determinate` flag. This gives us standard Nix without authentication requirements, which is ideal for ephemeral CI environments.
-
 ### Cache Upload Process
 
 After each successful build:

--- a/.buildkite/user-data
+++ b/.buildkite/user-data
@@ -77,7 +77,7 @@ write_files:
       export IFS=" "
 
       echo "Uploading paths to S3 cache: $OUT_PATHS"
-      exec nix copy --to "s3://elodin-nix-cache?region=us-west-2&secret-key=/etc/nix/cache-priv-key.pem" $OUT_PATHS
+      exec /nix/var/nix/profiles/default/bin/nix copy --to "s3://elodin-nix-cache?region=us-west-2&secret-key=/etc/nix/cache-priv-key.pem" $OUT_PATHS
       UPLOADEOF
       '
 


### PR DESCRIPTION
tweaks to fix caching

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update upload script to call nix via absolute path; remove an outdated note from README.
> 
> - **CI bootstrap (`.buildkite/user-data`)**:
>   - Update post-build upload script to call `nix` via absolute path: `exec /nix/var/nix/profiles/default/bin/nix copy ...` instead of `exec nix copy ...`.
> - **Docs (`.buildkite/README.md`)**:
>   - Remove note about installing Nix without the `--determinate` flag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b033a34e0faba7bcacf9b71e051d06401bae1e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->