### PR TITLE
perf(elodin-db): db sink snapshot and vtable plan.

### DIFF
--- a/libs/db/src/follow.rs
+++ b/libs/db/src/follow.rs
@@ -24,7 +24,7 @@ use impeller2_wkt::*;
 use stellarator::{io::SplitExt, net::TcpStream};
 use tracing::{debug, info, warn};
 
-use crate::{AtomicTimestampExt, ComponentSchema, DB, DBSink, Error};
+use crate::{AtomicTimestampExt, ComponentSchema, DB, Error};
 
 /// Configuration for a follower connection.
 pub struct FollowConfig {
@@ -361,41 +361,7 @@ async fn run_follower_inner(config: &FollowConfig, db: &Arc<DB>) -> Result<(), E
 
             // Table – decomponentize and write to local DB.
             Packet::Table(table) => {
-                db.with_state(|state| -> Result<(), Error> {
-                    let mut sink = DBSink {
-                        components: &state.components,
-                        component_metadata: &state.component_metadata,
-                        last_updated: &db.last_updated,
-                        earliest_timestamp: &db.earliest_timestamp,
-                        sunk_new_time_series: false,
-                        table_received: db.apply_implicit_timestamp(),
-                        followed_components: &db.followed_components,
-                        has_followed_components: db
-                            .has_followed_components
-                            .load(std::sync::atomic::Ordering::Acquire),
-                        is_follower: true,
-                        batch_max_ts: Timestamp(i64::MIN),
-                        batch_min_ts: Timestamp(i64::MAX),
-                        batch_has_ts: false,
-                    };
-                    match table.sink(&state.vtable_registry, &mut sink) {
-                        Ok(Ok(())) => {}
-                        Ok(Err(e)) => {
-                            warn!(?e, "error decomponentizing follow-stream table");
-                        }
-                        Err(e) => {
-                            warn!(?e, "vtable error in follow-stream table");
-                        }
-                    }
-                    sink.flush_timestamps();
-                    if sink.sunk_new_time_series {
-                        db.vtable_gen
-                            .value
-                            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                        db.vtable_gen.wait_queue.wake_all();
-                    }
-                    Ok(())
-                })?;
+                db.sink_decomponentize_table(table, true, true)?;
             }
 
             // MsgWithTimestamp – write message with original timestamp,

--- a/libs/db/src/lib.rs
+++ b/libs/db/src/lib.rs
@@ -6,14 +6,16 @@ use impeller2::types::{PacketHeader, PacketTy};
 use impeller2::vtable::builder::{
     OpBuilder, component, raw_field, raw_table, schema, timestamp, vtable,
 };
-use impeller2::vtable::{Op, RealizedField, TIMESTAMP_NS_EXT_ID, builder};
+use impeller2::vtable::{
+    Op, RealizedField, TIMESTAMP_NS_EXT_ID, apply_table_dispatch_plan, builder,
+};
 use impeller2::{
     com_de::Decomponentize,
     registry,
     schema::Schema,
     types::{
-        ComponentId, ComponentView, IntoLenPacket, LenPacket, Msg, OwnedPacket as Packet, PacketId,
-        PrimType, RequestId, Timestamp,
+        ComponentId, ComponentView, IntoLenPacket, LenPacket, Msg, OwnedPacket as Packet,
+        OwnedTable, PacketId, PrimType, RequestId, Timestamp,
     },
     vtable::VTable,
 };
@@ -38,7 +40,7 @@ use std::{
     time::{Duration, Instant},
 };
 use stellarator::{
-    buf::Slice,
+    buf::{IoBuf, Slice},
     io::{AsyncRead, AsyncWrite, OwnedReader, OwnedWriter, SplitExt},
     net::{TcpListener, TcpStream, UdpSocket},
     rent,
@@ -253,8 +255,9 @@ pub struct DB {
 
 #[derive(Default)]
 pub struct State {
-    components: HashMap<ComponentId, Component>,
-    component_metadata: HashMap<ComponentId, ComponentMetadata>,
+    components: Arc<HashMap<ComponentId, Component>>,
+    component_metadata: Arc<HashMap<ComponentId, ComponentMetadata>>,
+    table_dispatch_plans: HashMap<PacketId, Arc<Vec<impeller2::vtable::TableDispatchEntry>>>,
 
     msg_logs: HashMap<PacketId, MsgLog>,
 
@@ -510,8 +513,8 @@ impl DB {
         db_state.set_version_last_opened(env!("CARGO_PKG_VERSION"));
         let now = Timestamp::now();
         let state = State {
-            components,
-            component_metadata,
+            components: Arc::new(components),
+            component_metadata: Arc::new(component_metadata),
             msg_logs,
             db_config: db_state.clone(),
             ..Default::default()
@@ -741,7 +744,24 @@ impl DB {
                 )?;
                 self.vtable_gen.fetch_add(1, atomic::Ordering::SeqCst);
             }
-            state.vtable_registry.map.insert(vtable.id, vtable.vtable);
+            let vtable_id = vtable.id;
+            let plan = match vtable.vtable.build_table_dispatch_plan() {
+                Ok(entries) => Some(Arc::new(entries)),
+                Err(e) => {
+                    warn!(
+                        ?e,
+                        vtable_id = ?vtable_id,
+                        "could not build table dispatch plan; using dynamic realize path"
+                    );
+                    None
+                }
+            };
+            state.vtable_registry.map.insert(vtable_id, vtable.vtable);
+            if let Some(p) = plan {
+                state.table_dispatch_plans.insert(vtable_id, p);
+            } else {
+                state.table_dispatch_plans.remove(&vtable_id);
+            }
             Ok::<_, Error>(())
         })?;
         Ok(())
@@ -812,6 +832,89 @@ impl DB {
         }
         stream_state
     }
+
+    pub(crate) fn sink_decomponentize_table<B: IoBuf>(
+        &self,
+        table: &OwnedTable<B>,
+        is_follower: bool,
+        suppress_apply_errors: bool,
+    ) -> Result<(), Error> {
+        let table_id = table.id;
+        let table_buf_len = table.buf.len();
+        let table_bytes: &[u8] = &table.buf;
+
+        let (components, component_metadata, plan_opt) = self.with_state(|state| {
+            (
+                state.components.clone(),
+                state.component_metadata.clone(),
+                state.table_dispatch_plans.get(&table_id).cloned(),
+            )
+        });
+
+        let mut sink = DBSink {
+            components: components.as_ref(),
+            component_metadata: component_metadata.as_ref(),
+            last_updated: &self.last_updated,
+            earliest_timestamp: &self.earliest_timestamp,
+            sunk_new_time_series: false,
+            table_received: self.apply_implicit_timestamp(),
+            followed_components: &self.followed_components,
+            has_followed_components: self
+                .has_followed_components
+                .load(std::sync::atomic::Ordering::Acquire),
+            is_follower,
+            batch_max_ts: Timestamp(i64::MIN),
+            batch_min_ts: Timestamp(i64::MAX),
+            batch_has_ts: false,
+        };
+
+        let apply_out = if let Some(plan) = plan_opt {
+            apply_table_dispatch_plan(plan.as_slice(), table_bytes, &mut sink)
+        } else {
+            self.with_state(|state| {
+                let vtable = state
+                    .vtable_registry
+                    .get(&table_id)
+                    .ok_or(impeller2::error::Error::VTableNotFound(table_id))?;
+                vtable.apply(table_bytes, &mut sink)
+            })
+        };
+
+        let apply_err = match apply_out {
+            Ok(Ok(())) => None,
+            Ok(Err(e)) => Some(e),
+            Err(e) => Some(Error::from(e)),
+        };
+
+        sink.flush_timestamps();
+        if sink.sunk_new_time_series {
+            self.vtable_gen
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
+
+        match apply_err {
+            None => Ok(()),
+            Some(e) => {
+                if suppress_apply_errors {
+                    warn!(
+                        err = ?e,
+                        ?table_id,
+                        table_buf_len,
+                        "error decomponentizing table packet"
+                    );
+                    Ok(())
+                } else {
+                    debug!(
+                        err = ?e,
+                        ?table_id,
+                        table_buf_len,
+                        "error sinking table packet"
+                    );
+                    Err(e)
+                }
+            }
+        }
+    }
 }
 
 impl State {
@@ -855,7 +958,7 @@ impl State {
                 db_path,
             )?;
         }
-        self.components.insert(component_id, component);
+        Arc::make_mut(&mut self.components).insert(component_id, component);
         Ok(())
     }
 
@@ -878,7 +981,8 @@ impl State {
             }
             // If this component is a timestamp source, update the metadata
             if is_timestamp_source
-                && let Some(existing_meta) = self.component_metadata.get_mut(&component_id)
+                && let Some(existing_meta) =
+                    Arc::make_mut(&mut self.component_metadata).get_mut(&component_id)
                 && !existing_meta.is_timestamp_source()
             {
                 existing_meta.set_timestamp_source(true);
@@ -925,7 +1029,7 @@ impl State {
         if is_timestamp_source || !self.component_metadata.contains_key(&component_id) {
             self.set_component_metadata(component_metadata, db_path)?;
         }
-        self.components.insert(component_id, component);
+        Arc::make_mut(&mut self.components).insert(component_id, component);
         Ok(())
     }
 
@@ -978,8 +1082,7 @@ impl State {
         if let Some(component) = self.components.get(&metadata.component_id) {
             component.set_name(metadata.name.clone());
         }
-        self.component_metadata
-            .insert(metadata.component_id, metadata);
+        Arc::make_mut(&mut self.component_metadata).insert(metadata.component_id, metadata);
         Ok(())
     }
 
@@ -1794,30 +1897,7 @@ async fn handle_packet<A: AsyncWrite + Send + Sync + 'static>(
             trace!(table.len = table.buf.len(), "sinking table");
             let table_id = table.id;
             let table_buf_len = table.buf.len();
-            if let Err(err) = db.with_state(|state| {
-                let mut sink = DBSink {
-                    components: &state.components,
-                    component_metadata: &state.component_metadata,
-                    last_updated: &db.last_updated,
-                    earliest_timestamp: &db.earliest_timestamp,
-                    sunk_new_time_series: false,
-                    table_received: db.apply_implicit_timestamp(),
-                    followed_components: &db.followed_components,
-                    has_followed_components: db
-                        .has_followed_components
-                        .load(std::sync::atomic::Ordering::Acquire),
-                    is_follower: false,
-                    batch_max_ts: Timestamp(i64::MIN),
-                    batch_min_ts: Timestamp(i64::MAX),
-                    batch_has_ts: false,
-                };
-                table.sink(&state.vtable_registry, &mut sink)??;
-                sink.flush_timestamps();
-                if sink.sunk_new_time_series {
-                    db.vtable_gen.fetch_add(1, atomic::Ordering::SeqCst);
-                }
-                Ok::<_, Error>(())
-            }) {
+            if let Err(err) = db.sink_decomponentize_table(table, false, false) {
                 debug!(?err, ?table_id, table_buf_len, "error sinking table packet");
                 return Err(err);
             }
@@ -2806,7 +2886,7 @@ async fn handle_fixed_stream<A: AsyncWrite>(
             let stream = stream.lock().await;
             let id: PacketId = state.stream_id.to_le_bytes()[..2].try_into().unwrap();
             table = LenPacket::table(id, 2048 - 16);
-            let vtable = DBVisitor.vtable(&components)?;
+            let vtable = DBVisitor.vtable(components.as_ref())?;
             let msg = VTableMsg { id, vtable };
             stream.send(msg.with_request_id(req_id)).await.0?;
             current_gen = vtable_gen;
@@ -2814,7 +2894,7 @@ async fn handle_fixed_stream<A: AsyncWrite>(
         table.clear();
         let t0 = Instant::now();
         if let Err(err) = DBVisitor
-            .populate_table(&components, &mut table, current_timestamp)
+            .populate_table(components.as_ref(), &mut table, current_timestamp)
             .await
         {
             warn!(?err, "failed to populate table");

--- a/libs/impeller2/src/vtable.rs
+++ b/libs/impeller2/src/vtable.rs
@@ -48,6 +48,11 @@
 
 use core::ops::Range;
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
 use serde::{Deserialize, Serialize};
 use zerocopy::{FromBytes, IntoBytes, TryFromBytes};
 
@@ -201,6 +206,8 @@ pub struct RealizedTimestamp {
     pub timestamp: Option<Timestamp>,
     pub range: Option<Range<usize>>,
     pub arg: OpRef,
+    /// True when the source is nanoseconds (timestamp_ns ext); divide by 1000 for microseconds.
+    pub is_ns: bool,
 }
 
 /// A slice of a table realized from an operation
@@ -235,9 +242,29 @@ pub enum RealizedOp<'a> {
 pub struct RealizedField<'a> {
     pub component_id: ComponentId,
     pub shape: &'a [usize],
+    /// Schema dimensions backing [`Self::shape`].
+    pub dim: &'a [u64],
     pub ty: PrimType,
     pub view: Option<ComponentView<'a>>,
     pub timestamp: Option<Timestamp>,
+    /// When set, the row timestamp must be re-read from this byte range on each table packet.
+    pub timestamp_source_range: Option<Range<usize>>,
+    /// When `true`, [`Self::timestamp_source_range`] holds nanoseconds (`/ 1000` for microseconds).
+    pub timestamp_source_is_ns: bool,
+}
+
+/// Precomputed per-field dispatch for [`apply_table_dispatch_plan`].
+#[cfg(feature = "alloc")]
+#[derive(Debug, Clone)]
+pub struct TableDispatchEntry {
+    pub component_id: ComponentId,
+    pub ty: PrimType,
+    pub dim: Vec<u64>,
+    pub value_offset: usize,
+    pub value_len: usize,
+    pub timestamp_fixed: Option<Timestamp>,
+    pub timestamp_source_range: Option<Range<usize>>,
+    pub timestamp_source_is_ns: bool,
 }
 
 impl<'a> RealizedOp<'a> {
@@ -352,6 +379,7 @@ impl<Ops: Buf<Op>, Data: Buf<u8>, Fields: Buf<Field>> VTable<Ops, Data, Fields> 
                     timestamp,
                     arg: *arg,
                     range: source.as_table_range(),
+                    is_ns: false,
                 }))
             }
             Op::None => Ok(RealizedOp::None),
@@ -376,6 +404,90 @@ impl<Ops: Buf<Op>, Data: Buf<u8>, Fields: Buf<Field>> VTable<Ops, Data, Fields> 
         }
     }
 
