### PR TITLE
fix: reject component names containing whitespace #596

### DIFF
--- a/libs/nox-py/src/component.rs
+++ b/libs/nox-py/src/component.rs
@@ -43,7 +43,7 @@ use impeller2::types::ComponentId;
 #[derive(Clone, Debug)]
 #[pyclass(name = "Component")]
 pub struct PyComponent {
-    #[pyo3(set)]
+    #[pyo3(get)]
     pub name: String,
     #[pyo3(get, set)]
     pub ty: Option<ComponentType>,
@@ -70,6 +70,23 @@ impl PyComponent {
 
 #[pymethods]
 impl PyComponent {
+    #[setter]
+    pub fn set_name(&mut self, name: String) -> Result<(), Error> {
+        if name.contains(char::is_whitespace) {
+            return Err(PyValueError::new_err(format!(
+                "component name {:?} contains whitespace; \
+                 use snake_case or dot.separated names instead",
+                name
+            ))
+            .into());
+        }
+        if name.is_empty() {
+            return Err(PyValueError::new_err("component name must not be empty").into());
+        }
+        self.name = name;
+        Ok(())
+    }
+
     #[new]
     #[pyo3(signature = (name, ty = None, metadata = HashMap::default()))]
     pub fn new(
@@ -78,6 +95,19 @@ impl PyComponent {
         ty: Option<ComponentType>,
         metadata: HashMap<String, PyObject>,
     ) -> Result<Self, Error> {
+        if name.contains(char::is_whitespace) {
+            return Err(PyValueError::new_err(format!(
+                "component name {:?} contains whitespace; \
+                 use snake_case or dot.separated names instead",
+                name
+            ))
+            .into());
+        }
+
+        if name.is_empty() {
+            return Err(PyValueError::new_err("component name must not be empty").into());
+        }
+
         let metadata = metadata
             .into_iter()
             .map(|(k, v)| {
@@ -425,5 +455,31 @@ mod tests {
     fn component_names() {
         assert_eq!(WorldPos::<Op>::NAME, "world_pos");
         assert_eq!(Seed::<Op>::NAME, "seed");
+    }
+
+    #[test]
+    fn validate_component_name_rejects_whitespace() {
+        // Validation logic is tested via the helper since PyComponent::new
+        // requires a Python interpreter. Test the core rule here.
+        let bad_names = ["my component", "hello\tworld", "new\nline", " leading", "trailing "];
+        for name in bad_names {
+            assert!(
+                name.contains(char::is_whitespace),
+                "test setup: {:?} should contain whitespace",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn validate_component_name_accepts_valid() {
+        let good_names = ["world_pos", "rocket.fin_control", "my_component", "x", "a.b.c"];
+        for name in good_names {
+            assert!(
+                !name.contains(char::is_whitespace),
+                "test setup: {:?} should not contain whitespace",
+                name
+            );
+        }
     }
 }

--- a/libs/nox-py/src/component.rs
+++ b/libs/nox-py/src/component.rs
@@ -444,6 +444,11 @@ mod tests {
     use crate::{Seed, WorldPos};
     use impeller2::component::Component;
     use nox::Op;
+    use pyo3::prepare_freethreaded_python;
+
+    fn init_python() {
+        prepare_freethreaded_python();
+    }
 
     #[test]
     fn component_names() {
@@ -453,6 +458,8 @@ mod tests {
 
     #[test]
     fn validate_component_name_rejects_whitespace() {
+        init_python();
+
         let bad_names = [
             "my component",
             "hello\tworld",
@@ -496,7 +503,9 @@ mod tests {
 
     #[test]
     fn validate_component_name_rejects_empty() {
+        init_python();
+
         let err = validate_component_name("").unwrap_err().to_string();
-        assert_eq!(err, "component name must not be empty");
+        assert_eq!(err, "ValueError: component name must not be empty");
     }
 }

--- a/libs/nox-py/src/component.rs
+++ b/libs/nox-py/src/component.rs
@@ -68,21 +68,26 @@ impl PyComponent {
     }
 }
 
+fn validate_component_name(name: &str) -> Result<(), Error> {
+    if name.is_empty() {
+        return Err(PyValueError::new_err("component name must not be empty").into());
+    }
+    if name.contains(char::is_whitespace) {
+        return Err(PyValueError::new_err(format!(
+            "component name {:?} contains whitespace; \
+             use snake_case or dot.separated names instead",
+            name
+        ))
+        .into());
+    }
+    Ok(())
+}
+
 #[pymethods]
 impl PyComponent {
     #[setter]
     pub fn set_name(&mut self, name: String) -> Result<(), Error> {
-        if name.contains(char::is_whitespace) {
-            return Err(PyValueError::new_err(format!(
-                "component name {:?} contains whitespace; \
-                 use snake_case or dot.separated names instead",
-                name
-            ))
-            .into());
-        }
-        if name.is_empty() {
-            return Err(PyValueError::new_err("component name must not be empty").into());
-        }
+        validate_component_name(&name)?;
         self.name = name;
         Ok(())
     }
@@ -95,18 +100,7 @@ impl PyComponent {
         ty: Option<ComponentType>,
         metadata: HashMap<String, PyObject>,
     ) -> Result<Self, Error> {
-        if name.contains(char::is_whitespace) {
-            return Err(PyValueError::new_err(format!(
-                "component name {:?} contains whitespace; \
-                 use snake_case or dot.separated names instead",
-                name
-            ))
-            .into());
-        }
-
-        if name.is_empty() {
-            return Err(PyValueError::new_err("component name must not be empty").into());
-        }
+        validate_component_name(&name)?;
 
         let metadata = metadata
             .into_iter()
@@ -447,6 +441,7 @@ impl ShapeIndexer {
 
 #[cfg(test)]
 mod tests {
+    use super::validate_component_name;
     use crate::{Seed, WorldPos};
     use impeller2::component::Component;
     use nox::Op;
@@ -459,27 +454,40 @@ mod tests {
 
     #[test]
     fn validate_component_name_rejects_whitespace() {
-        // Validation logic is tested via the helper since PyComponent::new
-        // requires a Python interpreter. Test the core rule here.
-        let bad_names = ["my component", "hello\tworld", "new\nline", " leading", "trailing "];
+        let bad_names = [
+            "my component",
+            "hello\tworld",
+            "new\nline",
+            " leading",
+            "trailing ",
+        ];
         for name in bad_names {
             assert!(
-                name.contains(char::is_whitespace),
-                "test setup: {:?} should contain whitespace",
-                name
+                validate_component_name(name).is_err(),
+                "{name:?} should be rejected"
             );
         }
     }
 
     #[test]
     fn validate_component_name_accepts_valid() {
-        let good_names = ["world_pos", "rocket.fin_control", "my_component", "x", "a.b.c"];
+        let good_names = [
+            "world_pos",
+            "rocket.fin_control",
+            "my_component",
+            "x",
+            "a.b.c",
+        ];
         for name in good_names {
             assert!(
-                !name.contains(char::is_whitespace),
-                "test setup: {:?} should not contain whitespace",
-                name
+                validate_component_name(name).is_ok(),
+                "{name:?} should be accepted"
             );
         }
+    }
+
+    #[test]
+    fn validate_component_name_rejects_empty() {
+        assert!(validate_component_name("").is_err());
     }
 }

--- a/libs/nox-py/src/component.rs
+++ b/libs/nox-py/src/component.rs
@@ -185,7 +185,6 @@ impl PyComponent {
         }
 
         if component_data.ty.is_none() {
-            println!("{:?}", component_data);
             return Err(PyValueError::new_err("component type not found").into());
         }
         Ok(component_data)
@@ -467,6 +466,15 @@ mod tests {
                 "{name:?} should be rejected"
             );
         }
+
+        let err = validate_component_name("my component")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("contains whitespace"), "error was: {err}");
+        assert!(
+            err.contains("snake_case or dot.separated"),
+            "error was: {err}"
+        );
     }
 
     #[test]
@@ -488,6 +496,7 @@ mod tests {
 
     #[test]
     fn validate_component_name_rejects_empty() {
-        assert!(validate_component_name("").is_err());
+        let err = validate_component_name("").unwrap_err().to_string();
+        assert_eq!(err, "component name must not be empty");
     }
 }


### PR DESCRIPTION
- Based on  [#596](https://github.com/elodin-sys/elodin/pull/596).
- Original work is by @RCSharm07.