### PR TITLE
Update deepstreamer version to 7.1

### DIFF
--- a/aleph/pkgs/deepstreamer.nix
+++ b/aleph/pkgs/deepstreamer.nix
@@ -20,8 +20,8 @@
 stdenv.mkDerivation {
   name = "deepstream";
   src = fetchurl {
-    url = "https://elo-public-misc.s3.us-east-2.amazonaws.com/deepstream-6.3_6.3.0-1_arm64.deb";
-    sha256 = "f3961bc473312d46f5e2568f41b37913cb09a5aef69d905451eaea9cb5ad42cf";
+    url = "https://elo-public-misc.s3.us-east-2.amazonaws.com/deepstream-7.1_7.1.0-1_arm64.deb";
+    sha256 = "8cc657e4784108c1a17da9bb8fbf736bc2ae4017065bb493486548c274465ca4";
   };
   nativeBuildInputs = [dpkg autoPatchelfHook autoAddDriverRunpath];
   buildInputs = [
@@ -57,7 +57,7 @@ stdenv.mkDerivation {
 
   postPatch = ''
     ls -la
-    cp -r opt/nvidia/deepstream/deepstream-6.3/* .
+    cp -r opt/nvidia/deepstream/deepstream-7.1/* .
     rm -rf nvidia
     mv lib/gst-plugins lib/gstreamer-1.0
 


### PR DESCRIPTION
Updating to a Jetpack 6 compatible version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the DeepStream Nix derivation to use the 7.1 ARM64 .deb and aligns paths.
> 
> - Bumps `src` URL and `sha256` to DeepStream `7.1.0-1`
> - Adjusts `postPatch` to copy from `deepstream-7.1` instead of `deepstream-6.3`
> - Build inputs and cleanup steps (removing Azure/Kafka libs) remain unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5af7b943e2aa11c7dfc1a35e2fe78d69c1e0b00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->