+    /// Evaluates a single [`Field`] the same way [`Self::realize_fields`] does.
+    pub fn realize_field<'a>(
+        &'a self,
+        field: &'a Field,
+        table: Option<&'a [u8]>,
+    ) -> Result<RealizedField<'a>, Error> {
+        let mut realized_op = self.realize(field.arg, table)?;
+        let mut timestamp: Option<RealizedTimestamp> = None;
+        let mut schema: Option<RealizedSchema<'_>> = None;
+        loop {
+            match realized_op {
+                RealizedOp::Component(ref component) => {
+                    let RealizedComponent { component_id } = *component;
+
+                    let schema = schema.as_ref().ok_or(Error::SchemaNotFound)?;
+                    // NOTE(sphw): bogan version of zerocopy::transmute_ref
+                    // In the future this will need to also support 32 bit systems
+                    // remove when https://github.com/google/zerocopy/pull/2428 is merged and released
+                    let shape: &[usize] = <[usize]>::ref_from_bytes(schema.dim.as_bytes())?;
+                    let view = if let Some(table) = table {
+                        let offset = field.offset.to_index();
+                        let data = table
+                            .get(offset..offset + field.len as usize)
+                            .ok_or(Error::BufferUnderflow)?;
+                        Some(ComponentView::try_from_bytes_shape(data, shape, schema.ty)?)
+                    } else {
+                        None
+                    };
+                    let (timestamp, timestamp_source_range, timestamp_source_is_ns) =
+                        match &timestamp {
+                            None => (None, None, false),
+                            Some(t) => {
+                                if t.range.is_some() {
+                                    (None, t.range.clone(), t.is_ns)
+                                } else {
+                                    (t.timestamp, None, false)
+                                }
+                            }
+                        };
+                    return Ok(RealizedField {
+                        component_id,
+                        view,
+                        timestamp,
+                        timestamp_source_range,
+                        timestamp_source_is_ns,
+                        shape,
+                        dim: schema.dim,
+                        ty: schema.ty,
+                    });
+                }
+                RealizedOp::Schema(s) => {
+                    let s = schema.insert(s);
+                    realized_op = self.realize(s.arg, table)?;
+                }
+                RealizedOp::Timestamp(t) => {
+                    let t = timestamp.insert(t);
+                    realized_op = self.realize(t.arg, table)?;
+                }
+                RealizedOp::Ext(e) => {
+                    if e.id == TIMESTAMP_NS_EXT_ID {
+                        // Convert nanosecond timestamp to microseconds.
+                        // When table is None (e.g. during VTable registration),
+                        // e.data is empty so we skip reading the value -- only
+                        // the structural walk matters in that case.
+                        let ts = if e.data.len() >= core::mem::size_of::<Timestamp>() {
+                            let ns = Timestamp::read_from_bytes(e.data)?;
+                            Some(Timestamp(ns.0 / 1000))
+                        } else {
+                            None
+                        };
+                        timestamp = Some(RealizedTimestamp {
+                            timestamp: ts,
+                            arg: e.arg,
+                            range: e.range.clone(),
+                            is_ns: true,
+                        });
+                    }
+                    realized_op = self.realize(e.arg, table)?;
+                }
+                _ => return Err(Error::InvalidOp),
+            }
+        }
+    }
+
     /// Evaluated each `field`, returning a `RealizedField`
     ///
     /// `realized_fields` loops through each field, turning each [`Offset`] into a reference, and evaluating any [`Op`]
