### PR TITLE
fix: data overview default display when no schematic.

### DIFF
--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -812,13 +812,14 @@ impl LoadSchematicParams<'_, '_> {
 
         let target_id = {
             let tree = &window_state.tile_state.tree;
-            tree.root().and_then(|root_id| match tree.tiles.get(root_id) {
-                Some(Tile::Container(Container::Linear(linear))) => {
-                    let center_idx = linear.children.len() / 2;
-                    linear.children.get(center_idx).copied()
-                }
-                _ => Some(root_id),
-            })
+            tree.root()
+                .and_then(|root_id| match tree.tiles.get(root_id) {
+                    Some(Tile::Container(Container::Linear(linear))) => {
+                        let center_idx = linear.children.len() / 2;
+                        linear.children.get(center_idx).copied()
+                    }
+                    _ => Some(root_id),
+                })
         };
 
         let mut central_tabs_id = None;
@@ -827,9 +828,10 @@ impl LoadSchematicParams<'_, '_> {
                 Some(Tile::Container(Container::Tabs(_))) => central_tabs_id = Some(target_id),
                 Some(Tile::Container(_)) => {
                     let tabs_container = Tile::Container(Container::new_tabs(vec![]));
-                    central_tabs_id = window_state
-                        .tile_state
-                        .insert_tile(tabs_container, Some(target_id), false);
+                    central_tabs_id =
+                        window_state
+                            .tile_state
+                            .insert_tile(tabs_container, Some(target_id), false);
                 }
                 _ => {}
             }
@@ -846,9 +848,10 @@ impl LoadSchematicParams<'_, '_> {
         // so the tab bar (+) is visible, then add Data Overview inside it.
         if let Some(central_tabs_id) = central_tabs_id {
             let tabs_container = Tile::Container(Container::new_tabs(vec![]));
-            if let Some(tabs_id) = window_state
-                .tile_state
-                .insert_tile(tabs_container, Some(central_tabs_id), false)
+            if let Some(tabs_id) =
+                window_state
+                    .tile_state
+                    .insert_tile(tabs_container, Some(central_tabs_id), false)
             {
                 let pane = Pane::DataOverview(DataOverviewPane::default());
                 if let Some(tile_id) =


### PR DESCRIPTION
## Issue
- The default display of Data Overview when reading an Elodin DB without a Schematic is not correct (identified by 
@x46085, thanks).

<img width="600" alt="image" src="https://github.com/user-attachments/assets/11f3aca0-9205-4dda-905d-d2dbca78ec16" />

---

## Testing
- Execute editor rc-jet example + Command Palette > Save DB (`rc-jet.db`).
- `cargo run --bin elodin-db --manifest-path /elodin/libs/db/Cargo.toml -- run 127.0.0.1:2240 /rc-jet.db` (terminal 1)
- `cargo run --bin elodin --manifest-path /elodin/apps/elodin/Cargo.toml -- editor 127.0.0.1:2240` (terminal 2)

<img width="600" alt="image" src="https://github.com/user-attachments/assets/2ccd9284-d753-433a-8258-a39f50cbe791" />
