### PR TITLE
config(aleph) - add i2c-tools to aleph-dev

### DIFF
--- a/aleph/modules/aleph-dev.nix
+++ b/aleph/modules/aleph-dev.nix
@@ -118,6 +118,7 @@ in {
     ethtool
     wget
     iperf3
+    i2c-tools
     # Utilities for interfacing with the MCU
     (writeShellScriptBin "reset-mcu" (builtins.readFile ../scripts/reset-mcu.sh))
     (writeShellScriptBin "flash-mcu" (builtins.readFile ../scripts/flash-mcu.sh))


### PR DESCRIPTION
Add `i2c-tools` to the aleph-dev modules, as they're nice to have and they aid with i2c development on aleph :)