@@ -386,69 +498,9 @@ impl<Ops: Buf<Op>, Data: Buf<u8>, Fields: Buf<Field>> VTable<Ops, Data, Fields> 
         &'a self,
         table: Option<&'a [u8]>,
     ) -> impl Iterator<Item = Result<RealizedField<'a>, Error>> + 'a {
-        self.fields.iter().map(move |field| {
-            let mut realized_op = self.realize(field.arg, table)?;
-            let mut timestamp: Option<RealizedTimestamp> = None;
-            let mut schema: Option<RealizedSchema<'_>> = None;
-            loop {
-                match realized_op {
-                    RealizedOp::Component(ref component) => {
-                        let RealizedComponent { component_id } = *component;
-
-                        let schema = schema.as_ref().ok_or(Error::SchemaNotFound)?;
-                        // NOTE(sphw): bogan version of zerocopy::transmute_ref
-                        // In the future this will need to also support 32 bit systems
-                        // remove when https://github.com/google/zerocopy/pull/2428 is merged and released
-                        let shape: &[usize] = <[usize]>::ref_from_bytes(schema.dim.as_bytes())?;
-                        let view = if let Some(table) = table {
-                            let offset = field.offset.to_index();
-                            let data = table
-                                .get(offset..offset + field.len as usize)
-                                .ok_or(Error::BufferUnderflow)?;
-                            Some(ComponentView::try_from_bytes_shape(data, shape, schema.ty)?)
-                        } else {
-                            None
-                        };
-                        return Ok(RealizedField {
-                            component_id,
-                            view,
-                            timestamp: timestamp.and_then(|t| t.timestamp),
-                            shape,
-                            ty: schema.ty,
-                        });
-                    }
-                    RealizedOp::Schema(s) => {
-                        let s = schema.insert(s);
-                        realized_op = self.realize(s.arg, table)?;
-                    }
-                    RealizedOp::Timestamp(t) => {
-                        let t = timestamp.insert(t);
-                        realized_op = self.realize(t.arg, table)?;
-                    }
-                    RealizedOp::Ext(e) => {
-                        if e.id == TIMESTAMP_NS_EXT_ID {
-                            // Convert nanosecond timestamp to microseconds.
-                            // When table is None (e.g. during VTable registration),
-                            // e.data is empty so we skip reading the value -- only
-                            // the structural walk matters in that case.
-                            let ts = if e.data.len() >= core::mem::size_of::<Timestamp>() {
-                                let ns = Timestamp::read_from_bytes(e.data)?;
-                                Some(Timestamp(ns.0 / 1000))
-                            } else {
-                                None
-                            };
-                            timestamp = Some(RealizedTimestamp {
-                                timestamp: ts,
-                                arg: e.arg,
-                                range: e.range.clone(),
-                            });
-                        }
-                        realized_op = self.realize(e.arg, table)?;
-                    }
-                    _ => return Err(Error::InvalidOp),
-                }
-            }
-        })
+        self.fields
+            .iter()
+            .map(move |field| self.realize_field(field, table))
     }
 
     /// Parses the passed in table, and sinks the values into the sink
