### PR TITLE
chore(aleph): bump jetpack-nixos dep

### DIFF
--- a/aleph/flake.lock
+++ b/aleph/flake.lock
@@ -51,17 +51,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1766182822,
-        "narHash": "sha256-hQUjjQYHbD3oyws7niJRkIaR3a7+DkfZYvQpNCKwPRU=",
+        "lastModified": 1768685536,
+        "narHash": "sha256-94sYZ9jRsrBu24ia4pXEyudpQHCjKyy+4cN98bRrRjo=",
         "owner": "anduril",
         "repo": "jetpack-nixos",
-        "rev": "6e7aa572e435136a26bcf475d70aafdeef117e2d",
+        "rev": "2c98c9d6c326d67ae5f4909db61238d31352e18c",
         "type": "github"
       },
       "original": {
         "owner": "anduril",
         "repo": "jetpack-nixos",
-        "rev": "6e7aa572e435136a26bcf475d70aafdeef117e2d",
+        "rev": "2c98c9d6c326d67ae5f4909db61238d31352e18c",
         "type": "github"
       }
     },

--- a/aleph/flake.nix
+++ b/aleph/flake.nix
@@ -9,7 +9,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
-    jetpack.url = "github:anduril/jetpack-nixos/6e7aa572e435136a26bcf475d70aafdeef117e2d";
+    jetpack.url = "github:anduril/jetpack-nixos/2c98c9d6c326d67ae5f4909db61238d31352e18c";
     rust-overlay.url = "github:oxalica/rust-overlay";
     flake-utils.url = "github:numtide/flake-utils";
 
@@ -148,7 +148,7 @@
       packages.x86_64-linux = {
         flash-uefi = nixpkgs.legacyPackages.x86_64-linux.runCommand "flash-uefi" {} ''
           mkdir -p $out
-          cp ${jetpack.outputs.packages.x86_64-linux.flash-orin-nx-devkit}/bin/flash-orin-nx-devkit-cross $out/flash-uefi
+          cp ${jetpack.outputs.packages.x86_64-linux.flash-orin-nx-devkit}/bin/initrd-flash-orin-nx-devkit-cross $out/flash-uefi
           sed -i '46i\cp ${./tegra234-mb2-bct-misc-p3767-0000.dts} bootloader/generic/BCT/tegra234-mb2-bct-misc-p3767-0000.dts' $out/flash-uefi
           chmod +x $out/flash-uefi
         '';


### PR DESCRIPTION
chore(aleph): bump jetpack-nixos dependency. this fixes builds that were broken by upstream migration of nvidia git servers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates a hardware/firmware-related Nix flake input and switches the flashing script entrypoint, which can break image/flash workflows if upstream packaging or behavior changed.
> 
> **Overview**
> **Updates the Aleph Nix flake to a newer `jetpack-nixos` revision** (lockfile + input URL), pulling in upstream changes intended to restore builds impacted by NVIDIA repo migration.
> 
> **Adjusts the `packages.x86_64-linux.flash-uefi` wrapper** to copy `initrd-flash-orin-nx-devkit-cross` instead of `flash-orin-nx-devkit-cross`, aligning the local flash entrypoint with the updated `jetpack-nixos` package layout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f7f166d19e8caef6c9d39eef79e09aae117ab48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->