### PR TITLE
Always-on hierarchy/inspector sidebars per window.

### DIFF
--- a/docs/public/content/reference/command-palette.md
+++ b/docs/public/content/reference/command-palette.md
@@ -35,6 +35,8 @@ order = 8
 - `Create Data Overview`: add a data overview pane.
 - `Create 3D Object`: prompt for an EQL expression, pick a mesh type (GLTF or primitives), then
   optionally enter dimensions and color.
+- `Hierarchy` and `Inspector` are built-in sidebars; they are always present and do not appear in
+  the command palette.
 
 ## Viewport
 

--- a/docs/public/content/reference/command-palette.md
+++ b/docs/public/content/reference/command-palette.md
@@ -30,8 +30,6 @@ order = 8
 - `Create Action`: prompt for a label, then choose a `send_msg` preset or enter a custom Lua
   command to create an action pane.
 - `Create Video Stream`: prompt for the message name, then create a video stream pane.
-- `Create Hierarchy`: add a hierarchy pane.
-- `Create Inspector`: add an inspector pane.
 - `Create Schematic Tree`: add a schematic tree pane.
 - `Create Dashboard`: add a dashboard pane.
 - `Create Data Overview`: add a data overview pane.

--- a/docs/public/content/reference/schematic.md
+++ b/docs/public/content/reference/schematic.md
@@ -42,7 +42,7 @@ order = 6
 - `action_pane`: positional `label` (required), `lua` script (required).
 - `query_table`: positional `query` (defaults to empty), `type` (`eql` default, or `sql`).
 - `query_plot`: positional `label` (required), `query` (required), `refresh_interval` in ms (default 1000), `auto_refresh` (default false), `color` (default white), `type` (`eql` default, or `sql`).
-- `inspector`, `hierarchy`, `schematic_tree`: no properties.
+- `schematic_tree`: no properties. (Hierarchy/Inspector sidebars are implicit and not serialized.)
 - `dashboard`: layout node (Bevy UI style). Key properties: `label` (optional), `display` (`flex` default, or `grid`/`block`/`none`), `box_sizing` (`border-box` default or `content-box`), `position_type` (`relative` default or `absolute`), `overflow` (per-axis; defaults visible), `overflow_clip_margin` (visual_box + margin, defaults content-box / 0), sizing (`left`/`right`/`top`/`bottom`/`width`/`height`/`min_*`/`max_*` accept `auto`, `px`, `%`, `vw`, `vh`, `vmin`, `vmax`; default `auto`), `aspect_ratio` (optional f32), alignment (`align_items`/`justify_items`/`align_self`/`justify_self`/`align_content`/`justify_content`, all default to `default` variants), flex (`flex_direction`, `flex_wrap`, `flex_grow` default 0, `flex_shrink` default 1, `flex_basis` default `auto`, `row_gap`/`column_gap` default `auto`), `children` (nested dashboard nodes), colors via `bg`/`background` child (default transparent), `text` (optional), `font_size` (default 16), `text_color` child (default white), spacing via `margin`/`padding`/`border` children with `left`/`right`/`top`/`bottom`.
 
 ### object_3d
@@ -108,8 +108,6 @@ panel =
   | action_pane
   | query_table
   | query_plot
-  | inspector
-  | hierarchy
   | schematic_tree
   | dashboard
   | split
@@ -161,8 +159,6 @@ query_plot = "query_plot"
            [color]
            [type=eql|sql]
 
-inspector      = "inspector"
-hierarchy      = "hierarchy"
 schematic_tree = "schematic_tree"
 dashboard      = "dashboard" { dashboard_node }+
 

--- a/libs/elodin-editor/src/ui/command_palette/palette_items.rs
+++ b/libs/elodin-editor/src/ui/command_palette/palette_items.rs
@@ -651,34 +651,6 @@ pub fn create_query_plot(tile_id: Option<TileId>) -> PaletteItem {
     )
 }
 
-pub fn create_hierarchy(tile_id: Option<TileId>) -> PaletteItem {
-    PaletteItem::new(
-        "Create Hierarchy",
-        TILES_LABEL,
-        move |_: In<String>, mut tile_param: TileParam, palette_state: Res<CommandPaletteState>| {
-            let Some(mut tile_state) = tile_param.target(palette_state.target_window) else {
-                return PaletteEvent::Error("Secondary window unavailable".to_string());
-            };
-            tile_state.create_hierarchy_tile(tile_id);
-            PaletteEvent::Exit
-        },
-    )
-}
-
-pub fn create_inspector(tile_id: Option<TileId>) -> PaletteItem {
-    PaletteItem::new(
-        "Create Inspector",
-        TILES_LABEL,
-        move |_: In<String>, mut tile_param: TileParam, palette_state: Res<CommandPaletteState>| {
-            let Some(mut tile_state) = tile_param.target(palette_state.target_window) else {
-                return PaletteEvent::Error("Secondary window unavailable".to_string());
-            };
-            tile_state.create_inspector_tile(tile_id);
-            PaletteEvent::Exit
-        },
-    )
-}
-
 pub fn create_schematic_tree(tile_id: Option<TileId>) -> PaletteItem {
     PaletteItem::new(
         "Create Schematic Tree",
@@ -1642,11 +1614,9 @@ pub fn create_tiles(tile_id: TileId) -> PalettePage {
         create_query_table(Some(tile_id)),
         create_query_plot(Some(tile_id)),
         create_video_stream(Some(tile_id)),
-        create_hierarchy(Some(tile_id)),
         create_schematic_tree(Some(tile_id)),
         create_dashboard(Some(tile_id)),
         create_data_overview(Some(tile_id)),
-        create_inspector(Some(tile_id)),
     ])
 }
 
@@ -1713,8 +1683,6 @@ impl Default for PalettePage {
             create_query_table(None),
             create_query_plot(None),
             create_video_stream(None),
-            create_hierarchy(None),
-            create_inspector(None),
             create_schematic_tree(None),
             create_dashboard(None),
             create_data_overview(None),

--- a/libs/elodin-editor/src/ui/hierarchy.rs
+++ b/libs/elodin-editor/src/ui/hierarchy.rs
@@ -10,7 +10,9 @@ use fuzzy_matcher::{FuzzyMatcher, skim::SkimMatcherV2};
 use impeller2_bevy::EntityMap;
 use std::collections::BTreeMap;
 
-use super::{inspector::search, schematic::Branch, widgets::WidgetSystem};
+use super::{
+    inspector::search, schematic::Branch, tiles::sidebar::sidebar_content_ui, widgets::WidgetSystem,
+};
 
 #[derive(SystemParam)]
 pub struct HierarchyContent<'w> {
@@ -50,15 +52,17 @@ impl WidgetSystem for HierarchyContent<'_> {
         } = state.get_mut(world);
 
         let search_text = entity_filter.0.clone();
-        header(ui, entity_filter, icons.search);
-        entity_list(
-            ui,
-            &eql_ctx,
-            &entity_map,
-            &mut selected_object,
-            &search_text,
-            icons,
-        );
+        sidebar_content_ui(ui, |ui| {
+            header(ui, entity_filter, icons.search);
+            entity_list(
+                ui,
+                &eql_ctx,
+                &entity_map,
+                &mut selected_object,
+                &search_text,
+                icons,
+            );
+        });
     }
 }
 

