### PR TITLE
fix: Ctrl+C able to interrupt simulation on Linux

### DIFF
--- a/libs/stellarator/src/lib.rs
+++ b/libs/stellarator/src/lib.rs
@@ -181,8 +181,6 @@ where
     match Executor::with(|e| e.run(func)) {
         Ok(res) => res,
         Err(Error::Io(err)) if err.kind() == ErrorKind::Interrupted => {
-            // Treat EINTR as a graceful shutdown (e.g. Ctrl-C) and exit with a
-            // conventional 130 status instead of panicking.
             std::process::exit(130);
         }
         Err(err) => {

--- a/libs/stellarator/src/uring/mod.rs
+++ b/libs/stellarator/src/uring/mod.rs
@@ -23,8 +23,6 @@ pub struct UringReactor {
 }
 
 impl UringReactor {
-    /// Treat EINTR/ETIME from io_uring submissions as a harmless wakeup so Ctrl-C
-    /// doesn't bubble up as a panic while shutting down.
     fn handle_submit_error(err: io::Error) -> Result<(), Error> {
         if err.kind() == io::ErrorKind::Interrupted || err.raw_os_error() == Some(62) {
             return Ok(());
@@ -140,7 +138,7 @@ impl Reactor for UringReactor {
             })?;
             if let Err(err) = self.uring.submitter().submit() {
                 Self::handle_submit_error(err)?;
-            } // NOTE: not sure why this is required? It seems to be some sort of uring race condition?
+            }
         }
         // let mut args = io_uring::types::SubmitArgs::new();
         // let timeout = timeout.map(|d| {


### PR DESCRIPTION
## PR objective
- Address this issue [#312](https://github.com/elodin-sys/elodin/issues/312)
- Reproduced with:
```
cargo run --manifest-path=apps/elodin/Cargo.toml editor examples/drone/main.py
```

## Branch description
Two small changes: 
- Add a tiny timeout (50 ms) in the `io_uring` loop so it never stays stuck
- Ignore EINTR/ETIME and exit with code 130 on SIGINT. 

Effect: on Linux the loop wakes up regularly, sees Ctrl+C, and stops the simulation.
