### PR TITLE
Fix(Cube-Viewer): ZoomIn/ZoomOut with floating origin.

### DIFF
--- a/libs/elodin-editor/src/plugins/view_cube/camera.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/camera.rs
@@ -236,6 +236,18 @@ type FloatingOriginQuery<'w, 's> = Query<
     (With<FloatingOrigin>, Without<ViewCubeTargetCamera>),
 >;
 
+type ViewCubeCameraQuery<'w, 's> = Query<
+    'w,
+    's,
+    (
+        Entity,
+        &'static mut Transform,
+        &'static GlobalTransform,
+        &'static mut EditorCam,
+    ),
+    (With<ViewCubeTargetCamera>, Without<FloatingOrigin>),
+>;
+
 #[derive(SystemParam)]
 pub(super) struct ViewCubeEditorLookup<'w, 's> {
     viewports: Query<
@@ -256,10 +268,7 @@ pub fn handle_view_cube_editor(
     mut events: MessageReader<ViewCubeEvent>,
     view_cube_query: Query<&ViewCubeLink, With<ViewCubeRoot>>,
     cube_root_query: Query<&GlobalTransform, With<ViewCubeRoot>>,
-    mut camera_query: Query<
-        (Entity, &mut Transform, &GlobalTransform, &mut EditorCam),
-        (With<ViewCubeTargetCamera>, Without<FloatingOrigin>),
-    >,
+    mut camera_query: ViewCubeCameraQuery,
     mut lookup: ViewCubeEditorLookup,
     config: Res<ViewCubeConfig>,
     mut look_to: MessageWriter<LookToTrigger>,


### PR DESCRIPTION
## Problem
ZoomIn/ZoomOut buttons on the ViewCube did not work correctly with distant objects (e.g. rocket) — the camera lost the target after zooming.

## Solution
- Convert `orbit_target` to floating-origin space before distance calculations (it was in absolute world coordinates while the camera uses floating-origin space)
- Add `Without<>` filters to resolve B0001 query conflict between FloatingOrigin and ViewCubeTargetCamera queries