--- a/libs/elodin-editor/src/ui/inspector/entity.rs
+++ b/libs/elodin-editor/src/ui/inspector/entity.rs
@@ -163,6 +163,9 @@ fn inspector_item_value_ui(
     value: ElementValueMut<'_>,
     size: egui::Vec2,
 ) -> egui::Response {
+    if !size.x.is_finite() || !size.y.is_finite() || size.x <= 0.0 || size.y <= 0.0 {
+        return ui.allocate_response(egui::Vec2::ZERO, egui::Sense::hover());
+    }
     let label_color = get_scheme().text_secondary;
     ui.allocate_ui_with_layout(
         size,
@@ -226,6 +229,11 @@ fn inspector_item_multi(
     create_graph: &mut bool,
     line_width: f32,
 ) -> egui::Response {
+    let line_width = if line_width.is_finite() && line_width > 0.0 {
+        line_width
+    } else {
+        return ui.allocate_response(egui::Vec2::ZERO, egui::Sense::hover());
+    };
     let element_names = element_names
         .split(',')
         .filter(|s| !s.is_empty())
@@ -247,12 +255,18 @@ fn inspector_item_multi(
         let line_height = ui.spacing().interact_size.y * 1.4;
 
         let item_width_min = ui.spacing().interact_size.x * 2.4;
-        let items_per_line = (line_width / item_width_min).floor();
+        let mut items_per_line = (line_width / item_width_min).floor();
+        if !items_per_line.is_finite() || items_per_line < 1.0 {
+            items_per_line = 1.0;
+        }
 
         let necessary_spacing = (items_per_line - 1.0) * item_spacing.x;
-        let item_width = (line_width - necessary_spacing) / items_per_line;
+        let mut item_width = (line_width - necessary_spacing) / items_per_line;
+        if !item_width.is_finite() || item_width <= 1.0 {
+            item_width = item_width_min.max(1.0);
+        }
 
-        let desired_size = egui::vec2(item_width - 1.0, line_height);
+        let desired_size = egui::vec2((item_width - 1.0).max(0.0), line_height);
 
         ui.horizontal_wrapped(|ui| {
             ui.style_mut().spacing.item_spacing = item_spacing;

--- a/libs/elodin-editor/src/ui/inspector/mod.rs
+++ b/libs/elodin-editor/src/ui/inspector/mod.rs
@@ -12,6 +12,7 @@ use crate::ui::{
     InspectorAnchor, SelectedObject,
     colors::{self, get_scheme},
     tiles::TreeAction,
+    tiles::sidebar::sidebar_content_ui,
 };
 
 pub mod action;
@@ -83,68 +84,71 @@ impl WidgetSystem for InspectorContent<'_> {
         ui.painter()
             .rect_filled(ui.max_rect(), CornerRadius::ZERO, get_scheme().bg_primary);
 
-        egui::ScrollArea::vertical()
-            .max_width(ui.available_width())
-            .show(ui, |ui| {
-                egui::Frame::NONE
-                    .fill(get_scheme().bg_primary)
-                    .inner_margin(16.0)
-                    .show(ui, |ui| {
-                        ui.vertical(|ui| match selected_object {
-                            SelectedObject::None => {
-                                ui.add(empty_inspector());
-                                Default::default()
-                            }
-                            SelectedObject::Entity(pair) => ui.add_widget_with::<InspectorEntity>(
-                                world,
-                                "inspector_entity",
-                                (icons, pair),
-                            ),
-                            SelectedObject::Viewport { camera, .. } => {
-                                ui.add_widget_with::<InspectorViewport>(
-                                    world,
-                                    "inspector_viewport",
-                                    camera,
-                                );
-                                Default::default()
-                            }
-                            SelectedObject::Graph { graph_id, .. } => {
-                                ui.add_widget_with::<InspectorGraph>(
-                                    world,
-                                    "inspector_graph",
-                                    (icons, graph_id),
-                                );
-                                Default::default()
-                            }
-                            SelectedObject::Action { action_id, .. } => {
-                                ui.add_widget_with::<InspectorAction>(
-                                    world,
-                                    "inspector_action",
-                                    action_id,
-                                );
-                                Default::default()
-                            }
-                            SelectedObject::Object3D { entity, .. } => {
-                                ui.add_widget_with::<InspectorObject3D>(
-                                    world,
-                                    "inspector_object3d",
-                                    (icons, entity),
-                                );
-                                Default::default()
-                            }
-                            SelectedObject::DashboardNode { entity } => {
-                                ui.add_widget_with::<InspectorDashboardNode>(
-                                    world,
-                                    "inspector_dashboard_node",
-                                    entity,
-                                );
-                                Default::default()
-                            }
+        sidebar_content_ui(ui, |ui| {
+            egui::ScrollArea::vertical()
+                .max_width(ui.available_width())
+                .show(ui, |ui| {
+                    egui::Frame::NONE
+                        .fill(get_scheme().bg_primary)
+                        .inner_margin(16.0)
+                        .show(ui, |ui| {
+                            ui.vertical(|ui| match selected_object {
+                                SelectedObject::None => {
+                                    ui.add(empty_inspector());
+                                    Default::default()
+                                }
+                                SelectedObject::Entity(pair) => ui
+                                    .add_widget_with::<InspectorEntity>(
+                                        world,
+                                        "inspector_entity",
+                                        (icons, pair),
+                                    ),
+                                SelectedObject::Viewport { camera, .. } => {
+                                    ui.add_widget_with::<InspectorViewport>(
+                                        world,
+                                        "inspector_viewport",
+                                        camera,
+                                    );
+                                    Default::default()
+                                }
+                                SelectedObject::Graph { graph_id, .. } => {
+                                    ui.add_widget_with::<InspectorGraph>(
+                                        world,
+                                        "inspector_graph",
+                                        (icons, graph_id),
+                                    );
+                                    Default::default()
+                                }
+                                SelectedObject::Action { action_id, .. } => {
+                                    ui.add_widget_with::<InspectorAction>(
+                                        world,
+                                        "inspector_action",
+                                        action_id,
+                                    );
+                                    Default::default()
+                                }
+                                SelectedObject::Object3D { entity, .. } => {
+                                    ui.add_widget_with::<InspectorObject3D>(
+                                        world,
+                                        "inspector_object3d",
+                                        (icons, entity),
+                                    );
+                                    Default::default()
+                                }
+                                SelectedObject::DashboardNode { entity } => {
+                                    ui.add_widget_with::<InspectorDashboardNode>(
+                                        world,
+                                        "inspector_dashboard_node",
+                                        entity,
+                                    );
+                                    Default::default()
+                                }
+                            })
                         })
-                    })
-                    .inner
-                    .inner
-            })
-            .inner
+                        .inner
+                        .inner
+                })
+                .inner
+        })
     }
 }

--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -677,12 +677,7 @@ impl LoadSchematicParams<'_, '_> {
                 };
                 tile_state.insert_tile(Tile::Pane(Pane::ActionTile(pane)), parent_id, false)
             }
-            Panel::Inspector => {
-                tile_state.insert_tile(Tile::Pane(Pane::Inspector), parent_id, false)
-            }
-            Panel::Hierarchy => {
-                tile_state.insert_tile(Tile::Pane(Pane::Hierarchy), parent_id, false)
-            }
+            Panel::Inspector | Panel::Hierarchy => None,
             Panel::SchematicTree => {
                 let entity = self.commands.spawn(super::TreeWidgetState::default()).id();
                 let pane = TreePane { entity };

--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -735,6 +735,10 @@ impl LoadSchematicParams<'_, '_> {
     /// Create a default Data Overview panel when no schematic is found.
     /// This provides immediate visibility into the database contents.
     pub fn load_default_data_overview(&mut self) {
+        if self.eql.0.component_parts.is_empty() {
+            return;
+        }
+
         let primary_window = *self.primary_window;
         let mut window_state = self
             .window_states

--- a/libs/elodin-editor/src/ui/schematic/mod.rs
+++ b/libs/elodin-editor/src/ui/schematic/mod.rs
@@ -191,8 +191,7 @@ impl SchematicParam<'_, '_> {
                 Pane::DataOverview(_) => None,
 
                 // Structural panes
-                Pane::Hierarchy => Some(Panel::Hierarchy),
-                Pane::Inspector => Some(Panel::Inspector),
+                Pane::Hierarchy | Pane::Inspector => None,
                 Pane::SchematicTree(_) => Some(Panel::SchematicTree),
 
                 // Dashboard

--- a/libs/elodin-editor/src/ui/schematic/mod.rs
+++ b/libs/elodin-editor/src/ui/schematic/mod.rs
@@ -191,7 +191,6 @@ impl SchematicParam<'_, '_> {
                 Pane::DataOverview(_) => None,
 
                 // Structural panes
-                Pane::Hierarchy | Pane::Inspector => None,
                 Pane::SchematicTree(_) => Some(Panel::SchematicTree),
 
                 // Dashboard
@@ -199,6 +198,7 @@ impl SchematicParam<'_, '_> {
                     let dashboard = self.dashboards.get(dash.entity).ok()?;
                     Some(Panel::Dashboard(Box::new(dashboard.clone())))
                 }
+                _ => None,
             },
 
             // ---- Containers ----

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -63,7 +63,10 @@ use crate::{
 
 mod sidebar;
 
-use sidebar::{SidebarKind, SidebarMaskState, apply_share_updates, collect_sidebar_gutter_updates};
+use sidebar::{
+    SidebarKind, SidebarMaskState, apply_share_updates, collect_sidebar_gutter_updates,
+    tab_add_visible, tab_title_visible,
+};
 
 pub(crate) fn plugin(app: &mut App) {
     app.register_type::<WindowId>()
@@ -1393,50 +1396,6 @@ struct TreeBehavior<'w> {
 
 type ShareUpdate = (TileId, TileId, TileId, f32, f32);
 
-impl TreeBehavior<'_> {
-    fn tile_is_sidebar(tiles: &Tiles<Pane>, tile_id: TileId) -> bool {
-        match tiles.get(tile_id) {
-            Some(Tile::Pane(Pane::Hierarchy | Pane::Inspector)) => true,
-            Some(Tile::Container(Container::Tabs(tabs))) => {
-                !tabs.children.is_empty()
-                    && tabs
-                        .children
-                        .iter()
-                        .all(|child| Self::tile_is_sidebar(tiles, *child))
-            }
-            Some(Tile::Container(Container::Linear(linear))) => {
-                !linear.children.is_empty()
-                    && linear
-                        .children
-                        .iter()
-                        .all(|child| Self::tile_is_sidebar(tiles, *child))
-            }
-            Some(Tile::Container(Container::Grid(grid))) => {
-                let mut any = false;
-                let all = grid.children().all(|child| {
-                    any = true;
-                    Self::tile_is_sidebar(tiles, *child)
-                });
-                any && all
-            }
-            _ => false,
-        }
-    }
-
-    fn tabs_are_sidebar_only(tiles: &Tiles<Pane>, tile_id: TileId) -> bool {
-        match tiles.get(tile_id) {
-            Some(Tile::Container(Container::Tabs(tabs))) => {
-                !tabs.children.is_empty()
-                    && tabs
-                        .children
-                        .iter()
-                        .all(|child| Self::tile_is_sidebar(tiles, *child))
-            }
-            _ => false,
-        }
-    }
-}
-
 #[derive(Clone)]
 pub enum TreeAction {
     AddViewport(Option<TileId>),
@@ -1494,7 +1453,7 @@ impl egui_tiles::Behavior<Pane> for TreeBehavior<'_> {
         tile_id: egui_tiles::TileId,
         state: &egui_tiles::TabState,
     ) -> egui::Response {
-        if Self::tile_is_sidebar(tiles, tile_id) {
+        if !tab_title_visible(tiles, tile_id) {
             let min_width = self.tab_title_spacing(ui.visuals()) * 2.0;
             let (_, rect) = ui.allocate_space(vec2(min_width, ui.available_height()));
             let response = ui.interact(rect, id, egui::Sense::click_and_drag());
@@ -1766,10 +1725,7 @@ impl egui_tiles::Behavior<Pane> for TreeBehavior<'_> {
         if self.read_only {
             return;
         }
-        let active_is_sidebar = tabs
-            .active
-            .is_some_and(|active| Self::tile_is_sidebar(tiles, active));
-        if active_is_sidebar || Self::tabs_are_sidebar_only(tiles, tile_id) {
+        if !tab_add_visible(tiles, tabs) {
             return;
         }
         let mut layout = SystemState::<TileLayout>::new(self.world);

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -2164,394 +2164,394 @@ impl WidgetSystem for TileLayout<'_, '_> {
             )
         };
 
-        let mut state_mut = state.get_mut(world);
-        let Some(mut ui_state) = state_mut.tile_param.target(Some(target_window)) else {
-            return;
-        };
-        let _ = std::mem::replace(&mut ui_state.tree, tree);
-        apply_share_updates(&mut ui_state.tree, &share_updates);
-        ui_state.sidebar_state = sidebar_state;
-        state_mut.viewport_contains_pointer.0 = ui.ui_contains_pointer();
+        {
+            let mut state_mut = state.get_mut(world);
+            let Some(mut ui_state) = state_mut.tile_param.target(Some(target_window)) else {
+                return;
+            };
+            let _ = std::mem::replace(&mut ui_state.tree, tree);
+            apply_share_updates(&mut ui_state.tree, &share_updates);
+            ui_state.sidebar_state = sidebar_state;
+            state_mut.viewport_contains_pointer.0 = ui.ui_contains_pointer();
 
-        for mut editor_cam in state_mut.editor_cam.iter_mut() {
-            editor_cam.enabled_motion = EnabledMotion {
-                pan: state_mut.viewport_contains_pointer.0,
-                orbit: state_mut.viewport_contains_pointer.0,
-                zoom: state_mut.viewport_contains_pointer.0,
-            }
-        }
-
-        for diff in tree_actions.drain(..) {
-            if read_only && !matches!(diff, TreeAction::SelectTile(_)) {
-                continue;
-            }
-            match diff {
-                TreeAction::DeleteTab(tile_id) => {
-                    if read_only {
-                        continue;
-                    }
-                    let Some(tile) = ui_state.tree.tiles.get(tile_id) else {
-                        continue;
-                    };
-
-                    if let egui_tiles::Tile::Pane(Pane::Viewport(viewport)) = tile {
-                        if let Some(layer) = viewport.viewport_layer {
-                            state_mut.render_layer_alloc.free(layer);
-                        }
-                        if let Some(layer) = viewport.grid_layer {
-                            state_mut.render_layer_alloc.free(layer);
-                        }
-                        if let Some(camera) = viewport.camera {
-                            state_mut.commands.entity(camera).despawn();
-                        }
-                        if let Some(nav_gizmo_camera) = viewport.nav_gizmo_camera {
-                            state_mut.commands.entity(nav_gizmo_camera).despawn();
-                        }
-                        if let Some(nav_gizmo) = viewport.nav_gizmo {
-                            state_mut.commands.entity(nav_gizmo).despawn();
-                        }
-                    };
-
-                    if let egui_tiles::Tile::Pane(Pane::Graph(graph)) = tile {
-                        state_mut.commands.entity(graph.id).despawn();
-                    };
-
-                    if let egui_tiles::Tile::Pane(Pane::ActionTile(action)) = tile {
-                        state_mut.commands.entity(action.entity).despawn();
-                    };
-
-                    if let egui_tiles::Tile::Pane(Pane::VideoStream(pane)) = tile {
-                        state_mut.commands.entity(pane.entity).despawn();
-                    };
-
-                    if let egui_tiles::Tile::Pane(Pane::QueryPlot(pane)) = tile {
-                        state_mut.commands.entity(pane.entity).despawn();
-                    };
-
-                    if let egui_tiles::Tile::Pane(Pane::QueryTable(pane)) = tile {
-                        state_mut.commands.entity(pane.entity).despawn();
-                    };
-
-                    if let egui_tiles::Tile::Pane(Pane::SchematicTree(pane)) = tile {
-                        state_mut.commands.entity(pane.entity).despawn();
-                    };
-
-                    ui_state.tree.remove_recursively(tile_id);
-
-                    if let Some(graph_id) = ui_state.graphs.get(&tile_id) {
-                        state_mut.commands.entity(*graph_id).despawn();
-                        ui_state.graphs.remove(&tile_id);
-                    }
+            for mut editor_cam in state_mut.editor_cam.iter_mut() {
+                editor_cam.enabled_motion = EnabledMotion {
+                    pan: state_mut.viewport_contains_pointer.0,
+                    orbit: state_mut.viewport_contains_pointer.0,
+                    zoom: state_mut.viewport_contains_pointer.0,
                 }
-                TreeAction::AddViewport(parent_tile_id) => {
-                    if read_only {
-                        continue;
-                    }
-                    let viewport = Viewport::default();
-                    let label = viewport_label(&viewport);
-                    let viewport_pane = ViewportPane::spawn(
-                        &mut state_mut.commands,
-                        &state_mut.asset_server,
-                        &mut state_mut.meshes,
-                        &mut state_mut.materials,
-                        &mut state_mut.render_layer_alloc,
-                        &state_mut.eql_ctx.0,
-                        &viewport,
-                        label,
-                    );
+            }
 
-                    if let Some(tile_id) = ui_state.insert_tile(
-                        Tile::Pane(Pane::Viewport(viewport_pane)),
-                        parent_tile_id,
-                        true,
-                    ) {
+            for diff in tree_actions.drain(..) {
+                if read_only && !matches!(diff, TreeAction::SelectTile(_)) {
+                    continue;
+                }
+                match diff {
+                    TreeAction::DeleteTab(tile_id) => {
+                        if read_only {
+                            continue;
+                        }
+                        let Some(tile) = ui_state.tree.tiles.get(tile_id) else {
+                            continue;
+                        };
+
+                        if let egui_tiles::Tile::Pane(Pane::Viewport(viewport)) = tile {
+                            if let Some(layer) = viewport.viewport_layer {
+                                state_mut.render_layer_alloc.free(layer);
+                            }
+                            if let Some(layer) = viewport.grid_layer {
+                                state_mut.render_layer_alloc.free(layer);
+                            }
+                            if let Some(camera) = viewport.camera {
+                                state_mut.commands.entity(camera).despawn();
+                            }
+                            if let Some(nav_gizmo_camera) = viewport.nav_gizmo_camera {
+                                state_mut.commands.entity(nav_gizmo_camera).despawn();
+                            }
+                            if let Some(nav_gizmo) = viewport.nav_gizmo {
+                                state_mut.commands.entity(nav_gizmo).despawn();
+                            }
+                        };
+
+                        if let egui_tiles::Tile::Pane(Pane::Graph(graph)) = tile {
+                            state_mut.commands.entity(graph.id).despawn();
+                        };
+
+                        if let egui_tiles::Tile::Pane(Pane::ActionTile(action)) = tile {
+                            state_mut.commands.entity(action.entity).despawn();
+                        };
+
+                        if let egui_tiles::Tile::Pane(Pane::VideoStream(pane)) = tile {
+                            state_mut.commands.entity(pane.entity).despawn();
+                        };
+
+                        if let egui_tiles::Tile::Pane(Pane::QueryPlot(pane)) = tile {
+                            state_mut.commands.entity(pane.entity).despawn();
+                        };
+
+                        if let egui_tiles::Tile::Pane(Pane::QueryTable(pane)) = tile {
+                            state_mut.commands.entity(pane.entity).despawn();
+                        };
+
+                        if let egui_tiles::Tile::Pane(Pane::SchematicTree(pane)) = tile {
+                            state_mut.commands.entity(pane.entity).despawn();
+                        };
+
+                        ui_state.tree.remove_recursively(tile_id);
+
+                        if let Some(graph_id) = ui_state.graphs.get(&tile_id) {
+                            state_mut.commands.entity(*graph_id).despawn();
+                            ui_state.graphs.remove(&tile_id);
+                        }
+                    }
+                    TreeAction::AddViewport(parent_tile_id) => {
+                        if read_only {
+                            continue;
+                        }
+                        let viewport = Viewport::default();
+                        let label = viewport_label(&viewport);
+                        let viewport_pane = ViewportPane::spawn(
+                            &mut state_mut.commands,
+                            &state_mut.asset_server,
+                            &mut state_mut.meshes,
+                            &mut state_mut.materials,
+                            &mut state_mut.render_layer_alloc,
+                            &state_mut.eql_ctx.0,
+                            &viewport,
+                            label,
+                        );
+
+                        if let Some(tile_id) = ui_state.insert_tile(
+                            Tile::Pane(Pane::Viewport(viewport_pane)),
+                            parent_tile_id,
+                            true,
+                        ) {
+                            ui_state.tree.make_active(|id, _| id == tile_id);
+                        }
+                    }
+                    TreeAction::AddGraph(parent_tile_id, graph_bundle) => {
+                        if read_only {
+                            continue;
+                        }
+                        let graph_label = graph_label(&Graph::default());
+
+                        let graph_bundle = if let Some(graph_bundle) = *graph_bundle {
+                            graph_bundle
+                        } else {
+                            GraphBundle::new(
+                                &mut state_mut.render_layer_alloc,
+                                BTreeMap::default(),
+                                graph_label.clone(),
+                            )
+                        };
+                        let graph_id = state_mut.commands.spawn(graph_bundle).id();
+                        let graph = GraphPane::new(graph_id, graph_label.clone());
+                        let pane = Pane::Graph(graph);
+
+                        if let Some(tile_id) =
+                            ui_state.insert_tile(Tile::Pane(pane), parent_tile_id, true)
+                        {
+                            *state_mut.selected_object = SelectedObject::Graph { graph_id };
+                            ui_state.tree.make_active(|id, _| id == tile_id);
+                            ui_state.graphs.insert(tile_id, graph_id);
+                        }
+                    }
+                    TreeAction::AddMonitor(parent_tile_id, eql) => {
+                        if read_only {
+                            continue;
+                        }
+                        let monitor = MonitorPane::new("Monitor".to_string(), eql);
+
+                        let pane = Pane::Monitor(monitor);
+                        if let Some(tile_id) =
+                            ui_state.insert_tile(Tile::Pane(pane), parent_tile_id, true)
+                        {
+                            ui_state.tree.make_active(|id, _| id == tile_id);
+                        }
+                    }
+                    TreeAction::AddVideoStream(parent_tile_id, msg_id, label) => {
+                        if read_only {
+                            continue;
+                        }
+                        let entity = state_mut
+                            .commands
+                            .spawn((
+                                super::video_stream::VideoStream {
+                                    msg_id,
+                                    ..Default::default()
+                                },
+                                bevy::ui::Node {
+                                    position_type: PositionType::Absolute,
+                                    ..Default::default()
+                                },
+                                bevy::prelude::ImageNode {
+                                    image_mode: NodeImageMode::Stretch,
+                                    ..Default::default()
+                                },
+                                VideoDecoderHandle::default(),
+                            ))
+                            .id();
+                        let pane = Pane::VideoStream(super::video_stream::VideoStreamPane {
+                            entity,
+                            label: label.clone(),
+                        });
+                        if let Some(tile_id) =
+                            ui_state.insert_tile(Tile::Pane(pane), parent_tile_id, true)
+                        {
+                            ui_state.tree.make_active(|id, _| id == tile_id);
+                        }
+                    }
+                    TreeAction::AddDashboard(parent_tile_id, dashboard, label) => {
+                        if read_only {
+                            continue;
+                        }
+                        let entity = match spawn_dashboard(
+                            &dashboard,
+                            &state_mut.eql_ctx.0,
+                            &mut state_mut.commands,
+                            &state_mut.node_updater_params,
+                        ) {
+                            Ok(entity) => entity,
+                            Err(_) => state_mut.commands.spawn(bevy::ui::Node::default()).id(),
+                        };
+                        let pane = Pane::Dashboard(DashboardPane { entity, label });
+                        if let Some(tile_id) =
+                            ui_state.insert_tile(Tile::Pane(pane), parent_tile_id, true)
+                        {
+                            ui_state.tree.make_active(|id, _| id == tile_id);
+                        }
+                    }
+
+                    TreeAction::SelectTile(tile_id) => {
                         ui_state.tree.make_active(|id, _| id == tile_id);
-                    }
-                }
-                TreeAction::AddGraph(parent_tile_id, graph_bundle) => {
-                    if read_only {
-                        continue;
-                    }
-                    let graph_label = graph_label(&Graph::default());
 
-                    let graph_bundle = if let Some(graph_bundle) = *graph_bundle {
-                        graph_bundle
-                    } else {
-                        GraphBundle::new(
+                        if let Some(egui_tiles::Tile::Pane(pane)) = ui_state.tree.tiles.get(tile_id)
+                        {
+                            match pane {
+                                Pane::Graph(graph) => {
+                                    *state_mut.selected_object =
+                                        SelectedObject::Graph { graph_id: graph.id };
+                                }
+                                Pane::QueryPlot(plot) => {
+                                    *state_mut.selected_object = SelectedObject::Graph {
+                                        graph_id: plot.entity,
+                                    };
+                                }
+                                Pane::Viewport(viewport) => {
+                                    if let Some(camera) = viewport.camera {
+                                        *state_mut.selected_object =
+                                            SelectedObject::Viewport { camera };
+                                    }
+                                }
+                                _ => {}
+                            }
+                            if let Some(kind) = pane.sidebar_kind() {
+                                unmask_sidebar_by_kind(&mut ui_state, kind);
+                            }
+                            unmask_sidebar_by_kind(&mut ui_state, SidebarKind::Inspector);
+                        }
+                    }
+                    TreeAction::AddActionTile(parent_tile_id, button_name, lua_code) => {
+                        let entity = state_mut
+                            .commands
+                            .spawn(super::actions::ActionTile {
+                                button_name,
+                                lua: lua_code,
+                                status: Default::default(),
+                            })
+                            .id();
+                        let pane = Pane::ActionTile(ActionTilePane {
+                            entity,
+                            label: "Action".to_string(),
+                        });
+                        if let Some(tile_id) =
+                            ui_state.insert_tile(Tile::Pane(pane), parent_tile_id, true)
+                        {
+                            ui_state.tree.make_active(|id, _| id == tile_id);
+                        }
+                    }
+                    TreeAction::AddQueryTable(parent_tile_id) => {
+                        let entity = state_mut.commands.spawn(QueryTableData::default()).id();
+                        let pane = Pane::QueryTable(QueryTablePane { entity });
+                        if let Some(tile_id) =
+                            ui_state.insert_tile(Tile::Pane(pane), parent_tile_id, true)
+                        {
+                            ui_state.tree.make_active(|id, _| id == tile_id);
+                        }
+                    }
+                    TreeAction::AddQueryPlot(parent_tile_id) => {
+                        let graph_bundle = GraphBundle::new(
                             &mut state_mut.render_layer_alloc,
                             BTreeMap::default(),
-                            graph_label.clone(),
-                        )
-                    };
-                    let graph_id = state_mut.commands.spawn(graph_bundle).id();
-                    let graph = GraphPane::new(graph_id, graph_label.clone());
-                    let pane = Pane::Graph(graph);
-
-                    if let Some(tile_id) =
-                        ui_state.insert_tile(Tile::Pane(pane), parent_tile_id, true)
-                    {
-                        *state_mut.selected_object = SelectedObject::Graph { graph_id };
-                        ui_state.tree.make_active(|id, _| id == tile_id);
-                        ui_state.graphs.insert(tile_id, graph_id);
-                    }
-                }
-                TreeAction::AddMonitor(parent_tile_id, eql) => {
-                    if read_only {
-                        continue;
-                    }
-                    let monitor = MonitorPane::new("Monitor".to_string(), eql);
-
-                    let pane = Pane::Monitor(monitor);
-                    if let Some(tile_id) =
-                        ui_state.insert_tile(Tile::Pane(pane), parent_tile_id, true)
-                    {
-                        ui_state.tree.make_active(|id, _| id == tile_id);
-                    }
-                }
-                TreeAction::AddVideoStream(parent_tile_id, msg_id, label) => {
-                    if read_only {
-                        continue;
-                    }
-                    let entity = state_mut
-                        .commands
-                        .spawn((
-                            super::video_stream::VideoStream {
-                                msg_id,
-                                ..Default::default()
-                            },
-                            bevy::ui::Node {
-                                position_type: PositionType::Absolute,
-                                ..Default::default()
-                            },
-                            bevy::prelude::ImageNode {
-                                image_mode: NodeImageMode::Stretch,
-                                ..Default::default()
-                            },
-                            VideoDecoderHandle::default(),
-                        ))
-                        .id();
-                    let pane = Pane::VideoStream(super::video_stream::VideoStreamPane {
-                        entity,
-                        label: label.clone(),
-                    });
-                    if let Some(tile_id) =
-                        ui_state.insert_tile(Tile::Pane(pane), parent_tile_id, true)
-                    {
-                        ui_state.tree.make_active(|id, _| id == tile_id);
-                    }
-                }
-                TreeAction::AddDashboard(parent_tile_id, dashboard, label) => {
-                    if read_only {
-                        continue;
-                    }
-                    let entity = match spawn_dashboard(
-                        &dashboard,
-                        &state_mut.eql_ctx.0,
-                        &mut state_mut.commands,
-                        &state_mut.node_updater_params,
-                    ) {
-                        Ok(entity) => entity,
-                        Err(_) => state_mut.commands.spawn(bevy::ui::Node::default()).id(),
-                    };
-                    let pane = Pane::Dashboard(DashboardPane { entity, label });
-                    if let Some(tile_id) =
-                        ui_state.insert_tile(Tile::Pane(pane), parent_tile_id, true)
-                    {
-                        ui_state.tree.make_active(|id, _| id == tile_id);
-                    }
-                }
-
-                TreeAction::SelectTile(tile_id) => {
-                    ui_state.tree.make_active(|id, _| id == tile_id);
-
-                    if let Some(egui_tiles::Tile::Pane(pane)) = ui_state.tree.tiles.get(tile_id) {
-                        match pane {
-                            Pane::Graph(graph) => {
-                                *state_mut.selected_object =
-                                    SelectedObject::Graph { graph_id: graph.id };
-                            }
-                            Pane::QueryPlot(plot) => {
-                                *state_mut.selected_object = SelectedObject::Graph {
-                                    graph_id: plot.entity,
-                                };
-                            }
-                            Pane::Viewport(viewport) => {
-                                if let Some(camera) = viewport.camera {
-                                    *state_mut.selected_object =
-                                        SelectedObject::Viewport { camera };
-                                }
-                            }
-                            _ => {}
+                            "Query Plot".to_string(),
+                        );
+                        let entity = state_mut
+                            .commands
+                            .spawn(QueryPlotData::default())
+                            .insert(graph_bundle)
+                            .id();
+                        let pane = Pane::QueryPlot(super::query_plot::QueryPlotPane {
+                            entity,
+                            rect: None,
+                            scrub_icon: None,
+                        });
+                        if let Some(tile_id) =
+                            ui_state.insert_tile(Tile::Pane(pane), parent_tile_id, true)
+                        {
+                            *state_mut.selected_object = SelectedObject::Graph { graph_id: entity };
+                            ui_state.tree.make_active(|id, _| id == tile_id);
                         }
-                        if let Some(kind) = pane.sidebar_kind() {
-                            unmask_sidebar_by_kind(&mut ui_state, kind);
+                    }
+                    TreeAction::AddSchematicTree(parent_tile_id) => {
+                        if read_only {
+                            continue;
                         }
-                        unmask_sidebar_by_kind(&mut ui_state, SidebarKind::Inspector);
+                        let entity = state_mut
+                            .commands
+                            .spawn(super::schematic::tree::TreeWidgetState::default())
+                            .id();
+                        let pane = Pane::SchematicTree(TreePane { entity });
+                        if let Some(tile_id) =
+                            ui_state.insert_tile(Tile::Pane(pane), parent_tile_id, true)
+                        {
+                            ui_state.tree.make_active(|id, _| id == tile_id);
+                        }
+                    }
+                    TreeAction::AddDataOverview(parent_tile_id) => {
+                        if read_only {
+                            continue;
+                        }
+                        let pane = Pane::DataOverview(DataOverviewPane::default());
+                        if let Some(tile_id) =
+                            ui_state.insert_tile(Tile::Pane(pane), parent_tile_id, true)
+                        {
+                            ui_state.tree.make_active(|id, _| id == tile_id);
+                        }
+                    }
+                    TreeAction::AddSidebars => {
+                        if read_only {
+                            continue;
+                        }
+                        ui_state.apply_sidebars_layout();
+                    }
+                    TreeAction::RenameContainer(tile_id, title) => {
+                        if read_only {
+                            continue;
+                        }
+                        ui_state.set_container_title(tile_id, title);
                     }
                 }
-                TreeAction::AddActionTile(parent_tile_id, button_name, lua_code) => {
-                    let entity = state_mut
-                        .commands
-                        .spawn(super::actions::ActionTile {
-                            button_name,
-                            lua: lua_code,
-                            status: Default::default(),
-                        })
-                        .id();
-                    let pane = Pane::ActionTile(ActionTilePane {
-                        entity,
-                        label: "Action".to_string(),
-                    });
-                    if let Some(tile_id) =
-                        ui_state.insert_tile(Tile::Pane(pane), parent_tile_id, true)
-                    {
-                        ui_state.tree.make_active(|id, _| id == tile_id);
+            }
+            let tiles = ui_state.tree.tiles.iter();
+            let active_tiles = ui_state.tree.active_tiles();
+            for (tile_id, tile) in tiles {
+                let egui_tiles::Tile::Pane(pane) = tile else {
+                    continue;
+                };
+                let visible = read_only || active_tiles.contains(tile_id);
+                match pane {
+                    Pane::Viewport(viewport) => {
+                        let Some(cam) = viewport.camera else { continue };
+                        if visible {
+                            if let Ok(mut cam) = state_mut.commands.get_entity(cam) {
+                                cam.try_insert(ViewportRect(viewport.rect));
+                            }
+                        } else if let Ok(mut cam) = state_mut.commands.get_entity(cam) {
+                            cam.try_insert(ViewportRect(None));
+                        }
                     }
-                }
-                TreeAction::AddQueryTable(parent_tile_id) => {
-                    let entity = state_mut.commands.spawn(QueryTableData::default()).id();
-                    let pane = Pane::QueryTable(QueryTablePane { entity });
-                    if let Some(tile_id) =
-                        ui_state.insert_tile(Tile::Pane(pane), parent_tile_id, true)
-                    {
-                        ui_state.tree.make_active(|id, _| id == tile_id);
+                    Pane::Hierarchy => {}
+                    Pane::Inspector => {}
+                    Pane::SchematicTree(_) => {}
+                    Pane::Graph(graph) => {
+                        if visible {
+                            if let Ok(mut cam) = state_mut.commands.get_entity(graph.id) {
+                                cam.try_insert(ViewportRect(graph.rect));
+                            }
+                        } else if let Ok(mut cam) = state_mut.commands.get_entity(graph.id) {
+                            cam.try_insert(ViewportRect(None));
+                        }
                     }
-                }
-                TreeAction::AddQueryPlot(parent_tile_id) => {
-                    let graph_bundle = GraphBundle::new(
-                        &mut state_mut.render_layer_alloc,
-                        BTreeMap::default(),
-                        "Query Plot".to_string(),
-                    );
-                    let entity = state_mut
-                        .commands
-                        .spawn(QueryPlotData::default())
-                        .insert(graph_bundle)
-                        .id();
-                    let pane = Pane::QueryPlot(super::query_plot::QueryPlotPane {
-                        entity,
-                        rect: None,
-                        scrub_icon: None,
-                    });
-                    if let Some(tile_id) =
-                        ui_state.insert_tile(Tile::Pane(pane), parent_tile_id, true)
-                    {
-                        *state_mut.selected_object = SelectedObject::Graph { graph_id: entity };
-                        ui_state.tree.make_active(|id, _| id == tile_id);
+                    Pane::Monitor(_) => {}
+                    Pane::QueryTable(_) => {}
+                    Pane::QueryPlot(query_plot) => {
+                        if visible {
+                            if let Ok(mut cam) = state_mut.commands.get_entity(query_plot.entity) {
+                                cam.try_insert(ViewportRect(query_plot.rect));
+                            }
+                        } else if let Ok(mut cam) = state_mut.commands.get_entity(query_plot.entity)
+                        {
+                            cam.try_insert(ViewportRect(None));
+                        }
                     }
-                }
-                TreeAction::AddSchematicTree(parent_tile_id) => {
-                    if read_only {
-                        continue;
+                    Pane::ActionTile(_) => {}
+                    Pane::VideoStream(stream) => {
+                        if let Ok(mut stream) = state_mut.commands.get_entity(stream.entity) {
+                            stream.try_insert(IsTileVisible(visible));
+                        }
                     }
-                    let entity = state_mut
-                        .commands
-                        .spawn(super::schematic::tree::TreeWidgetState::default())
-                        .id();
-                    let pane = Pane::SchematicTree(TreePane { entity });
-                    if let Some(tile_id) =
-                        ui_state.insert_tile(Tile::Pane(pane), parent_tile_id, true)
-                    {
-                        ui_state.tree.make_active(|id, _| id == tile_id);
+
+                    Pane::Dashboard(dash) => {
+                        if let Ok(mut stream) = state_mut.commands.get_entity(dash.entity) {
+                            stream.try_insert(IsTileVisible(visible));
+                        }
                     }
-                }
-                TreeAction::AddDataOverview(parent_tile_id) => {
-                    if read_only {
-                        continue;
-                    }
-                    let pane = Pane::DataOverview(DataOverviewPane::default());
-                    if let Some(tile_id) =
-                        ui_state.insert_tile(Tile::Pane(pane), parent_tile_id, true)
-                    {
-                        ui_state.tree.make_active(|id, _| id == tile_id);
-                    }
-                }
-                TreeAction::AddSidebars => {
-                    if read_only {
-                        continue;
-                    }
-                    ui_state.apply_sidebars_layout();
-                }
-                TreeAction::RenameContainer(tile_id, title) => {
-                    if read_only {
-                        continue;
-                    }
-                    ui_state.set_container_title(tile_id, title);
+                    Pane::DataOverview(_) => {}
                 }
             }
         }
-        let tiles = ui_state.tree.tiles.iter();
-        let active_tiles = ui_state.tree.active_tiles();
-        for (tile_id, tile) in tiles {
-            let egui_tiles::Tile::Pane(pane) = tile else {
-                continue;
-            };
-            let visible = read_only || active_tiles.contains(tile_id);
-            match pane {
-                Pane::Viewport(viewport) => {
-                    let Some(cam) = viewport.camera else { continue };
-                    if visible {
-                        if let Ok(mut cam) = state_mut.commands.get_entity(cam) {
-                            cam.try_insert(ViewportRect(viewport.rect));
-                        }
-                    } else if let Ok(mut cam) = state_mut.commands.get_entity(cam) {
-                        cam.try_insert(ViewportRect(None));
-                    }
-                }
-                Pane::Hierarchy => {}
-                Pane::Inspector => {}
-                Pane::SchematicTree(_) => {}
-                Pane::Graph(graph) => {
-                    if visible {
-                        if let Ok(mut cam) = state_mut.commands.get_entity(graph.id) {
-                            cam.try_insert(ViewportRect(graph.rect));
-                        }
-                    } else if let Ok(mut cam) = state_mut.commands.get_entity(graph.id) {
-                        cam.try_insert(ViewportRect(None));
-                    }
-                }
-                Pane::Monitor(_) => {}
-                Pane::QueryTable(_) => {}
-                Pane::QueryPlot(query_plot) => {
-                    if visible {
-                        if let Ok(mut cam) = state_mut.commands.get_entity(query_plot.entity) {
-                            cam.try_insert(ViewportRect(query_plot.rect));
-                        }
-                    } else if let Ok(mut cam) = state_mut.commands.get_entity(query_plot.entity) {
-                        cam.try_insert(ViewportRect(None));
-                    }
-                }
-                Pane::ActionTile(_) => {}
-                Pane::VideoStream(stream) => {
-                    if let Ok(mut stream) = state_mut.commands.get_entity(stream.entity) {
-                        stream.try_insert(IsTileVisible(visible));
-                    }
-                }
 
-                Pane::Dashboard(dash) => {
-                    if let Ok(mut stream) = state_mut.commands.get_entity(dash.entity) {
-                        stream.try_insert(IsTileVisible(visible));
-                    }
-                }
-                Pane::DataOverview(_) => {}
-            }
-        }
-
-        drop(state_mut);
-
-        if show_empty_overlay {
-            if let Some(rect) = empty_overlay_rect {
-                ui.allocate_new_ui(UiBuilder::new().max_rect(rect), |ui| {
-                    ui.add_widget_with::<TileLayoutEmpty>(
-                        world,
-                        "tile_layout_empty",
-                        TileLayoutEmptyArgs {
-                            icons: overlay_icons,
-                            window: Some(target_window),
-                        },
-                    );
-                });
-            }
+        if show_empty_overlay && let Some(rect) = empty_overlay_rect {
+            ui.allocate_new_ui(UiBuilder::new().max_rect(rect), |ui| {
+                ui.add_widget_with::<TileLayoutEmpty>(
+                    world,
+                    "tile_layout_empty",
+                    TileLayoutEmptyArgs {
+                        icons: overlay_icons,
+                        window: Some(target_window),
+                    },
+                );
+            });
         }
     }
 }

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -61,7 +61,7 @@ use crate::{
     ui::dashboard::NodeUpdaterParams,
 };
 
-mod sidebar;
+pub(crate) mod sidebar;
 
 use sidebar::{
     SidebarKind, SidebarMaskState, apply_share_updates, collect_sidebar_gutter_updates,

--- a/libs/elodin-editor/src/ui/tiles/sidebar.rs
+++ b/libs/elodin-editor/src/ui/tiles/sidebar.rs
@@ -1,11 +1,12 @@
 use super::{Pane, ShareUpdate, TileId};
-use egui::{Color32, Stroke};
+use egui::{Color32, Stroke, UiBuilder};
 use egui_tiles::{Container, Tile, Tiles};
 
 pub const MIN_SIDEBAR_FRACTION: f32 = 0.05;
 pub const MIN_SIDEBAR_PX: f32 = 16.0;
 pub const MIN_SIDEBAR_MASKED_PX: f32 = 4.0;
 pub const MIN_OTHER_PX: f32 = 32.0;
+pub const SIDEBAR_CONTENT_PAD_LEFT: f32 = 8.0;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SidebarKind {
@@ -495,6 +496,27 @@ pub fn apply_share_updates(tree: &mut egui_tiles::Tree<Pane>, updates: &[ShareUp
             linear.shares.set_share(*right_id, *right_share);
         }
     }
+}
+
+pub fn sidebar_content_ui<R>(
+    ui: &mut egui::Ui,
+    add_contents: impl FnOnce(&mut egui::Ui) -> R,
+) -> R {
+    let mut rect = ui.max_rect();
+    let width = rect.width();
+    let height = rect.height();
+    if !width.is_finite() || !height.is_finite() || width <= 0.0 || height <= 0.0 {
+        return add_contents(ui);
+    }
+
+    let pad = SIDEBAR_CONTENT_PAD_LEFT.min(width);
+    if !pad.is_finite() || pad <= 0.0 {
+        return add_contents(ui);
+    }
+
+    rect.min.x = (rect.min.x + pad).min(rect.max.x);
+    ui.allocate_new_ui(UiBuilder::new().max_rect(rect), add_contents)
+        .inner
 }
 
 pub fn tile_is_sidebar(tiles: &Tiles<Pane>, tile_id: TileId) -> bool {

--- a/libs/elodin-editor/src/ui/tiles/sidebar.rs
+++ b/libs/elodin-editor/src/ui/tiles/sidebar.rs
@@ -1,0 +1,498 @@
+use super::{Pane, ShareUpdate, TileId};
+use egui::{Color32, Stroke};
+use egui_tiles::{Container, Tile};
+
+pub const MIN_SIDEBAR_FRACTION: f32 = 0.05;
+pub const MIN_SIDEBAR_PX: f32 = 16.0;
+pub const MIN_SIDEBAR_MASKED_PX: f32 = 4.0;
+pub const MIN_OTHER_PX: f32 = 32.0;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SidebarKind {
+    Hierarchy,
+    Inspector,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct SidebarMaskState {
+    pub hierarchy_masked: bool,
+    pub inspector_masked: bool,
+    pub last_hierarchy_share: Option<f32>,
+    pub last_inspector_share: Option<f32>,
+}
+
+impl Default for SidebarMaskState {
+    fn default() -> Self {
+        Self {
+            hierarchy_masked: true,
+            inspector_masked: true,
+            last_hierarchy_share: Some(0.2),
+            last_inspector_share: Some(0.2),
+        }
+    }
+}
+
+impl SidebarMaskState {
+    pub fn masked(&self, kind: SidebarKind) -> bool {
+        match kind {
+            SidebarKind::Hierarchy => self.hierarchy_masked,
+            SidebarKind::Inspector => self.inspector_masked,
+        }
+    }
+
+    pub fn set_masked(&mut self, kind: SidebarKind, masked: bool) {
+        match kind {
+            SidebarKind::Hierarchy => self.hierarchy_masked = masked,
+            SidebarKind::Inspector => self.inspector_masked = masked,
+        }
+    }
+
+    pub fn last_share(&self, kind: SidebarKind) -> Option<f32> {
+        match kind {
+            SidebarKind::Hierarchy => self.last_hierarchy_share,
+            SidebarKind::Inspector => self.last_inspector_share,
+        }
+    }
+
+    pub fn set_last_share(&mut self, kind: SidebarKind, share: Option<f32>) {
+        match kind {
+            SidebarKind::Hierarchy => self.last_hierarchy_share = share,
+            SidebarKind::Inspector => self.last_inspector_share = share,
+        }
+    }
+}
+
+// Compute sidebar gutter interactions and return share updates to apply.
+pub fn collect_sidebar_gutter_updates(
+    tree: &mut egui_tiles::Tree<Pane>,
+    ui: &mut egui::Ui,
+    painter: egui::Painter,
+    gutter_width: f32,
+    mask_state: &mut SidebarMaskState,
+) -> Vec<ShareUpdate> {
+    struct GutterCtx<'a> {
+        tree: &'a mut egui_tiles::Tree<Pane>,
+        ui: &'a mut egui::Ui,
+        painter: egui::Painter,
+        gutter_width: f32,
+        mask_state: &'a mut SidebarMaskState,
+        share_updates: Vec<ShareUpdate>,
+    }
+
+    #[derive(Clone, Copy)]
+    struct PairInfo {
+        container_id: TileId,
+        parent_rect: egui::Rect,
+        left_id: TileId,
+        left_rect: egui::Rect,
+        left_kind: Option<SidebarKind>,
+        right_id: TileId,
+        right_rect: egui::Rect,
+        right_kind: Option<SidebarKind>,
+    }
+
+    impl<'a> GutterCtx<'a> {
+        fn sidebar_kind(&self, id: TileId) -> Option<SidebarKind> {
+            match self.tree.tiles.get(id) {
+                Some(Tile::Pane(Pane::Hierarchy)) => Some(SidebarKind::Hierarchy),
+                Some(Tile::Pane(Pane::Inspector)) => Some(SidebarKind::Inspector),
+                Some(Tile::Container(Container::Tabs(tabs))) => {
+                    for child in tabs.children.iter() {
+                        if let Some(kind) = self.sidebar_kind(*child) {
+                            return Some(kind);
+                        }
+                    }
+                    None
+                }
+                Some(Tile::Container(Container::Linear(linear))) => {
+                    for child in linear.children.iter() {
+                        if let Some(kind) = self.sidebar_kind(*child) {
+                            return Some(kind);
+                        }
+                    }
+                    None
+                }
+                Some(Tile::Container(Container::Grid(grid))) => {
+                    for child in grid.children() {
+                        if let Some(kind) = self.sidebar_kind(*child) {
+                            return Some(kind);
+                        }
+                    }
+                    None
+                }
+                _ => None,
+            }
+        }
+
+        fn apply_shares(
+            &mut self,
+            container_id: TileId,
+            left_id: TileId,
+            right_id: TileId,
+            left: f32,
+            right: f32,
+        ) {
+            if let Some(Tile::Container(Container::Linear(linear))) =
+                self.tree.tiles.get_mut(container_id)
+            {
+                linear.shares.set_share(left_id, left);
+                linear.shares.set_share(right_id, right);
+            }
+            self.share_updates
+                .push((container_id, left_id, right_id, left, right));
+            self.ui.ctx().request_repaint();
+        }
+
+        fn compute_sidebar_shares(
+            &self,
+            pair_sum: f32,
+            min_other_share: f32,
+            min_sidebar_share: f32,
+            target_sidebar_share: f32,
+            sidebar_on_left: bool,
+        ) -> (f32, f32) {
+            let max_sidebar_share = (pair_sum - min_other_share).max(0.01);
+            let clamped = target_sidebar_share
+                .max(min_sidebar_share.max(0.01))
+                .min(max_sidebar_share);
+            let left_share = if sidebar_on_left {
+                clamped
+            } else {
+                pair_sum - clamped
+            };
+            let right_share = pair_sum - left_share;
+            (left_share.max(0.01), right_share.max(0.01))
+        }
+
+        fn process_pair(&mut self, pair: PairInfo) {
+            let left_sidebar = pair.left_kind.is_some();
+            let right_sidebar = pair.right_kind.is_some();
+            if left_sidebar == right_sidebar {
+                return;
+            }
+            let sidebar_kind = match (pair.left_kind, pair.right_kind) {
+                (Some(k), _) => k,
+                (_, Some(k)) => k,
+                _ => return,
+            };
+            let gutter_draw_width = self.gutter_width.max(MIN_SIDEBAR_MASKED_PX);
+            let sidebar_on_left = left_sidebar;
+            let pair_width = pair.left_rect.width() + pair.right_rect.width();
+            let (share_left, share_right) = match self.tree.tiles.get(pair.container_id) {
+                Some(Tile::Container(Container::Linear(linear))) => {
+                    (linear.shares[pair.left_id], linear.shares[pair.right_id])
+                }
+                _ => return,
+            };
+            let pair_sum = share_left + share_right;
+            if pair_sum <= 0.0 {
+                return;
+            }
+            let share_per_px = if pair_width > 0.0 {
+                pair_sum / pair_width
+            } else {
+                0.0
+            };
+            let min_sidebar_px =
+                (pair.parent_rect.width() * MIN_SIDEBAR_FRACTION).max(MIN_SIDEBAR_PX);
+            let min_other_px = MIN_OTHER_PX;
+            let min_sidebar_share = if share_per_px > 0.0 {
+                min_sidebar_px * share_per_px
+            } else {
+                pair_sum * MIN_SIDEBAR_FRACTION
+            };
+            let min_other_share = if share_per_px > 0.0 {
+                min_other_px * share_per_px
+            } else {
+                pair_sum * MIN_SIDEBAR_FRACTION
+            };
+
+            let gap = pair.right_rect.min.x - pair.left_rect.max.x;
+            let mut center_x = (pair.left_rect.max.x + pair.right_rect.min.x) * 0.5;
+            if gap < gutter_draw_width {
+                let offset = (gutter_draw_width - gap).max(0.0) * 0.5;
+                if left_sidebar {
+                    center_x -= offset;
+                } else {
+                    center_x += offset;
+                }
+            }
+            let half = gutter_draw_width * 0.5;
+            center_x = center_x
+                .max(pair.parent_rect.left() + half)
+                .min(pair.parent_rect.right() - half);
+            let gutter_rect = egui::Rect::from_min_max(
+                egui::pos2(center_x - half, pair.parent_rect.top()),
+                egui::pos2(center_x + half, pair.parent_rect.bottom()),
+            );
+
+            let gutter_color = Color32::from_gray(80);
+            let fill = gutter_color;
+            let stroke = Stroke::new(1.0, gutter_color);
+            self.painter.rect_filled(gutter_rect, 0.0, fill);
+            self.painter
+                .rect_stroke(gutter_rect, 0.0, stroke, egui::StrokeKind::Inside);
+
+            let id = self.ui.id().with((
+                "sidebar_gutter",
+                pair.container_id,
+                pair.left_id,
+                pair.right_id,
+            ));
+            #[derive(Clone, Copy, Default)]
+            struct DragState {
+                left_width: f32,
+                right_width: f32,
+                start_x: f32,
+                active: bool,
+            }
+            let mut drag_state = self
+                .ui
+                .ctx()
+                .data(|d| d.get_temp::<DragState>(id))
+                .unwrap_or_default();
+
+            let response = self
+                .ui
+                .interact(gutter_rect, id, egui::Sense::click_and_drag())
+                .on_hover_cursor(egui::CursorIcon::PointingHand);
+
+            if response.hovered() {
+                self.ui
+                    .output_mut(|o| o.cursor_icon = egui::CursorIcon::PointingHand);
+            }
+
+            let mut sidebar_masked = self.mask_state.masked(sidebar_kind);
+
+            let click_inside_gutter = response.clicked_by(egui::PointerButton::Primary)
+                && self
+                    .ui
+                    .input(|i| i.pointer.interact_pos())
+                    .map(|p| gutter_rect.shrink(1.0).contains(p))
+                    .unwrap_or(false);
+
+            if click_inside_gutter {
+                let (left_share, right_share) = if sidebar_masked {
+                    let default_px = (pair.parent_rect.width() * 0.15).max(min_sidebar_px);
+                    let restore_share = if share_per_px > 0.0 {
+                        default_px * share_per_px
+                    } else {
+                        pair_sum * 0.15
+                    };
+                    self.compute_sidebar_shares(
+                        pair_sum,
+                        min_other_share,
+                        min_sidebar_share,
+                        restore_share,
+                        sidebar_on_left,
+                    )
+                } else {
+                    let current_sidebar_share = if sidebar_on_left {
+                        share_left
+                    } else {
+                        share_right
+                    };
+                    self.mask_state
+                        .set_last_share(sidebar_kind, Some(current_sidebar_share));
+
+                    let collapsed_px = gutter_draw_width;
+                    let collapsed_share = if share_per_px > 0.0 {
+                        collapsed_px * share_per_px
+                    } else {
+                        pair_sum * 0.01
+                    };
+
+                    self.compute_sidebar_shares(
+                        pair_sum,
+                        min_other_share,
+                        collapsed_share,
+                        collapsed_share,
+                        sidebar_on_left,
+                    )
+                };
+                self.apply_shares(
+                    pair.container_id,
+                    pair.left_id,
+                    pair.right_id,
+                    left_share,
+                    right_share,
+                );
+                self.mask_state.set_masked(sidebar_kind, !sidebar_masked);
+                sidebar_masked = !sidebar_masked;
+            }
+
+            if sidebar_masked {
+                if drag_state.active {
+                    self.ui.ctx().data_mut(|d| d.remove::<DragState>(id));
+                }
+                return;
+            }
+
+            let pointer_pos = self.ui.input(|i| i.pointer.interact_pos());
+            let pointer_down = self.ui.input(|i| i.pointer.primary_down());
+            if !drag_state.active && pointer_down && response.hovered() {
+                let start_x = pointer_pos.map(|p| p.x).unwrap_or(gutter_rect.center().x);
+                drag_state = DragState {
+                    left_width: pair.left_rect.width(),
+                    right_width: pair.right_rect.width(),
+                    start_x,
+                    active: true,
+                };
+                self.ui.ctx().data_mut(|d| d.insert_temp(id, drag_state));
+            }
+
+            if drag_state.active && pointer_down {
+                let delta = pointer_pos.map(|p| p.x - drag_state.start_x).unwrap_or(0.0);
+                let min_left = if left_sidebar {
+                    MIN_SIDEBAR_MASKED_PX
+                } else {
+                    MIN_OTHER_PX
+                };
+                let min_right = if right_sidebar {
+                    MIN_SIDEBAR_MASKED_PX
+                } else {
+                    MIN_OTHER_PX
+                };
+                let new_left = (drag_state.left_width + delta).max(min_left);
+                let new_right = (drag_state.right_width - delta).max(min_right);
+                if let Some(Tile::Container(Container::Linear(linear))) =
+                    self.tree.tiles.get_mut(pair.container_id)
+                {
+                    let share_left = linear.shares[pair.left_id];
+                    let share_right = linear.shares[pair.right_id];
+                    let share_sum = share_left + share_right;
+                    let current_sidebar_share = if sidebar_on_left {
+                        share_left
+                    } else {
+                        share_right
+                    };
+
+                    let total = new_left + new_right;
+                    let new_left_share = share_sum * new_left / total.max(1.0);
+                    let new_right_share = share_sum - new_left_share;
+                    let left_clamped = new_left_share.max(0.01);
+                    let right_clamped = new_right_share.max(0.01);
+                    self.apply_shares(
+                        pair.container_id,
+                        pair.left_id,
+                        pair.right_id,
+                        left_clamped,
+                        right_clamped,
+                    );
+
+                    let new_sidebar_share = if sidebar_on_left {
+                        new_left_share
+                    } else {
+                        new_right_share
+                    };
+                    let mask_threshold = min_sidebar_share * 1.05;
+                    if new_sidebar_share <= mask_threshold && !self.mask_state.masked(sidebar_kind)
+                    {
+                        let prev_last = self.mask_state.last_share(sidebar_kind);
+                        let should_update_last = current_sidebar_share > min_sidebar_share * 1.5;
+                        let store_share = if should_update_last {
+                            Some(current_sidebar_share)
+                        } else {
+                            prev_last
+                        };
+                        self.mask_state.set_last_share(sidebar_kind, store_share);
+                        self.mask_state.set_masked(sidebar_kind, true);
+                    }
+                }
+            }
+
+            if drag_state.active && !pointer_down {
+                self.ui.ctx().data_mut(|d| d.remove::<DragState>(id));
+            }
+        }
+
+        fn process_container(&mut self, container_id: TileId) {
+            let parent_rect = match self.tree.tiles.rect(container_id) {
+                Some(rect) => rect,
+                None => return,
+            };
+
+            let visible_children: Vec<TileId> = match self.tree.tiles.get(container_id) {
+                Some(Tile::Container(Container::Linear(linear))) => linear
+                    .children
+                    .iter()
+                    .copied()
+                    .filter(|child| self.tree.tiles.is_visible(*child))
+                    .collect(),
+                _ => Vec::new(),
+            };
+
+            if visible_children.len() < 2 {
+                return;
+            }
+
+            let mut child_data = Vec::new();
+            for child in &visible_children {
+                if let Some(rect) = self.tree.tiles.rect(*child) {
+                    let sidebar_kind = self.sidebar_kind(*child);
+                    child_data.push((*child, rect, sidebar_kind));
+                }
+            }
+
+            if child_data.len() < 2 {
+                return;
+            }
+
+            for pair in child_data.windows(2) {
+                let (left_id, left_rect, left_kind) = pair[0];
+                let (right_id, right_rect, right_kind) = pair[1];
+                self.process_pair(PairInfo {
+                    container_id,
+                    parent_rect,
+                    left_id,
+                    left_rect,
+                    left_kind,
+                    right_id,
+                    right_rect,
+                    right_kind,
+                });
+            }
+        }
+
+        fn run(mut self) -> Vec<ShareUpdate> {
+            let linear_ids: Vec<_> = self
+                .tree
+                .tiles
+                .iter()
+                .filter_map(|(id, tile)| {
+                    if matches!(tile, Tile::Container(Container::Linear(_))) {
+                        Some(*id)
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            for container_id in linear_ids {
+                self.process_container(container_id);
+            }
+            self.share_updates
+        }
+    }
+
+    let ctx = GutterCtx {
+        tree,
+        ui,
+        painter,
+        gutter_width,
+        mask_state,
+        share_updates: Vec::new(),
+    };
+    ctx.run()
+}
+
+// Apply gutter-driven share adjustments back onto the stored tree.
+pub fn apply_share_updates(tree: &mut egui_tiles::Tree<Pane>, updates: &[ShareUpdate]) {
+    for (container_id, left_id, right_id, left_share, right_share) in updates {
+        if let Some(Tile::Container(Container::Linear(linear))) = tree.tiles.get_mut(*container_id)
+        {
+            linear.shares.set_share(*left_id, *left_share);
+            linear.shares.set_share(*right_id, *right_share);
+        }
+    }
+}

--- a/libs/elodin-editor/src/ui/tiles/sidebar.rs
+++ b/libs/elodin-editor/src/ui/tiles/sidebar.rs
@@ -95,8 +95,7 @@ pub fn collect_sidebar_gutter_updates(
     impl<'a> GutterCtx<'a> {
         fn sidebar_kind(&self, id: TileId) -> Option<SidebarKind> {
             match self.tree.tiles.get(id) {
-                Some(Tile::Pane(Pane::Hierarchy)) => Some(SidebarKind::Hierarchy),
-                Some(Tile::Pane(Pane::Inspector)) => Some(SidebarKind::Inspector),
+                Some(Tile::Pane(pane)) => pane.sidebar_kind(),
                 Some(Tile::Container(Container::Tabs(tabs))) => {
                     for child in tabs.children.iter() {
                         if let Some(kind) = self.sidebar_kind(*child) {
@@ -521,7 +520,7 @@ pub fn sidebar_content_ui<R>(
 
 pub fn tile_is_sidebar(tiles: &Tiles<Pane>, tile_id: TileId) -> bool {
     match tiles.get(tile_id) {
-        Some(Tile::Pane(Pane::Hierarchy | Pane::Inspector)) => true,
+        Some(Tile::Pane(pane)) => pane.is_sidebar(),
         Some(Tile::Container(Container::Tabs(tabs))) => {
             !tabs.children.is_empty()
                 && tabs


### PR DESCRIPTION
> Merged through https://github.com/elodin-sys/elodin/pull/385

## Content
- Always-on hierarchy/inspector sidebars per window:
   - Sidebars can be masked/unmasked by clicking their gutters.
   - When unmasked, sidebars are resizable via the gutter slider.
   - Clicking a pane (e.g. a Graph) unmasks the Inspector and shows the matching content.
   - Clicking a Hierarchy row, updates the Inspector to the corresponding entity.

## Following PRs:
- https://github.com/elodin-sys/elodin/pull/384 (based on current 382)
   - https://github.com/elodin-sys/elodin/pull/385 (based on 384)
   
---
- Video (on a single window):

https://github.com/user-attachments/assets/04c32722-90b0-46d0-aa31-444e70104ee2
 
