### PR TITLE
Update Aleph-dev gcc version

### DIFF
--- a/aleph/modules/aleph-dev.nix
+++ b/aleph/modules/aleph-dev.nix
@@ -51,7 +51,7 @@ in {
       nvidia-jetpack.l4t-multimedia
       nvidia-jetpack.l4t-camera
     ];
-    NVCC_PREPEND_FLAGS = "--compiler-bindir ${pkgs.gcc11}/bin/gcc";
+    NVCC_PREPEND_FLAGS = "--compiler-bindir ${pkgs.gcc13}/bin/gcc";
     CONTAINER_HOST = "unix:///run/podman/podman.sock";
     GST_PLUGIN_PATH = lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" [
       gst_all_1.gstreamer


### PR DESCRIPTION
Enables use of GCC 13 on Aleph

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches NVCC to GCC 13 in `aleph/modules/aleph-dev.nix` to align `NVCC_PREPEND_FLAGS` with the GCC 13 toolchain.
> 
> - Update `NVCC_PREPEND_FLAGS` from `gcc11` to `gcc13` for CUDA builds
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f329c560c5d7b7f20c5b350f76ce298d8b6f7617. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->