### PR TITLE
fix: Camera reset behavior. [abandoned]

### DIFF
--- a/libs/elodin-editor/src/ui/command_palette/palette_items.rs
+++ b/libs/elodin-editor/src/ui/command_palette/palette_items.rs
@@ -15,7 +15,7 @@ use bevy::{
     },
     log::{error, info, warn},
     pbr::{StandardMaterial, wireframe::WireframeConfig},
-    prelude::{Deref, DerefMut, Entity, In, Mut, Resource, Transform},
+    prelude::{Deref, DerefMut, Entity, In, Mut, Quat, Resource, Transform},
     window::PrimaryWindow,
 };
 use bevy_editor_cam::controller::{component::EditorCam, motion::CurrentMotion};
@@ -322,9 +322,11 @@ fn viewport_display_label(label: &str, window_label: &str) -> String {
 }
 
 fn reset_editor_cam(transform: &mut Transform, editor_cam: &mut EditorCam) {
-    *transform = Transform::IDENTITY;
+    transform.rotation = Quat::IDENTITY;
     editor_cam.current_motion = CurrentMotion::Stationary;
-    editor_cam.last_anchor_depth = -2.0;
+    if !editor_cam.last_anchor_depth.is_finite() || editor_cam.last_anchor_depth >= -1.0e-6 {
+        editor_cam.last_anchor_depth = -2.0;
+    }
 }
 
 #[derive(bevy::ecs::system::SystemParam)]


### PR DESCRIPTION
## Why this PR

The camera reset (from the ViewCube and the Command Palette) was setting `Transform::IDENTITY`, which effectively teleported the camera back to the world origin.

## Expected behavior
A camera reset should:
- reset the direction/orientation,
- stop any ongoing movement,
- without changing the camera’s current position.