### PR TITLE
chore: Bump to version 0.16.0-alpha.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-serial-bridge"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "anyhow",
  "blackbox",
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-setup"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "anyhow",
  "fastrand 1.9.0",
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-status"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "anyhow",
  "image",
@@ -2595,7 +2595,7 @@ dependencies = [
 
 [[package]]
 name = "blackbox"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "roci",
  "zerocopy",
@@ -4838,7 +4838,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elodin"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "base64 0.22.1",
  "bevy",
@@ -4868,7 +4868,7 @@ dependencies = [
 
 [[package]]
 name = "elodin-db"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -4934,7 +4934,7 @@ dependencies = [
 
 [[package]]
 name = "elodin-db-tests"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "arrow",
  "elodin-db",
@@ -4957,7 +4957,7 @@ dependencies = [
 
 [[package]]
 name = "elodin-editor"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "arc-swap",
  "arrow",
@@ -5212,7 +5212,7 @@ checksum = "fc7e7a64c02cf7a5b51e745a9e45f60660a286f151c238b9d397b3e923f5082f"
 
 [[package]]
 name = "eql"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "hifitime",
  "impeller2",
@@ -6283,7 +6283,7 @@ checksum = "36119f3a540b086b4e436bb2b588cf98a68863470e0e880f4d0842f112a3183a"
 
 [[package]]
 name = "gst-elodin-plugin"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "anyhow",
  "gst-plugin-version-helper",
@@ -7032,7 +7032,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "bevy",
  "const-fnv1a-hash",
@@ -7054,7 +7054,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-bbq"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "bbq2",
  "impeller2",
@@ -7063,7 +7063,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-bevy"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "bbq2",
  "bevy",
@@ -7086,7 +7086,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-cli"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -7115,7 +7115,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-frame"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "cobs 0.2.3",
  "impeller2",
@@ -7123,7 +7123,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-kdl"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "impeller2",
  "impeller2-wkt",
@@ -7135,7 +7135,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-stellar"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "bbq2",
  "futures-concurrency",
@@ -7154,7 +7154,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-wkt"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "bevy",
  "compact_str",
@@ -7171,7 +7171,7 @@ dependencies = [
 
 [[package]]
 name = "impeller_py"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "anyhow",
  "futures-lite",
@@ -7291,7 +7291,7 @@ checksum = "d57a1694cff80cdd6c8a4cae63984578e2617528d3c266e53f56dfd3e279e9f7"
 
 [[package]]
 name = "inscriber"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "anyhow",
  "clap 4.5.53",
@@ -7897,7 +7897,7 @@ dependencies = [
 
 [[package]]
 name = "lqr"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "anyhow",
  "clap 4.5.53",
@@ -8132,7 +8132,7 @@ dependencies = [
 
 [[package]]
 name = "mekf"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "anyhow",
  "clap 4.5.53",
@@ -8820,7 +8820,7 @@ dependencies = [
 
 [[package]]
 name = "nox"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "approx",
  "boxcar",
@@ -8852,14 +8852,14 @@ dependencies = [
 
 [[package]]
 name = "nox-array"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "zerocopy",
 ]
 
 [[package]]
 name = "nox-ecs"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "approx",
  "arrow",
@@ -8890,7 +8890,7 @@ dependencies = [
 
 [[package]]
 name = "nox-ecs-macros"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "convert_case 0.6.0",
  "darling 0.20.11",
@@ -8902,7 +8902,7 @@ dependencies = [
 
 [[package]]
 name = "nox-frames"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "approx",
  "hifitime",
@@ -8912,7 +8912,7 @@ dependencies = [
 
 [[package]]
 name = "nox-py"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "bytes",
  "clap 4.5.53",
@@ -8947,7 +8947,7 @@ dependencies = [
 
 [[package]]
 name = "noxla"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "anyhow",
  "cc",
@@ -10119,7 +10119,7 @@ dependencies = [
 
 [[package]]
 name = "postcard-c-codegen"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "clap 4.5.53",
  "convert_case 0.6.0",
@@ -10845,7 +10845,7 @@ dependencies = [
 
 [[package]]
 name = "rc-jet-controller"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "anyhow",
  "clap 4.5.53",
@@ -11116,7 +11116,7 @@ dependencies = [
 
 [[package]]
 name = "roci"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "anyhow",
  "bbq2",
@@ -11142,7 +11142,7 @@ dependencies = [
 
 [[package]]
 name = "roci-adcs"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "approx",
  "nox",
@@ -11150,7 +11150,7 @@ dependencies = [
 
 [[package]]
 name = "roci-macros"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "convert_case 0.6.0",
  "darling 0.20.11",
@@ -11410,7 +11410,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "s10"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "async-watcher",
  "cargo_metadata",
@@ -12049,7 +12049,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stellarator"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "blocking",
  "futures",
@@ -12077,11 +12077,11 @@ dependencies = [
 
 [[package]]
 name = "stellarator-buf"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 
 [[package]]
 name = "stellarator-macros"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -12502,7 +12502,7 @@ checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tegrastats-bridge"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "anyhow",
  "fastrand 2.3.0",
@@ -13552,7 +13552,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "video-streamer"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -13571,7 +13571,7 @@ dependencies = [
 
 [[package]]
 name = "video-toolbox"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "bitflags 2.10.0",
  "block2 0.6.2",
@@ -14824,7 +14824,7 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "wmm"
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 dependencies = [
  "approx",
  "bindgen 0.70.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ members = [
 exclude = ["fsw/sensor-fw", "fsw/blackbox", "docs/memserve"]
 
 [workspace.package]
-version = "0.15.6-alpha.0"
+version = "0.16.0-alpha.0"
 edition = "2024"
 repository = "https://github.com/elodin-sys/elodin"
 


### PR DESCRIPTION
Bump to version 0.16.0-alpha.0 so we can do a patch release just in case it's needed since Aleph has been updated.