### PR TITLE
fix(viewport inspector): prevent bevy_editor_cam from overriding near= (used by frustum) clip.

### DIFF
--- a/libs/elodin-editor/src/ui/inspector/viewport.rs
+++ b/libs/elodin-editor/src/ui/inspector/viewport.rs
@@ -194,10 +194,8 @@ impl WidgetSystem for InspectorViewport<'_, '_> {
                         persp.near = near;
                         persp.far = far;
 
-                        if near_changed {
-                            if let Ok(mut editor_cam) = editor_cams.get_mut(camera) {
-                                editor_cam.perspective.near_clip_limits = near..near;
-                            }
+                        if near_changed && let Ok(mut editor_cam) = editor_cams.get_mut(camera) {
+                            editor_cam.perspective.near_clip_limits = near..near;
                         }
                     }
 


### PR DESCRIPTION
## Content
Fix: bevy_editor_cam's update_perspective system overwrites perspective.near every frame based on anchor depth. When the user edits near/far in the viewport inspector, lock EditorCam's near_clip_limits so the value persists instead of reverting immediately.