### PR TITLE
Increase Buildkite CI Runner RamFS disk size

### DIFF
--- a/.buildkite/user-data
+++ b/.buildkite/user-data
@@ -29,7 +29,7 @@ write_files:
     permissions: "0644"
     owner: root:root
     content: |
-      overlayroot="tmpfs"
+      overlayroot="tmpfs:tmpfs_size=75%"
 
   - path: /etc/systemd/system/buildkite-bootstrap.service
     permissions: "0644"


### PR DESCRIPTION
Should fix our out of space issues a bit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set `overlayroot="tmpfs:tmpfs_size=75%"` in `.buildkite/user-data` to increase ephemeral filesystem size for Buildkite agents.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de472bcfddcbc56e97d0b65e56c43b2939145edc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->