@@ -462,18 +514,124 @@ impl<Ops: Buf<Op>, Data: Buf<u8>, Fields: Buf<Field>> VTable<Ops, Data, Fields> 
         sink: &mut D,
     ) -> Result<Result<(), D::Error>, Error> {
         for res in self.realize_fields(Some(table)) {
-            let RealizedField {
-                component_id,
-                view,
-                timestamp,
-                ..
-            } = res?;
-            let view = view.expect("table not found");
-            if let Err(err) = sink.apply_value(component_id, view, timestamp) {
+            let rf = res?;
+            let ts = Self::resolve_apply_timestamp(table, &rf)?;
+            let view = rf.view.expect("table not found");
+            if let Err(err) = sink.apply_value(rf.component_id, view, ts) {
                 return Ok(Err(err));
             }
         }
         Ok(Ok(()))
+    }
+
+    fn resolve_apply_timestamp(
+        table: &[u8],
+        rf: &RealizedField<'_>,
+    ) -> Result<Option<Timestamp>, Error> {
+        if let Some(r) = &rf.timestamp_source_range {
+            let data = table
+                .get(r.clone())
+                .ok_or(Error::BufferUnderflow)?
+                .get(..core::mem::size_of::<Timestamp>())
+                .ok_or(Error::BufferUnderflow)?;
+            let t = Timestamp::read_from_bytes(data)?;
+            Ok(Some(if rf.timestamp_source_is_ns {
+                Timestamp(t.0 / 1000)
+            } else {
+                t
+            }))
+        } else {
+            Ok(rf.timestamp)
+        }
+    }
+}
+
+/// Applies a precomputed [`TableDispatchEntry`] plan (see [`VTable::build_table_dispatch_plan`]).
+#[cfg(feature = "alloc")]
+pub fn apply_table_dispatch_plan<D: Decomponentize>(
+    plan: &[TableDispatchEntry],
+    table: &[u8],
+    sink: &mut D,
+) -> Result<Result<(), D::Error>, Error> {
+    for e in plan {
+        let dim = e.dim.as_slice();
+        let shape = <[usize]>::ref_from_bytes(dim.as_bytes())?;
+        let data = table
+            .get(e.value_offset..e.value_offset + e.value_len)
+            .ok_or(Error::BufferUnderflow)?;
+        let view = ComponentView::try_from_bytes_shape(data, shape, e.ty)?;
+        let ts = if let Some(r) = &e.timestamp_source_range {
+            let slice = table
+                .get(r.clone())
+                .ok_or(Error::BufferUnderflow)?
+                .get(..core::mem::size_of::<Timestamp>())
+                .ok_or(Error::BufferUnderflow)?;
+            let t = Timestamp::read_from_bytes(slice)?;
+            Some(if e.timestamp_source_is_ns {
+                Timestamp(t.0 / 1000)
+            } else {
+                t
+            })
+        } else {
+            e.timestamp_fixed
+        };
+        if let Err(err) = sink.apply_value(e.component_id, view, ts) {
+            return Ok(Err(err));
+        }
+    }
+    Ok(Ok(()))
+}
+
+#[cfg(feature = "alloc")]
+impl<Ops: Buf<Op>, Data: Buf<u8>, Fields: Buf<Field>> VTable<Ops, Data, Fields> {
+    /// Builds a static dispatch plan for repeated `apply` on table buffers of sufficient length.
+    pub fn build_table_dispatch_plan(&self) -> Result<Vec<TableDispatchEntry>, Error> {
+        let mut need = 0usize;
+        for field in self.fields.iter() {
+            need = need.max(field.offset.to_index() + field.len as usize);
+        }
+        for op in self.ops.as_slice() {
+            if let Op::Table { offset, len } = op {
+                need = need.max(offset.to_index() + *len as usize);
+            }
+        }
+        let mut probe = vec![0u8; need.max(1)];
+        for _ in 0..64 {
+            let mut out = Vec::with_capacity(self.fields.len());
+            let mut ok = true;
+            for field in self.fields.iter() {
+                match self.realize_field(field, Some(&probe)) {
+                    Ok(rf) => {
+                        if rf.view.is_none() {
+                            ok = false;
+                            break;
+                        }
+                        let offset = field.offset.to_index();
+                        out.push(TableDispatchEntry {
+                            component_id: rf.component_id,
+                            ty: rf.ty,
+                            dim: rf.dim.to_vec(),
+                            value_offset: offset,
+                            value_len: field.len as usize,
+                            timestamp_fixed: rf.timestamp,
+                            timestamp_source_range: rf.timestamp_source_range.clone(),
+                            timestamp_source_is_ns: rf.timestamp_source_is_ns,
+                        });
+                    }
+                    Err(Error::BufferUnderflow) => {
+                        ok = false;
+                        break;
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+            if ok {
+                return Ok(out);
+            }
+            let next = probe.len().saturating_mul(2).max(probe.len() + 256);
+            probe.resize(next, 0);
+        }
+        Err(Error::InvalidOp)
     }
 }
 
@@ -835,5 +993,59 @@ mod tests {
         let bar = sink.f64_components.get(&ComponentId::new("bar")).unwrap();
         assert_eq!(bar.buf.as_buf(), &[5.0]);
         assert_eq!(sink.timestamp, Some(foo.timestamp));
+    }
+
+    #[test]
+    fn test_dispatch_plan_matches_apply() {
+        use super::apply_table_dispatch_plan;
+        use super::builder::*;
+
+        #[derive(IntoBytes, Immutable)]
+        struct Foo {
+            timestamp: Timestamp,
+            test: [f32; 4],
+            bar: f64,
+        }
+
+        let time = table!(Foo::timestamp);
+        let v = vtable([
+            field!(
+                Foo::test,
+                schema(
+                    PrimType::F32,
+                    &[4],
+                    timestamp(time.clone(), component("test")),
+                ),
+            ),
+            field!(
+                Foo::bar,
+                schema(PrimType::F64, &[], timestamp(time, component("bar")))
+            ),
+        ]);
+
+        let plan = v.build_table_dispatch_plan().expect("plan");
+        let foo = Foo {
+            timestamp: Timestamp(1000),
+            test: [1.0, 2.0, 3.0, 4.0],
+            bar: 5.0,
+        };
+        let bytes = foo.as_bytes();
+
+        let mut sink_apply = TestSink::default();
+        v.apply(bytes, &mut sink_apply).unwrap().unwrap();
+        let mut sink_plan = TestSink::default();
+        apply_table_dispatch_plan(&plan, bytes, &mut sink_plan)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(sink_apply.timestamp, sink_plan.timestamp);
+        assert_eq!(
+            sink_apply.f32_components.get(&ComponentId::new("test")),
+            sink_plan.f32_components.get(&ComponentId::new("test"))
+        );
+        assert_eq!(
+            sink_apply.f64_components.get(&ComponentId::new("bar")),
+            sink_plan.f64_components.get(&ComponentId::new("bar"))
+        );
     }
 }


### PR DESCRIPTION
# Summary
Adds a compiled **VTable dispatch plan** plus **Arc snapshots** so table ingest does not hold `State`’s `RwLock` across the full decomponentize path when a plan exists.

Large internal win on the table ingest hot path; measured throughput gains are smaller and scenario-dependent.

## Performance (measured)
**Profile** (`elodin-db-profile --all`, 8 s/run, release, macOS): compared to the historical pre-change profile (~**39%** of `sink_table` in “VTable resolve” from `elodin-db/profiling-tool`), this branch shows **~1.9%** (customer per-component) and **≈0%** (customer batch, high-fanout, stress) in that bucket — the per-packet `realize_fields` walk is effectively gone on batch / wide-table paths. Tick p50 for customer per-component **~1.1 µs** (in line with the old ~1.3 µs sample).
**Throughput** (`elodin-db-bench --release`, 6 s): **customer + batch** **73.9k → 76.9k writes/s (+3.9%)** vs baseline `f973d0825`; **high-fanout + batch** ~flat (~94–96k writes/s), i.e. client/network bound.
