### PR TITLE
Fix: render layer exhaust issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5026,6 +5026,7 @@ dependencies = [
  "const-fnv1a-hash",
  "convert_case 0.7.1",
  "crossbeam-channel",
+ "crossbeam-queue",
  "directories",
  "egui",
  "egui_material_icons",

--- a/libs/elodin-editor/Cargo.toml
+++ b/libs/elodin-editor/Cargo.toml
@@ -77,6 +77,7 @@ tracing = "0.1"
 fuzzy-matcher = "0.3.7"
 
 # data-structures
+crossbeam-queue = "0.3"
 roaring = "0.10.4"
 smallvec.version = "1.11.2"
 smallvec.features = ["const_generics", "union"]

--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -39,7 +39,7 @@ use object_3d::create_object_3d_entity;
 use plugins::frustum::FrustumPlugin;
 use plugins::frustum_intersection::FrustumIntersectionPlugin;
 use plugins::gizmos::GizmoPlugin;
-use plugins::navigation_gizmo::{NavigationGizmoPlugin, RenderLayerAlloc};
+use plugins::navigation_gizmo::{NavigationGizmoPlugin, RenderLayerAllocator};
 use plugins::view_cube::{ViewCubeConfig, ViewCubePlugin};
 use ui::{
     UI_ORDER_BASE,
@@ -1102,7 +1102,7 @@ pub fn setup_clear_state(mut packet_handlers: ResMut<PacketHandlers>, mut comman
 fn clear_state_new_connection(
     PacketHandlerInput { packet, .. }: PacketHandlerInput,
     mut entity_map: ResMut<EntityMap>,
-    mut render_layer_alloc: ResMut<RenderLayerAlloc>,
+    mut render_layer_alloc: ResMut<RenderLayerAllocator>,
     mut value_map: Query<&mut ComponentValueMap>,
     mut graph_data: ResMut<CollectedGraphData>,
     lines: Query<Entity, With<LineHandle>>,

--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -1163,7 +1163,6 @@ fn clear_state_new_connection(
         commands.entity(entity).despawn();
     }
     *graph_data = CollectedGraphData::default();
-    render_layer_alloc.free_all();
     *telemetry_cache = impeller2_bevy::TelemetryCache::default();
     *backfill_state = impeller2_bevy::BackfillState::default();
 }

--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -40,7 +40,6 @@ use plugins::frustum::FrustumPlugin;
 use plugins::frustum_intersection::FrustumIntersectionPlugin;
 use plugins::gizmos::GizmoPlugin;
 use plugins::navigation_gizmo::NavigationGizmoPlugin;
-use plugins::render_layer_alloc::RenderLayerAllocator;
 use plugins::view_cube::{ViewCubeConfig, ViewCubePlugin};
 use ui::{
     UI_ORDER_BASE,
@@ -1103,7 +1102,6 @@ pub fn setup_clear_state(mut packet_handlers: ResMut<PacketHandlers>, mut comman
 fn clear_state_new_connection(
     PacketHandlerInput { packet, .. }: PacketHandlerInput,
     mut entity_map: ResMut<EntityMap>,
-    mut render_layer_alloc: ResMut<RenderLayerAllocator>,
     mut value_map: Query<&mut ComponentValueMap>,
     mut graph_data: ResMut<CollectedGraphData>,
     lines: Query<Entity, With<LineHandle>>,

--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -1150,10 +1150,7 @@ fn clear_state_new_connection(
     let Ok(mut primary_state) = windows_state.get_mut(primary_id) else {
         return;
     };
-    primary_state
-        .1
-        .tile_state
-        .clear(&mut commands, &mut render_layer_alloc);
+    primary_state.1.tile_state.clear(&mut commands);
     for (entity, secondary) in &windows_state {
         if entity == primary_id {
             // We don't despawn the primary window ever.

--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -39,7 +39,8 @@ use object_3d::create_object_3d_entity;
 use plugins::frustum::FrustumPlugin;
 use plugins::frustum_intersection::FrustumIntersectionPlugin;
 use plugins::gizmos::GizmoPlugin;
-use plugins::navigation_gizmo::{NavigationGizmoPlugin, RenderLayerAllocator};
+use plugins::navigation_gizmo::{NavigationGizmoPlugin};
+use plugins::render_layer_alloc::{RenderLayerAllocator};
 use plugins::view_cube::{ViewCubeConfig, ViewCubePlugin};
 use ui::{
     UI_ORDER_BASE,

--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -39,8 +39,8 @@ use object_3d::create_object_3d_entity;
 use plugins::frustum::FrustumPlugin;
 use plugins::frustum_intersection::FrustumIntersectionPlugin;
 use plugins::gizmos::GizmoPlugin;
-use plugins::navigation_gizmo::{NavigationGizmoPlugin};
-use plugins::render_layer_alloc::{RenderLayerAllocator};
+use plugins::navigation_gizmo::NavigationGizmoPlugin;
+use plugins::render_layer_alloc::RenderLayerAllocator;
 use plugins::view_cube::{ViewCubeConfig, ViewCubePlugin};
 use ui::{
     UI_ORDER_BASE,

--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -40,6 +40,7 @@ use plugins::frustum::FrustumPlugin;
 use plugins::frustum_intersection::FrustumIntersectionPlugin;
 use plugins::gizmos::GizmoPlugin;
 use plugins::navigation_gizmo::NavigationGizmoPlugin;
+use plugins::render_layer_alloc;
 use plugins::view_cube::{ViewCubeConfig, ViewCubePlugin};
 use ui::{
     UI_ORDER_BASE,
@@ -223,6 +224,7 @@ impl Plugin for EditorPlugin {
             .add_plugins(EmbeddedAssetPlugin)
             .add_plugins(EguiPlugin::default())
             .add_plugins(bevy_infinite_grid::InfiniteGridPlugin)
+            .add_plugins(render_layer_alloc::plugin)
             .add_plugins(NavigationGizmoPlugin)
             .add_plugins(ViewCubePlugin {
                 config: ViewCubeConfig::editor_mode(),

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -1789,16 +1789,8 @@ pub fn update_object_3d_billboard_system(
     mut commands: Commands,
     mut objects: Query<(Entity, &mut Object3DIconState, &GlobalTransform), With<WorldPosReceived>>,
     cameras: Query<
-        (
-            Entity,
-            &Camera,
-            &GlobalTransform,
-            &Projection,
-            Option<&ViewportConfig>,
-            Option<&RenderLayers>,
-            Option<&RenderLayerLease>,
-        ),
-        With<MainCamera>,
+        (Entity, &Camera, &GlobalTransform, &Projection, &RenderLayerLease),
+        (With<MainCamera>, With<ViewportConfig>),
     >,
     mut billboard_transforms: Query<&mut Transform, (With<BillboardIcon>, Without<MainCamera>)>,
     billboard_materials_query: Query<
@@ -1826,26 +1818,16 @@ pub fn update_object_3d_billboard_system(
         let bb_mesh_handle = icon_state.billboard_mesh.clone();
         let bb_mat_source = icon_state.billboard_material.clone();
 
-        for (
-            cam_entity,
-            camera,
-            cam_gt,
-            projection,
-            _viewport_config,
-            camera_layers,
-            render_layer_lease,
-        ) in cameras.iter()
-        {
+        for (cam_entity, camera, cam_gt, projection, render_layer_lease) in cameras.iter() {
             let viewport_h = camera.logical_viewport_size().map(|s| s.y).unwrap_or(0.0);
             if viewport_h < 1.0 {
                 continue;
             }
-            let Some(lease) = render_layer_lease else {
-                continue;
-            };
-            let render_layers = camera_layers
-                .cloned()
-                .unwrap_or_else(|| lease.render_layers());
+            // Billboards and mesh visibility must stay isolated to the
+            // viewport-specific lease layer. Reusing the camera's full
+            // RenderLayers mask would also copy shared layers like 0 / gizmo /
+            // grid and make icons leak into other viewports.
+            let render_layers = render_layer_lease.render_layers();
 
             seen_cameras.insert(cam_entity);
             let distance = (obj_pos - cam_gt.translation()).length();
@@ -1883,7 +1865,7 @@ pub fn update_object_3d_billboard_system(
                             InheritedVisibility::default(),
                             ViewVisibility::default(),
                             render_layers.clone(),
-                            lease.clone(),
+                            render_layer_lease.clone(),
                             BillboardIcon,
                             ChildOf(parent_entity),
                             Name::new(format!("billboard_icon_cam_{cam_entity}")),

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -18,9 +18,9 @@ use smallvec::smallvec;
 
 use crate::icon_rasterizer::IconTextureCache;
 use crate::iter::JoinDisplayExt;
+use crate::plugins::render_layer_alloc::{RenderLayerAllocator, RenderLayerLease};
 use crate::ui::tiles::ViewportConfig;
 use crate::{BevyExt, EqlContext, MainCamera, plugins::navigation_gizmo::NavGizmoCamera};
-use crate::plugins::render_layer_alloc::{RenderLayerAllocator, RenderLayerLease};
 use bevy_geo_frames::prelude::*;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
@@ -1825,7 +1825,9 @@ pub fn update_object_3d_billboard_system(
         let bb_mesh_handle = icon_state.billboard_mesh.clone();
         let bb_mat_source = icon_state.billboard_material.clone();
 
-        for (cam_entity, camera, cam_gt, projection, viewport_config, render_layer_lease) in cameras.iter() {
+        for (cam_entity, camera, cam_gt, projection, viewport_config, render_layer_lease) in
+            cameras.iter()
+        {
             let viewport_h = camera.logical_viewport_size().map(|s| s.y).unwrap_or(0.0);
             if viewport_h < 1.0 {
                 continue;
@@ -1879,9 +1881,7 @@ pub fn update_object_3d_billboard_system(
                         .id()
                 });
 
-                commands
-                    .entity(*bb_entity)
-                    .insert(render_layers);
+                commands.entity(*bb_entity).insert(render_layers);
 
                 let alpha = if icon_fade > 0.0 {
                     let min_fade = if distance < icon_min + icon_fade {

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -1831,6 +1831,7 @@ pub fn update_object_3d_billboard_system(
             let Some(layer) = viewport_config.and_then(|c| c.viewport_layer) else {
                 continue;
             };
+            let render_layers = layer.render_layers();
 
             seen_cameras.insert(cam_entity);
             let distance = (obj_pos - cam_gt.translation()).length();
@@ -1867,7 +1868,7 @@ pub fn update_object_3d_billboard_system(
                             Visibility::Hidden,
                             InheritedVisibility::default(),
                             ViewVisibility::default(),
-                            RenderLayers::layer(layer),
+                            render_layers,
                             BillboardIcon,
                             ChildOf(parent_entity),
                             Name::new(format!("billboard_icon_cam_{cam_entity}")),
@@ -1877,7 +1878,7 @@ pub fn update_object_3d_billboard_system(
 
                 commands
                     .entity(*bb_entity)
-                    .insert(RenderLayers::layer(layer));
+                    .insert(render_layers);
 
                 let alpha = if icon_fade > 0.0 {
                     let min_fade = if distance < icon_min + icon_fade {

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -18,7 +18,7 @@ use smallvec::smallvec;
 
 use crate::icon_rasterizer::IconTextureCache;
 use crate::iter::JoinDisplayExt;
-use crate::plugins::render_layer_alloc::{RenderLayerAllocator, RenderLayerLease};
+use crate::plugins::render_layer_alloc::RenderLayerLease;
 use crate::ui::tiles::ViewportConfig;
 use crate::{BevyExt, EqlContext, MainCamera, plugins::navigation_gizmo::NavGizmoCamera};
 use bevy_geo_frames::prelude::*;
@@ -1795,6 +1795,7 @@ pub fn update_object_3d_billboard_system(
             &GlobalTransform,
             &Projection,
             Option<&ViewportConfig>,
+            Option<&RenderLayers>,
             Option<&RenderLayerLease>,
         ),
         With<MainCamera>,
@@ -1825,17 +1826,26 @@ pub fn update_object_3d_billboard_system(
         let bb_mesh_handle = icon_state.billboard_mesh.clone();
         let bb_mat_source = icon_state.billboard_material.clone();
 
-        for (cam_entity, camera, cam_gt, projection, viewport_config, render_layer_lease) in
-            cameras.iter()
+        for (
+            cam_entity,
+            camera,
+            cam_gt,
+            projection,
+            _viewport_config,
+            camera_layers,
+            render_layer_lease,
+        ) in cameras.iter()
         {
             let viewport_h = camera.logical_viewport_size().map(|s| s.y).unwrap_or(0.0);
             if viewport_h < 1.0 {
                 continue;
             }
-            let Some(render_layer_lease) = render_layer_lease else {
+            let Some(lease) = render_layer_lease else {
                 continue;
             };
-            let render_layers = render_layer_lease.render_layers();
+            let render_layers = camera_layers
+                .cloned()
+                .unwrap_or_else(|| lease.render_layers());
 
             seen_cameras.insert(cam_entity);
             let distance = (obj_pos - cam_gt.translation()).length();
@@ -1873,7 +1883,7 @@ pub fn update_object_3d_billboard_system(
                             InheritedVisibility::default(),
                             ViewVisibility::default(),
                             render_layers.clone(),
-                            render_layer_lease.clone(),
+                            lease.clone(),
                             BillboardIcon,
                             ChildOf(parent_entity),
                             Name::new(format!("billboard_icon_cam_{cam_entity}")),

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -20,6 +20,7 @@ use crate::icon_rasterizer::IconTextureCache;
 use crate::iter::JoinDisplayExt;
 use crate::ui::tiles::ViewportConfig;
 use crate::{BevyExt, EqlContext, MainCamera, plugins::navigation_gizmo::NavGizmoCamera};
+use crate::plugins::render_layer_alloc::{RenderLayerAllocator, RenderLayerLease};
 use bevy_geo_frames::prelude::*;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
@@ -1794,6 +1795,7 @@ pub fn update_object_3d_billboard_system(
             &GlobalTransform,
             &Projection,
             Option<&ViewportConfig>,
+            Option<&RenderLayerLease>,
         ),
         With<MainCamera>,
     >,
@@ -1823,15 +1825,15 @@ pub fn update_object_3d_billboard_system(
         let bb_mesh_handle = icon_state.billboard_mesh.clone();
         let bb_mat_source = icon_state.billboard_material.clone();
 
-        for (cam_entity, camera, cam_gt, projection, viewport_config) in cameras.iter() {
+        for (cam_entity, camera, cam_gt, projection, viewport_config, render_layer_lease) in cameras.iter() {
             let viewport_h = camera.logical_viewport_size().map(|s| s.y).unwrap_or(0.0);
             if viewport_h < 1.0 {
                 continue;
             }
-            let Some(layer) = viewport_config.and_then(|c| c.viewport_layer) else {
+            let Some(render_layer_lease) = render_layer_lease else {
                 continue;
             };
-            let render_layers = layer.render_layers();
+            let render_layers = render_layer_lease.render_layers();
 
             seen_cameras.insert(cam_entity);
             let distance = (obj_pos - cam_gt.translation()).length();
@@ -1839,7 +1841,7 @@ pub fn update_object_3d_billboard_system(
             let shows_mesh = distance >= mesh_min && distance <= mesh_max;
 
             if shows_mesh {
-                mesh_layers = mesh_layers.with(layer);
+                mesh_layers = mesh_layers.union(&render_layers);
             }
 
             if shows_billboard {
@@ -1868,7 +1870,8 @@ pub fn update_object_3d_billboard_system(
                             Visibility::Hidden,
                             InheritedVisibility::default(),
                             ViewVisibility::default(),
-                            render_layers,
+                            render_layers.clone(),
+                            render_layer_lease.clone(),
                             BillboardIcon,
                             ChildOf(parent_entity),
                             Name::new(format!("billboard_icon_cam_{cam_entity}")),

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -1789,7 +1789,13 @@ pub fn update_object_3d_billboard_system(
     mut commands: Commands,
     mut objects: Query<(Entity, &mut Object3DIconState, &GlobalTransform), With<WorldPosReceived>>,
     cameras: Query<
-        (Entity, &Camera, &GlobalTransform, &Projection, &RenderLayerLease),
+        (
+            Entity,
+            &Camera,
+            &GlobalTransform,
+            &Projection,
+            &RenderLayerLease,
+        ),
         (With<MainCamera>, With<ViewportConfig>),
     >,
     mut billboard_transforms: Query<&mut Transform, (With<BillboardIcon>, Without<MainCamera>)>,

--- a/libs/elodin-editor/src/plugins/frustum/mod.rs
+++ b/libs/elodin-editor/src/plugins/frustum/mod.rs
@@ -273,11 +273,7 @@ fn draw_viewport_frustums(mut params: FrustumDrawParams<'_, '_>, mut commands: C
 
         camera_positions.insert(camera_entity, global_transform.translation());
         if config.show_frustums {
-            targets.push((
-                camera_entity,
-                render_layer_lease.render_layers(),
-                render_layer_lease,
-            ));
+            targets.push((camera_entity, render_layer_lease.render_layers()));
         }
 
         if !config.create_frustum {
@@ -332,7 +328,7 @@ fn draw_viewport_frustums(mut params: FrustumDrawParams<'_, '_>, mut commands: C
             &mut params.material_cache,
         );
         let segments = frustum_segments(points);
-        for (target_camera, render_layers, _render_layers_lease) in &targets {
+        for (target_camera, render_layers) in &targets {
             if source_camera == *target_camera {
                 continue;
             }

--- a/libs/elodin-editor/src/plugins/frustum/mod.rs
+++ b/libs/elodin-editor/src/plugins/frustum/mod.rs
@@ -273,8 +273,11 @@ fn draw_viewport_frustums(mut params: FrustumDrawParams<'_, '_>, mut commands: C
 
         camera_positions.insert(camera_entity, global_transform.translation());
         if config.show_frustums {
-            targets.push((camera_entity, render_layer_lease.render_layers(),
-                          render_layer_lease));
+            targets.push((
+                camera_entity,
+                render_layer_lease.render_layers(),
+                render_layer_lease,
+            ));
         }
 
         if !config.create_frustum {

--- a/libs/elodin-editor/src/plugins/frustum/mod.rs
+++ b/libs/elodin-editor/src/plugins/frustum/mod.rs
@@ -332,7 +332,7 @@ fn draw_viewport_frustums(mut params: FrustumDrawParams<'_, '_>, mut commands: C
             &mut params.material_cache,
         );
         let segments = frustum_segments(points);
-        for (target_camera, render_layers, render_layers_lease) in &targets {
+        for (target_camera, render_layers, _render_layers_lease) in &targets {
             if source_camera == *target_camera {
                 continue;
             }

--- a/libs/elodin-editor/src/plugins/frustum/mod.rs
+++ b/libs/elodin-editor/src/plugins/frustum/mod.rs
@@ -256,7 +256,7 @@ fn draw_viewport_frustums(mut params: FrustumDrawParams<'_, '_>, mut commands: C
     let mut targets = Vec::new();
     let mut camera_positions: HashMap<Entity, Vec3> = HashMap::new();
 
-    for (camera_entity, camera, projection, global_transform, config) in
+    for (camera_entity, camera, projection, global_transform, config, render_layer_lease) in
         params.main_viewports.iter()
     {
         if !camera.is_active {
@@ -267,13 +267,14 @@ fn draw_viewport_frustums(mut params: FrustumDrawParams<'_, '_>, mut commands: C
             continue;
         };
 
-        let Some(viewport_layer) = config.viewport_layer else {
+        let Some(render_layer_lease) = render_layer_lease else {
             continue;
         };
 
         camera_positions.insert(camera_entity, global_transform.translation());
         if config.show_frustums {
-            targets.push((camera_entity, RenderLayers::layer(viewport_layer)));
+            targets.push((camera_entity, render_layer_lease.render_layers(),
+                          render_layer_lease));
         }
 
         if !config.create_frustum {
@@ -328,7 +329,7 @@ fn draw_viewport_frustums(mut params: FrustumDrawParams<'_, '_>, mut commands: C
             &mut params.material_cache,
         );
         let segments = frustum_segments(points);
-        for (target_camera, render_layers) in &targets {
+        for (target_camera, render_layers, render_layers_lease) in &targets {
             if source_camera == *target_camera {
                 continue;
             }

--- a/libs/elodin-editor/src/plugins/frustum_common.rs
+++ b/libs/elodin-editor/src/plugins/frustum_common.rs
@@ -1,5 +1,5 @@
+use crate::plugins::render_layer_alloc::RenderLayerLease;
 use crate::ui::tiles::ViewportConfig;
-use crate::plugins::render_layer_alloc::{RenderLayerLease};
 use bevy::prelude::*;
 
 pub type MainViewportQueryItem = (

--- a/libs/elodin-editor/src/plugins/frustum_common.rs
+++ b/libs/elodin-editor/src/plugins/frustum_common.rs
@@ -1,4 +1,5 @@
 use crate::ui::tiles::ViewportConfig;
+use crate::plugins::render_layer_alloc::{RenderLayerLease};
 use bevy::prelude::*;
 
 pub type MainViewportQueryItem = (
@@ -7,6 +8,7 @@ pub type MainViewportQueryItem = (
     &'static Projection,
     &'static GlobalTransform,
     Option<&'static ViewportConfig>,
+    Option<&'static RenderLayerLease>,
 );
 
 pub fn frustum_local_points(perspective: &PerspectiveProjection) -> Option<[Vec3; 8]> {

--- a/libs/elodin-editor/src/plugins/frustum_intersection/mod.rs
+++ b/libs/elodin-editor/src/plugins/frustum_intersection/mod.rs
@@ -386,7 +386,6 @@ fn draw_frustum_ellipsoid_intersections(
             targets.push((
                 camera_entity,
                 render_layer_lease.render_layers(),
-                render_layer_lease,
                 config.projection_color,
                 config.show_coverage_in_viewport,
                 config.show_projection_2d,
@@ -492,7 +491,7 @@ fn draw_frustum_ellipsoid_intersections(
     let mut desired_lights = Vec::new();
     let mut desired_tint_overlays = Vec::new();
     let mut coverage_layers = RenderLayers::none();
-    for (_, render_layers, _render_layer_lease, _, show_coverage, _) in &targets {
+    for (_, render_layers, _, show_coverage, _) in &targets {
         if *show_coverage {
             coverage_layers = coverage_layers.union(render_layers);
         }
@@ -500,7 +499,7 @@ fn draw_frustum_ellipsoid_intersections(
     let any_target_wants_coverage = coverage_layers.iter().next().is_some();
     let any_target_wants_projection = targets
         .iter()
-        .any(|(_, _, _, _, _, show_projection)| *show_projection);
+        .any(|(_, _, _, _, show_projection)| *show_projection);
     // Per-ellipsoid max coverage ratio across all frustums. Empty when coverage is disabled.
     let mut ellipsoid_max_ratio: HashMap<Entity, f32> = if any_target_wants_coverage {
         ellipsoids
@@ -544,7 +543,6 @@ fn draw_frustum_ellipsoid_intersections(
             for (
                 target_camera,
                 render_layers,
-                _render_layer_lease,
                 target_projection_color,
                 _show_coverage,
                 target_show_projection,

--- a/libs/elodin-editor/src/plugins/frustum_intersection/mod.rs
+++ b/libs/elodin-editor/src/plugins/frustum_intersection/mod.rs
@@ -368,7 +368,7 @@ fn draw_frustum_ellipsoid_intersections(
     let mut sources = Vec::new();
     let mut targets = Vec::new();
 
-    for (camera_entity, camera, projection, global_transform, config) in
+    for (camera_entity, camera, projection, global_transform, config, render_layer_lease) in
         params.main_viewports.iter()
     {
         if !camera.is_active {
@@ -378,14 +378,15 @@ fn draw_frustum_ellipsoid_intersections(
         let Some(config) = config else {
             continue;
         };
-        let Some(viewport_layer) = config.viewport_layer else {
+        let Some(render_layer_lease) = render_layer_lease else {
             continue;
         };
 
         if config.show_frustums && (config.show_coverage_in_viewport || config.show_projection_2d) {
             targets.push((
                 camera_entity,
-                RenderLayers::layer(viewport_layer),
+                render_layer_lease.render_layers(),
+                render_layer_lease,
                 config.projection_color,
                 config.show_coverage_in_viewport,
                 config.show_projection_2d,
@@ -491,7 +492,7 @@ fn draw_frustum_ellipsoid_intersections(
     let mut desired_lights = Vec::new();
     let mut desired_tint_overlays = Vec::new();
     let mut coverage_layers = RenderLayers::none();
-    for (_, render_layers, _, show_coverage, _) in &targets {
+    for (_, render_layers, render_layer_lease, _, show_coverage, _) in &targets {
         if *show_coverage {
             coverage_layers = coverage_layers.union(render_layers);
         }
@@ -499,7 +500,7 @@ fn draw_frustum_ellipsoid_intersections(
     let any_target_wants_coverage = coverage_layers.iter().next().is_some();
     let any_target_wants_projection = targets
         .iter()
-        .any(|(_, _, _, _, show_projection)| *show_projection);
+        .any(|(_, _, _, _, _, show_projection)| *show_projection);
     // Per-ellipsoid max coverage ratio across all frustums. Empty when coverage is disabled.
     let mut ellipsoid_max_ratio: HashMap<Entity, f32> = if any_target_wants_coverage {
         ellipsoids
@@ -543,6 +544,7 @@ fn draw_frustum_ellipsoid_intersections(
             for (
                 target_camera,
                 render_layers,
+                render_layer_lease,
                 target_projection_color,
                 _show_coverage,
                 target_show_projection,

--- a/libs/elodin-editor/src/plugins/frustum_intersection/mod.rs
+++ b/libs/elodin-editor/src/plugins/frustum_intersection/mod.rs
@@ -492,7 +492,7 @@ fn draw_frustum_ellipsoid_intersections(
     let mut desired_lights = Vec::new();
     let mut desired_tint_overlays = Vec::new();
     let mut coverage_layers = RenderLayers::none();
-    for (_, render_layers, render_layer_lease, _, show_coverage, _) in &targets {
+    for (_, render_layers, _render_layer_lease, _, show_coverage, _) in &targets {
         if *show_coverage {
             coverage_layers = coverage_layers.union(render_layers);
         }
@@ -544,7 +544,7 @@ fn draw_frustum_ellipsoid_intersections(
             for (
                 target_camera,
                 render_layers,
-                render_layer_lease,
+                _render_layer_lease,
                 target_projection_color,
                 _show_coverage,
                 target_show_projection,

--- a/libs/elodin-editor/src/plugins/gizmos/mod.rs
+++ b/libs/elodin-editor/src/plugins/gizmos/mod.rs
@@ -51,7 +51,6 @@ type MainCameraQueryItem<'w> = (
     &'w Projection,
     &'w GlobalTransform,
     Option<&'w ViewportConfig>,
-    Option<&'w RenderLayers>,
     Option<&'w RenderLayerLease>,
 );
 
@@ -261,7 +260,7 @@ fn render_vector_arrow(
     }
     let has_show_arrows = main_camera_data
         .iter()
-        .any(|(_, _, _, _, config, _, _)| config.as_ref().map(|c| c.show_arrows).unwrap_or(true));
+        .any(|(_, _, _, _, config, _)| config.as_ref().map(|c| c.show_arrows).unwrap_or(true));
 
     for (entity, arrow, mut state) in vector_arrows.iter_mut() {
         if !has_show_arrows {
@@ -327,7 +326,7 @@ fn render_vector_arrow(
         let mut seen_cameras: HashSet<Entity> = HashSet::new();
 
         let mut render_for_camera = |idx: usize| {
-            let (cam_entity, cam, proj, cam_tf, viewport_config, camera_layers, render_layer_lease) =
+            let (cam_entity, cam, proj, cam_tf, viewport_config, render_layer_lease) =
                 main_camera_data[idx];
             seen_cameras.insert(cam_entity);
 
@@ -347,15 +346,15 @@ fn render_vector_arrow(
                 return;
             }
 
-            let arrow_layers = match (camera_layers, render_layer_lease) {
-                (Some(layers), _) => layers.clone(),
-                (None, Some(lease)) => lease.render_layers(),
-                (None, None) => {
-                    if let Some(visual) = state.visuals.remove(&cam_entity) {
-                        hide_arrow_visual(&mut commands, &visual);
-                    }
-                    return;
+            // Arrows must stay isolated to the viewport-specific lease layer.
+            // Using the camera's full RenderLayers mask would also copy shared
+            // layers like 0 / gizmo / grid, causing cross-render between
+            // otherwise independent viewports.
+            let Some(arrow_layers) = render_layer_lease.map(RenderLayerLease::render_layers) else {
+                if let Some(visual) = state.visuals.remove(&cam_entity) {
+                    hide_arrow_visual(&mut commands, &visual);
                 }
+                return;
             };
 
             let world_per_px = world_units_per_pixel(cam, proj, cam_tf, start);

--- a/libs/elodin-editor/src/plugins/gizmos/mod.rs
+++ b/libs/elodin-editor/src/plugins/gizmos/mod.rs
@@ -26,6 +26,7 @@ use impeller2_wkt::{
 };
 use std::collections::{HashMap, HashSet};
 
+use crate::plugins::render_layer_alloc::{RenderLayerLease};
 use crate::{
     MainCamera, WorldPosExt,
     object_3d::ComponentArrayExt,
@@ -50,6 +51,7 @@ type MainCameraQueryItem<'w> = (
     &'w Projection,
     &'w GlobalTransform,
     Option<&'w ViewportConfig>,
+    Option<&'w RenderLayerLease>,
 );
 
 /// Marker for UI cameras spawned specifically for arrow labels per window.
@@ -258,7 +260,7 @@ fn render_vector_arrow(
     }
     let has_show_arrows = main_camera_data
         .iter()
-        .any(|(_, _, _, _, config)| config.as_ref().map(|c| c.show_arrows).unwrap_or(true));
+        .any(|(_, _, _, _, config, _)| config.as_ref().map(|c| c.show_arrows).unwrap_or(true));
 
     for (entity, arrow, mut state) in vector_arrows.iter_mut() {
         if !has_show_arrows {
@@ -324,7 +326,7 @@ fn render_vector_arrow(
         let mut seen_cameras: HashSet<Entity> = HashSet::new();
 
         let mut render_for_camera = |idx: usize| {
-            let (cam_entity, cam, proj, cam_tf, viewport_config) = main_camera_data[idx];
+            let (cam_entity, cam, proj, cam_tf, viewport_config, render_layer_lease) = main_camera_data[idx];
             seen_cameras.insert(cam_entity);
 
             let show_arrows = viewport_config
@@ -343,14 +345,14 @@ fn render_vector_arrow(
                 return;
             }
 
-            let Some(viewport_layer) = viewport_config.and_then(|config| config.viewport_layer)
-            else {
+            let Some(render_layer_lease) = render_layer_lease else {
                 if let Some(visual) = state.visuals.remove(&cam_entity) {
                     hide_arrow_visual(&mut commands, &visual);
                 }
                 return;
             };
-            let arrow_layers = RenderLayers::layer(viewport_layer);
+
+            let arrow_layers = render_layer_lease.render_layers();
 
             let world_per_px = world_units_per_pixel(cam, proj, cam_tf, start);
             let shaft_radius = (TARGET_DIAMETER_PX * 0.5 * world_per_px)

--- a/libs/elodin-editor/src/plugins/gizmos/mod.rs
+++ b/libs/elodin-editor/src/plugins/gizmos/mod.rs
@@ -26,7 +26,7 @@ use impeller2_wkt::{
 };
 use std::collections::{HashMap, HashSet};
 
-use crate::plugins::render_layer_alloc::{RenderLayerLease};
+use crate::plugins::render_layer_alloc::RenderLayerLease;
 use crate::{
     MainCamera, WorldPosExt,
     object_3d::ComponentArrayExt,
@@ -326,7 +326,8 @@ fn render_vector_arrow(
         let mut seen_cameras: HashSet<Entity> = HashSet::new();
 
         let mut render_for_camera = |idx: usize| {
-            let (cam_entity, cam, proj, cam_tf, viewport_config, render_layer_lease) = main_camera_data[idx];
+            let (cam_entity, cam, proj, cam_tf, viewport_config, render_layer_lease) =
+                main_camera_data[idx];
             seen_cameras.insert(cam_entity);
 
             let show_arrows = viewport_config

--- a/libs/elodin-editor/src/plugins/gizmos/mod.rs
+++ b/libs/elodin-editor/src/plugins/gizmos/mod.rs
@@ -51,6 +51,7 @@ type MainCameraQueryItem<'w> = (
     &'w Projection,
     &'w GlobalTransform,
     Option<&'w ViewportConfig>,
+    Option<&'w RenderLayers>,
     Option<&'w RenderLayerLease>,
 );
 
@@ -260,7 +261,7 @@ fn render_vector_arrow(
     }
     let has_show_arrows = main_camera_data
         .iter()
-        .any(|(_, _, _, _, config, _)| config.as_ref().map(|c| c.show_arrows).unwrap_or(true));
+        .any(|(_, _, _, _, config, _, _)| config.as_ref().map(|c| c.show_arrows).unwrap_or(true));
 
     for (entity, arrow, mut state) in vector_arrows.iter_mut() {
         if !has_show_arrows {
@@ -326,7 +327,7 @@ fn render_vector_arrow(
         let mut seen_cameras: HashSet<Entity> = HashSet::new();
 
         let mut render_for_camera = |idx: usize| {
-            let (cam_entity, cam, proj, cam_tf, viewport_config, render_layer_lease) =
+            let (cam_entity, cam, proj, cam_tf, viewport_config, camera_layers, render_layer_lease) =
                 main_camera_data[idx];
             seen_cameras.insert(cam_entity);
 
@@ -346,14 +347,16 @@ fn render_vector_arrow(
                 return;
             }
 
-            let Some(render_layer_lease) = render_layer_lease else {
-                if let Some(visual) = state.visuals.remove(&cam_entity) {
-                    hide_arrow_visual(&mut commands, &visual);
+            let arrow_layers = match (camera_layers, render_layer_lease) {
+                (Some(layers), _) => layers.clone(),
+                (None, Some(lease)) => lease.render_layers(),
+                (None, None) => {
+                    if let Some(visual) = state.visuals.remove(&cam_entity) {
+                        hide_arrow_visual(&mut commands, &visual);
+                    }
+                    return;
                 }
-                return;
             };
-
-            let arrow_layers = render_layer_lease.render_layers();
 
             let world_per_px = world_units_per_pixel(cam, proj, cam_tf, start);
             let shaft_radius = (TARGET_DIAMETER_PX * 0.5 * world_per_px)

--- a/libs/elodin-editor/src/plugins/mod.rs
+++ b/libs/elodin-editor/src/plugins/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod kdl_asset_source;
 pub(crate) mod kdl_document;
 mod logical_key;
 pub mod navigation_gizmo;
+pub mod render_layer_alloc;
 pub mod view_cube;
 mod web_asset;
 

--- a/libs/elodin-editor/src/plugins/navigation_gizmo/README.md
+++ b/libs/elodin-editor/src/plugins/navigation_gizmo/README.md
@@ -3,14 +3,14 @@
 Navigation gizmo support and camera-overlay synchronization helpers.
 
 ## What it does
-- Provides render-layer allocation (`RenderLayerAlloc`).
+- Provides render-layer allocation (`RenderLayerAllocator`).
 - Provides shared components (`NavGizmoParent`, `NavGizmoCamera`).
 - Keeps overlay camera viewport/rotation synchronized with the main camera.
 - Still contains legacy `spawn_gizmo` behavior for the previous 3D nav gizmo.
 
 ## Main API
 - `NavigationGizmoPlugin`
-- `RenderLayerAlloc`
+- `RenderLayerAllocator`
 - `NavGizmoParent`
 - `NavGizmoCamera`
 - `spawn_gizmo` (legacy)

--- a/libs/elodin-editor/src/plugins/navigation_gizmo/mod.rs
+++ b/libs/elodin-editor/src/plugins/navigation_gizmo/mod.rs
@@ -10,8 +10,7 @@ use bevy_editor_cam::prelude::EnabledMotion;
 use bevy_egui::EguiContexts;
 use std::{collections::HashMap, f32::consts};
 
-mod render_layer_alloc;
-pub use render_layer_alloc::{RenderLayerLease, RenderLayerAllocator};
+use super::render_layer_alloc::{self, RenderLayerLease, RenderLayerAllocator};
 
 pub struct NavigationGizmoPlugin;
 

--- a/libs/elodin-editor/src/plugins/navigation_gizmo/mod.rs
+++ b/libs/elodin-editor/src/plugins/navigation_gizmo/mod.rs
@@ -13,13 +13,11 @@ use std::{collections::HashMap, f32::consts};
 mod render_layer_alloc;
 pub use render_layer_alloc::{AllocatedRenderLayer, RenderLayerAlloc};
 
-
 pub struct NavigationGizmoPlugin;
 
 impl Plugin for NavigationGizmoPlugin {
     fn build(&self, app: &mut App) {
-        app
-            .init_resource::<NavGizmoAnchorState>()
+        app.init_resource::<NavGizmoAnchorState>()
             .add_systems(PostUpdate, set_camera_viewport)
             .add_systems(PostUpdate, sync_nav_camera)
             .add_plugins(MeshPickingPlugin)

--- a/libs/elodin-editor/src/plugins/navigation_gizmo/mod.rs
+++ b/libs/elodin-editor/src/plugins/navigation_gizmo/mod.rs
@@ -11,7 +11,7 @@ use bevy_egui::EguiContexts;
 use std::{collections::HashMap, f32::consts};
 
 mod render_layer_alloc;
-pub use render_layer_alloc::{AllocatedRenderLayer, RenderLayerAlloc};
+pub use render_layer_alloc::{RenderLayerLease, RenderLayerAllocator};
 
 pub struct NavigationGizmoPlugin;
 
@@ -127,7 +127,7 @@ pub fn spawn_gizmo(
     commands: &mut Commands,
     meshes: &mut ResMut<Assets<Mesh>>,
     materials: &mut ResMut<Assets<StandardMaterial>>,
-    render_layer_alloc: &mut ResMut<RenderLayerAlloc>,
+    render_layer_alloc: &mut ResMut<RenderLayerAllocator>,
 ) -> (Option<Entity>, Option<Entity>) {
     let Some(lease) = render_layer_alloc.alloc() else {
         return (None, None);

--- a/libs/elodin-editor/src/plugins/navigation_gizmo/mod.rs
+++ b/libs/elodin-editor/src/plugins/navigation_gizmo/mod.rs
@@ -10,7 +10,7 @@ use bevy_editor_cam::prelude::EnabledMotion;
 use bevy_egui::EguiContexts;
 use std::{collections::HashMap, f32::consts};
 
-use super::render_layer_alloc::{self, RenderLayerAllocator, RenderLayerLease};
+use super::render_layer_alloc::{self, RenderLayerAllocator};
 
 pub struct NavigationGizmoPlugin;
 

--- a/libs/elodin-editor/src/plugins/navigation_gizmo/mod.rs
+++ b/libs/elodin-editor/src/plugins/navigation_gizmo/mod.rs
@@ -1,10 +1,5 @@
-use crate::{
-    MainCamera,
-    plugins::{camera_anchor::camera_anchor_from_transform, gizmos::GIZMO_RENDER_LAYER},
-    ui::ViewportRect,
-};
+use crate::{MainCamera, plugins::camera_anchor::camera_anchor_from_transform, ui::ViewportRect};
 use bevy::animation::{AnimationTarget, AnimationTargetId, animated_field};
-use bevy::camera::visibility::RenderLayers;
 use bevy::camera::{RenderTarget, Viewport};
 use bevy::math::Dir3;
 use bevy::prelude::*;
@@ -15,15 +10,20 @@ use bevy_editor_cam::prelude::EnabledMotion;
 use bevy_egui::EguiContexts;
 use std::{collections::HashMap, f32::consts};
 
+mod render_layer_alloc;
+pub use render_layer_alloc::{AllocatedRenderLayer, RenderLayerAlloc};
+
+
 pub struct NavigationGizmoPlugin;
 
 impl Plugin for NavigationGizmoPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<RenderLayerAlloc>()
+        app
             .init_resource::<NavGizmoAnchorState>()
             .add_systems(PostUpdate, set_camera_viewport)
             .add_systems(PostUpdate, sync_nav_camera)
-            .add_plugins(MeshPickingPlugin);
+            .add_plugins(MeshPickingPlugin)
+            .add_plugins(render_layer_alloc::plugin);
     }
 }
 
@@ -102,41 +102,6 @@ fn cube_color_reset(
     }
 }
 
-#[derive(Resource, Debug)]
-pub struct RenderLayerAlloc(usize);
-
-impl Default for RenderLayerAlloc {
-    fn default() -> Self {
-        let mut bits = !1usize;
-        bits &= !(1usize << GIZMO_RENDER_LAYER);
-        Self(bits)
-    }
-}
-
-impl RenderLayerAlloc {
-    pub fn alloc(&mut self) -> Option<usize> {
-        let bits = self.0;
-        let mut mask = 1;
-        for i in 0..32 {
-            if (bits & mask) != 0 {
-                self.0 &= !mask;
-                return Some(i);
-            }
-            mask <<= 1;
-        }
-        None
-    }
-
-    #[allow(dead_code)]
-    pub fn free(&mut self, layer: usize) {
-        self.0 |= 1 << layer;
-    }
-
-    pub fn free_all(&mut self) {
-        self.0 = !0;
-    }
-}
-
 #[derive(Component, Debug)]
 pub struct NavGizmo;
 
@@ -166,10 +131,10 @@ pub fn spawn_gizmo(
     materials: &mut ResMut<Assets<StandardMaterial>>,
     render_layer_alloc: &mut ResMut<RenderLayerAlloc>,
 ) -> (Option<Entity>, Option<Entity>) {
-    let Some(render_layer) = render_layer_alloc.alloc() else {
+    let Some(lease) = render_layer_alloc.alloc() else {
         return (None, None);
     };
-    let render_layers = RenderLayers::layer(render_layer);
+    let render_layers = lease.render_layers();
     let sphere = meshes.add(Mesh::from(Sphere::new(0.075)));
 
     let nav_gizmo = commands
@@ -182,6 +147,7 @@ pub fn spawn_gizmo(
         ))
         .observe(drag_nav_gizmo)
         .observe(drag_nav_gizmo_end)
+        .insert(lease)
         .id();
 
     let distance = 0.35;
@@ -585,15 +551,3 @@ fn set_camera_viewport(
 //         target.translation = self.anchor + rot_matrix.mul_vec3(Vec3::new(0.0, 0.0, self.radius));
 //     }
 // }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_render_layer_alloc() {
-        let mut default = RenderLayerAlloc::default();
-        assert_eq!(default.alloc().unwrap(), 1);
-        assert_eq!(default.alloc().unwrap(), 2);
-    }
-}

--- a/libs/elodin-editor/src/plugins/navigation_gizmo/mod.rs
+++ b/libs/elodin-editor/src/plugins/navigation_gizmo/mod.rs
@@ -10,7 +10,7 @@ use bevy_editor_cam::prelude::EnabledMotion;
 use bevy_egui::EguiContexts;
 use std::{collections::HashMap, f32::consts};
 
-use super::render_layer_alloc::{self, RenderLayerLease, RenderLayerAllocator};
+use super::render_layer_alloc::{self, RenderLayerAllocator, RenderLayerLease};
 
 pub struct NavigationGizmoPlugin;
 

--- a/libs/elodin-editor/src/plugins/navigation_gizmo/mod.rs
+++ b/libs/elodin-editor/src/plugins/navigation_gizmo/mod.rs
@@ -10,7 +10,7 @@ use bevy_editor_cam::prelude::EnabledMotion;
 use bevy_egui::EguiContexts;
 use std::{collections::HashMap, f32::consts};
 
-use super::render_layer_alloc::{self, RenderLayerAllocator};
+use super::render_layer_alloc::RenderLayerAllocator;
 
 pub struct NavigationGizmoPlugin;
 
@@ -19,8 +19,7 @@ impl Plugin for NavigationGizmoPlugin {
         app.init_resource::<NavGizmoAnchorState>()
             .add_systems(PostUpdate, set_camera_viewport)
             .add_systems(PostUpdate, sync_nav_camera)
-            .add_plugins(MeshPickingPlugin)
-            .add_plugins(render_layer_alloc::plugin);
+            .add_plugins(MeshPickingPlugin);
     }
 }
 

--- a/libs/elodin-editor/src/plugins/navigation_gizmo/render_layer_alloc.rs
+++ b/libs/elodin-editor/src/plugins/navigation_gizmo/render_layer_alloc.rs
@@ -1,0 +1,192 @@
+use crate::plugins::gizmos::GIZMO_RENDER_LAYER;
+use bevy::camera::visibility::RenderLayers;
+use bevy::prelude::*;
+use crossbeam_queue::SegQueue;
+use std::sync::Arc;
+
+pub(crate) fn plugin(app: &mut App) {
+    app.init_resource::<RenderLayerAlloc>()
+        .add_systems(First, process_dropped_render_layer_leases);
+
+}
+
+/// When the last [`Arc`] to this value is dropped, the layer index is pushed to
+/// the shared queue; [`process_dropped_render_layer_leases`] then frees that
+/// layer from [`RenderLayerAlloc`].
+pub struct RenderLayerLease {
+    pub layer: usize,
+    dropped: Arc<SegQueue<usize>>,
+}
+
+/// This is where the magic happens. 
+impl Drop for RenderLayerLease {
+    fn drop(&mut self) {
+        self.dropped.push(self.layer);
+    }
+}
+
+impl std::fmt::Debug for RenderLayerLease {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RenderLayerLease")
+            .field("layer", &self.layer)
+            .finish_non_exhaustive()
+    }
+}
+
+fn render_layer_mask(layer: usize) -> RenderLayers {
+    RenderLayers::none().with(layer)
+}
+
+
+/// Tracks render layers in use. The [`SegQueue`] is shared with every [`RenderLayerLease`] via
+/// [`Arc`]; cloning a lease’s [`Arc`] delays freeing until all clones drop.
+#[derive(Resource)]
+pub struct RenderLayerAlloc {
+    in_use: RenderLayers,
+    dropped: Arc<SegQueue<usize>>,
+}
+
+impl std::fmt::Debug for RenderLayerAlloc {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RenderLayerAlloc")
+            .field("in_use", &self.in_use)
+            .finish_non_exhaustive()
+    }
+}
+
+impl RenderLayerAlloc {
+    /// Layers never returned from [`Self::alloc`]: Bevy default (0) and [`GIZMO_RENDER_LAYER`].
+    pub fn reserved() -> RenderLayers {
+        RenderLayers::layer(0).with(GIZMO_RENDER_LAYER)
+    }
+
+    /// Return the first free layer index.
+    fn first_free_layer_index(&self, in_use: &RenderLayers) -> Option<usize> {
+        let bits = in_use.bits();
+        for word_index in 0..bits.len() + 1 {
+            let used = bits.get(word_index).copied().unwrap_or(0);
+            let free = !used;
+            if free != 0 {
+                let layer = word_index * 64 + free.trailing_zeros() as usize;
+                return Some(layer);
+            }
+        }
+        None
+    }
+
+    /// Current union of in-use layers (including [`RenderLayerAlloc::reserved`]).
+    pub fn in_use(&self) -> RenderLayers {
+        self.in_use.clone()
+    }
+
+    /// Allocates the lowest free render layer below `65_536`, excluding [`Self::reserved`].
+    pub fn alloc(&mut self) -> Option<AllocatedRenderLayer> {
+        let n = self.first_free_layer_index(&self.in_use)?;
+        self.in_use = self.in_use.union(&render_layer_mask(n));
+        Some(AllocatedRenderLayer(Arc::new(RenderLayerLease {
+            layer: n,
+            dropped: Arc::clone(&self.dropped),
+        })))
+    }
+
+    /// Free the given layer. Returns true if the layer was freed. Return false
+    /// if a reserved layer is given or the layer was not allocated.
+    fn free(&mut self, layer: usize) -> bool {
+        let mask = render_layer_mask(layer);
+        if Self::reserved().intersects(&mask) {
+            return false;
+        }
+        if self.in_use.intersects(&mask) {
+            self.in_use = self.in_use.symmetric_difference(&mask);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /// Drains the drop queue and updates `in_use`. Used by
+    /// [`process_dropped_render_layer_leases`] and by tests.
+    pub fn drain_dropped(&mut self) {
+        while let Some(layer) = self.dropped.pop() {
+            if !self.free(layer) {
+                warn!("Could notfree render layer {layer}.");
+            }
+        }
+    }
+
+    /// Resets dynamic allocations while keeping [`RenderLayerAlloc::reserved`] layers blocked.
+    pub fn free_all(&mut self) {
+        while self.dropped.pop().is_some() {}
+        self.in_use = Self::reserved();
+    }
+}
+
+impl Default for RenderLayerAlloc {
+    fn default() -> Self {
+        Self {
+            in_use: Self::reserved(),
+            dropped: Arc::new(SegQueue::new()),
+        }
+    }
+}
+
+fn process_dropped_render_layer_leases(mut alloc: ResMut<RenderLayerAlloc>) {
+    alloc.drain_dropped();
+}
+
+/// Bevy component: holds [`Arc<RenderLayerLease>`]. Cloning the component clones the [`Arc`], so
+/// the layer stays reserved until every clone is dropped (then one queue push, one free).
+#[derive(Component, Clone, Debug)]
+pub struct AllocatedRenderLayer(pub Arc<RenderLayerLease>);
+
+impl AllocatedRenderLayer {
+    /// Return the layer number.
+    pub fn layer(&self) -> usize {
+        self.0.layer
+    }
+
+    /// Convert this to render layers.
+    pub fn render_layers(&self) -> RenderLayers {
+        render_layer_mask(self.layer())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_render_layer_alloc() {
+        let mut default = RenderLayerAlloc::default();
+        let a = default.alloc().expect("layer 1");
+        let b = default.alloc().expect("layer 2");
+        assert_eq!(a.layer(), 1);
+        assert_eq!(b.layer(), 2);
+    }
+
+    #[test]
+    fn test_lease_drop_frees_after_drain() {
+        let mut alloc = RenderLayerAlloc::default();
+        let lease = alloc.alloc().expect("layer 1");
+        assert_eq!(lease.layer(), 1);
+        drop(lease);
+        alloc.drain_dropped();
+        let again = alloc.alloc().expect("layer 1 again");
+        assert_eq!(again.layer(), 1);
+    }
+
+    #[test]
+    fn test_arc_clone_delays_free_until_last_drop() {
+        let mut alloc = RenderLayerAlloc::default();
+        let a = alloc.alloc().expect("layer 1");
+        let b = Arc::clone(&a.0);
+        drop(a);
+        alloc.drain_dropped();
+        let c = alloc.alloc().expect("layer 2 while 1 still held");
+        assert_eq!(c.layer(), 2);
+        drop(b);
+        alloc.drain_dropped();
+        let d = alloc.alloc().expect("layer 1 free again");
+        assert_eq!(d.layer(), 1);
+    }
+}

--- a/libs/elodin-editor/src/plugins/navigation_gizmo/render_layer_alloc.rs
+++ b/libs/elodin-editor/src/plugins/navigation_gizmo/render_layer_alloc.rs
@@ -1,3 +1,14 @@
+///! Handle render layer allocation and deallocation. One allocates a
+///! `AllocatedRenderLayer` component from the `RenderLayerAlloc` resource. Add
+///! it and its `Renderlayer` to whatever entity needs it. When all the
+///! `AllocatedRenderLayer`s are dropped, then the allocated render layer is
+///! freed for use again.
+///!
+///! This can work with any render layer, and it uses the bits to find the next
+///! available layer, so its fast and uses the lowest available number first.
+///!
+///! This module was created to avoid a maximum limit of 64 that were not
+///! deallocated.
 use crate::plugins::gizmos::GIZMO_RENDER_LAYER;
 use bevy::camera::visibility::RenderLayers;
 use bevy::prelude::*;

--- a/libs/elodin-editor/src/plugins/navigation_gizmo/render_layer_alloc.rs
+++ b/libs/elodin-editor/src/plugins/navigation_gizmo/render_layer_alloc.rs
@@ -1,7 +1,7 @@
 //! Handle render layer allocation and deallocation. One allocates a
-//! `AllocatedRenderLayer` component from the `RenderLayerAlloc` resource. Add
+//! `RenderLayerLease` component from the `RenderLayerAllocator` resource. Add
 //! it and its `Renderlayer` to whatever entity needs it. When all the
-//! `AllocatedRenderLayer`s are dropped, then the allocated render layer is
+//! `RenderLayerLease`s are dropped, then the allocated render layer is
 //! freed for use again.
 //!
 //! This can work with any render layer, and it uses the bits to find the next
@@ -16,28 +16,28 @@ use crossbeam_queue::SegQueue;
 use std::sync::Arc;
 
 pub(crate) fn plugin(app: &mut App) {
-    app.init_resource::<RenderLayerAlloc>()
+    app.init_resource::<RenderLayerAllocator>()
         .add_systems(First, process_dropped_render_layer_leases);
 }
 
 /// When the last [`Arc`] to this value is dropped, the layer index is pushed to
 /// the shared queue; [`process_dropped_render_layer_leases`] then frees that
-/// layer from [`RenderLayerAlloc`].
-pub struct RenderLayerLease {
+/// layer from [`RenderLayerAllocator`].
+pub struct RenderLayerLeaseInner {
     pub layer: usize,
     dropped: Arc<SegQueue<usize>>,
 }
 
 /// This is where the magic happens.
-impl Drop for RenderLayerLease {
+impl Drop for RenderLayerLeaseInner {
     fn drop(&mut self) {
         self.dropped.push(self.layer);
     }
 }
 
-impl std::fmt::Debug for RenderLayerLease {
+impl std::fmt::Debug for RenderLayerLeaseInner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RenderLayerLease")
+        f.debug_struct("RenderLayerLeaseInner")
             .field("layer", &self.layer)
             .finish_non_exhaustive()
     }
@@ -47,23 +47,23 @@ fn render_layer_mask(layer: usize) -> RenderLayers {
     RenderLayers::none().with(layer)
 }
 
-/// Tracks render layers in use. The [`SegQueue`] is shared with every [`RenderLayerLease`] via
+/// Tracks render layers in use. The [`SegQueue`] is shared with every [`RenderLayerLeaseInner`] via
 /// [`Arc`]; cloning a lease’s [`Arc`] delays freeing until all clones drop.
 #[derive(Resource)]
-pub struct RenderLayerAlloc {
+pub struct RenderLayerAllocator {
     in_use: RenderLayers,
     dropped: Arc<SegQueue<usize>>,
 }
 
-impl std::fmt::Debug for RenderLayerAlloc {
+impl std::fmt::Debug for RenderLayerAllocator {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RenderLayerAlloc")
+        f.debug_struct("RenderLayerAllocator")
             .field("in_use", &self.in_use)
             .finish_non_exhaustive()
     }
 }
 
-impl RenderLayerAlloc {
+impl RenderLayerAllocator {
     /// Layers never returned from [`Self::alloc`]: Bevy default (0) and [`GIZMO_RENDER_LAYER`].
     pub fn reserved() -> RenderLayers {
         RenderLayers::layer(0).with(GIZMO_RENDER_LAYER)
@@ -83,16 +83,16 @@ impl RenderLayerAlloc {
         None
     }
 
-    /// Current union of in-use layers (including [`RenderLayerAlloc::reserved`]).
+    /// Current union of in-use layers (including [`RenderLayerAllocator::reserved`]).
     pub fn in_use(&self) -> RenderLayers {
         self.in_use.clone()
     }
 
     /// Allocates the lowest free render layer below `65_536`, excluding [`Self::reserved`].
-    pub fn alloc(&mut self) -> Option<AllocatedRenderLayer> {
+    pub fn alloc(&mut self) -> Option<RenderLayerLease> {
         let n = self.first_free_layer_index(&self.in_use)?;
         self.in_use = self.in_use.union(&render_layer_mask(n));
-        Some(AllocatedRenderLayer(Arc::new(RenderLayerLease {
+        Some(RenderLayerLease(Arc::new(RenderLayerLeaseInner {
             layer: n,
             dropped: Arc::clone(&self.dropped),
         })))
@@ -123,14 +123,14 @@ impl RenderLayerAlloc {
         }
     }
 
-    /// Resets dynamic allocations while keeping [`RenderLayerAlloc::reserved`] layers blocked.
+    /// Resets dynamic allocations while keeping [`RenderLayerAllocator::reserved`] layers blocked.
     pub fn free_all(&mut self) {
         while self.dropped.pop().is_some() {}
         self.in_use = Self::reserved();
     }
 }
 
-impl Default for RenderLayerAlloc {
+impl Default for RenderLayerAllocator {
     fn default() -> Self {
         Self {
             in_use: Self::reserved(),
@@ -139,16 +139,16 @@ impl Default for RenderLayerAlloc {
     }
 }
 
-fn process_dropped_render_layer_leases(mut alloc: ResMut<RenderLayerAlloc>) {
+fn process_dropped_render_layer_leases(mut alloc: ResMut<RenderLayerAllocator>) {
     alloc.drain_dropped();
 }
 
-/// Bevy component: holds [`Arc<RenderLayerLease>`]. Cloning the component clones the [`Arc`], so
+/// Bevy component: holds [`Arc<RenderLayerLeaseInner>`]. Cloning the component clones the [`Arc`], so
 /// the layer stays reserved until every clone is dropped (then one queue push, one free).
 #[derive(Component, Clone, Debug)]
-pub struct AllocatedRenderLayer(pub Arc<RenderLayerLease>);
+pub struct RenderLayerLease(pub Arc<RenderLayerLeaseInner>);
 
-impl AllocatedRenderLayer {
+impl RenderLayerLease {
     /// Return the layer number.
     pub fn layer(&self) -> usize {
         self.0.layer
@@ -166,7 +166,7 @@ mod tests {
 
     #[test]
     fn test_render_layer_alloc() {
-        let mut default = RenderLayerAlloc::default();
+        let mut default = RenderLayerAllocator::default();
         let a = default.alloc().expect("layer 1");
         let b = default.alloc().expect("layer 2");
         assert_eq!(a.layer(), 1);
@@ -175,7 +175,7 @@ mod tests {
 
     #[test]
     fn test_lease_drop_frees_after_drain() {
-        let mut alloc = RenderLayerAlloc::default();
+        let mut alloc = RenderLayerAllocator::default();
         let lease = alloc.alloc().expect("layer 1");
         assert_eq!(lease.layer(), 1);
         drop(lease);
@@ -186,7 +186,7 @@ mod tests {
 
     #[test]
     fn test_arc_clone_delays_free_until_last_drop() {
-        let mut alloc = RenderLayerAlloc::default();
+        let mut alloc = RenderLayerAllocator::default();
         let a = alloc.alloc().expect("layer 1");
         let b = Arc::clone(&a.0);
         drop(a);
@@ -197,5 +197,5 @@ mod tests {
         alloc.drain_dropped();
         let d = alloc.alloc().expect("layer 1 free again");
         assert_eq!(d.layer(), 1);
-    }
+    
 }

--- a/libs/elodin-editor/src/plugins/navigation_gizmo/render_layer_alloc.rs
+++ b/libs/elodin-editor/src/plugins/navigation_gizmo/render_layer_alloc.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 pub(crate) fn plugin(app: &mut App) {
     app.init_resource::<RenderLayerAlloc>()
         .add_systems(First, process_dropped_render_layer_leases);
-
 }
 
 /// When the last [`Arc`] to this value is dropped, the layer index is pushed to
@@ -29,7 +28,7 @@ pub struct RenderLayerLease {
     dropped: Arc<SegQueue<usize>>,
 }
 
-/// This is where the magic happens. 
+/// This is where the magic happens.
 impl Drop for RenderLayerLease {
     fn drop(&mut self) {
         self.dropped.push(self.layer);
@@ -47,7 +46,6 @@ impl std::fmt::Debug for RenderLayerLease {
 fn render_layer_mask(layer: usize) -> RenderLayers {
     RenderLayers::none().with(layer)
 }
-
 
 /// Tracks render layers in use. The [`SegQueue`] is shared with every [`RenderLayerLease`] via
 /// [`Arc`]; cloning a lease’s [`Arc`] delays freeing until all clones drop.

--- a/libs/elodin-editor/src/plugins/navigation_gizmo/render_layer_alloc.rs
+++ b/libs/elodin-editor/src/plugins/navigation_gizmo/render_layer_alloc.rs
@@ -1,14 +1,14 @@
-///! Handle render layer allocation and deallocation. One allocates a
-///! `AllocatedRenderLayer` component from the `RenderLayerAlloc` resource. Add
-///! it and its `Renderlayer` to whatever entity needs it. When all the
-///! `AllocatedRenderLayer`s are dropped, then the allocated render layer is
-///! freed for use again.
-///!
-///! This can work with any render layer, and it uses the bits to find the next
-///! available layer, so its fast and uses the lowest available number first.
-///!
-///! This module was created to avoid a maximum limit of 64 that were not
-///! deallocated.
+//! Handle render layer allocation and deallocation. One allocates a
+//! `AllocatedRenderLayer` component from the `RenderLayerAlloc` resource. Add
+//! it and its `Renderlayer` to whatever entity needs it. When all the
+//! `AllocatedRenderLayer`s are dropped, then the allocated render layer is
+//! freed for use again.
+//!
+//! This can work with any render layer, and it uses the bits to find the next
+//! available layer, so its fast and uses the lowest available number first.
+//!
+//! This module was created to avoid a maximum limit of 64 that were not
+//! deallocated.
 use crate::plugins::gizmos::GIZMO_RENDER_LAYER;
 use bevy::camera::visibility::RenderLayers;
 use bevy::prelude::*;
@@ -107,9 +107,9 @@ impl RenderLayerAlloc {
         }
         if self.in_use.intersects(&mask) {
             self.in_use = self.in_use.symmetric_difference(&mask);
-            return true;
+            true
         } else {
-            return false;
+            false
         }
     }
 

--- a/libs/elodin-editor/src/plugins/render_layer_alloc.rs
+++ b/libs/elodin-editor/src/plugins/render_layer_alloc.rs
@@ -168,6 +168,43 @@ impl RenderLayerLease {
     }
 }
 
+/// Insertion helper for [`RenderLayerLease`].
+///
+/// `RenderLayerLease` is a regular Bevy component, so a second `insert` on the
+/// same entity silently overwrites the first. The dropped `Arc` then frees the
+/// layer back to the [`RenderLayerAllocator`], which reuses it for an unrelated
+/// viewport. Two viewports end up sharing one render layer — visually visible
+/// as cross-rendered frustums or gizmos.
+///
+/// Always go through [`EntityCommandsExt::insert_render_layer_lease`] when
+/// touching an entity that already exists. In debug builds it panics on the
+/// duplicate insertion; in release it falls back to a single insert (the
+/// historical behaviour).
+pub trait EntityCommandsExt {
+    /// Insert a [`RenderLayerLease`] together with its [`RenderLayers`] mask.
+    /// Panics in debug if the entity already holds a `RenderLayerLease`.
+    fn insert_render_layer_lease(&mut self, lease: RenderLayerLease) -> &mut Self;
+}
+
+impl EntityCommandsExt for EntityCommands<'_> {
+    fn insert_render_layer_lease(&mut self, lease: RenderLayerLease) -> &mut Self {
+        let layers = lease.render_layers();
+        self.queue(move |mut entity: EntityWorldMut| {
+            debug_assert!(
+                entity.get::<RenderLayerLease>().is_none(),
+                "RenderLayerLease already present on entity {:?}: a second insert \
+                 would silently drop the previous lease and free its render layer \
+                 while other entities may still rely on it (two viewports sharing \
+                 one layer). Use a child entity, or remove the existing lease \
+                 explicitly first.",
+                entity.id()
+            );
+            entity.insert((lease, layers));
+        });
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -247,6 +284,53 @@ mod tests {
         );
         let next = alloc.alloc().expect("layer 64 must be available");
         assert_eq!(next.layer(), 64);
+    }
+
+    #[test]
+    #[should_panic(expected = "RenderLayerLease already present")]
+    fn test_insert_render_layer_lease_panics_on_double_insert() {
+        // Reproduces the silent-overwrite bug the helper guards against:
+        // inserting a second RenderLayerLease on an entity that already holds
+        // one would drop the first Arc and free its layer behind the back of
+        // any other entity still pointing at it.
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.init_resource::<RenderLayerAllocator>();
+
+        let mut alloc = app.world_mut().resource_mut::<RenderLayerAllocator>();
+        let lease_a = alloc.alloc().expect("layer 1");
+        let lease_b = alloc.alloc().expect("layer 2");
+
+        let entity = app.world_mut().spawn_empty().id();
+        let mut commands = app.world_mut().commands();
+        commands
+            .entity(entity)
+            .insert_render_layer_lease(lease_a)
+            .insert_render_layer_lease(lease_b);
+        app.world_mut().flush();
+    }
+
+    #[test]
+    fn test_insert_render_layer_lease_inserts_lease_and_layers() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.init_resource::<RenderLayerAllocator>();
+
+        let lease = app
+            .world_mut()
+            .resource_mut::<RenderLayerAllocator>()
+            .alloc()
+            .expect("layer 1");
+        let expected_layers = lease.render_layers();
+
+        let entity = app.world_mut().spawn_empty().id();
+        let mut commands = app.world_mut().commands();
+        commands.entity(entity).insert_render_layer_lease(lease);
+        app.world_mut().flush();
+
+        let entity_ref = app.world().entity(entity);
+        assert!(entity_ref.contains::<RenderLayerLease>());
+        assert_eq!(entity_ref.get::<RenderLayers>(), Some(&expected_layers));
     }
 
     #[test]

--- a/libs/elodin-editor/src/plugins/render_layer_alloc.rs
+++ b/libs/elodin-editor/src/plugins/render_layer_alloc.rs
@@ -197,5 +197,6 @@ mod tests {
         alloc.drain_dropped();
         let d = alloc.alloc().expect("layer 1 free again");
         assert_eq!(d.layer(), 1);
+    }
     
 }

--- a/libs/elodin-editor/src/plugins/render_layer_alloc.rs
+++ b/libs/elodin-editor/src/plugins/render_layer_alloc.rs
@@ -122,11 +122,6 @@ impl RenderLayerAllocator {
         }
     }
 
-    /// Resets dynamic allocations.
-    pub fn free_all(&mut self) {
-        while self.dropped.pop().is_some() {}
-        self.in_use = self.reserved.clone();
-    }
 }
 
 impl Default for RenderLayerAllocator {

--- a/libs/elodin-editor/src/plugins/render_layer_alloc.rs
+++ b/libs/elodin-editor/src/plugins/render_layer_alloc.rs
@@ -198,5 +198,4 @@ mod tests {
         let d = alloc.alloc().expect("layer 1 free again");
         assert_eq!(d.layer(), 1);
     }
-    
 }

--- a/libs/elodin-editor/src/plugins/render_layer_alloc.rs
+++ b/libs/elodin-editor/src/plugins/render_layer_alloc.rs
@@ -177,12 +177,12 @@ impl RenderLayerLease {
 /// as cross-rendered frustums or gizmos.
 ///
 /// Always go through [`EntityCommandsExt::insert_render_layer_lease`] when
-/// touching an entity that already exists. In debug builds it panics on the
-/// duplicate insertion; in release it falls back to a single insert (the
-/// historical behaviour).
+/// touching an entity that already exists. Test builds panic on duplicate
+/// insertion so CI catches the misuse; non-test builds keep the historical
+/// permissive behavior.
 pub trait EntityCommandsExt {
     /// Insert a [`RenderLayerLease`] together with its [`RenderLayers`] mask.
-    /// Panics in debug if the entity already holds a `RenderLayerLease`.
+    /// Test builds panic if the entity already holds a `RenderLayerLease`.
     fn insert_render_layer_lease(&mut self, lease: RenderLayerLease) -> &mut Self;
 }
 
@@ -190,7 +190,8 @@ impl EntityCommandsExt for EntityCommands<'_> {
     fn insert_render_layer_lease(&mut self, lease: RenderLayerLease) -> &mut Self {
         let layers = lease.render_layers();
         self.queue(move |mut entity: EntityWorldMut| {
-            debug_assert!(
+            #[cfg(test)]
+            assert!(
                 entity.get::<RenderLayerLease>().is_none(),
                 "RenderLayerLease already present on entity {:?}: a second insert \
                  would silently drop the previous lease and free its render layer \

--- a/libs/elodin-editor/src/plugins/render_layer_alloc.rs
+++ b/libs/elodin-editor/src/plugins/render_layer_alloc.rs
@@ -15,6 +15,10 @@ use bevy::prelude::*;
 use crossbeam_queue::SegQueue;
 use std::sync::Arc;
 
+/// Render layer shared by every viewport's infinite grid. Reserved so it is
+/// never handed out by [`RenderLayerAllocator::alloc`].
+pub const GRID_RENDER_LAYER: usize = 31;
+
 pub(crate) fn plugin(app: &mut App) {
     app.register_type::<RenderLayerAllocator>()
         .init_resource::<RenderLayerAllocator>()
@@ -125,7 +129,9 @@ impl RenderLayerAllocator {
 
 impl Default for RenderLayerAllocator {
     fn default() -> Self {
-        let reserved = RenderLayers::layer(0).with(GIZMO_RENDER_LAYER);
+        let reserved = RenderLayers::layer(0)
+            .with(GIZMO_RENDER_LAYER)
+            .with(GRID_RENDER_LAYER);
         Self {
             in_use: reserved.clone(),
             reserved,
@@ -177,6 +183,20 @@ mod tests {
         alloc.drain_dropped();
         let again = alloc.alloc().expect("layer 1 again");
         assert_eq!(again.layer(), 1);
+    }
+
+    #[test]
+    fn test_reserved_layers_are_never_allocated() {
+        let mut alloc = RenderLayerAllocator::default();
+        let reserved = alloc.reserved.clone();
+        for _ in 0..64 {
+            let lease = alloc.alloc().expect("plenty of layers available");
+            assert!(
+                !reserved.intersects(&lease.render_layers()),
+                "alloc returned a reserved layer: {}",
+                lease.layer(),
+            );
+        }
     }
 
     #[test]

--- a/libs/elodin-editor/src/plugins/render_layer_alloc.rs
+++ b/libs/elodin-editor/src/plugins/render_layer_alloc.rs
@@ -121,7 +121,6 @@ impl RenderLayerAllocator {
             }
         }
     }
-
 }
 
 impl Default for RenderLayerAllocator {

--- a/libs/elodin-editor/src/plugins/render_layer_alloc.rs
+++ b/libs/elodin-editor/src/plugins/render_layer_alloc.rs
@@ -1,6 +1,6 @@
 //! Handle render layer allocation and deallocation. One allocates a
 //! `RenderLayerLease` component from the `RenderLayerAllocator` resource. Add
-//! it and its `Renderlayer` to whatever entity needs it. When all the
+//! it and its `RenderLayers` to whatever entity needs it. When all the
 //! `RenderLayerLease`s are dropped, then the allocated render layer is
 //! freed for use again.
 //!

--- a/libs/elodin-editor/src/plugins/render_layer_alloc.rs
+++ b/libs/elodin-editor/src/plugins/render_layer_alloc.rs
@@ -73,6 +73,13 @@ impl std::fmt::Debug for RenderLayerAllocator {
 
 impl RenderLayerAllocator {
     /// Return the first free layer index.
+    ///
+    /// We probe one virtual word past `bits.len()`: that word is conceptually
+    /// all zeros (no layer used yet) and lets us return a layer beyond the
+    /// current bitset size — `RenderLayers` is a growable `SmallVec<u64>`, so
+    /// `union` will extend the storage on the next allocation. Without that
+    /// extra iteration the allocator would re-introduce the historical 64-layer
+    /// cap as soon as the first word filled up.
     fn first_free_layer_index(&self, in_use: &RenderLayers) -> Option<usize> {
         let bits = in_use.bits();
         for word_index in 0..bits.len() + 1 {
@@ -197,6 +204,49 @@ mod tests {
                 lease.layer(),
             );
         }
+    }
+
+    #[test]
+    fn test_alloc_grows_past_64_layers() {
+        // Locks in the intent of the `+ 1` in `first_free_layer_index`: the
+        // allocator must hand out layers beyond the first 64-bit word once the
+        // word fills up, instead of returning `None` like the legacy
+        // `RenderLayerAlloc`.
+        let mut alloc = RenderLayerAllocator::default();
+        let mut leases = Vec::new();
+        let mut max_layer = 0;
+        for _ in 0..200 {
+            let lease = alloc.alloc().expect("allocator must not exhaust");
+            max_layer = max_layer.max(lease.layer());
+            leases.push(lease);
+        }
+        assert!(
+            max_layer >= 64,
+            "expected to allocate past layer 63, got max layer {max_layer}",
+        );
+        assert!(
+            alloc.in_use().bits().len() >= 2,
+            "in_use bitset should have grown past one 64-bit word",
+        );
+    }
+
+    #[test]
+    fn test_alloc_returns_layer_64_when_first_word_is_full() {
+        // Direct trace of the scenario the supposed bug report describes:
+        // after layers 1..=63 (plus reserved 0/30/31) are taken, the next
+        // alloc must return layer 64, not None.
+        let mut alloc = RenderLayerAllocator::default();
+        let mut leases = Vec::new();
+        for _ in 0..61 {
+            leases.push(alloc.alloc().expect("layer < 64"));
+        }
+        assert_eq!(
+            alloc.in_use().bits(),
+            &[u64::MAX],
+            "first 64-bit word should be saturated",
+        );
+        let next = alloc.alloc().expect("layer 64 must be available");
+        assert_eq!(next.layer(), 64);
     }
 
     #[test]

--- a/libs/elodin-editor/src/plugins/render_layer_alloc.rs
+++ b/libs/elodin-editor/src/plugins/render_layer_alloc.rs
@@ -16,7 +16,8 @@ use crossbeam_queue::SegQueue;
 use std::sync::Arc;
 
 pub(crate) fn plugin(app: &mut App) {
-    app.init_resource::<RenderLayerAllocator>()
+    app.register_type::<RenderLayerAllocator>()
+        .init_resource::<RenderLayerAllocator>()
         .add_systems(First, process_dropped_render_layer_leases);
 }
 
@@ -49,9 +50,12 @@ fn render_layer_mask(layer: usize) -> RenderLayers {
 
 /// Tracks render layers in use. The [`SegQueue`] is shared with every [`RenderLayerLeaseInner`] via
 /// [`Arc`]; cloning a lease’s [`Arc`] delays freeing until all clones drop.
-#[derive(Resource)]
+#[derive(Resource, Reflect)]
+#[reflect(Resource)]
 pub struct RenderLayerAllocator {
     in_use: RenderLayers,
+    pub reserved: RenderLayers,
+    #[reflect(ignore)]
     dropped: Arc<SegQueue<usize>>,
 }
 
@@ -64,11 +68,6 @@ impl std::fmt::Debug for RenderLayerAllocator {
 }
 
 impl RenderLayerAllocator {
-    /// Layers never returned from [`Self::alloc`]: Bevy default (0) and [`GIZMO_RENDER_LAYER`].
-    pub fn reserved() -> RenderLayers {
-        RenderLayers::layer(0).with(GIZMO_RENDER_LAYER)
-    }
-
     /// Return the first free layer index.
     fn first_free_layer_index(&self, in_use: &RenderLayers) -> Option<usize> {
         let bits = in_use.bits();
@@ -83,12 +82,12 @@ impl RenderLayerAllocator {
         None
     }
 
-    /// Current union of in-use layers (including [`RenderLayerAllocator::reserved`]).
+    /// Current union of in-use layers.
     pub fn in_use(&self) -> RenderLayers {
         self.in_use.clone()
     }
 
-    /// Allocates the lowest free render layer below `65_536`, excluding [`Self::reserved`].
+    /// Allocates the lowest free render layer excluding [`self.reserved`].
     pub fn alloc(&mut self) -> Option<RenderLayerLease> {
         let n = self.first_free_layer_index(&self.in_use)?;
         self.in_use = self.in_use.union(&render_layer_mask(n));
@@ -102,7 +101,7 @@ impl RenderLayerAllocator {
     /// if a reserved layer is given or the layer was not allocated.
     fn free(&mut self, layer: usize) -> bool {
         let mask = render_layer_mask(layer);
-        if Self::reserved().intersects(&mask) {
+        if self.reserved.intersects(&mask) {
             return false;
         }
         if self.in_use.intersects(&mask) {
@@ -118,22 +117,24 @@ impl RenderLayerAllocator {
     pub fn drain_dropped(&mut self) {
         while let Some(layer) = self.dropped.pop() {
             if !self.free(layer) {
-                warn!("Could notfree render layer {layer}.");
+                warn!("Could not free render layer {layer}.");
             }
         }
     }
 
-    /// Resets dynamic allocations while keeping [`RenderLayerAllocator::reserved`] layers blocked.
+    /// Resets dynamic allocations.
     pub fn free_all(&mut self) {
         while self.dropped.pop().is_some() {}
-        self.in_use = Self::reserved();
+        self.in_use = self.reserved.clone();
     }
 }
 
 impl Default for RenderLayerAllocator {
     fn default() -> Self {
+        let reserved = RenderLayers::layer(0).with(GIZMO_RENDER_LAYER);
         Self {
-            in_use: Self::reserved(),
+            in_use: reserved.clone(),
+            reserved,
             dropped: Arc::new(SegQueue::new()),
         }
     }

--- a/libs/elodin-editor/src/plugins/view_cube/camera.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/camera.rs
@@ -15,7 +15,8 @@ use impeller2_wkt::ComponentValue;
 use std::collections::HashMap;
 
 use super::components::{
-    AxisLabelBillboard, RotationArrow, ViewCubeCamera, ViewCubeLink, ViewCubeRoot, ViewportActionButton,
+    AxisLabelBillboard, RotationArrow, ViewCubeCamera, ViewCubeLink, ViewCubeRoot,
+    ViewportActionButton,
 };
 use super::config::ViewCubeConfig;
 use super::events::ViewCubeEvent;

--- a/libs/elodin-editor/src/plugins/view_cube/camera.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/camera.rs
@@ -21,6 +21,7 @@ use super::config::ViewCubeConfig;
 use super::events::ViewCubeEvent;
 use crate::WorldPosExt;
 use crate::object_3d::ComponentArrayExt;
+use crate::plugins::render_layer_alloc::RenderLayerLease;
 
 const FACE_IN_SCREEN_PLANE_DOT_THRESHOLD: f32 = 0.999;
 const CORNER_IN_SCREEN_AXIS_DOT_THRESHOLD: f32 = 0.998;
@@ -186,13 +187,13 @@ pub fn orient_axis_labels_to_screen_plane(
 }
 
 pub fn apply_render_layers_to_scene(
-    view_cube_query: Query<(Entity, &ViewCubeRenderLayer, &Visibility), With<ViewCubeRoot>>,
+    view_cube_query: Query<(Entity, &RenderLayerLease, &Visibility), With<ViewCubeRoot>>,
     children_query: Query<&Children>,
     entities_without_layer: Query<Entity, (Without<RenderLayers>, Without<ViewCubeCamera>)>,
     mut commands: Commands,
 ) {
     for (cube_root, layer, visibility) in view_cube_query.iter() {
-        let render_layers = RenderLayers::layer(layer.0);
+        let render_layers = layer.render_layers();
 
         let had_untagged = apply_layers_recursive(
             cube_root,

--- a/libs/elodin-editor/src/plugins/view_cube/camera.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/camera.rs
@@ -15,8 +15,7 @@ use impeller2_wkt::ComponentValue;
 use std::collections::HashMap;
 
 use super::components::{
-    AxisLabelBillboard, RotationArrow, ViewCubeCamera, ViewCubeLink, ViewCubeRenderLayer,
-    ViewCubeRoot, ViewportActionButton,
+    AxisLabelBillboard, RotationArrow, ViewCubeCamera, ViewCubeLink, ViewCubeRoot, ViewportActionButton,
 };
 use super::config::ViewCubeConfig;
 use super::events::ViewCubeEvent;

--- a/libs/elodin-editor/src/plugins/view_cube/components.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/components.rs
@@ -33,10 +33,6 @@ pub struct ViewCubeLink {
 #[derive(Component)]
 pub struct ViewCubeCamera;
 
-/// Stores the render layer for this ViewCube instance
-#[derive(Component)]
-pub struct ViewCubeRenderLayer(pub usize);
-
 // ============================================================================
 // Cube Elements
 // ============================================================================

--- a/libs/elodin-editor/src/plugins/view_cube/config.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/config.rs
@@ -223,8 +223,6 @@ pub struct ViewCubeConfig {
     /// Optional extra rotation applied when syncing the cube to the camera.
     /// This is applied after the system-specific correction.
     pub axis_correction: Quat,
-    /// Render layer used by the dedicated ViewCube overlay camera.
-    pub render_layer: u8,
 }
 
 impl Default for ViewCubeConfig {
@@ -236,7 +234,6 @@ impl Default for ViewCubeConfig {
             camera_distance: 2.5,
             sync_with_camera: true,
             axis_correction: Quat::IDENTITY,
-            render_layer: 31,
         }
     }
 }

--- a/libs/elodin-editor/src/plugins/view_cube/spawn.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/spawn.rs
@@ -8,6 +8,7 @@ use bevy::prelude::*;
 use bevy_fontmesh::prelude::*;
 use std::f32::consts::{FRAC_PI_2, PI};
 
+use crate::plugins::render_layer_alloc::{RenderLayerLease};
 use super::components::*;
 use super::config::*;
 use super::theme::ViewCubeColors;
@@ -37,10 +38,9 @@ pub fn spawn_view_cube(
     meshes: &mut ResMut<Assets<Mesh>>,
     materials: &mut ResMut<Assets<StandardMaterial>>,
     config: &ViewCubeConfig,
+    render_layer_lease: RenderLayerLease,
     main_camera_entity: Entity,
 ) -> SpawnedViewCube {
-    // TODO: Need to know where this render_layer comes from.
-    let render_layers = RenderLayers::none().with(config.render_layer as usize);
 
     // Load the axes-cube.glb (embedded)
     let scene = asset_server.load("embedded://elodin_editor/assets/axes-cube.glb#Scene0");
@@ -58,10 +58,9 @@ pub fn spawn_view_cube(
         ViewCubeLink {
             main_camera: main_camera_entity,
         },
-        //TODO: This needs to be corrected.
-        //ViewCubeRenderLayer(config.render_layer as usize),
         Name::new("view_cube_root"),
-        render_layers.clone(),
+        render_layer_lease.render_layers(),
+        render_layer_lease.clone(),
     ));
 
     let cube_root = cube_root_cmd.id();
@@ -73,8 +72,8 @@ pub fn spawn_view_cube(
         meshes,
         materials,
         config,
-        Some(render_layers.clone()),
         cube_root,
+        Some(&render_layer_lease),
     );
 
     // Spawn 3D text labels on cube faces (as children of cube root)
@@ -83,18 +82,20 @@ pub fn spawn_view_cube(
         asset_server,
         materials,
         config,
-        Some(render_layers.clone()),
+        Some(&render_layer_lease),
         cube_root,
     );
 
-    let gizmo_camera = spawn_overlay_camera(commands, config, main_camera_entity);
+    let gizmo_camera = spawn_overlay_camera(commands, config, main_camera_entity,
+        Some(&render_layer_lease),
+    );
     spawn_rotation_arrows(
         commands,
         asset_server,
         meshes,
         materials,
         gizmo_camera,
-        Some(render_layers.clone()),
+        Some(&render_layer_lease),
     );
     spawn_viewport_action_buttons(
         commands,
@@ -102,7 +103,7 @@ pub fn spawn_view_cube(
         meshes,
         materials,
         gizmo_camera,
-        Some(render_layers),
+        Some(&render_layer_lease),
     );
 
     SpawnedViewCube {
@@ -116,10 +117,9 @@ fn spawn_overlay_camera(
     commands: &mut Commands,
     config: &ViewCubeConfig,
     main_camera: Entity,
+    render_layer_lease: Option<&RenderLayerLease>,
 ) -> Entity {
-    let render_layers = RenderLayers::layer(config.render_layer as usize);
-
-    commands
+    let mut overlay_cmd = commands
         .spawn((
             Transform::from_xyz(0.0, 0.0, config.camera_distance).looking_at(Vec3::ZERO, Vec3::Y),
             Camera {
@@ -130,12 +130,15 @@ fn spawn_overlay_camera(
                 ..default()
             },
             Camera3d::default(),
-            render_layers,
             ViewCubeCamera,
             ViewCubeLink { main_camera },
             Name::new("view_cube_camera"),
-        ))
-        .id()
+        ));
+
+    if let Some(lease) = render_layer_lease.clone() {
+        overlay_cmd.insert((lease.render_layers(), lease.clone()));
+    }
+    overlay_cmd.id()
 }
 
 // ============================================================================
@@ -159,8 +162,8 @@ fn spawn_axes(
     meshes: &mut Assets<Mesh>,
     materials: &mut Assets<StandardMaterial>,
     config: &ViewCubeConfig,
-    render_layers: Option<RenderLayers>,
     parent: Entity,
+    render_layer_lease: Option<&RenderLayerLease>,
 ) {
     const AXIS_SCALE_BUMP: f32 = 0.95;
     const CUBE_HALF_EXTENT: f32 = 0.5;
@@ -213,8 +216,8 @@ fn spawn_axes(
             ChildOf(parent),
             Name::new(format!("axis_{}_shaft", name)),
         ));
-        if let Some(layers) = render_layers.clone() {
-            shaft_cmd.insert(layers);
+        if let Some(lease) = render_layer_lease.clone() {
+            shaft_cmd.insert((lease.render_layers(), lease.clone()));
         }
 
         let label_pos = axis_origin + direction * axis_label_distance;
@@ -248,8 +251,8 @@ fn spawn_axes(
             ChildOf(parent),
             Name::new(format!("axis_{}_label", name)),
         ));
-        if let Some(layers) = render_layers.clone() {
-            label_cmd.insert(layers);
+        if let Some(lease) = render_layer_lease.clone() {
+            label_cmd.insert((lease.render_layers(), lease.clone()));
         }
     }
 }
@@ -322,7 +325,7 @@ fn spawn_face_labels(
     asset_server: &Res<AssetServer>,
     materials: &mut ResMut<Assets<StandardMaterial>>,
     config: &ViewCubeConfig,
-    render_layers: Option<RenderLayers>,
+    render_layer_lease: Option<&RenderLayerLease>,
     parent: Entity,
 ) {
     // Load the embedded font for ViewCube labels
@@ -371,8 +374,8 @@ fn spawn_face_labels(
             ChildOf(parent),
             Name::new(format!("label_{}", label.text)),
         ));
-        if let Some(layers) = render_layers.clone() {
-            label_cmd.insert(layers);
+        if let Some(lease) = render_layer_lease.clone() {
+            label_cmd.insert((lease.render_layers(), lease.clone()));
         }
     }
 }
@@ -388,7 +391,7 @@ fn spawn_rotation_arrows(
     meshes: &mut ResMut<Assets<Mesh>>,
     materials: &mut ResMut<Assets<StandardMaterial>>,
     camera_entity: Entity,
-    render_layers: Option<RenderLayers>,
+    render_layer_lease: Option<&RenderLayerLease>,
 ) {
     let colors = ViewCubeColors::default();
     let arrow_color = colors.arrow_normal;
@@ -469,8 +472,9 @@ fn spawn_rotation_arrows(
             direction,
             Name::new(format!("rotation_arrow_{:?}", direction)),
         ));
-        if let Some(layers) = render_layers.clone() {
-            arrow_cmd.insert(layers);
+        if let Some(lease) = render_layer_lease.clone() {
+            arrow_cmd.insert((lease.render_layers(),
+                              lease.clone()));
         }
         arrow_cmd.insert(ChildOf(camera_entity));
         let arrow_entity = arrow_cmd.id();
@@ -482,8 +486,8 @@ fn spawn_rotation_arrows(
             ChildOf(arrow_entity),
             Name::new(format!("rotation_arrow_{:?}_hitbox", direction)),
         ));
-        if let Some(layers) = render_layers.clone() {
-            hitbox_cmd.insert(layers);
+        if let Some(lease) = render_layer_lease.clone() {
+            hitbox_cmd.insert((lease.render_layers(), lease.clone()));
         }
     }
 
@@ -526,8 +530,8 @@ fn spawn_rotation_arrows(
             direction,
             Name::new(format!("rotation_arrow_{:?}", direction)),
         ));
-        if let Some(layers) = render_layers.clone() {
-            arrow_cmd.insert(layers);
+        if let Some(lease) = render_layer_lease.clone() {
+            arrow_cmd.insert((lease.render_layers(), lease.clone()));
         }
         arrow_cmd.insert(ChildOf(camera_entity));
         let arrow_entity = arrow_cmd.id();
@@ -539,8 +543,8 @@ fn spawn_rotation_arrows(
             ChildOf(arrow_entity),
             Name::new(format!("rotation_arrow_{:?}_hitbox", direction)),
         ));
-        if let Some(layers) = render_layers.clone() {
-            hitbox_cmd.insert(layers);
+        if let Some(lease) = render_layer_lease.clone() {
+            hitbox_cmd.insert((lease.render_layers(), lease.clone()));
         }
     }
 }
@@ -559,7 +563,7 @@ fn spawn_viewport_action_buttons(
     meshes: &mut ResMut<Assets<Mesh>>,
     materials: &mut ResMut<Assets<StandardMaterial>>,
     camera_entity: Entity,
-    render_layers: Option<RenderLayers>,
+    render_layer_lease: Option<&RenderLayerLease>,
 ) {
     let colors = ViewCubeColors::default();
     let button_color = colors.arrow_normal;
@@ -601,8 +605,8 @@ fn spawn_viewport_action_buttons(
         ViewportActionButton::Reset,
         Name::new("viewport_action_button_Reset"),
     ));
-    if let Some(layers) = render_layers.clone() {
-        reset_cmd.insert(layers);
+    if let Some(lease) = render_layer_lease.clone() {
+        reset_cmd.insert((lease.render_layers(), lease.clone()));
     }
     reset_cmd.insert(ChildOf(camera_entity));
     let reset_button = reset_cmd.id();
@@ -613,8 +617,8 @@ fn spawn_viewport_action_buttons(
         ChildOf(reset_button),
         Name::new("viewport_action_button_Reset_hitbox"),
     ));
-    if let Some(layers) = render_layers.clone() {
-        reset_hitbox_cmd.insert(layers);
+    if let Some(lease) = render_layer_lease.clone() {
+        reset_hitbox_cmd.insert((lease.render_layers(), lease.clone()));
     }
 
     // Circular zoom-out button for clearer visual hierarchy.
@@ -636,8 +640,8 @@ fn spawn_viewport_action_buttons(
         ))
         .id();
     let mut zoom_button_cmd = commands.entity(zoom_button);
-    if let Some(layers) = render_layers.clone() {
-        zoom_button_cmd.insert(layers.clone());
+    if let Some(lease) = render_layer_lease.clone() {
+        zoom_button_cmd.insert((lease.render_layers(), lease.clone()));
     }
     zoom_button_cmd.insert(ChildOf(camera_entity));
 
@@ -662,8 +666,8 @@ fn spawn_viewport_action_buttons(
         ChildOf(zoom_button),
         Name::new("viewport_action_button_ZoomOut_icon"),
     ));
-    if let Some(layers) = render_layers.clone() {
-        zoom_icon_cmd.insert(layers);
+    if let Some(lease) = render_layer_lease.clone() {
+        zoom_icon_cmd.insert((lease.render_layers(), lease.clone()));
     }
 
     let mut zoom_hitbox_cmd = commands.spawn((
@@ -673,8 +677,8 @@ fn spawn_viewport_action_buttons(
         ChildOf(zoom_button),
         Name::new("viewport_action_button_ZoomOut_hitbox"),
     ));
-    if let Some(layers) = render_layers.clone() {
-        zoom_hitbox_cmd.insert(layers);
+    if let Some(lease) = render_layer_lease.clone() {
+        zoom_hitbox_cmd.insert((lease.render_layers(), lease.clone()));
     }
 }
 

--- a/libs/elodin-editor/src/plugins/view_cube/spawn.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/spawn.rs
@@ -8,10 +8,10 @@ use bevy::prelude::*;
 use bevy_fontmesh::prelude::*;
 use std::f32::consts::{FRAC_PI_2, PI};
 
-use crate::plugins::render_layer_alloc::{RenderLayerLease};
 use super::components::*;
 use super::config::*;
 use super::theme::ViewCubeColors;
+use crate::plugins::render_layer_alloc::RenderLayerLease;
 
 pub(crate) fn plugin(app: &mut App) {
     app.add_systems(PreUpdate, swap_zoom_buttons_on_alt);
@@ -41,7 +41,6 @@ pub fn spawn_view_cube(
     render_layer_lease: RenderLayerLease,
     main_camera_entity: Entity,
 ) -> SpawnedViewCube {
-
     // Load the axes-cube.glb (embedded)
     let scene = asset_server.load("embedded://elodin_editor/assets/axes-cube.glb#Scene0");
 
@@ -86,7 +85,10 @@ pub fn spawn_view_cube(
         cube_root,
     );
 
-    let gizmo_camera = spawn_overlay_camera(commands, config, main_camera_entity,
+    let gizmo_camera = spawn_overlay_camera(
+        commands,
+        config,
+        main_camera_entity,
         Some(&render_layer_lease),
     );
     spawn_rotation_arrows(
@@ -119,21 +121,20 @@ fn spawn_overlay_camera(
     main_camera: Entity,
     render_layer_lease: Option<&RenderLayerLease>,
 ) -> Entity {
-    let mut overlay_cmd = commands
-        .spawn((
-            Transform::from_xyz(0.0, 0.0, config.camera_distance).looking_at(Vec3::ZERO, Vec3::Y),
-            Camera {
-                order: 3, // Match navigation_gizmo camera order
-                // NOTE: Don't clear on the ViewCube camera because the
-                // MainCamera already cleared the window.
-                clear_color: ClearColorConfig::None,
-                ..default()
-            },
-            Camera3d::default(),
-            ViewCubeCamera,
-            ViewCubeLink { main_camera },
-            Name::new("view_cube_camera"),
-        ));
+    let mut overlay_cmd = commands.spawn((
+        Transform::from_xyz(0.0, 0.0, config.camera_distance).looking_at(Vec3::ZERO, Vec3::Y),
+        Camera {
+            order: 3, // Match navigation_gizmo camera order
+            // NOTE: Don't clear on the ViewCube camera because the
+            // MainCamera already cleared the window.
+            clear_color: ClearColorConfig::None,
+            ..default()
+        },
+        Camera3d::default(),
+        ViewCubeCamera,
+        ViewCubeLink { main_camera },
+        Name::new("view_cube_camera"),
+    ));
 
     if let Some(lease) = render_layer_lease.clone() {
         overlay_cmd.insert((lease.render_layers(), lease.clone()));
@@ -473,8 +474,7 @@ fn spawn_rotation_arrows(
             Name::new(format!("rotation_arrow_{:?}", direction)),
         ));
         if let Some(lease) = render_layer_lease.clone() {
-            arrow_cmd.insert((lease.render_layers(),
-                              lease.clone()));
+            arrow_cmd.insert((lease.render_layers(), lease.clone()));
         }
         arrow_cmd.insert(ChildOf(camera_entity));
         let arrow_entity = arrow_cmd.id();

--- a/libs/elodin-editor/src/plugins/view_cube/spawn.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/spawn.rs
@@ -1,7 +1,6 @@
 //! Spawning functions for the ViewCube widget
 
 use bevy::camera::ClearColorConfig;
-use bevy::camera::visibility::RenderLayers;
 use bevy::ecs::hierarchy::ChildOf;
 use bevy::picking::prelude::*;
 use bevy::prelude::*;
@@ -48,7 +47,7 @@ pub fn spawn_view_cube(
     // Visibility::Inherited once every descendant has been assigned the correct
     // RenderLayers, preventing the GLB children from briefly appearing on all
     // cameras via the default layer 0.
-    let mut cube_root_cmd = commands.spawn((
+    let cube_root_cmd = commands.spawn((
         SceneRoot(scene),
         Transform::from_xyz(0.0, 0.0, 0.0).with_scale(Vec3::splat(config.scale)),
         Visibility::Hidden,
@@ -136,7 +135,7 @@ fn spawn_overlay_camera(
         Name::new("view_cube_camera"),
     ));
 
-    if let Some(lease) = render_layer_lease.clone() {
+    if let Some(lease) = render_layer_lease {
         overlay_cmd.insert((lease.render_layers(), lease.clone()));
     }
     overlay_cmd.id()
@@ -217,7 +216,7 @@ fn spawn_axes(
             ChildOf(parent),
             Name::new(format!("axis_{}_shaft", name)),
         ));
-        if let Some(lease) = render_layer_lease.clone() {
+        if let Some(lease) = render_layer_lease {
             shaft_cmd.insert((lease.render_layers(), lease.clone()));
         }
 
@@ -252,7 +251,7 @@ fn spawn_axes(
             ChildOf(parent),
             Name::new(format!("axis_{}_label", name)),
         ));
-        if let Some(lease) = render_layer_lease.clone() {
+        if let Some(lease) = render_layer_lease {
             label_cmd.insert((lease.render_layers(), lease.clone()));
         }
     }
@@ -375,7 +374,7 @@ fn spawn_face_labels(
             ChildOf(parent),
             Name::new(format!("label_{}", label.text)),
         ));
-        if let Some(lease) = render_layer_lease.clone() {
+        if let Some(lease) = render_layer_lease {
             label_cmd.insert((lease.render_layers(), lease.clone()));
         }
     }
@@ -473,7 +472,7 @@ fn spawn_rotation_arrows(
             direction,
             Name::new(format!("rotation_arrow_{:?}", direction)),
         ));
-        if let Some(lease) = render_layer_lease.clone() {
+        if let Some(lease) = render_layer_lease {
             arrow_cmd.insert((lease.render_layers(), lease.clone()));
         }
         arrow_cmd.insert(ChildOf(camera_entity));
@@ -486,7 +485,7 @@ fn spawn_rotation_arrows(
             ChildOf(arrow_entity),
             Name::new(format!("rotation_arrow_{:?}_hitbox", direction)),
         ));
-        if let Some(lease) = render_layer_lease.clone() {
+        if let Some(lease) = render_layer_lease {
             hitbox_cmd.insert((lease.render_layers(), lease.clone()));
         }
     }
@@ -530,7 +529,7 @@ fn spawn_rotation_arrows(
             direction,
             Name::new(format!("rotation_arrow_{:?}", direction)),
         ));
-        if let Some(lease) = render_layer_lease.clone() {
+        if let Some(lease) = render_layer_lease {
             arrow_cmd.insert((lease.render_layers(), lease.clone()));
         }
         arrow_cmd.insert(ChildOf(camera_entity));
@@ -543,7 +542,7 @@ fn spawn_rotation_arrows(
             ChildOf(arrow_entity),
             Name::new(format!("rotation_arrow_{:?}_hitbox", direction)),
         ));
-        if let Some(lease) = render_layer_lease.clone() {
+        if let Some(lease) = render_layer_lease {
             hitbox_cmd.insert((lease.render_layers(), lease.clone()));
         }
     }
@@ -605,7 +604,7 @@ fn spawn_viewport_action_buttons(
         ViewportActionButton::Reset,
         Name::new("viewport_action_button_Reset"),
     ));
-    if let Some(lease) = render_layer_lease.clone() {
+    if let Some(lease) = render_layer_lease {
         reset_cmd.insert((lease.render_layers(), lease.clone()));
     }
     reset_cmd.insert(ChildOf(camera_entity));
@@ -617,7 +616,7 @@ fn spawn_viewport_action_buttons(
         ChildOf(reset_button),
         Name::new("viewport_action_button_Reset_hitbox"),
     ));
-    if let Some(lease) = render_layer_lease.clone() {
+    if let Some(lease) = render_layer_lease {
         reset_hitbox_cmd.insert((lease.render_layers(), lease.clone()));
     }
 
@@ -640,7 +639,7 @@ fn spawn_viewport_action_buttons(
         ))
         .id();
     let mut zoom_button_cmd = commands.entity(zoom_button);
-    if let Some(lease) = render_layer_lease.clone() {
+    if let Some(lease) = render_layer_lease {
         zoom_button_cmd.insert((lease.render_layers(), lease.clone()));
     }
     zoom_button_cmd.insert(ChildOf(camera_entity));
@@ -666,7 +665,7 @@ fn spawn_viewport_action_buttons(
         ChildOf(zoom_button),
         Name::new("viewport_action_button_ZoomOut_icon"),
     ));
-    if let Some(lease) = render_layer_lease.clone() {
+    if let Some(lease) = render_layer_lease {
         zoom_icon_cmd.insert((lease.render_layers(), lease.clone()));
     }
 
@@ -677,7 +676,7 @@ fn spawn_viewport_action_buttons(
         ChildOf(zoom_button),
         Name::new("viewport_action_button_ZoomOut_hitbox"),
     ));
-    if let Some(lease) = render_layer_lease.clone() {
+    if let Some(lease) = render_layer_lease {
         zoom_hitbox_cmd.insert((lease.render_layers(), lease.clone()));
     }
 }

--- a/libs/elodin-editor/src/plugins/view_cube/spawn.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/spawn.rs
@@ -39,7 +39,8 @@ pub fn spawn_view_cube(
     config: &ViewCubeConfig,
     main_camera_entity: Entity,
 ) -> SpawnedViewCube {
-    let render_layers = Some(RenderLayers::layer(config.render_layer as usize));
+    // TODO: Need to know where this render_layer comes from.
+    let render_layers = RenderLayers::none().with(config.render_layer as usize);
 
     // Load the axes-cube.glb (embedded)
     let scene = asset_server.load("embedded://elodin_editor/assets/axes-cube.glb#Scene0");
@@ -57,13 +58,11 @@ pub fn spawn_view_cube(
         ViewCubeLink {
             main_camera: main_camera_entity,
         },
-        ViewCubeRenderLayer(config.render_layer as usize),
+        //TODO: This needs to be corrected.
+        //ViewCubeRenderLayer(config.render_layer as usize),
         Name::new("view_cube_root"),
+        render_layers.clone(),
     ));
-
-    if let Some(layers) = render_layers.clone() {
-        cube_root_cmd.insert(layers);
-    }
 
     let cube_root = cube_root_cmd.id();
 
@@ -74,7 +73,7 @@ pub fn spawn_view_cube(
         meshes,
         materials,
         config,
-        render_layers.clone(),
+        Some(render_layers.clone()),
         cube_root,
     );
 
@@ -84,7 +83,7 @@ pub fn spawn_view_cube(
         asset_server,
         materials,
         config,
-        render_layers.clone(),
+        Some(render_layers.clone()),
         cube_root,
     );
 
@@ -95,7 +94,7 @@ pub fn spawn_view_cube(
         meshes,
         materials,
         gizmo_camera,
-        render_layers.clone(),
+        Some(render_layers.clone()),
     );
     spawn_viewport_action_buttons(
         commands,
@@ -103,7 +102,7 @@ pub fn spawn_view_cube(
         meshes,
         materials,
         gizmo_camera,
-        render_layers,
+        Some(render_layers),
     );
 
     SpawnedViewCube {

--- a/libs/elodin-editor/src/ui/command_palette/palette_items.rs
+++ b/libs/elodin-editor/src/ui/command_palette/palette_items.rs
@@ -33,7 +33,7 @@ use nox::ArrayBuf;
 
 use crate::{
     EqlContext, MainCamera, Offset, SelectedTimeRange, TimeRangeBehavior, TimeRangeError,
-    plugins::navigation_gizmo::RenderLayerAlloc,
+    plugins::navigation_gizmo::RenderLayerAllocator,
     ui::{
         FocusedWindow, HdrEnabled, Paused, colors,
         command_palette::CommandPaletteState,
@@ -440,7 +440,7 @@ fn graph_parts(
                 move |_: In<String>,
                       query: Query<&ComponentValue>,
                       entity_map: Res<EntityMap>,
-                      mut render_layer_alloc: ResMut<RenderLayerAlloc>,
+                      mut render_layer_alloc: ResMut<RenderLayerAllocator>,
                       mut tile_param: TileParam,
                       path_reg: Res<ComponentPathRegistry>,
                       palette_state: Res<CommandPaletteState>| {

--- a/libs/elodin-editor/src/ui/command_palette/palette_items.rs
+++ b/libs/elodin-editor/src/ui/command_palette/palette_items.rs
@@ -33,7 +33,7 @@ use nox::ArrayBuf;
 
 use crate::{
     EqlContext, MainCamera, Offset, SelectedTimeRange, TimeRangeBehavior, TimeRangeError,
-    plugins::navigation_gizmo::RenderLayerAllocator,
+    plugins::render_layer_alloc::RenderLayerAllocator,
     ui::{
         FocusedWindow, HdrEnabled, Paused, colors,
         command_palette::CommandPaletteState,

--- a/libs/elodin-editor/src/ui/inspector/entity.rs
+++ b/libs/elodin-editor/src/ui/inspector/entity.rs
@@ -16,7 +16,7 @@ use impeller2_wkt::{ComponentMetadata, MetadataExt};
 use smallvec::SmallVec;
 
 use crate::{
-    plugins::navigation_gizmo::RenderLayerAllocator,
+    plugins::render_layer_alloc::RenderLayerAllocator,
     ui::{
         EntityPair,
         colors::get_scheme,

--- a/libs/elodin-editor/src/ui/inspector/entity.rs
+++ b/libs/elodin-editor/src/ui/inspector/entity.rs
@@ -16,7 +16,7 @@ use impeller2_wkt::{ComponentMetadata, MetadataExt};
 use smallvec::SmallVec;
 
 use crate::{
-    plugins::navigation_gizmo::RenderLayerAlloc,
+    plugins::navigation_gizmo::RenderLayerAllocator,
     ui::{
         EntityPair,
         colors::get_scheme,
@@ -39,7 +39,7 @@ pub struct InspectorEntity<'w, 's> {
     metadata_query: Query<'w, 's, &'static mut ComponentMetadata>,
     metadata_store: Res<'w, ComponentMetadataRegistry>,
     path_reg: Res<'w, ComponentPathRegistry>,
-    render_layer_alloc: ResMut<'w, RenderLayerAlloc>,
+    render_layer_alloc: ResMut<'w, RenderLayerAllocator>,
     filter: ResMut<'w, ComponentFilter>,
 }
 

--- a/libs/elodin-editor/src/ui/plot/state.rs
+++ b/libs/elodin-editor/src/ui/plot/state.rs
@@ -13,7 +13,7 @@ use impeller2_wkt::GraphType;
 
 use super::gpu::LineVisibleRange;
 use crate::MainCamera;
-use crate::plugins::render_layer_alloc::{RenderLayerLease, RenderLayerAllocator};
+use crate::plugins::render_layer_alloc::{RenderLayerAllocator, RenderLayerLease};
 use crate::ui::{ViewportRect, colors};
 
 pub type GraphStateComponent = Vec<(bool, egui::Color32)>;

--- a/libs/elodin-editor/src/ui/plot/state.rs
+++ b/libs/elodin-editor/src/ui/plot/state.rs
@@ -13,7 +13,7 @@ use impeller2_wkt::GraphType;
 
 use super::gpu::LineVisibleRange;
 use crate::MainCamera;
-use crate::plugins::navigation_gizmo::{AllocatedRenderLayer, RenderLayerAlloc};
+use crate::plugins::navigation_gizmo::{RenderLayerLease, RenderLayerAllocator};
 use crate::ui::{ViewportRect, colors};
 
 pub type GraphStateComponent = Vec<(bool, egui::Color32)>;
@@ -28,7 +28,7 @@ pub struct GraphBundle {
     pub tonemapping: Tonemapping,
     pub viewport_rect: ViewportRect,
     pub render_layers: RenderLayers,
-    pub allocated_layer: AllocatedRenderLayer,
+    pub allocated_layer: RenderLayerLease,
     pub main_camera: MainCamera,
 }
 
@@ -57,7 +57,7 @@ pub struct GraphState {
 
 impl GraphBundle {
     pub fn new(
-        render_layer_alloc: &mut RenderLayerAlloc,
+        render_layer_alloc: &mut RenderLayerAllocator,
         components: BTreeMap<ComponentPath, GraphStateComponent>,
         label: String,
     ) -> Self {

--- a/libs/elodin-editor/src/ui/plot/state.rs
+++ b/libs/elodin-editor/src/ui/plot/state.rs
@@ -13,7 +13,7 @@ use impeller2_wkt::GraphType;
 
 use super::gpu::LineVisibleRange;
 use crate::MainCamera;
-use crate::plugins::navigation_gizmo::RenderLayerAlloc;
+use crate::plugins::navigation_gizmo::{AllocatedRenderLayer, RenderLayerAlloc};
 use crate::ui::{ViewportRect, colors};
 
 pub type GraphStateComponent = Vec<(bool, egui::Color32)>;
@@ -28,6 +28,7 @@ pub struct GraphBundle {
     pub tonemapping: Tonemapping,
     pub viewport_rect: ViewportRect,
     pub render_layers: RenderLayers,
+    pub allocated_layer: AllocatedRenderLayer,
     pub main_camera: MainCamera,
 }
 
@@ -60,10 +61,10 @@ impl GraphBundle {
         components: BTreeMap<ComponentPath, GraphStateComponent>,
         label: String,
     ) -> Self {
-        let Some(layer) = render_layer_alloc.alloc() else {
+        let Some(allocated_layer) = render_layer_alloc.alloc() else {
             todo!("ran out of layers")
         };
-        let render_layers = RenderLayers::layer(layer);
+        let render_layers = allocated_layer.render_layers();
         let graph_state = GraphState {
             components,
             enabled_lines: BTreeMap::new(),
@@ -105,6 +106,7 @@ impl GraphBundle {
             viewport_rect: ViewportRect(None),
             main_camera: MainCamera,
             render_layers,
+            allocated_layer,
         }
     }
 }

--- a/libs/elodin-editor/src/ui/plot/state.rs
+++ b/libs/elodin-editor/src/ui/plot/state.rs
@@ -13,7 +13,7 @@ use impeller2_wkt::GraphType;
 
 use super::gpu::LineVisibleRange;
 use crate::MainCamera;
-use crate::plugins::navigation_gizmo::{RenderLayerLease, RenderLayerAllocator};
+use crate::plugins::render_layer_alloc::{RenderLayerLease, RenderLayerAllocator};
 use crate::ui::{ViewportRect, colors};
 
 pub type GraphStateComponent = Vec<(bool, egui::Color32)>;

--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -231,7 +231,6 @@ impl LoadSchematicParams<'_, '_> {
         // Set global coordinate frame from schematic
         self.coordinate.0 = schematic.frame;
 
-        self.render_layer_alloc.free_all();
         for (id, window_id, window_state) in &self.window_states {
             if window_id.is_primary() {
                 continue;

--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -251,7 +251,7 @@ impl LoadSchematicParams<'_, '_> {
                 .2;
             std::mem::take(&mut window_state.tile_state)
         };
-        main_state.clear(&mut self.commands, &mut self.render_layer_alloc);
+        main_state.clear(&mut self.commands);
         self.hdr_enabled.0 = false;
         for entity in self.objects_3d.iter() {
             self.commands.entity(entity).despawn();
@@ -577,9 +577,7 @@ impl LoadSchematicParams<'_, '_> {
                     return false;
                 };
                 let window_id = *window_id;
-                window_state
-                    .tile_state
-                    .clear(&mut self.commands, &mut self.render_layer_alloc);
+                window_state.tile_state.clear(&mut self.commands);
                 window_state.graph_entities.clear();
                 window_id
             };

--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -31,7 +31,7 @@ use crate::{
             DocumentLoaded, DocumentReloaded, DocumentSaved, SchematicDocumentAsset,
             SchematicWindow,
         },
-        navigation_gizmo::RenderLayerAlloc,
+        navigation_gizmo::RenderLayerAllocator,
     },
     ui::{
         DEFAULT_SECONDARY_RECT, HdrEnabled,
@@ -120,7 +120,7 @@ pub struct LoadSchematicParams<'w, 's> {
     pub mat3_materials: ResMut<'w, Assets<Mat3Material>>,
     pub images: ResMut<'w, Assets<Image>>,
     pub icon_cache: ResMut<'w, IconTextureCache>,
-    pub render_layer_alloc: ResMut<'w, RenderLayerAlloc>,
+    pub render_layer_alloc: ResMut<'w, RenderLayerAllocator>,
     pub hdr_enabled: ResMut<'w, HdrEnabled>,
     pub timeline_settings: ResMut<'w, TimelineSettings>,
     pub schema_reg: Res<'w, ComponentSchemaRegistry>,

--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -31,7 +31,7 @@ use crate::{
             DocumentLoaded, DocumentReloaded, DocumentSaved, SchematicDocumentAsset,
             SchematicWindow,
         },
-        navigation_gizmo::RenderLayerAllocator,
+        render_layer_alloc::RenderLayerAllocator,
     },
     ui::{
         DEFAULT_SECONDARY_RECT, HdrEnabled,

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -59,9 +59,8 @@ use crate::{
     plugins::{
         LogicalKeyState,
         gizmos::GIZMO_RENDER_LAYER,
-        render_layer_alloc::{RenderLayerLease, RenderLayerAllocator},
-        navigation_gizmo::{
-            NavGizmoCamera, NavGizmoParent, },
+        navigation_gizmo::{NavGizmoCamera, NavGizmoParent},
+        render_layer_alloc::{RenderLayerAllocator, RenderLayerLease},
         view_cube::{
             CoordinateSystem, NeedsInitialSnap, ViewCubeConfig, ViewCubeTargetCamera,
             spawn::spawn_view_cube,
@@ -1274,9 +1273,8 @@ impl ViewportPane {
             None
         };
 
-        let viewport_lease: Option<RenderLayerLease> = render_layer_alloc
-            .alloc()
-            .inspect(|lease| {
+        let viewport_lease: Option<RenderLayerLease> =
+            render_layer_alloc.alloc().inspect(|lease| {
                 main_camera_layers = main_camera_layers.union(&lease.render_layers());
             });
 
@@ -1475,10 +1473,7 @@ impl ViewportPane {
         ));
 
         if let Some(viewport_lease) = viewport_lease.as_ref() {
-            camera.insert((
-            viewport_lease.render_layers(),
-            viewport_lease.clone(),
-                ));
+            camera.insert((viewport_lease.render_layers(), viewport_lease.clone()));
         }
 
         camera.insert(Bloom { ..default() });
@@ -1493,8 +1488,7 @@ impl ViewportPane {
 
         let viewport_layer = viewport_lease.map(|lease| {
             let layer = lease.layer();
-            commands.entity(camera)
-                    .insert(lease);
+            commands.entity(camera).insert(lease);
             layer
         });
 
@@ -1526,9 +1520,11 @@ impl ViewportPane {
         };
         let view_cube_layer = view_cube_lease.layer();
 
-        commands
-            .entity(camera)
-            .insert((ViewCubeTargetCamera, NeedsInitialSnap, view_cube_lease.clone()));
+        commands.entity(camera).insert((
+            ViewCubeTargetCamera,
+            NeedsInitialSnap,
+            view_cube_lease.clone(),
+        ));
 
         // Spawn ViewCube with editor mode configuration, only override the per-viewport render layer
         let mut view_cube_config = ViewCubeConfig::editor_mode();
@@ -1560,7 +1556,9 @@ impl ViewportPane {
             ));
         }
 
-        commands.entity(spawned.cube_root).insert(view_cube_lease.clone());
+        commands
+            .entity(spawned.cube_root)
+            .insert(view_cube_lease.clone());
 
         Self {
             camera: Some(camera),

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -59,9 +59,9 @@ use crate::{
     plugins::{
         LogicalKeyState,
         gizmos::GIZMO_RENDER_LAYER,
+        render_layer_alloc::{RenderLayerLease, RenderLayerAllocator},
         navigation_gizmo::{
-            RenderLayerLease, NavGizmoCamera, NavGizmoParent, RenderLayerAllocator,
-        },
+            NavGizmoCamera, NavGizmoParent, },
         view_cube::{
             CoordinateSystem, NeedsInitialSnap, ViewCubeConfig, ViewCubeTargetCamera,
             spawn::spawn_view_cube,
@@ -1274,15 +1274,11 @@ impl ViewportPane {
             None
         };
 
-        let mut viewport_lease: Option<RenderLayerLease> = None;
-        let viewport_layer = if let Some(lease) = render_layer_alloc.alloc() {
-            let layer = lease.layer();
-            viewport_lease = Some(lease);
-            main_camera_layers = main_camera_layers.with(layer);
-            Some(layer)
-        } else {
-            None
-        };
+        let viewport_lease: Option<RenderLayerLease> = render_layer_alloc
+            .alloc()
+            .inspect(|lease| {
+                main_camera_layers = main_camera_layers.union(&lease.render_layers());
+            });
 
         let grid_visibility = if viewport.show_grid {
             Visibility::Visible
@@ -1472,12 +1468,18 @@ impl ViewportPane {
                 projection_color: default_projection_color(),
                 frustums_color: viewport.frustums_color,
                 frustums_thickness: viewport.frustums_thickness,
-                viewport_layer,
             },
             crate::ui::inspector::viewport::Viewport::new(parent, pos, look_at, up, viewport.frame),
             ChildOf(parent),
             Name::new("viewport camera3d"),
         ));
+
+        if let Some(viewport_lease) = viewport_lease.as_ref() {
+            camera.insert((
+            viewport_lease.render_layers(),
+            viewport_lease.clone(),
+                ));
+        }
 
         camera.insert(Bloom { ..default() });
         camera.insert(EnvironmentMapLight {
@@ -1489,9 +1491,12 @@ impl ViewportPane {
 
         let camera = camera.id();
 
-        if let Some(lease) = viewport_lease {
-            commands.entity(camera).insert(lease);
-        }
+        let viewport_layer = viewport_lease.map(|lease| {
+            let layer = lease.layer();
+            commands.entity(camera)
+                    .insert(lease);
+            layer
+        });
 
         if !viewport.show_view_cube {
             return Self {

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -59,7 +59,9 @@ use crate::{
     plugins::{
         LogicalKeyState,
         gizmos::GIZMO_RENDER_LAYER,
-        navigation_gizmo::{NavGizmoCamera, NavGizmoParent, RenderLayerAlloc},
+        navigation_gizmo::{
+            AllocatedRenderLayer, NavGizmoCamera, NavGizmoParent, RenderLayerAlloc,
+        },
         view_cube::{
             CoordinateSystem, NeedsInitialSnap, ViewCubeConfig, ViewCubeTargetCamera,
             spawn::spawn_view_cube,
@@ -767,19 +769,10 @@ impl TileState {
         !self.has_content()
     }
 
-    pub fn clear(&mut self, commands: &mut Commands, render_layer_alloc: &mut RenderLayerAlloc) {
+    pub fn clear(&mut self, commands: &mut Commands) {
         for (tile_id, tile) in self.tree.tiles.iter() {
             match tile {
                 Tile::Pane(Pane::Viewport(viewport)) => {
-                    if let Some(layer) = viewport.viewport_layer {
-                        render_layer_alloc.free(layer);
-                    }
-                    if let Some(layer) = viewport.grid_layer {
-                        render_layer_alloc.free(layer);
-                    }
-                    if let Some(layer) = viewport.view_cube_layer {
-                        render_layer_alloc.free(layer);
-                    }
                     if let Some(camera) = viewport.camera
                         && let Ok(mut e) = commands.get_entity(camera)
                     {
@@ -1271,15 +1264,26 @@ impl ViewportPane {
     ) -> Self {
         let mut main_camera_layers = RenderLayers::default().with(GIZMO_RENDER_LAYER);
         let mut grid_layers = RenderLayers::none();
-        let grid_layer = render_layer_alloc.alloc();
-        if let Some(layer) = grid_layer {
+        let mut grid_lease: Option<AllocatedRenderLayer> = None;
+        let grid_layer = if let Some(lease) = render_layer_alloc.alloc() {
+            let layer = lease.layer();
+            grid_lease = Some(lease);
             main_camera_layers = main_camera_layers.with(layer);
             grid_layers = grid_layers.with(layer);
-        }
-        let viewport_layer = render_layer_alloc.alloc();
-        if let Some(layer) = viewport_layer {
+            Some(layer)
+        } else {
+            None
+        };
+
+        let mut viewport_lease: Option<AllocatedRenderLayer> = None;
+        let viewport_layer = if let Some(lease) = render_layer_alloc.alloc() {
+            let layer = lease.layer();
+            viewport_lease = Some(lease);
             main_camera_layers = main_camera_layers.with(layer);
-        }
+            Some(layer)
+        } else {
+            None
+        };
 
         let grid_visibility = if viewport.show_grid {
             Visibility::Visible
@@ -1313,6 +1317,10 @@ impl ViewportPane {
                 grid_layers,
             ))
             .id();
+
+        if let Some(lease) = grid_lease {
+            commands.entity(grid_id).insert(lease);
+        }
 
         let transform =
             Transform::from_translation(Vec3::new(5.0, 5.0, 10.0)).looking_at(Vec3::ZERO, Vec3::Y);
@@ -1482,6 +1490,10 @@ impl ViewportPane {
 
         let camera = camera.id();
 
+        if let Some(lease) = viewport_lease {
+            commands.entity(camera).insert(lease);
+        }
+
         if !viewport.show_view_cube {
             return Self {
                 camera: Some(camera),
@@ -1496,7 +1508,7 @@ impl ViewportPane {
         }
 
         // Allocate render layer for ViewCube (same approach as navigation_gizmo)
-        let Some(view_cube_layer) = render_layer_alloc.alloc() else {
+        let Some(view_cube_lease) = render_layer_alloc.alloc() else {
             return Self {
                 camera: Some(camera),
                 nav_gizmo: None,
@@ -1508,6 +1520,7 @@ impl ViewportPane {
                 view_cube_layer: None,
             };
         };
+        let view_cube_layer = view_cube_lease.layer();
 
         commands
             .entity(camera)
@@ -1542,6 +1555,8 @@ impl ViewportPane {
                 NavGizmoCamera,
             ));
         }
+
+        commands.entity(spawned.cube_root).insert(view_cube_lease);
 
         Self {
             camera: Some(camera),
@@ -2615,15 +2630,6 @@ impl WidgetSystem for TileLayout<'_, '_> {
                         };
 
                         if let egui_tiles::Tile::Pane(Pane::Viewport(viewport)) = tile {
-                            if let Some(layer) = viewport.viewport_layer {
-                                state_mut.render_layer_alloc.free(layer);
-                            }
-                            if let Some(layer) = viewport.grid_layer {
-                                state_mut.render_layer_alloc.free(layer);
-                            }
-                            if let Some(layer) = viewport.view_cube_layer {
-                                state_mut.render_layer_alloc.free(layer);
-                            }
                             if let Some(camera) = viewport.camera {
                                 state_mut.commands.entity(camera).despawn();
                             }

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -1472,10 +1472,6 @@ impl ViewportPane {
             Name::new("viewport camera3d"),
         ));
 
-        if let Some(viewport_lease) = viewport_lease.as_ref() {
-            camera.insert((viewport_lease.render_layers(), viewport_lease.clone()));
-        }
-
         camera.insert(Bloom { ..default() });
         camera.insert(EnvironmentMapLight {
             diffuse_map: asset_server.load("embedded://elodin_editor/assets/diffuse.ktx2"),
@@ -1520,11 +1516,13 @@ impl ViewportPane {
         };
         let view_cube_layer = view_cube_lease.layer();
 
-        commands.entity(camera).insert((
-            ViewCubeTargetCamera,
-            NeedsInitialSnap,
-            view_cube_lease.clone(),
-        ));
+        // Do not insert `view_cube_lease` here: the main camera already carries the viewport
+        // `RenderLayerLease`, and a second lease would replace it (single component), breaking
+        // anything that reads the lease (e.g. vector arrows). The cube root and overlay camera
+        // still own clones of this lease.
+        commands
+            .entity(camera)
+            .insert((ViewCubeTargetCamera, NeedsInitialSnap));
 
         // Spawn ViewCube with editor mode configuration, only override the per-viewport render layer
         let mut view_cube_config = ViewCubeConfig::editor_mode();

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -1541,9 +1541,11 @@ impl ViewportPane {
             ));
         }
 
-        commands
-            .entity(spawned.cube_root)
-            .insert(view_cube_lease.clone());
+        // `cube_root` already received `view_cube_lease` inside `spawn_view_cube`.
+        // Re-inserting it here would silently drop the previous component (Bevy
+        // overwrites same-typed components on insert) — see the `debug_assert!`
+        // in `EntityCommandsExt::insert_render_layer_lease`.
+        let _ = view_cube_lease;
 
         Self {
             camera: Some(camera),

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -60,7 +60,7 @@ use crate::{
         LogicalKeyState,
         gizmos::GIZMO_RENDER_LAYER,
         navigation_gizmo::{
-            AllocatedRenderLayer, NavGizmoCamera, NavGizmoParent, RenderLayerAlloc,
+            RenderLayerLease, NavGizmoCamera, NavGizmoParent, RenderLayerAllocator,
         },
         view_cube::{
             CoordinateSystem, NeedsInitialSnap, ViewCubeConfig, ViewCubeTargetCamera,
@@ -127,7 +127,6 @@ pub struct ViewportConfig {
     pub projection_color: impeller2_wkt::Color,
     pub frustums_color: impeller2_wkt::Color,
     pub frustums_thickness: f32,
-    pub viewport_layer: Option<usize>,
 }
 
 #[derive(Clone)]
@@ -1257,14 +1256,14 @@ impl ViewportPane {
         asset_server: &Res<AssetServer>,
         meshes: &mut ResMut<Assets<Mesh>>,
         materials: &mut ResMut<Assets<StandardMaterial>>,
-        render_layer_alloc: &mut ResMut<RenderLayerAlloc>,
+        render_layer_alloc: &mut ResMut<RenderLayerAllocator>,
         eql_ctx: &eql::Context,
         viewport: &Viewport,
         name: PaneName,
     ) -> Self {
         let mut main_camera_layers = RenderLayers::default().with(GIZMO_RENDER_LAYER);
         let mut grid_layers = RenderLayers::none();
-        let mut grid_lease: Option<AllocatedRenderLayer> = None;
+        let mut grid_lease: Option<RenderLayerLease> = None;
         let grid_layer = if let Some(lease) = render_layer_alloc.alloc() {
             let layer = lease.layer();
             grid_lease = Some(lease);
@@ -1275,7 +1274,7 @@ impl ViewportPane {
             None
         };
 
-        let mut viewport_lease: Option<AllocatedRenderLayer> = None;
+        let mut viewport_lease: Option<RenderLayerLease> = None;
         let viewport_layer = if let Some(lease) = render_layer_alloc.alloc() {
             let layer = lease.layer();
             viewport_lease = Some(lease);
@@ -2498,7 +2497,7 @@ pub struct TileLayout<'w, 's> {
     asset_server: Res<'w, AssetServer>,
     meshes: ResMut<'w, Assets<Mesh>>,
     materials: ResMut<'w, Assets<StandardMaterial>>,
-    render_layer_alloc: ResMut<'w, RenderLayerAlloc>,
+    render_layer_alloc: ResMut<'w, RenderLayerAllocator>,
     viewport_contains_pointer: ResMut<'w, ViewportContainsPointer>,
     editor_cam: Query<'w, 's, &'static mut EditorCam, With<MainCamera>>,
     primary_window: Single<'w, 's, Entity, With<PrimaryWindow>>,

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -1528,11 +1528,10 @@ impl ViewportPane {
 
         commands
             .entity(camera)
-            .insert((ViewCubeTargetCamera, NeedsInitialSnap));
+            .insert((ViewCubeTargetCamera, NeedsInitialSnap, view_cube_lease.clone()));
 
         // Spawn ViewCube with editor mode configuration, only override the per-viewport render layer
         let mut view_cube_config = ViewCubeConfig::editor_mode();
-        view_cube_config.render_layer = view_cube_layer as u8;
 
         // Set coordinate system based on viewport's geo frame
         if let Some(frame) = viewport.frame {
@@ -1546,6 +1545,7 @@ impl ViewportPane {
             meshes,
             materials,
             &view_cube_config,
+            view_cube_lease.clone(),
             camera,
         );
 
@@ -1560,7 +1560,7 @@ impl ViewportPane {
             ));
         }
 
-        commands.entity(spawned.cube_root).insert(view_cube_lease);
+        commands.entity(spawned.cube_root).insert(view_cube_lease.clone());
 
         Self {
             camera: Some(camera),

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -60,7 +60,7 @@ use crate::{
         LogicalKeyState,
         gizmos::GIZMO_RENDER_LAYER,
         navigation_gizmo::{NavGizmoCamera, NavGizmoParent},
-        render_layer_alloc::{RenderLayerAllocator, RenderLayerLease},
+        render_layer_alloc::{GRID_RENDER_LAYER, RenderLayerAllocator, RenderLayerLease},
         view_cube::{
             CoordinateSystem, NeedsInitialSnap, ViewCubeConfig, ViewCubeTargetCamera,
             spawn::spawn_view_cube,
@@ -1243,7 +1243,6 @@ pub struct ViewportPane {
     pub nav_gizmo_camera: Option<Entity>,
     pub rect: Option<egui::Rect>,
     pub name: PaneName,
-    pub grid_layer: Option<usize>,
     pub viewport_layer: Option<usize>,
     pub view_cube_layer: Option<usize>,
 }
@@ -1260,18 +1259,12 @@ impl ViewportPane {
         viewport: &Viewport,
         name: PaneName,
     ) -> Self {
-        let mut main_camera_layers = RenderLayers::default().with(GIZMO_RENDER_LAYER);
-        let mut grid_layers = RenderLayers::none();
-        let mut grid_lease: Option<RenderLayerLease> = None;
-        let grid_layer = if let Some(lease) = render_layer_alloc.alloc() {
-            let layer = lease.layer();
-            grid_lease = Some(lease);
-            main_camera_layers = main_camera_layers.with(layer);
-            grid_layers = grid_layers.with(layer);
-            Some(layer)
-        } else {
-            None
-        };
+        // The grid render layer is reserved and shared by every viewport, so we
+        // never allocate one per viewport. See `RenderLayerAllocator::default`.
+        let mut main_camera_layers = RenderLayers::default()
+            .with(GIZMO_RENDER_LAYER)
+            .with(GRID_RENDER_LAYER);
+        let grid_layers = RenderLayers::layer(GRID_RENDER_LAYER);
 
         let viewport_lease: Option<RenderLayerLease> =
             render_layer_alloc.alloc().inspect(|lease| {
@@ -1310,10 +1303,6 @@ impl ViewportPane {
                 grid_layers,
             ))
             .id();
-
-        if let Some(lease) = grid_lease {
-            commands.entity(grid_id).insert(lease);
-        }
 
         let transform =
             Transform::from_translation(Vec3::new(5.0, 5.0, 10.0)).looking_at(Vec3::ZERO, Vec3::Y);
@@ -1495,7 +1484,6 @@ impl ViewportPane {
                 nav_gizmo_camera: None,
                 rect: None,
                 name,
-                grid_layer,
                 viewport_layer,
                 view_cube_layer: None,
             };
@@ -1509,7 +1497,6 @@ impl ViewportPane {
                 nav_gizmo_camera: None,
                 rect: None,
                 name,
-                grid_layer,
                 viewport_layer,
                 view_cube_layer: None,
             };
@@ -1564,7 +1551,6 @@ impl ViewportPane {
             nav_gizmo_camera: spawned.camera,
             rect: None,
             name,
-            grid_layer,
             viewport_layer,
             view_cube_layer: Some(view_cube_layer),
         }

--- a/libs/elodin-editor/src/ui/window/placement.rs
+++ b/libs/elodin-editor/src/ui/window/placement.rs
@@ -21,12 +21,9 @@ use winit::{
     window::Window as WinitWindow,
 };
 
-use crate::{
-    plugins::navigation_gizmo::RenderLayerAlloc,
-    ui::{
-        FocusedWindow,
-        tiles::{WindowId, WindowRelayout, WindowState},
-    },
+use crate::ui::{
+    FocusedWindow,
+    tiles::{WindowId, WindowRelayout, WindowState},
 };
 
 const WINDOW_READY_TIMEOUT: Duration = Duration::from_millis(2000);
@@ -39,7 +36,6 @@ const WINDOW_RECT_APPLY_TIMEOUT: Duration = Duration::from_millis(1000);
 pub struct WindowCleanup<'w, 's> {
     primary: Query<'w, 's, &'static WindowId, With<PrimaryWindow>>,
     window_states: Query<'w, 's, (Entity, &'static WindowId, &'static mut WindowState)>,
-    render_layer_alloc: ResMut<'w, RenderLayerAlloc>,
     focused_window: ResMut<'w, FocusedWindow>,
     commands: Commands<'w, 's>,
     exit: MessageWriter<'w, AppExit>,
@@ -94,9 +90,7 @@ pub fn handle_window_destroyed(
 
 fn cleanup_secondary_window(entity: Entity, cleanup: &mut WindowCleanup) {
     if let Ok((_, _, mut window_state)) = cleanup.window_states.get_mut(entity) {
-        window_state
-            .tile_state
-            .clear(&mut cleanup.commands, &mut cleanup.render_layer_alloc);
+        window_state.tile_state.clear(&mut cleanup.commands);
         window_state.graph_entities.clear();
     }
 


### PR DESCRIPTION
# Problem

There is a maximum limit of 64 in our code on dynamically allocated render layers that are not ever deallocated. So we will exhaust them if the app runs long enough.

# Solution

Handle render layer allocation and deallocation. One allocates a `AllocatedRenderLayer` component from the `RenderLayerAlloc` resource. Add it and its `Renderlayer` to whatever entity needs it. When all the `AllocatedRenderLayer`s are dropped (each contain an `Arc`), then the allocated render layer is freed for use again.

This can work with any `RenderLayer` which do go beyond 64 bits, and it uses the bits to find the next available layer, so it's fast and provides the lowest available number first.


