### PR TITLE
Add Hamann-Chen-line crate and wire curve compression into plot / 3D line.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5222,6 +5222,7 @@ dependencies = [
  "fastrand 2.3.0",
  "flume",
  "fuzzy-matcher",
+ "hamann-chen-line",
  "heapless 0.8.0",
  "hex",
  "hifitime",
@@ -6760,6 +6761,15 @@ dependencies = [
  "crunchy",
  "num-traits",
  "zerocopy",
+]
+
+[[package]]
+name = "hamann-chen-line"
+version = "0.16.3-alpha.0"
+dependencies = [
+ "anyhow",
+ "clap 4.6.0",
+ "glam",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ resolver = "2"
 #
 # default-members = ["apps/elodin"]
 members = [
+    "libs/hamann-chen-line",
     "libs/elodin-editor",
     "libs/nox",
     "libs/elodin-macros",

--- a/libs/elodin-editor/Cargo.toml
+++ b/libs/elodin-editor/Cargo.toml
@@ -14,6 +14,7 @@ tracy = ["bevy/trace_tracy"]
 
 [dependencies]
 # math
+hamann-chen-line = { path = "../hamann-chen-line" }
 nox.path = "../nox"
 nox.default-features = false
 egui_material_icons = "0.5"

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -67,16 +67,34 @@ pub struct CurveCompressSettings {
     /// - `0.2` — keep roughly the last 20% at full resolution; Hamann–Chen runs on the leading
     ///   prefix only.
     pub keep_recent_fraction: f32,
+    /// Non-destructive **archive + view** architecture. When `true`,
+    /// [`PlotDataComponent::push_value`] appends each accepted live sample to
+    /// [`LineTree::raw_slice`], and [`LineTree::compress_time_value_hamann`] reads from that
+    /// archive instead of the decimated view. Switching this off at runtime reverts to the
+    /// historical destructive pipeline (no archive, HC reads and rewrites the view).
+    pub archive_enabled: bool,
+    /// Throttle: recompute the view as soon as the archive has grown by this many samples since
+    /// the last HC pass. Set small (relative to [`Self::compress_after_total_points`]) to keep
+    /// the UI responsive; too small wastes CPU recomputing the view too often.
+    pub view_recompute_min_samples: usize,
+    /// Throttle: if the archive hasn't grown enough for [`Self::view_recompute_min_samples`],
+    /// still recompute when at least this many milliseconds have passed since the last pass.
+    /// Caps worst-case staleness for low-rate telemetry.
+    pub view_recompute_min_interval_ms: u64,
 }
 
 impl Default for CurveCompressSettings {
     fn default() -> Self {
         let cap = CHUNK_COUNT.saturating_mul(CHUNK_LEN);
+        let threshold = cap.saturating_mul(3) / 4;
         Self {
             enabled: true,
-            compress_after_total_points: cap.saturating_mul(3) / 4,
+            compress_after_total_points: threshold,
             compress_to_points: cap / 2,
             keep_recent_fraction: 0.0,
+            archive_enabled: true,
+            view_recompute_min_samples: (threshold / 20).max(1),
+            view_recompute_min_interval_ms: 250,
         }
     }
 }
@@ -117,6 +135,7 @@ impl PlotDataComponent {
         assets: &mut Assets<Line>,
         timestamp: Timestamp,
         earliest_timestamp: Timestamp,
+        archive_enabled: bool,
     ) {
         let element_names = self
             .element_names
@@ -138,6 +157,7 @@ impl PlotDataComponent {
             // line.  The FixedRate stream sends a snapshot at the current
             // playback position each frame; skipping timestamps already covered
             // prevents corrupting historical data loaded by GetTimeSeries.
+            let mut accepted = false;
             if let Some(last) = line.data.last() {
                 if timestamp <= last.summary.end_timestamp {
                     continue;
@@ -146,11 +166,17 @@ impl PlotDataComponent {
                     line.data.update_last(|c| {
                         c.push(timestamp, earliest_timestamp, new_value);
                     });
-                    continue;
+                    accepted = true;
                 }
             }
-            let new_chunk = Chunk::from_initial_value(timestamp, earliest_timestamp, new_value);
-            line.data.insert(new_chunk);
+            if !accepted {
+                let new_chunk = Chunk::from_initial_value(timestamp, earliest_timestamp, new_value);
+                line.data.insert(new_chunk);
+            }
+            // Archive mirrors exactly the sequence accepted by the view. Monotonicity of raw is
+            // enforced by `push_raw` itself, so re-ingestion of historical timestamps (already
+            // rejected above) is doubly safe.
+            line.data.push_raw(archive_enabled, timestamp, new_value);
         }
     }
 }
@@ -198,7 +224,13 @@ pub fn pkt_handler(
                     return;
                 };
                 if let Some(timestamp) = timestamp {
-                    plot_data.push_value(view, &mut lines, timestamp, earliest_timestamp.0);
+                    plot_data.push_value(
+                        view,
+                        &mut lines,
+                        timestamp,
+                        earliest_timestamp.0,
+                        curve_compress.archive_enabled,
+                    );
                 }
             },
         ) {
@@ -242,6 +274,26 @@ pub fn maybe_compress_all_graph_lines(
             line.maybe_compress_live(earliest, settings);
         }
     }
+    if settings.archive_enabled {
+        // Safety net: flag outsized archives so multi-hour aerospace runs don't silently blow up
+        // RAM. V1 has no enforced horizon; a user report on this warning is the trigger to add
+        // `archive_horizon_seconds` in a follow-up.
+        const RAW_ARCHIVE_WARN_BYTES: usize = 100 * 1024 * 1024;
+        for component in graph_data.components.values() {
+            for line_handle in component.lines.values() {
+                if let Some(line) = lines.get(line_handle)
+                    && line.data.raw_archive_bytes() > RAW_ARCHIVE_WARN_BYTES
+                {
+                    let mb = line.data.raw_archive_bytes() / (1024 * 1024);
+                    warn_once!(
+                        raw_mb = mb,
+                        line_label = %line.label,
+                        "curve_compress: raw archive exceeds 100 MB on a single line; consider lowering run length or adding archive_horizon_seconds"
+                    );
+                }
+            }
+        }
+    }
 }
 
 fn try_joint_triline_compress(
@@ -258,12 +310,33 @@ fn try_joint_triline_compress(
         (Some(x), Some(y), Some(z)) => (x, y, z),
         _ => return false,
     };
-    if lx.data.total_points() <= settings.compress_after_total_points {
+    if settings.archive_enabled {
+        if !lx.data.should_recompress(settings) {
+            return false;
+        }
+    } else if lx.data.total_points() <= settings.compress_after_total_points {
         return false;
     }
-    let (tsx, vx) = lx.data.flattened_time_series();
-    let (tsy, vy) = ly.data.flattened_time_series();
-    let (tsz, vz) = lz.data.flattened_time_series();
+    // Own the sequence: archive slices borrow from `lines`, which conflicts with the later
+    // `lines.get_mut` on the same assets.
+    let (tsx, vx): (Vec<Timestamp>, Vec<f32>) = if settings.archive_enabled {
+        let (t, v) = lx.data.raw_slice();
+        (t.to_vec(), v.to_vec())
+    } else {
+        lx.data.flattened_time_series()
+    };
+    let (tsy, vy): (Vec<Timestamp>, Vec<f32>) = if settings.archive_enabled {
+        let (t, v) = ly.data.raw_slice();
+        (t.to_vec(), v.to_vec())
+    } else {
+        ly.data.flattened_time_series()
+    };
+    let (tsz, vz): (Vec<Timestamp>, Vec<f32>) = if settings.archive_enabled {
+        let (t, v) = lz.data.raw_slice();
+        (t.to_vec(), v.to_vec())
+    } else {
+        lz.data.flattened_time_series()
+    };
     if tsx.len() != tsy.len() || tsx.len() != tsz.len() {
         return false;
     }
@@ -331,16 +404,19 @@ fn try_joint_triline_compress(
     };
     xl.data
         .rebuild_from_time_value_pairs(earliest, &new_ts, &new_x);
+    xl.data.mark_compressed();
     let Some(yl) = lines.get_mut(hy) else {
         return false;
     };
     yl.data
         .rebuild_from_time_value_pairs(earliest, &new_ts, &new_y);
+    yl.data.mark_compressed();
     let Some(zl) = lines.get_mut(hz) else {
         return false;
     };
     zl.data
         .rebuild_from_time_value_pairs(earliest, &new_ts, &new_z);
+    zl.data.mark_compressed();
     true
 }
 
@@ -870,7 +946,12 @@ pub struct Line {
 
 impl Line {
     fn maybe_compress_live(&mut self, earliest: Timestamp, settings: &CurveCompressSettings) {
-        if self.data.total_points() > settings.compress_after_total_points {
+        let should = if settings.archive_enabled {
+            self.data.should_recompress(settings)
+        } else {
+            self.data.total_points() > settings.compress_after_total_points
+        };
+        if should {
             self.data.compress_time_value_hamann(earliest, settings);
         }
     }
@@ -1228,6 +1309,23 @@ pub struct LineTree<D: Clone + BoundOrd> {
     tree: NoditMap<i64, nodit::Interval<i64>, Chunk<D>>,
     data_buffer_shard_alloc: Option<BufferShardAlloc>,
     timestamp_buffer_shard_alloc: Option<BufferShardAlloc>,
+    /// Append-only archive of raw `(timestamp, value)` samples ingested live.
+    ///
+    /// When [`CurveCompressSettings::archive_enabled`] is true, [`PlotDataComponent::push_value`]
+    /// pushes every accepted sample here in addition to the view (`tree`). The Hamann-Chen pass
+    /// then reads from this archive and rebuilds the view, leaving the archive untouched. Because
+    /// the archive is never decimated, running HC multiple times produces identical output
+    /// (monotone quality) and parameter changes can be re-applied without loss.
+    ///
+    /// Populated only for live streaming. Samples arriving via `GetTimeSeries` (historical DB
+    /// scroll) go through `handle_time_series`, which bypasses `push_value` and fills the view
+    /// directly — the archive stays empty for those ranges (elodin-db itself is the archive).
+    raw_timestamps: Vec<Timestamp>,
+    raw_values: Vec<D>,
+    /// Archive length at the end of the last HC pass, for throttling decisions.
+    last_hc_archive_len: usize,
+    /// Wall-clock instant of the last HC pass, for time-based throttling.
+    last_hc_instant: Option<std::time::Instant>,
 }
 
 impl<D: Clone + BoundOrd> Default for LineTree<D> {
@@ -1236,6 +1334,10 @@ impl<D: Clone + BoundOrd> Default for LineTree<D> {
             tree: Default::default(),
             data_buffer_shard_alloc: None,
             timestamp_buffer_shard_alloc: None,
+            raw_timestamps: Vec::new(),
+            raw_values: Vec::new(),
+            last_hc_archive_len: 0,
+            last_hc_instant: None,
         }
     }
 }
@@ -1274,6 +1376,68 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
 
     pub fn chunk_count(&self) -> usize {
         self.tree.iter().count()
+    }
+
+    /// Append `(ts, value)` to the raw archive. Rejects out-of-order timestamps
+    /// (`ts <= last`) so the archive stays monotonic by construction. No-op if
+    /// `enabled` is false — the caller gates on [`CurveCompressSettings::archive_enabled`].
+    pub fn push_raw(&mut self, enabled: bool, ts: Timestamp, value: D) {
+        if !enabled {
+            return;
+        }
+        if let Some(last) = self.raw_timestamps.last()
+            && ts <= *last
+        {
+            return;
+        }
+        self.raw_timestamps.push(ts);
+        self.raw_values.push(value);
+    }
+
+    pub fn raw_len(&self) -> usize {
+        self.raw_timestamps.len()
+    }
+
+    pub fn raw_slice(&self) -> (&[Timestamp], &[D]) {
+        (&self.raw_timestamps, &self.raw_values)
+    }
+
+    pub fn clear_raw(&mut self) {
+        self.raw_timestamps.clear();
+        self.raw_values.clear();
+        self.last_hc_archive_len = 0;
+        self.last_hc_instant = None;
+    }
+
+    /// True when the archive has grown enough (samples or time) since the last HC pass to justify
+    /// recomputing the view. Always false below [`CurveCompressSettings::compress_after_total_points`].
+    pub fn should_recompress(&self, settings: &CurveCompressSettings) -> bool {
+        if self.raw_len() <= settings.compress_after_total_points {
+            return false;
+        }
+        let grew = self.raw_len().saturating_sub(self.last_hc_archive_len)
+            >= settings.view_recompute_min_samples;
+        if grew {
+            return true;
+        }
+        match self.last_hc_instant {
+            None => true,
+            Some(t) => {
+                t.elapsed()
+                    >= std::time::Duration::from_millis(settings.view_recompute_min_interval_ms)
+            }
+        }
+    }
+
+    /// Record that an HC pass has just run (updates throttle bookkeeping).
+    pub fn mark_compressed(&mut self) {
+        self.last_hc_archive_len = self.raw_len();
+        self.last_hc_instant = Some(std::time::Instant::now());
+    }
+
+    /// Approximate memory cost of the raw archive in bytes (timestamps + values).
+    pub fn raw_archive_bytes(&self) -> usize {
+        self.raw_timestamps.len() * (std::mem::size_of::<Timestamp>() + std::mem::size_of::<D>())
     }
 
     pub fn range_summary(&self, range: Range<Timestamp>) -> ChunkSummary<D> {
@@ -1701,12 +1865,26 @@ impl LineTree<f32> {
 
     /// Hamann–Chen in `(t, y)`; optional [`CurveCompressSettings::keep_recent_fraction`] leaves a
     /// suffix of recent samples uncompressed.
+    ///
+    /// Source of truth depends on [`CurveCompressSettings::archive_enabled`]:
+    /// - `true` (non-destructive) — reads from [`LineTree::raw_slice`]. Repeated passes produce
+    ///   identical output (monotone quality); archive is never touched.
+    /// - `false` (legacy destructive) — reads from [`Self::flattened_time_series`] (the already
+    ///   decimated view), so successive passes compound decimation. Kept as rollback switch.
     pub fn compress_time_value_hamann(
         &mut self,
         earliest: Timestamp,
         settings: &CurveCompressSettings,
     ) {
-        let (ts_all, v_all) = self.flattened_time_series();
+        // Own the source slice: the archive path needs a borrow of `self` that conflicts with the
+        // later `&mut self` in `rebuild_from_time_value_pairs`. The clone of ~1-10 MB is cheap
+        // compared to the HC pass itself (50-100 ms).
+        let (ts_all, v_all): (Vec<Timestamp>, Vec<f32>) = if settings.archive_enabled {
+            let (t, v) = self.raw_slice();
+            (t.to_vec(), v.to_vec())
+        } else {
+            self.flattened_time_series()
+        };
         let n = ts_all.len();
         if n < 3 {
             return;
@@ -1738,6 +1916,7 @@ impl LineTree<f32> {
             new_ts.extend_from_slice(recent_ts);
             new_v.extend_from_slice(recent_v);
             self.rebuild_from_time_value_pairs(earliest, &new_ts, &new_v);
+            self.mark_compressed();
             return;
         }
 
@@ -1750,6 +1929,7 @@ impl LineTree<f32> {
         let new_ts: Vec<Timestamp> = idx.iter().map(|&i| ts_all[i]).collect();
         let new_v: Vec<f32> = idx.iter().map(|&i| v_all[i]).collect();
         self.rebuild_from_time_value_pairs(earliest, &new_ts, &new_v);
+        self.mark_compressed();
     }
 }
 
@@ -1908,6 +2088,214 @@ mod tests {
             c, 12,
             "leading 0 + 10 indices + trailing 0 (no duplicate last)"
         );
+    }
+
+    // === Archive + view (non-destructive HC) tests ===
+
+    fn archive_settings(
+        archive_enabled: bool,
+        threshold: usize,
+        target: usize,
+    ) -> CurveCompressSettings {
+        CurveCompressSettings {
+            enabled: true,
+            compress_after_total_points: threshold,
+            compress_to_points: target,
+            keep_recent_fraction: 0.0,
+            archive_enabled,
+            view_recompute_min_samples: 1,
+            view_recompute_min_interval_ms: 0,
+        }
+    }
+
+    #[test]
+    fn push_raw_enforces_monotonicity() {
+        let mut tree = LineTree::<f32>::default();
+        tree.push_raw(true, Timestamp(10), 1.0);
+        tree.push_raw(true, Timestamp(20), 2.0);
+        tree.push_raw(true, Timestamp(15), 99.0);
+        tree.push_raw(true, Timestamp(20), 99.0);
+        tree.push_raw(true, Timestamp(30), 3.0);
+        let (ts, vs) = tree.raw_slice();
+        assert_eq!(ts, &[Timestamp(10), Timestamp(20), Timestamp(30)]);
+        assert_eq!(vs, &[1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn push_raw_disabled_is_noop() {
+        let mut tree = LineTree::<f32>::default();
+        tree.push_raw(false, Timestamp(10), 1.0);
+        tree.push_raw(false, Timestamp(20), 2.0);
+        assert_eq!(tree.raw_len(), 0);
+    }
+
+    #[test]
+    fn clear_raw_resets_state() {
+        let mut tree = LineTree::<f32>::default();
+        tree.push_raw(true, Timestamp(10), 1.0);
+        tree.mark_compressed();
+        assert_eq!(tree.raw_len(), 1);
+        assert!(tree.last_hc_instant.is_some());
+        tree.clear_raw();
+        assert_eq!(tree.raw_len(), 0);
+        assert_eq!(tree.last_hc_archive_len, 0);
+        assert!(tree.last_hc_instant.is_none());
+    }
+
+    #[test]
+    fn rebuild_from_time_value_pairs_preserves_raw_archive() {
+        let mut tree = LineTree::<f32>::default();
+        for i in 0..20 {
+            tree.push_raw(true, Timestamp(i * 10), i as f32);
+        }
+        let raw_before = tree.raw_slice();
+        let (ts_before, vs_before) = (raw_before.0.to_vec(), raw_before.1.to_vec());
+        let new_ts = vec![Timestamp(0), Timestamp(100), Timestamp(190)];
+        let new_v = vec![0.0, 10.0, 19.0];
+        tree.rebuild_from_time_value_pairs(Timestamp(0), &new_ts, &new_v);
+        let (ts_after, vs_after) = tree.raw_slice();
+        assert_eq!(
+            ts_after,
+            ts_before.as_slice(),
+            "archive timestamps must be untouched"
+        );
+        assert_eq!(
+            vs_after,
+            vs_before.as_slice(),
+            "archive values must be untouched"
+        );
+    }
+
+    #[test]
+    fn should_recompress_below_threshold_is_false() {
+        let mut tree = LineTree::<f32>::default();
+        let settings = archive_settings(true, 1000, 100);
+        tree.push_raw(true, Timestamp(1), 0.0);
+        assert!(!tree.should_recompress(&settings));
+    }
+
+    #[test]
+    fn should_recompress_above_threshold_triggers_once_no_prior_pass() {
+        let mut tree = LineTree::<f32>::default();
+        let settings = archive_settings(true, 5, 3);
+        for i in 0..10 {
+            tree.push_raw(true, Timestamp(i), i as f32);
+        }
+        assert!(tree.should_recompress(&settings));
+    }
+
+    #[test]
+    fn should_recompress_throttled_by_sample_delta() {
+        let mut tree = LineTree::<f32>::default();
+        let settings = CurveCompressSettings {
+            view_recompute_min_samples: 100,
+            view_recompute_min_interval_ms: 60_000,
+            ..archive_settings(true, 5, 3)
+        };
+        for i in 0..10 {
+            tree.push_raw(true, Timestamp(i), i as f32);
+        }
+        tree.mark_compressed();
+        tree.push_raw(true, Timestamp(11), 11.0);
+        assert!(
+            !tree.should_recompress(&settings),
+            "1 new sample, 100 required + recent pass -> should skip"
+        );
+    }
+
+    #[test]
+    fn should_recompress_fires_when_interval_elapsed_even_without_enough_samples() {
+        let mut tree = LineTree::<f32>::default();
+        let settings = CurveCompressSettings {
+            view_recompute_min_samples: 100,
+            view_recompute_min_interval_ms: 0,
+            ..archive_settings(true, 5, 3)
+        };
+        for i in 0..10 {
+            tree.push_raw(true, Timestamp(i), i as f32);
+        }
+        tree.mark_compressed();
+        tree.push_raw(true, Timestamp(11), 11.0);
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        assert!(
+            tree.should_recompress(&settings),
+            "interval=0 means elapsed check always fires"
+        );
+    }
+
+    #[test]
+    fn hc_pass_is_deterministic_on_stable_archive() {
+        let mut tree = LineTree::<f32>::default();
+        let settings = archive_settings(true, 5, 20);
+        for i in 0..200 {
+            let t = Timestamp(i);
+            let v = (i as f32 * 0.05).sin();
+            tree.push_raw(true, t, v);
+        }
+        tree.compress_time_value_hamann(Timestamp(0), &settings);
+        let view_1 = tree.flattened_time_series();
+        tree.compress_time_value_hamann(Timestamp(0), &settings);
+        let view_2 = tree.flattened_time_series();
+        assert_eq!(
+            view_1.0, view_2.0,
+            "two successive passes must pick identical timestamps"
+        );
+        assert_eq!(
+            view_1.1, view_2.1,
+            "two successive passes must pick identical values"
+        );
+    }
+
+    #[test]
+    fn hc_pass_is_monotone_across_many_passes() {
+        let mut tree = LineTree::<f32>::default();
+        let settings = archive_settings(true, 5, 20);
+        for i in 0..200 {
+            tree.push_raw(true, Timestamp(i), (i as f32 * 0.05).sin());
+        }
+        tree.compress_time_value_hamann(Timestamp(0), &settings);
+        let reference = tree.flattened_time_series();
+        for _ in 0..10 {
+            tree.compress_time_value_hamann(Timestamp(0), &settings);
+        }
+        let after = tree.flattened_time_series();
+        assert_eq!(
+            reference.0, after.0,
+            "10 passes with no new samples must not shift the view"
+        );
+        assert_eq!(reference.1, after.1);
+    }
+
+    #[test]
+    fn hc_pass_disabled_archive_reads_from_view_like_before() {
+        let mut tree = LineTree::<f32>::default();
+        let settings = archive_settings(false, 5, 20);
+        for i in 0..200 {
+            let t = Timestamp(i);
+            let v = (i as f32 * 0.05).sin();
+            // Use insert path so the view gets populated without touching the archive
+            let chunk = Chunk::from_iter(&[t], Timestamp(0), [v].into_iter()).expect("chunk");
+            tree.insert(chunk);
+        }
+        assert_eq!(
+            tree.raw_len(),
+            0,
+            "archive_enabled=false keeps archive empty"
+        );
+        tree.compress_time_value_hamann(Timestamp(0), &settings);
+        let (ts, _) = tree.flattened_time_series();
+        assert!(!ts.is_empty() && ts.len() <= settings.compress_to_points);
+    }
+
+    #[test]
+    fn raw_archive_bytes_scales_with_sample_count() {
+        let mut tree = LineTree::<f32>::default();
+        assert_eq!(tree.raw_archive_bytes(), 0);
+        for i in 0..1_000 {
+            tree.push_raw(true, Timestamp(i), i as f32);
+        }
+        // Timestamp(i64) = 8 bytes + f32 = 4 bytes => 12 bytes per sample.
+        assert_eq!(tree.raw_archive_bytes(), 1_000 * 12);
     }
 }
 

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -273,6 +273,13 @@ fn try_joint_triline_compress(
         let pos_old = &pos[..split];
         let idx = select_polyline3_indices(pos_old, target_old);
         if idx.len() < 2 {
+            warn_once!(
+                target: "elodin_plot_hamann",
+                axis = "xyz_joint",
+                points = n,
+                target_old,
+                "Hamann-Chen polyline3: degenerate index set (< 2); skipping joint compress"
+            );
             return false;
         }
         let mut new_ts: Vec<Timestamp> = idx.iter().map(|&i| tsx[i]).collect();
@@ -296,6 +303,13 @@ fn try_joint_triline_compress(
         let target = settings.compress_to_points.max(2).min(n);
         let idx = select_polyline3_indices(&pos, target);
         if idx.len() < 2 {
+            warn_once!(
+                target: "elodin_plot_hamann",
+                axis = "xyz_joint",
+                points = n,
+                target,
+                "Hamann-Chen polyline3: degenerate index set (< 2); skipping joint compress"
+            );
             return false;
         }
         let new_ts: Vec<Timestamp> = idx.iter().map(|&i| tsx[i]).collect();
@@ -319,6 +333,15 @@ fn try_joint_triline_compress(
     };
     zl.data
         .rebuild_from_time_value_pairs(earliest, &new_ts, &new_z);
+    bevy::log::debug!(
+        target: "elodin_plot_hamann",
+        axis = "xyz_joint",
+        points_in = n,
+        points_out = new_ts.len(),
+        keep_recent_fraction = settings.keep_recent_fraction,
+        compress_to = settings.compress_to_points,
+        "Hamann-Chen polyline3 joint compression"
+    );
     true
 }
 
@@ -844,6 +867,8 @@ pub struct Line {
     pub label: String,
     pub data: LineTree<f32>,
     pub last_queried: Option<Instant>,
+    /// Rate-limits `elodin_plot_hamann` debug logs for time-value compression.
+    last_hamann_compress_log: Option<Instant>,
 }
 
 impl Line {
@@ -852,7 +877,27 @@ impl Line {
         if total <= settings.compress_after_total_points {
             return;
         }
+        const HAMANN_LOG_INTERVAL: Duration = Duration::from_secs(2);
+        let now = Instant::now();
+        let log_now = self.last_hamann_compress_log.is_none_or(|t| {
+            now.saturating_duration_since(t) >= HAMANN_LOG_INTERVAL
+        });
+        let before = total;
         self.data.compress_time_value_hamann(earliest, settings);
+        let after = self.data.total_points();
+        if log_now {
+            bevy::log::debug!(
+                target: "elodin_plot_hamann",
+                label = %self.label,
+                before,
+                after,
+                compress_to = settings.compress_to_points,
+                keep_recent_fraction = settings.keep_recent_fraction,
+                compress_after_total_points = settings.compress_after_total_points,
+                "Hamann-Chen time-value compression pass"
+            );
+            self.last_hamann_compress_log = Some(now);
+        }
     }
 }
 
@@ -899,7 +944,6 @@ impl XYLine {
         }
         let step = total_points.div_ceil(desired_index_len.max(1)).max(1);
 
-        let mut count = 0;
         let mut view = render_queue
             .write_buffer_with(
                 index_buffer,
@@ -908,6 +952,7 @@ impl XYLine {
             )
             .expect("no write buf");
         let mut view = &mut view[..];
+        let mut written_u32s: u32 = 0;
         let mut global_index = 0usize;
         for buf in &mut self.x_values {
             let gpu = buf.gpu.lock();
@@ -918,14 +963,22 @@ impl XYLine {
             for (i, index) in chunk.into_index_iter().enumerate() {
                 let absolute = global_index + i;
                 if absolute.is_multiple_of(step) || absolute + 1 == total_points {
-                    view = append_u32(view, index);
-                    count += 1;
+                    let Some(v) = try_append_u32(view, index) else {
+                        warn_once!(
+                            target: "elodin_plot_index",
+                            "XY plot index buffer is full (capacity {} u32); tail omitted",
+                            INDEX_BUFFER_LEN
+                        );
+                        return written_u32s;
+                    };
+                    view = v;
+                    written_u32s += 1;
                 }
             }
             global_index += buf.cpu().len();
         }
 
-        count
+        written_u32s
     }
 
     pub fn plot_bounds(&self) -> PlotBounds {
@@ -1438,27 +1491,68 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
             )
             .expect("no write buf");
         let mut view = &mut view[..];
-        let mut count = 0;
-        for chunk in self.draw_index_chunk_iter(line_visible_range) {
-            view = append_u32(view, 0);
+        let mut written_u32s: u32 = 0;
+        'chunks: for chunk in self.draw_index_chunk_iter(line_visible_range) {
+            let Some(v) = try_append_u32(view, 0) else {
+                warn_once!(
+                    target: "elodin_plot_index",
+                    "timeseries plot index buffer is full (capacity {} u32); tail of the curve is not drawn — zoom to a shorter time span",
+                    INDEX_BUFFER_LEN
+                );
+                break 'chunks;
+            };
+            view = v;
+            written_u32s += 1;
             let end = chunk.clone().into_index_iter().last();
             let mut index_iter = chunk.into_index_iter();
             if let Some(index) = index_iter.next() {
-                count += 1;
-                view = append_u32(view, index);
+                let Some(v) = try_append_u32(view, index) else {
+                    warn_once!(
+                        target: "elodin_plot_index",
+                        "timeseries plot index buffer is full (capacity {} u32); tail of the curve is not drawn — zoom to a shorter time span",
+                        INDEX_BUFFER_LEN
+                    );
+                    break 'chunks;
+                };
+                view = v;
+                written_u32s += 1;
             }
             for index in index_iter.step_by(step) {
-                count += 1;
-                view = append_u32(view, index);
+                let Some(v) = try_append_u32(view, index) else {
+                    warn_once!(
+                        target: "elodin_plot_index",
+                        "timeseries plot index buffer is full (capacity {} u32); tail of the curve is not drawn — zoom to a shorter time span",
+                        INDEX_BUFFER_LEN
+                    );
+                    break 'chunks;
+                };
+                view = v;
+                written_u32s += 1;
             }
             if let Some(end) = end {
-                count += 1;
-                view = append_u32(view, end);
+                let Some(v) = try_append_u32(view, end) else {
+                    warn_once!(
+                        target: "elodin_plot_index",
+                        "timeseries plot index buffer is full (capacity {} u32); tail of the curve is not drawn — zoom to a shorter time span",
+                        INDEX_BUFFER_LEN
+                    );
+                    break 'chunks;
+                };
+                view = v;
+                written_u32s += 1;
             }
-            view = append_u32(view, 0);
-            count += 2;
+            let Some(v) = try_append_u32(view, 0) else {
+                warn_once!(
+                    target: "elodin_plot_index",
+                    "timeseries plot index buffer is full (capacity {} u32); tail of the curve is not drawn — zoom to a shorter time span",
+                    INDEX_BUFFER_LEN
+                );
+                break 'chunks;
+            };
+            view = v;
+            written_u32s += 1;
         }
-        count
+        written_u32s
     }
 
     pub fn garbage_collect(&mut self, line_visible_range: Range<Timestamp>) {
@@ -1589,6 +1683,14 @@ impl LineTree<f32> {
             let t_rel: Vec<f32> = old_ts.iter().map(|t| (t.0 - earliest.0) as f32).collect();
             let idx = select_time_value_indices(&t_rel, old_v, target_old);
             if idx.len() < 2 {
+                warn_once!(
+                    target: "elodin_plot_hamann",
+                    points = n,
+                    target_old,
+                    split,
+                    keep,
+                    "Hamann-Chen time-value: degenerate index set (< 2) on old prefix; skipping compress"
+                );
                 return;
             }
             let mut new_ts: Vec<Timestamp> = idx.iter().map(|&i| old_ts[i]).collect();
@@ -1609,6 +1711,12 @@ impl LineTree<f32> {
         let t_rel: Vec<f32> = ts_all.iter().map(|t| (t.0 - earliest.0) as f32).collect();
         let idx = select_time_value_indices(&t_rel, &v_all, target);
         if idx.len() < 2 {
+            warn_once!(
+                target: "elodin_plot_hamann",
+                points = n,
+                target,
+                "Hamann-Chen time-value: degenerate index set (< 2); skipping compress"
+            );
             return;
         }
         let new_ts: Vec<Timestamp> = idx.iter().map(|&i| ts_all[i]).collect();
@@ -1747,12 +1855,12 @@ mod tests {
     }
 }
 
-fn append_u32(view: &mut [u8], val: u32) -> &mut [u8] {
-    if view.len() < 4 {
-        return view;
+fn try_append_u32(view: &mut [u8], val: u32) -> Option<&mut [u8]> {
+    if view.len() < size_of::<u32>() {
+        return None;
     }
     view[..size_of::<u32>()].copy_from_slice(&val.to_le_bytes());
-    &mut view[size_of::<u32>()..]
+    Some(&mut view[size_of::<u32>()..])
 }
 
 pub fn collect_garbage(

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -879,9 +879,9 @@ impl Line {
         }
         const HAMANN_LOG_INTERVAL: Duration = Duration::from_secs(2);
         let now = Instant::now();
-        let log_now = self.last_hamann_compress_log.is_none_or(|t| {
-            now.saturating_duration_since(t) >= HAMANN_LOG_INTERVAL
-        });
+        let log_now = self
+            .last_hamann_compress_log
+            .is_none_or(|t| now.saturating_duration_since(t) >= HAMANN_LOG_INTERVAL);
         let before = total;
         self.data.compress_time_value_hamann(earliest, settings);
         let after = self.data.total_points();

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -42,15 +42,30 @@ use super::PlotBounds;
 /// Must be <= CHUNK_LEN to fit within a single GPU buffer shard
 pub const OVERVIEW_MAX_POINTS: usize = CHUNK_LEN;
 
-/// Tuning for optional downsampling of live `LineTree` data (see `maybe_compress_all_graph_lines`).
+/// Tuning for **Hamann–Chen** downsampling of live [`LineTree`] telemetry.
+///
+/// The simplifier lives in the `hamann-chen-line` workspace crate; its steps follow Shane Celis’s
+/// C# reference [`PiecewiseLinearCurveApproximation.cs`](https://gist.github.com/shanecelis/2e0ffd790e31507fba04dd56f806667a)
+/// (Hamann–Chen style curvature sampling). Integration notes: `libs/hamann-chen-line/README.md`.
+///
+/// After graph ingest, [`maybe_compress_all_graph_lines`] walks components and may rewrite
+/// [`Line`] assets so total stored points stay bounded. Scalar graphs use
+/// [`LineTree::compress_time_value_hamann`]; exactly **three** lines per component with identical
+/// timestamps use joint 3D polyline simplification so `line_3d` trails stay coherent.
 #[derive(Resource, Clone, Debug)]
 pub struct CurveCompressSettings {
+    /// When `false`, no Hamann–Chen pass runs (series grow until other limits apply).
     pub enabled: bool,
+    /// Run a compression pass when [`LineTree::total_points`] **exceeds** this threshold.
     pub compress_after_total_points: usize,
+    /// Target vertex count **`m`** passed to `hamann-chen-line` after a pass (per line, or shared
+    /// across the three joint XYZ lines).
     pub compress_to_points: usize,
     /// Fraction of the **last** samples (by time order) left uncompressed after a pass.
-    /// `0.0` = compress the whole series (subject to `compress_to_points`).  
-    /// `0.2` ≈ keep the last 20 % at full resolution; Hamann–Chen applies only to the leading ~80 %.
+    ///
+    /// - `0.0` — compress the whole series (still capped by `compress_to_points`).
+    /// - `0.2` — keep roughly the last 20% at full resolution; Hamann–Chen runs on the leading
+    ///   prefix only.
     pub keep_recent_fraction: f32,
 }
 
@@ -198,7 +213,14 @@ pub fn pkt_handler(
     }
 }
 
-/// Keeps live telemetry within GPU / index-buffer budgets by merging oversize series.
+/// Optionally rewrites oversized [`Line`] / [`LineTree`] series using **Hamann–Chen** sampling
+/// (`hamann-chen-line`, algorithm structure from Shane Celis’s C# gist linked on
+/// [`CurveCompressSettings`]).
+///
+/// Does nothing when [`CurveCompressSettings::enabled`] is false. Otherwise, for each plot
+/// component: if there are **three** lines and timestamps match across them, tries joint 3D
+/// compression; else compresses each line independently. GPU index-buffer sizing is handled
+/// separately in the plot render path.
 pub fn maybe_compress_all_graph_lines(
     graph_data: &mut CollectedGraphData,
     lines: &mut Assets<Line>,

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -273,13 +273,6 @@ fn try_joint_triline_compress(
         let pos_old = &pos[..split];
         let idx = select_polyline3_indices(pos_old, target_old);
         if idx.len() < 2 {
-            warn_once!(
-                target: "elodin_plot_hamann",
-                axis = "xyz_joint",
-                points = n,
-                target_old,
-                "Hamann-Chen polyline3: degenerate index set (< 2); skipping joint compress"
-            );
             return false;
         }
         let mut new_ts: Vec<Timestamp> = idx.iter().map(|&i| tsx[i]).collect();
@@ -303,13 +296,6 @@ fn try_joint_triline_compress(
         let target = settings.compress_to_points.max(2).min(n);
         let idx = select_polyline3_indices(&pos, target);
         if idx.len() < 2 {
-            warn_once!(
-                target: "elodin_plot_hamann",
-                axis = "xyz_joint",
-                points = n,
-                target,
-                "Hamann-Chen polyline3: degenerate index set (< 2); skipping joint compress"
-            );
             return false;
         }
         let new_ts: Vec<Timestamp> = idx.iter().map(|&i| tsx[i]).collect();
@@ -333,15 +319,6 @@ fn try_joint_triline_compress(
     };
     zl.data
         .rebuild_from_time_value_pairs(earliest, &new_ts, &new_z);
-    bevy::log::debug!(
-        target: "elodin_plot_hamann",
-        axis = "xyz_joint",
-        points_in = n,
-        points_out = new_ts.len(),
-        keep_recent_fraction = settings.keep_recent_fraction,
-        compress_to = settings.compress_to_points,
-        "Hamann-Chen polyline3 joint compression"
-    );
     true
 }
 
@@ -867,36 +844,12 @@ pub struct Line {
     pub label: String,
     pub data: LineTree<f32>,
     pub last_queried: Option<Instant>,
-    /// Rate-limits `elodin_plot_hamann` debug logs for time-value compression.
-    last_hamann_compress_log: Option<Instant>,
 }
 
 impl Line {
     fn maybe_compress_live(&mut self, earliest: Timestamp, settings: &CurveCompressSettings) {
-        let total = self.data.total_points();
-        if total <= settings.compress_after_total_points {
-            return;
-        }
-        const HAMANN_LOG_INTERVAL: Duration = Duration::from_secs(2);
-        let now = Instant::now();
-        let log_now = self
-            .last_hamann_compress_log
-            .is_none_or(|t| now.saturating_duration_since(t) >= HAMANN_LOG_INTERVAL);
-        let before = total;
-        self.data.compress_time_value_hamann(earliest, settings);
-        let after = self.data.total_points();
-        if log_now {
-            bevy::log::debug!(
-                target: "elodin_plot_hamann",
-                label = %self.label,
-                before,
-                after,
-                compress_to = settings.compress_to_points,
-                keep_recent_fraction = settings.keep_recent_fraction,
-                compress_after_total_points = settings.compress_after_total_points,
-                "Hamann-Chen time-value compression pass"
-            );
-            self.last_hamann_compress_log = Some(now);
+        if self.data.total_points() > settings.compress_after_total_points {
+            self.data.compress_time_value_hamann(earliest, settings);
         }
     }
 }
@@ -964,11 +917,6 @@ impl XYLine {
                 let absolute = global_index + i;
                 if absolute.is_multiple_of(step) || absolute + 1 == total_points {
                     let Some(v) = try_append_u32(view, index) else {
-                        warn_once!(
-                            target: "elodin_plot_index",
-                            "XY plot index buffer is full (capacity {} u32); tail omitted",
-                            INDEX_BUFFER_LEN
-                        );
                         return written_u32s;
                     };
                     view = v;
@@ -1494,11 +1442,6 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
         let mut written_u32s: u32 = 0;
         'chunks: for chunk in self.draw_index_chunk_iter(line_visible_range) {
             let Some(v) = try_append_u32(view, 0) else {
-                warn_once!(
-                    target: "elodin_plot_index",
-                    "timeseries plot index buffer is full (capacity {} u32); tail of the curve is not drawn — zoom to a shorter time span",
-                    INDEX_BUFFER_LEN
-                );
                 break 'chunks;
             };
             view = v;
@@ -1507,11 +1450,6 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
             let mut index_iter = chunk.into_index_iter();
             if let Some(index) = index_iter.next() {
                 let Some(v) = try_append_u32(view, index) else {
-                    warn_once!(
-                        target: "elodin_plot_index",
-                        "timeseries plot index buffer is full (capacity {} u32); tail of the curve is not drawn — zoom to a shorter time span",
-                        INDEX_BUFFER_LEN
-                    );
                     break 'chunks;
                 };
                 view = v;
@@ -1519,11 +1457,6 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
             }
             for index in index_iter.step_by(step) {
                 let Some(v) = try_append_u32(view, index) else {
-                    warn_once!(
-                        target: "elodin_plot_index",
-                        "timeseries plot index buffer is full (capacity {} u32); tail of the curve is not drawn — zoom to a shorter time span",
-                        INDEX_BUFFER_LEN
-                    );
                     break 'chunks;
                 };
                 view = v;
@@ -1531,22 +1464,12 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
             }
             if let Some(end) = end {
                 let Some(v) = try_append_u32(view, end) else {
-                    warn_once!(
-                        target: "elodin_plot_index",
-                        "timeseries plot index buffer is full (capacity {} u32); tail of the curve is not drawn — zoom to a shorter time span",
-                        INDEX_BUFFER_LEN
-                    );
                     break 'chunks;
                 };
                 view = v;
                 written_u32s += 1;
             }
             let Some(v) = try_append_u32(view, 0) else {
-                warn_once!(
-                    target: "elodin_plot_index",
-                    "timeseries plot index buffer is full (capacity {} u32); tail of the curve is not drawn — zoom to a shorter time span",
-                    INDEX_BUFFER_LEN
-                );
                 break 'chunks;
             };
             view = v;
@@ -1683,14 +1606,6 @@ impl LineTree<f32> {
             let t_rel: Vec<f32> = old_ts.iter().map(|t| (t.0 - earliest.0) as f32).collect();
             let idx = select_time_value_indices(&t_rel, old_v, target_old);
             if idx.len() < 2 {
-                warn_once!(
-                    target: "elodin_plot_hamann",
-                    points = n,
-                    target_old,
-                    split,
-                    keep,
-                    "Hamann-Chen time-value: degenerate index set (< 2) on old prefix; skipping compress"
-                );
                 return;
             }
             let mut new_ts: Vec<Timestamp> = idx.iter().map(|&i| old_ts[i]).collect();
@@ -1711,12 +1626,6 @@ impl LineTree<f32> {
         let t_rel: Vec<f32> = ts_all.iter().map(|t| (t.0 - earliest.0) as f32).collect();
         let idx = select_time_value_indices(&t_rel, &v_all, target);
         if idx.len() < 2 {
-            warn_once!(
-                target: "elodin_plot_hamann",
-                points = n,
-                target,
-                "Hamann-Chen time-value: degenerate index set (< 2); skipping compress"
-            );
             return;
         }
         let new_ts: Vec<Timestamp> = idx.iter().map(|&i| ts_all[i]).collect();

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -1,5 +1,5 @@
 use bevy::asset::Asset;
-use bevy::log::{info, warn_once};
+use bevy::log::warn_once;
 use bevy::prelude::{DetectChanges, InRef, Res, ResMut};
 use bevy::reflect::TypePath;
 use bevy::{
@@ -230,21 +230,8 @@ pub fn maybe_compress_all_graph_lines(
     if !settings.enabled {
         return;
     }
-    static TICK: atomic::AtomicUsize = atomic::AtomicUsize::new(0);
-    let tick = TICK.fetch_add(1, atomic::Ordering::Relaxed);
-    let mut max_pts = 0usize;
-    let mut max_label: String = String::new();
     for component in graph_data.components.values_mut() {
         let handles: Vec<Handle<Line>> = component.lines.values().cloned().collect();
-        for h in &handles {
-            if let Some(l) = lines.get(h) {
-                let p = l.data.total_points();
-                if p > max_pts {
-                    max_pts = p;
-                    max_label = l.label.clone();
-                }
-            }
-        }
         if handles.len() == 3 && try_joint_triline_compress(lines, &handles, earliest, settings) {
             continue;
         }
@@ -254,16 +241,6 @@ pub fn maybe_compress_all_graph_lines(
             };
             line.maybe_compress_live(earliest, settings);
         }
-    }
-    if tick.is_multiple_of(240) {
-        info!(
-            target: "elodin::compress",
-            "heartbeat tick={} max_line_pts={} ({:?}) threshold={}",
-            tick,
-            max_pts,
-            max_label,
-            settings.compress_after_total_points,
-        );
     }
 }
 
@@ -284,15 +261,6 @@ fn try_joint_triline_compress(
     if lx.data.total_points() <= settings.compress_after_total_points {
         return false;
     }
-    let pre_total = lx.data.total_points();
-    info!(
-        target: "elodin::compress",
-        "triline_compress FIRE pre_total={} threshold={} target={} keep_recent_fraction={}",
-        pre_total,
-        settings.compress_after_total_points,
-        settings.compress_to_points,
-        settings.keep_recent_fraction,
-    );
     let (tsx, vx) = lx.data.flattened_time_series();
     let (tsy, vy) = ly.data.flattened_time_series();
     let (tsz, vz) = lz.data.flattened_time_series();
@@ -373,17 +341,6 @@ fn try_joint_triline_compress(
     };
     zl.data
         .rebuild_from_time_value_pairs(earliest, &new_ts, &new_z);
-    let post_total = lines
-        .get(hx)
-        .map(|l| l.data.total_points())
-        .unwrap_or_default();
-    info!(
-        target: "elodin::compress",
-        "triline_compress DONE pre_total={} post_total={} new_pts_per_axis={}",
-        pre_total,
-        post_total,
-        new_ts.len(),
-    );
     true
 }
 
@@ -914,17 +871,7 @@ pub struct Line {
 impl Line {
     fn maybe_compress_live(&mut self, earliest: Timestamp, settings: &CurveCompressSettings) {
         if self.data.total_points() > settings.compress_after_total_points {
-            let pre = self.data.total_points();
             self.data.compress_time_value_hamann(earliest, settings);
-            info!(
-                target: "elodin::compress",
-                "scalar_compress DONE label={:?} pre_total={} post_total={} threshold={} target={}",
-                self.label,
-                pre,
-                self.data.total_points(),
-                settings.compress_after_total_points,
-                settings.compress_to_points,
-            );
         }
     }
 }

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -1424,6 +1424,27 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
         self.write_to_index_buffer_with_step(index_buffer, render_queue, line_visible_range, step)
     }
 
+    /// Upper bound on `u32` indices written by [`Self::write_to_index_buffer_with_step`] for this
+    /// range and step (must stay in sync with that loop).
+    pub fn count_strip_index_u32s(&self, line_visible_range: Range<Timestamp>, step: usize) -> u32 {
+        let step = step.max(1);
+        let mut n: u32 = 0;
+        for chunk in self.draw_index_chunk_iter(line_visible_range) {
+            n = n.saturating_add(1);
+            let end = chunk.clone().into_index_iter().last();
+            let mut index_iter = chunk.into_index_iter();
+            if index_iter.next().is_some() {
+                n = n.saturating_add(1);
+                n = n.saturating_add(index_iter.step_by(step).count() as u32);
+            }
+            if end.is_some() {
+                n = n.saturating_add(1);
+            }
+            n = n.saturating_add(1);
+        }
+        n
+    }
+
     pub fn write_to_index_buffer_with_step(
         &self,
         index_buffer: &Buffer,
@@ -1761,6 +1782,20 @@ mod tests {
         assert_eq!(recent_tail_keep_count(100, 0.2), 20);
         assert_eq!(recent_tail_keep_count(5, 0.2), 1);
         assert_eq!(recent_tail_keep_count(100, 1.0), 99);
+    }
+
+    #[test]
+    fn count_strip_index_u32s_decreases_with_larger_step() {
+        let mut tree = LineTree::<f32>::default();
+        let ts: Vec<Timestamp> = (0i64..200).map(Timestamp).collect();
+        let vals: Vec<f32> = (0..200).map(|i| i as f32).collect();
+        let chunk = Chunk::from_iter(&ts, Timestamp(0), vals.into_iter()).expect("chunk");
+        tree.insert(chunk);
+        let range = Timestamp(0)..Timestamp(199);
+        let c1 = tree.count_strip_index_u32s(range.clone(), 1);
+        let c8 = tree.count_strip_index_u32s(range.clone(), 8);
+        assert!(c8 <= c1, "c1={c1} c8={c8}");
+        assert!(c1 > 0);
     }
 }
 

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -34,12 +34,37 @@ use std::{collections::BTreeMap, fmt::Debug, ops::Range};
 
 use crate::ui::plot::gpu::INDEX_BUFFER_LEN;
 use crate::{SelectedTimeRange, TimeRangeBehavior};
+use hamann_chen_line::{select_polyline3_indices, select_time_value_indices};
 
 use super::PlotBounds;
 
 /// Maximum points to request for overview data (LTTB downsampled)
 /// Must be <= CHUNK_LEN to fit within a single GPU buffer shard
 pub const OVERVIEW_MAX_POINTS: usize = CHUNK_LEN;
+
+/// Tuning for optional downsampling of live `LineTree` data (see `maybe_compress_all_graph_lines`).
+#[derive(Resource, Clone, Debug)]
+pub struct CurveCompressSettings {
+    pub enabled: bool,
+    pub compress_after_total_points: usize,
+    pub compress_to_points: usize,
+    /// Fraction of the **last** samples (by time order) left uncompressed after a pass.
+    /// `0.0` = compress the whole series (subject to `compress_to_points`).  
+    /// `0.2` ≈ keep the last 20 % at full resolution; Hamann–Chen applies only to the leading ~80 %.
+    pub keep_recent_fraction: f32,
+}
+
+impl Default for CurveCompressSettings {
+    fn default() -> Self {
+        let cap = CHUNK_COUNT.saturating_mul(CHUNK_LEN);
+        Self {
+            enabled: true,
+            compress_after_total_points: cap.saturating_mul(3) / 4,
+            compress_to_points: cap / 2,
+            keep_recent_fraction: 0.0,
+        }
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct PlotDataComponent {
@@ -144,6 +169,7 @@ pub fn pkt_handler(
     mut lines: ResMut<Assets<Line>>,
     tick: Res<CurrentTimestamp>,
     earliest_timestamp: Res<EarliestTimestamp>,
+    curve_compress: Res<CurveCompressSettings>,
 ) {
     let mut tick = *tick;
     if let OwnedPacket::Table(table) = packet {
@@ -163,7 +189,137 @@ pub fn pkt_handler(
         ) {
             warn_once!(?err, "graph sink failed");
         }
+        maybe_compress_all_graph_lines(
+            &mut collected_graph_data,
+            &mut lines,
+            earliest_timestamp.0,
+            &curve_compress,
+        );
     }
+}
+
+/// Keeps live telemetry within GPU / index-buffer budgets by merging oversize series.
+pub fn maybe_compress_all_graph_lines(
+    graph_data: &mut CollectedGraphData,
+    lines: &mut Assets<Line>,
+    earliest: Timestamp,
+    settings: &CurveCompressSettings,
+) {
+    if !settings.enabled {
+        return;
+    }
+    for component in graph_data.components.values_mut() {
+        let handles: Vec<Handle<Line>> = component.lines.values().cloned().collect();
+        if handles.len() == 3 && try_joint_triline_compress(lines, &handles, earliest, settings) {
+            continue;
+        }
+        for line_handle in &handles {
+            let Some(line) = lines.get_mut(line_handle) else {
+                continue;
+            };
+            line.maybe_compress_live(earliest, settings);
+        }
+    }
+}
+
+fn try_joint_triline_compress(
+    lines: &mut Assets<Line>,
+    handles: &[Handle<Line>],
+    earliest: Timestamp,
+    settings: &CurveCompressSettings,
+) -> bool {
+    if handles.len() != 3 {
+        return false;
+    }
+    let (hx, hy, hz) = (&handles[0], &handles[1], &handles[2]);
+    let (lx, ly, lz) = match (lines.get(hx), lines.get(hy), lines.get(hz)) {
+        (Some(x), Some(y), Some(z)) => (x, y, z),
+        _ => return false,
+    };
+    if lx.data.total_points() <= settings.compress_after_total_points {
+        return false;
+    }
+    let (tsx, vx) = lx.data.flattened_time_series();
+    let (tsy, vy) = ly.data.flattened_time_series();
+    let (tsz, vz) = lz.data.flattened_time_series();
+    if tsx.len() != tsy.len() || tsx.len() != tsz.len() {
+        return false;
+    }
+    if tsx
+        .iter()
+        .zip(&tsy)
+        .zip(&tsz)
+        .any(|((&a, &b), &c)| a != b || a != c)
+    {
+        return false;
+    }
+    if tsx.len() < 3 {
+        return false;
+    }
+    let n = tsx.len();
+    let pos: Vec<bevy::prelude::Vec3> = vx
+        .iter()
+        .zip(vy.iter())
+        .zip(vz.iter())
+        .map(|((&x, &y), &z)| bevy::prelude::Vec3::new(x, y, z))
+        .collect();
+
+    let keep = recent_tail_keep_count(n, settings.keep_recent_fraction);
+    let split = n.saturating_sub(keep);
+
+    let (new_ts, new_x, new_y, new_z) = if settings.keep_recent_fraction > 0.0 && split >= 3 {
+        let budget = settings.compress_to_points.saturating_sub(keep).max(2);
+        let target_old = budget.min(split).max(2);
+        let pos_old = &pos[..split];
+        let idx = select_polyline3_indices(pos_old, target_old);
+        if idx.len() < 2 {
+            return false;
+        }
+        let mut new_ts: Vec<Timestamp> = idx.iter().map(|&i| tsx[i]).collect();
+        let mut new_x: Vec<f32> = idx.iter().map(|&i| vx[i]).collect();
+        let mut new_y: Vec<f32> = idx.iter().map(|&i| vy[i]).collect();
+        let mut new_z: Vec<f32> = idx.iter().map(|&i| vz[i]).collect();
+        if let (Some(tl), Some(tr)) = (new_ts.last(), tsx.get(split))
+            && *tl == *tr
+        {
+            new_ts.pop();
+            new_x.pop();
+            new_y.pop();
+            new_z.pop();
+        }
+        new_ts.extend_from_slice(&tsx[split..]);
+        new_x.extend_from_slice(&vx[split..]);
+        new_y.extend_from_slice(&vy[split..]);
+        new_z.extend_from_slice(&vz[split..]);
+        (new_ts, new_x, new_y, new_z)
+    } else {
+        let target = settings.compress_to_points.max(2).min(n);
+        let idx = select_polyline3_indices(&pos, target);
+        if idx.len() < 2 {
+            return false;
+        }
+        let new_ts: Vec<Timestamp> = idx.iter().map(|&i| tsx[i]).collect();
+        let new_x: Vec<f32> = idx.iter().map(|&i| vx[i]).collect();
+        let new_y: Vec<f32> = idx.iter().map(|&i| vy[i]).collect();
+        let new_z: Vec<f32> = idx.iter().map(|&i| vz[i]).collect();
+        (new_ts, new_x, new_y, new_z)
+    };
+    let Some(xl) = lines.get_mut(hx) else {
+        return false;
+    };
+    xl.data
+        .rebuild_from_time_value_pairs(earliest, &new_ts, &new_x);
+    let Some(yl) = lines.get_mut(hy) else {
+        return false;
+    };
+    yl.data
+        .rebuild_from_time_value_pairs(earliest, &new_ts, &new_y);
+    let Some(zl) = lines.get_mut(hz) else {
+        return false;
+    };
+    zl.data
+        .rebuild_from_time_value_pairs(earliest, &new_ts, &new_z);
+    true
 }
 
 pub fn setup_pkt_handler(mut packet_handlers: ResMut<PacketHandlers>, mut commands: Commands) {
@@ -690,6 +846,16 @@ pub struct Line {
     pub last_queried: Option<Instant>,
 }
 
+impl Line {
+    fn maybe_compress_live(&mut self, earliest: Timestamp, settings: &CurveCompressSettings) {
+        let total = self.data.total_points();
+        if total <= settings.compress_after_total_points {
+            return;
+        }
+        self.data.compress_time_value_hamann(earliest, settings);
+    }
+}
+
 #[derive(Asset, TypePath, Default)]
 pub struct XYLine {
     pub label: String,
@@ -1079,6 +1245,14 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
         );
     }
 
+    pub fn total_points(&self) -> usize {
+        self.tree.iter().map(|(_, c)| c.summary.len).sum()
+    }
+
+    pub fn chunk_count(&self) -> usize {
+        self.tree.iter().count()
+    }
+
     pub fn range_summary(&self, range: Range<Timestamp>) -> ChunkSummary<D> {
         self.range_iter(range)
             .fold(ChunkSummary::default(), |mut xs, x| {
@@ -1320,6 +1494,138 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
     }
 }
 
+fn release_line_chunk_gpu(
+    chunk: &mut Chunk<f32>,
+    data_alloc: &mut Option<BufferShardAlloc>,
+    ts_alloc: &mut Option<BufferShardAlloc>,
+) {
+    if let Some(alloc) = data_alloc
+        && let Some(gpu) = chunk.data.gpu.lock().take()
+    {
+        alloc.dealloc(gpu);
+        chunk.data.gpu_dirty.store(true, atomic::Ordering::SeqCst);
+    }
+    if let Some(alloc) = ts_alloc
+        && let Some(gpu) = chunk.timestamps_float.gpu.lock().take()
+    {
+        alloc.dealloc(gpu);
+        chunk
+            .timestamps_float
+            .gpu_dirty
+            .store(true, atomic::Ordering::SeqCst);
+    }
+}
+
+impl LineTree<f32> {
+    pub fn flattened_time_series(&self) -> (Vec<Timestamp>, Vec<f32>) {
+        let mut ts = Vec::new();
+        let mut vs = Vec::new();
+        for (_, chunk) in self.tree.iter() {
+            for (&t, &v) in chunk.timestamps.iter().zip(chunk.data.cpu().iter()) {
+                ts.push(t);
+                vs.push(v);
+            }
+        }
+        (ts, vs)
+    }
+
+    fn clear_tree_release_gpu(&mut self) {
+        let old = std::mem::take(&mut self.tree);
+        for (_, mut chunk) in old {
+            release_line_chunk_gpu(
+                &mut chunk,
+                &mut self.data_buffer_shard_alloc,
+                &mut self.timestamp_buffer_shard_alloc,
+            );
+        }
+    }
+
+    /// Drop existing chunks (releasing GPU shards) and insert `new_ts` / `new_v` in `CHUNK_LEN` shards.
+    pub fn rebuild_from_time_value_pairs(
+        &mut self,
+        earliest: Timestamp,
+        new_ts: &[Timestamp],
+        new_v: &[f32],
+    ) {
+        self.clear_tree_release_gpu();
+        let n = new_ts.len().min(new_v.len());
+        let mut offset = 0usize;
+        while offset < n {
+            let end = (offset + CHUNK_LEN).min(n);
+            if let Some(chunk) = Chunk::from_iter(
+                &new_ts[offset..end],
+                earliest,
+                new_v[offset..end].iter().copied(),
+            ) {
+                self.insert(chunk);
+            }
+            offset = end;
+        }
+    }
+
+    /// Hamann–Chen in `(t, y)`; optional [`CurveCompressSettings::keep_recent_fraction`] leaves a
+    /// suffix of recent samples uncompressed.
+    pub fn compress_time_value_hamann(
+        &mut self,
+        earliest: Timestamp,
+        settings: &CurveCompressSettings,
+    ) {
+        let (ts_all, v_all) = self.flattened_time_series();
+        let n = ts_all.len();
+        if n < 3 {
+            return;
+        }
+
+        let keep = recent_tail_keep_count(n, settings.keep_recent_fraction);
+        let split = n.saturating_sub(keep);
+
+        if settings.keep_recent_fraction > 0.0 && split >= 3 {
+            let old_ts = &ts_all[..split];
+            let old_v = &v_all[..split];
+            let recent_ts = &ts_all[split..];
+            let recent_v = &v_all[split..];
+            let budget = settings.compress_to_points.saturating_sub(keep).max(2);
+            let target_old = budget.min(split).max(2);
+            let t_rel: Vec<f32> = old_ts.iter().map(|t| (t.0 - earliest.0) as f32).collect();
+            let idx = select_time_value_indices(&t_rel, old_v, target_old);
+            if idx.len() < 2 {
+                return;
+            }
+            let mut new_ts: Vec<Timestamp> = idx.iter().map(|&i| old_ts[i]).collect();
+            let mut new_v: Vec<f32> = idx.iter().map(|&i| old_v[i]).collect();
+            if let (Some(tl), Some(tr)) = (new_ts.last(), recent_ts.first())
+                && *tl == *tr
+            {
+                new_ts.pop();
+                new_v.pop();
+            }
+            new_ts.extend_from_slice(recent_ts);
+            new_v.extend_from_slice(recent_v);
+            self.rebuild_from_time_value_pairs(earliest, &new_ts, &new_v);
+            return;
+        }
+
+        let target = settings.compress_to_points.max(2).min(n);
+        let t_rel: Vec<f32> = ts_all.iter().map(|t| (t.0 - earliest.0) as f32).collect();
+        let idx = select_time_value_indices(&t_rel, &v_all, target);
+        if idx.len() < 2 {
+            return;
+        }
+        let new_ts: Vec<Timestamp> = idx.iter().map(|&i| ts_all[i]).collect();
+        let new_v: Vec<f32> = idx.iter().map(|&i| v_all[i]).collect();
+        self.rebuild_from_time_value_pairs(earliest, &new_ts, &new_v);
+    }
+}
+
+fn recent_tail_keep_count(n: usize, keep_recent_fraction: f32) -> usize {
+    if n == 0 || keep_recent_fraction <= 0.0 {
+        return 0;
+    }
+    let f = keep_recent_fraction.clamp(0.0_f32, 0.999_f32);
+    let keep = (n as f32 * f).ceil() as usize;
+    keep.min(n.saturating_sub(1))
+}
+
 fn chunk_visible_offsets(
     timestamps: &[Timestamp],
     range: &Range<Timestamp>,
@@ -1330,13 +1636,17 @@ fn chunk_visible_offsets(
 }
 
 pub fn index_sampling_step(chunk_count: usize, index_count: usize, pixel_width: usize) -> usize {
-    let desired_index_len = INDEX_BUFFER_LEN.min(pixel_width * 4);
-    let divisor = desired_index_len.saturating_sub(2 * chunk_count);
-    if divisor != 0 {
-        index_count.div_ceil(divisor).max(1)
-    } else {
-        1
+    let desired_index_len = INDEX_BUFFER_LEN.min(pixel_width.max(1) * 4);
+    // Per-chunk index overhead: leading sentinel, first point, strided interior, last point,
+    // trailing sentinel (see `write_to_index_buffer_with_step`).
+    const PER_CHUNK_OVERHEAD: usize = 6;
+    let overhead = PER_CHUNK_OVERHEAD.saturating_mul(chunk_count.max(1));
+    let divisor = desired_index_len.saturating_sub(overhead);
+    if divisor > 0 {
+        return index_count.div_ceil(divisor).max(1);
     }
+    // Many chunks: `2 * chunk_count` alone can exceed the index budget — never fall back to step 1.
+    index_count.div_ceil(desired_index_len.max(1)).max(1)
 }
 
 #[cfg(test)]
@@ -1416,6 +1726,24 @@ mod tests {
     fn index_sampling_step_matches_index_budget() {
         assert_eq!(index_sampling_step(1, 100, 100), 1);
         assert_eq!(index_sampling_step(1, 1_000, 100), 3);
+    }
+
+    #[test]
+    fn index_sampling_step_many_chunks_never_returns_one() {
+        let step = index_sampling_step(5000, 1_000_000, 1920);
+        assert!(step > 1, "step={step}");
+    }
+
+    #[test]
+    fn recent_tail_keep_count_zero_fraction_is_zero() {
+        assert_eq!(recent_tail_keep_count(100, 0.0), 0);
+    }
+
+    #[test]
+    fn recent_tail_keep_count_respects_fraction_and_caps_at_n_minus_one() {
+        assert_eq!(recent_tail_keep_count(100, 0.2), 20);
+        assert_eq!(recent_tail_keep_count(5, 0.2), 1);
+        assert_eq!(recent_tail_keep_count(100, 1.0), 99);
     }
 }
 

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -1,5 +1,5 @@
 use bevy::asset::Asset;
-use bevy::log::warn_once;
+use bevy::log::{info, warn_once};
 use bevy::prelude::{DetectChanges, InRef, Res, ResMut};
 use bevy::reflect::TypePath;
 use bevy::{
@@ -230,8 +230,21 @@ pub fn maybe_compress_all_graph_lines(
     if !settings.enabled {
         return;
     }
+    static TICK: atomic::AtomicUsize = atomic::AtomicUsize::new(0);
+    let tick = TICK.fetch_add(1, atomic::Ordering::Relaxed);
+    let mut max_pts = 0usize;
+    let mut max_label: String = String::new();
     for component in graph_data.components.values_mut() {
         let handles: Vec<Handle<Line>> = component.lines.values().cloned().collect();
+        for h in &handles {
+            if let Some(l) = lines.get(h) {
+                let p = l.data.total_points();
+                if p > max_pts {
+                    max_pts = p;
+                    max_label = l.label.clone();
+                }
+            }
+        }
         if handles.len() == 3 && try_joint_triline_compress(lines, &handles, earliest, settings) {
             continue;
         }
@@ -241,6 +254,16 @@ pub fn maybe_compress_all_graph_lines(
             };
             line.maybe_compress_live(earliest, settings);
         }
+    }
+    if tick.is_multiple_of(240) {
+        info!(
+            target: "elodin::compress",
+            "heartbeat tick={} max_line_pts={} ({:?}) threshold={}",
+            tick,
+            max_pts,
+            max_label,
+            settings.compress_after_total_points,
+        );
     }
 }
 
@@ -261,6 +284,15 @@ fn try_joint_triline_compress(
     if lx.data.total_points() <= settings.compress_after_total_points {
         return false;
     }
+    let pre_total = lx.data.total_points();
+    info!(
+        target: "elodin::compress",
+        "triline_compress FIRE pre_total={} threshold={} target={} keep_recent_fraction={}",
+        pre_total,
+        settings.compress_after_total_points,
+        settings.compress_to_points,
+        settings.keep_recent_fraction,
+    );
     let (tsx, vx) = lx.data.flattened_time_series();
     let (tsy, vy) = ly.data.flattened_time_series();
     let (tsz, vz) = lz.data.flattened_time_series();
@@ -341,6 +373,17 @@ fn try_joint_triline_compress(
     };
     zl.data
         .rebuild_from_time_value_pairs(earliest, &new_ts, &new_z);
+    let post_total = lines
+        .get(hx)
+        .map(|l| l.data.total_points())
+        .unwrap_or_default();
+    info!(
+        target: "elodin::compress",
+        "triline_compress DONE pre_total={} post_total={} new_pts_per_axis={}",
+        pre_total,
+        post_total,
+        new_ts.len(),
+    );
     true
 }
 
@@ -871,7 +914,17 @@ pub struct Line {
 impl Line {
     fn maybe_compress_live(&mut self, earliest: Timestamp, settings: &CurveCompressSettings) {
         if self.data.total_points() > settings.compress_after_total_points {
+            let pre = self.data.total_points();
             self.data.compress_time_value_hamann(earliest, settings);
+            info!(
+                target: "elodin::compress",
+                "scalar_compress DONE label={:?} pre_total={} post_total={} threshold={} target={}",
+                self.label,
+                pre,
+                self.data.total_points(),
+                settings.compress_after_total_points,
+                settings.compress_to_points,
+            );
         }
     }
 }
@@ -1084,20 +1137,20 @@ impl<D: Immutable + IntoBytes + BoundOrd + Clone + Debug> Chunk<D> {
             gpu: Default::default(),
             gpu_dirty: Arc::new(AtomicBool::new(true)),
         };
-        let min = data.cpu().iter().fold(None, |xs: Option<D>, x| {
-            if let Some(xs) = xs.clone() {
-                Some(xs.min(x.clone()))
-            } else {
-                Some(x.clone())
-            }
-        });
-        let max = data.cpu().iter().fold(None, |xs: Option<D>, x| {
-            if let Some(xs) = xs.clone() {
-                Some(xs.max(x.clone()))
-            } else {
-                Some(x.clone())
-            }
-        });
+        let (min, max) = data
+            .cpu()
+            .iter()
+            .fold((None::<D>, None::<D>), |(min_acc, max_acc), x| {
+                let min_acc = Some(match min_acc {
+                    Some(m) => m.min(x.clone()),
+                    None => x.clone(),
+                });
+                let max_acc = Some(match max_acc {
+                    Some(m) => m.max(x.clone()),
+                    None => x.clone(),
+                });
+                (min_acc, max_acc)
+            });
 
         let summary = ChunkSummary {
             len: timestamps.len(),
@@ -1619,26 +1672,39 @@ impl LineTree<f32> {
         (ts, vs)
     }
 
-    fn clear_tree_release_gpu(&mut self) {
-        let old = std::mem::take(&mut self.tree);
-        for (_, mut chunk) in old {
-            release_line_chunk_gpu(
-                &mut chunk,
-                &mut self.data_buffer_shard_alloc,
-                &mut self.timestamp_buffer_shard_alloc,
-            );
-        }
-    }
-
-    /// Drop existing chunks (releasing GPU shards) and insert `new_ts` / `new_v` in `CHUNK_LEN` shards.
+    /// Rebuild the tree from `new_ts` / `new_v`, atomically, in `CHUNK_LEN` shards.
+    ///
+    /// Uses **build-then-swap**: a fresh tree is constructed off-band, swapped in
+    /// with `mem::replace`, and only then are the old GPU shards released. Render
+    /// frames therefore observe either the previous tree in full or the new tree
+    /// in full — never an empty intermediate state. This is what kills the trail
+    /// blink at high tick counts when [`compress_time_value_hamann`] fires.
     pub fn rebuild_from_time_value_pairs(
         &mut self,
         earliest: Timestamp,
         new_ts: &[Timestamp],
         new_v: &[f32],
     ) {
-        self.clear_tree_release_gpu();
         let n = new_ts.len().min(new_v.len());
+
+        if n == self.total_points()
+            && n > 0
+            && self
+                .tree
+                .iter()
+                .next()
+                .map(|(_, c)| c.summary.start_timestamp)
+                == new_ts.first().copied()
+            && self
+                .tree
+                .last_key_value()
+                .map(|(_, c)| c.summary.end_timestamp)
+                == new_ts.last().copied()
+        {
+            return;
+        }
+
+        let mut new_tree: NoditMap<i64, nodit::Interval<i64>, Chunk<f32>> = NoditMap::default();
         let mut offset = 0usize;
         while offset < n {
             let end = (offset + CHUNK_LEN).min(n);
@@ -1647,9 +1713,24 @@ impl LineTree<f32> {
                 earliest,
                 new_v[offset..end].iter().copied(),
             ) {
-                self.insert(chunk);
+                let _ = new_tree.insert_overwrite(
+                    ii(
+                        chunk.summary.start_timestamp.0,
+                        chunk.summary.end_timestamp.0,
+                    ),
+                    chunk,
+                );
             }
             offset = end;
+        }
+
+        let old_tree = std::mem::replace(&mut self.tree, new_tree);
+        for (_, mut chunk) in old_tree {
+            release_line_chunk_gpu(
+                &mut chunk,
+                &mut self.data_buffer_shard_alloc,
+                &mut self.timestamp_buffer_shard_alloc,
+            );
         }
     }
 

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -1523,6 +1523,17 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
         chunk.timestamps.get(idx).copied()
     }
 
+    /// Timestamp of the most recent sample stored in the view, or `None` when empty.
+    /// Used by `line_3d` to tell apart "playhead between ticks" (snap the future
+    /// segment back one sample to keep ≥ 2 indices and avoid a single-sample
+    /// blink) from "playhead on the latest sample" (live follow, future must
+    /// stay empty so no white tail overdraws the yellow trail).
+    pub fn latest_sample_timestamp(&self) -> Option<Timestamp> {
+        self.tree
+            .last_key_value()
+            .map(|(_, c)| c.summary.end_timestamp)
+    }
+
     pub fn data_buffer_shard_alloc(&self) -> Option<&BufferShardAlloc> {
         self.data_buffer_shard_alloc.as_ref()
     }

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -1394,6 +1394,24 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
         Some((*chunk.timestamps.get(index)?, chunk.data.cpu().get(index)?))
     }
 
+    /// Returns the latest sample timestamp **strictly less than** `target`.
+    ///
+    /// Used by `line_3d` rendering to snap the played/future split onto the
+    /// previous sample boundary. Without this, the future segment can collapse
+    /// to a single index per frame when `current_timestamp` falls between
+    /// discrete sim ticks, which disappears from the shader (NaN-only draw)
+    /// and shows up as a blink near the current position.
+    pub fn last_timestamp_strictly_before(&self, target: Timestamp) -> Option<Timestamp> {
+        let upper = target.0.checked_sub(1)?;
+        let (_, chunk) = self.tree.overlapping(ii(i64::MIN, upper)).last()?;
+        let probe = Timestamp(upper);
+        let idx = match chunk.timestamps.binary_search(&probe) {
+            Ok(i) => i,
+            Err(i) => i.checked_sub(1)?,
+        };
+        chunk.timestamps.get(idx).copied()
+    }
+
     pub fn data_buffer_shard_alloc(&self) -> Option<&BufferShardAlloc> {
         self.data_buffer_shard_alloc.as_ref()
     }

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -1446,8 +1446,8 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
         self.write_to_index_buffer_with_step(index_buffer, render_queue, line_visible_range, step)
     }
 
-    /// Upper bound on `u32` indices written by [`Self::write_to_index_buffer_with_step`] for this
-    /// range and step (must stay in sync with that loop).
+    /// Count of `u32` indices written by [`Self::write_to_index_buffer_with_step`] for this range
+    /// and step (must stay in sync with that loop, including when `step == 1`).
     ///
     /// Uses the same visibility clipping as [`Self::draw_index_chunk_iter`] but does **not**
     /// require GPU-resident chunks (counts from CPU timestamps + visible length only).
@@ -1473,11 +1473,18 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
             n = n.saturating_add(1);
             let end = chunk.clone().into_index_iter().last();
             let mut index_iter = chunk.into_index_iter();
-            if index_iter.next().is_some() {
+            let mut last_written: Option<u32> = None;
+            if let Some(index) = index_iter.next() {
                 n = n.saturating_add(1);
-                n = n.saturating_add(index_iter.step_by(step).count() as u32);
+                last_written = Some(index);
             }
-            if end.is_some() {
+            for index in index_iter.step_by(step) {
+                n = n.saturating_add(1);
+                last_written = Some(index);
+            }
+            if let Some(end) = end
+                && last_written != Some(end)
+            {
                 n = n.saturating_add(1);
             }
             n = n.saturating_add(1);
@@ -1509,12 +1516,14 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
             written_u32s += 1;
             let end = chunk.clone().into_index_iter().last();
             let mut index_iter = chunk.into_index_iter();
+            let mut last_written: Option<u32> = None;
             if let Some(index) = index_iter.next() {
                 let Some(v) = try_append_u32(view, index) else {
                     break 'chunks;
                 };
                 view = v;
                 written_u32s += 1;
+                last_written = Some(index);
             }
             for index in index_iter.step_by(step) {
                 let Some(v) = try_append_u32(view, index) else {
@@ -1522,8 +1531,11 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
                 };
                 view = v;
                 written_u32s += 1;
+                last_written = Some(index);
             }
-            if let Some(end) = end {
+            if let Some(end) = end
+                && last_written != Some(end)
+            {
                 let Some(v) = try_append_u32(view, end) else {
                     break 'chunks;
                 };
@@ -1836,6 +1848,20 @@ mod tests {
         let c8 = tree.count_strip_index_u32s(range.clone(), 8);
         assert!(c8 <= c1, "c1={c1} c8={c8}");
         assert!(c1 > 0);
+    }
+
+    #[test]
+    fn count_strip_index_u32s_step_one_matches_sentinels_plus_vertices() {
+        let mut tree = LineTree::<f32>::default();
+        let ts: Vec<Timestamp> = (0i64..10).map(Timestamp).collect();
+        let vals: Vec<f32> = (0..10).map(|i| i as f32).collect();
+        let chunk = Chunk::from_iter(&ts, Timestamp(0), vals.into_iter()).expect("chunk");
+        tree.insert(chunk);
+        let c = tree.count_strip_index_u32s(Timestamp(0)..Timestamp(10), 1);
+        assert_eq!(
+            c, 12,
+            "leading 0 + 10 indices + trailing 0 (no duplicate last)"
+        );
     }
 }
 

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -1448,10 +1448,28 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
 
     /// Upper bound on `u32` indices written by [`Self::write_to_index_buffer_with_step`] for this
     /// range and step (must stay in sync with that loop).
+    ///
+    /// Uses the same visibility clipping as [`Self::draw_index_chunk_iter`] but does **not**
+    /// require GPU-resident chunks (counts from CPU timestamps + visible length only).
     pub fn count_strip_index_u32s(&self, line_visible_range: Range<Timestamp>, step: usize) -> u32 {
         let step = step.max(1);
         let mut n: u32 = 0;
-        for chunk in self.draw_index_chunk_iter(line_visible_range) {
+        for c in self.range_iter(line_visible_range.clone()) {
+            let Some((start_offset, end_offset)) =
+                chunk_visible_offsets(&c.timestamps, &line_visible_range)
+            else {
+                continue;
+            };
+            let vis_len = end_offset.saturating_sub(start_offset);
+            if vis_len == 0 {
+                continue;
+            }
+            // `into_index_iter` length depends only on `len`; absolute indices match GPU path
+            // after clip, but counts are identical for any `range.start` with sufficient span.
+            let chunk = IndexChunk {
+                range: 0..u32::MAX,
+                len: vis_len,
+            };
             n = n.saturating_add(1);
             let end = chunk.clone().into_index_iter().last();
             let mut index_iter = chunk.into_index_iter();

--- a/libs/elodin-editor/src/ui/plot/mod.rs
+++ b/libs/elodin-editor/src/ui/plot/mod.rs
@@ -1,7 +1,14 @@
 pub mod data;
+
+pub use hamann_chen_line::{
+    select_point_indices, select_polyline2_indices, select_polyline3_indices,
+    select_time_value_indices, select_trajectory_time_norm_indices,
+};
+
 pub use data::{
-    BufferShardAlloc, CHUNK_COUNT, CHUNK_LEN, CollectedGraphData, Line, OVERVIEW_MAX_POINTS,
-    PlotDataComponent, XYLine, collect_garbage, queue_timestamp_read, setup_pkt_handler,
+    BufferShardAlloc, CHUNK_COUNT, CHUNK_LEN, CollectedGraphData, CurveCompressSettings, Line,
+    OVERVIEW_MAX_POINTS, PlotDataComponent, XYLine, collect_garbage,
+    maybe_compress_all_graph_lines, queue_timestamp_read, setup_pkt_handler,
 };
 
 pub mod gpu;
@@ -31,6 +38,7 @@ pub struct PlotPlugin;
 impl Plugin for PlotPlugin {
     fn build(&self, app: &mut bevy::prelude::App) {
         app.init_resource::<CollectedGraphData>()
+            .init_resource::<CurveCompressSettings>()
             .init_resource::<LockTracker>()
             .init_resource::<XSyncClock>()
             .add_systems(Startup, setup_pkt_handler)

--- a/libs/elodin-editor/src/ui/plot_3d/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/gpu.rs
@@ -476,7 +476,13 @@ fn extract_lines(
         future_color.w *= timeline_settings.future_trail_alpha;
 
         let played_range = selected_range.start..selected_range.end.min(current_timestamp.0);
-        let future_range = selected_range.start.max(current_timestamp.0)..selected_range.end;
+        // Future segment must contain >= 2 samples or the shader draws only
+        // sentinel(NaN)-to-point instances and nothing shows up. When
+        // `current_timestamp` falls between sim ticks (the common case in live
+        // streaming), the naive split leaves a single index in the future
+        // range, which blinks at the render framerate near the rocket. Snap
+        // the split back onto the previous sample boundary instead.
+        let split = selected_range.start.max(current_timestamp.0);
 
         'outer: for (entity, line_handles, config, uniform, gpu_line) in lines.iter_mut() {
             for line in &line_handles.0 {
@@ -613,6 +619,16 @@ fn extract_lines(
                     TemporaryRenderEntity,
                 ));
             }
+
+            // Snap the future range's start to the previous sample so the
+            // segment always has >= 2 indices per axis near the playhead. Fall
+            // back to `split` when no earlier sample exists.
+            let future_start = line_assets
+                .get(&line_handles.0[0])
+                .and_then(|l| l.data.last_timestamp_strictly_before(split))
+                .map(|ts| selected_range.start.max(ts))
+                .unwrap_or(split);
+            let future_range = future_start..selected_range.end;
 
             if let Some(gpu_line) = build_gpu_line(future_range.clone()) {
                 let mut future_uniform = *uniform;

--- a/libs/elodin-editor/src/ui/plot_3d/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/gpu.rs
@@ -620,15 +620,27 @@ fn extract_lines(
                 ));
             }
 
-            // Snap the future range's start to the previous sample so the
-            // segment always has >= 2 indices per axis near the playhead. Fall
-            // back to `split` when no earlier sample exists.
-            let future_start = line_assets
+            // Snap the future range's start to the previous sample when there
+            // are actual samples past `split` (the usual playhead case between
+            // sim ticks) — otherwise the segment would collapse to a single
+            // index and blink. In live-follow mode `split == latest sample`
+            // and no snap is wanted: the future segment must stay empty, else
+            // a tiny white tail overdraws the yellow trail.
+            let has_future_samples = line_assets
                 .get(&line_handles.0[0])
-                .and_then(|l| l.data.last_timestamp_strictly_before(split))
-                .map(|ts| selected_range.start.max(ts))
-                .unwrap_or(split);
-            let future_range = future_start..selected_range.end;
+                .and_then(|l| l.data.latest_sample_timestamp())
+                .map(|latest| latest > split)
+                .unwrap_or(false);
+            let future_range = if has_future_samples {
+                let future_start = line_assets
+                    .get(&line_handles.0[0])
+                    .and_then(|l| l.data.last_timestamp_strictly_before(split))
+                    .map(|ts| selected_range.start.max(ts))
+                    .unwrap_or(split);
+                future_start..selected_range.end
+            } else {
+                split..split
+            };
 
             if let Some(gpu_line) = build_gpu_line(future_range.clone()) {
                 let mut future_uniform = *uniform;

--- a/libs/elodin-editor/src/ui/plot_3d/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/gpu.rs
@@ -415,6 +415,7 @@ struct CachedSystemState {
         Res<'static, LastUpdated>,
         Res<'static, CurrentTimestamp>,
         Res<'static, TimelineSettings>,
+        Res<'static, crate::ui::timeline::LatestFollow>,
     )>,
 }
 
@@ -453,6 +454,7 @@ fn extract_lines(
             latest_timestamp,
             current_timestamp,
             timeline_settings,
+            latest_follow,
         ) = cached_state.state.get_mut(world);
         let selected_range = selected_time_range.0.clone();
         let sampling_range = if replay_mode && earliest_timestamp.0 < latest_timestamp.0 {
@@ -475,7 +477,18 @@ fn extract_lines(
         );
         future_color.w *= timeline_settings.future_trail_alpha;
 
-        let played_range = selected_range.start..selected_range.end.min(current_timestamp.0);
+        // Live-follow mode: the whole trail is "already played", so render
+        // everything in the played color (yolk) and skip the future pass
+        // entirely. Without this, Table packets racing ahead of
+        // LastUpdated put `latest_sample_ts > current_ts` for one frame,
+        // the snap-back below manufactures a 1-sample future range, and
+        // the white trail overdraws the tail of the yellow trail.
+        let live_follow = latest_follow.0;
+        let played_range = if live_follow {
+            selected_range.clone()
+        } else {
+            selected_range.start..selected_range.end.min(current_timestamp.0)
+        };
         // Future segment must contain >= 2 samples or the shader draws only
         // sentinel(NaN)-to-point instances and nothing shows up. When
         // `current_timestamp` falls between sim ticks (the common case in live
@@ -620,26 +633,19 @@ fn extract_lines(
                 ));
             }
 
-            // Snap the future range's start to the previous sample when there
-            // are actual samples past `split` (the usual playhead case between
-            // sim ticks) — otherwise the segment would collapse to a single
-            // index and blink. In live-follow mode `split == latest sample`
-            // and no snap is wanted: the future segment must stay empty, else
-            // a tiny white tail overdraws the yellow trail.
-            let has_future_samples = line_assets
-                .get(&line_handles.0[0])
-                .and_then(|l| l.data.latest_sample_timestamp())
-                .map(|latest| latest > split)
-                .unwrap_or(false);
-            let future_range = if has_future_samples {
+            // Live-follow: played covers everything, nothing is "future".
+            // Otherwise snap the start back to the previous sample so the
+            // future segment always has >= 2 indices (single-index segments
+            // collapse to a NaN draw and blink at framerate).
+            let future_range = if live_follow {
+                split..split
+            } else {
                 let future_start = line_assets
                     .get(&line_handles.0[0])
                     .and_then(|l| l.data.last_timestamp_strictly_before(split))
                     .map(|ts| selected_range.start.max(ts))
                     .unwrap_or(split);
                 future_start..selected_range.end
-            } else {
-                split..split
             };
 
             if let Some(gpu_line) = build_gpu_line(future_range.clone()) {

--- a/libs/elodin-editor/src/ui/plot_3d/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/gpu.rs
@@ -546,10 +546,8 @@ fn extract_lines(
                     for i in 0..3 {
                         let line = &line_handles.0[i];
                         let line = line_assets.get(line).expect("line missing");
-                        max_needed = max_needed.max(
-                            line.data
-                                .count_strip_index_u32s(range.clone(), step),
-                        );
+                        max_needed =
+                            max_needed.max(line.data.count_strip_index_u32s(range.clone(), step));
                     }
                     if max_needed <= MAX_INDEX_U32 {
                         break;

--- a/libs/elodin-editor/src/ui/plot_3d/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/gpu.rs
@@ -539,6 +539,23 @@ fn extract_lines(
                 if range.start >= range.end {
                     return None;
                 }
+                let mut step = sampling_step.max(1);
+                const MAX_INDEX_U32: u32 = INDEX_BUFFER_LEN as u32;
+                for _ in 0..26 {
+                    let mut max_needed = 0u32;
+                    for i in 0..3 {
+                        let line = &line_handles.0[i];
+                        let line = line_assets.get(line).expect("line missing");
+                        max_needed = max_needed.max(
+                            line.data
+                                .count_strip_index_u32s(range.clone(), step),
+                        );
+                    }
+                    if max_needed <= MAX_INDEX_U32 {
+                        break;
+                    }
+                    step = step.saturating_mul(2).max(2);
+                }
                 let index_buffers = ['x', 'y', 'z'].map(|axis| {
                     render_device.create_buffer(
                         &(BufferDescriptor {
@@ -566,7 +583,7 @@ fn extract_lines(
                         &index_buffers[i],
                         &render_queue,
                         range.clone(),
-                        sampling_step,
+                        step,
                     )
                 });
                 let count = counts.into_iter().min().unwrap_or_default();

--- a/libs/hamann-chen-line/Cargo.toml
+++ b/libs/hamann-chen-line/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "hamann-chen-line"
+description = "Hamann–Chen (1994) curvature-based polyline simplification"
+license = "MIT OR Apache-2.0"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[lib]
+name = "hamann_chen_line"
+
+[[bin]]
+name = "hamann-chen-line"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1"
+glam = { version = "0.30", default-features = false, features = ["std"] }
+clap = { version = "4.4.18", features = ["derive"] }

--- a/libs/hamann-chen-line/Cargo.toml
+++ b/libs/hamann-chen-line/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "hamann-chen-line"
 description = "Hamann–Chen (1994) curvature-based polyline simplification"
+readme = "README.md"
 license = "MIT OR Apache-2.0"
 version.workspace = true
 edition.workspace = true

--- a/libs/hamann-chen-line/README.md
+++ b/libs/hamann-chen-line/README.md
@@ -41,6 +41,28 @@ If you need to **diff behaviour** against another port, start from the gist and 
 
 ---
 
+## Archive vs view (integration guidance)
+
+The crate itself is **pure**: you hand it indices-in-arrays, it hands you a sorted subset. It has no state, no I/O, no allocation semantics beyond internal scratch buffers.
+
+Consumers that keep a live-growing time series should resist the temptation to **overwrite their dataset** with the output of each pass. That pattern (repeatedly simplifying an already simplified series) compounds decimation over time: quality is **monotonically degrading** and parameter changes (e.g. a larger `m`) can never recover detail that prior passes threw away.
+
+A better pattern, used by the Elodin editor in [`libs/elodin-editor/src/ui/plot/data.rs`](../elodin-editor/src/ui/plot/data.rs):
+
+- **Archive** — append every accepted raw `(timestamp, value)` to a dedicated append-only buffer (`LineTree::raw_timestamps`, `LineTree::raw_values`). The archive is the source of truth and is never touched by HC.
+- **View** — the rendered subset (chunks on GPU). Rebuilt from the archive each time the HC pass runs, via `LineTree::rebuild_from_time_value_pairs`.
+
+Properties that fall out:
+
+- **Deterministic / idempotent** — running HC twice on the same archive with the same `m` gives identical indices.
+- **Monotone quality** — with a fixed archive, `m_new ≥ m_old` cannot produce a worse view; `m_new < m_old` cannot corrupt the archive.
+- **Reversible tuning** — UI sliders for `m`, keep-recent fraction, sample-tail budget, etc. are free to change at runtime; no data is lost when they move.
+- **Throttle-safe** — re-rendering the view is a pure function of `(archive, settings)`, so skipping passes (e.g. under UI throttling) is never destructive.
+
+The trade-off is memory: the archive stores every sample. For long-running or high-rate telemetry, cap it (time horizon, sample count, or a fallback to destructive decimation past a certain age).
+
+---
+
 ## Algorithm sketch (intuition)
 
 1. **Curvature samples** along the polyline (2D, or 3D via local triangle flattening).

--- a/libs/hamann-chen-line/README.md
+++ b/libs/hamann-chen-line/README.md
@@ -1,0 +1,104 @@
+# `hamann-chen-line`
+
+Rust implementation of **Hamann–Chen (1994)** curvature-based polyline simplification: pick `n` vertices that approximate the shape of a long polyline or time series.
+
+## Library API
+
+Add the path dependency (as in this repo) or publish name TBD.
+
+| Function | Input | Role |
+|----------|--------|------|
+| [`select_polyline2_indices`](src/lib.rs) | `&[Vec2]`, target `n` | Planar polyline |
+| [`select_polyline3_indices`](src/lib.rs) | `&[Vec3]`, target `n` | 3D spatial polyline (per-vertex local frame, same curvature idea) |
+| [`select_time_value_indices`](src/lib.rs) | `t: &[f32]`, `y: &[f32]`, `n` | Graph / telemetry: polyline in the `(t, y)` plane |
+| [`select_trajectory_time_norm_indices`](src/lib.rs) | `t`, positions, `n` | One shared index set from `(t, ‖p‖)` so **X/Y/Z lines stay time-aligned** (not full 3D curvature on each axis separately) |
+
+All return **indices into the original arrays** (sorted, first and last included when possible). Downstream code copies `(t, y)` or `Vec3` by those indices.
+
+## CLI
+
+The package builds a binary with the same name:
+
+```bash
+cargo run -p hamann-chen-line -- --help
+```
+
+Examples (CSV: comma-separated floats, **no header**; `-` = stdin/stdout):
+
+```bash
+# 2D polyline: columns x,y
+cargo run -p hamann-chen-line -- -n 80 --kind polyline2 -i path.csv -o out.csv
+
+# Time series: columns t,y
+cargo run -p hamann-chen-line -- -n 200 --kind time-value -i series.csv -o reduced.csv
+
+# 3D path: columns x,y,z
+cargo run -p hamann-chen-line -- -n 150 --kind polyline3 -i traj.csv -o out.csv
+
+# Trajectory t,x,y,z → indices from (t, ‖p‖)
+cargo run -p hamann-chen-line -- -n 150 --kind trajectory-time-norm -i traj4.csv -o out.csv
+```
+
+`-n` / `--target` is the desired vertex count (≥ 2).
+
+## Use inside Elodin (Editor)
+
+The Editor does **not** call the CLI; it uses the crate from `libs/elodin-editor` and applies simplification to **live `Line` assets** (chunked time series) when buffers grow large.
+
+### Settings
+
+[`CurveCompressSettings`](../elodin-editor/src/ui/plot/data.rs) is a Bevy `Resource` (default initialized in `PlotPlugin`):
+
+- **`enabled`** — master switch.
+- **`compress_after_total_points`** — run simplification once a line’s total point count exceeds this.
+- **`compress_to_points`** — target total points after a pass (Hamann–Chen `n`).
+- **`keep_recent_fraction`** — e.g. `0.2` keeps roughly the **last 20 %** of samples **uncompressed**; Hamann–Chen runs only on the older prefix so the recent window stays full resolution. `0.0` = compress the whole series (still capped by `compress_to_points`).
+
+At runtime you can override the resource, for example:
+
+```rust
+use elodin_editor::ui::plot::CurveCompressSettings;
+
+fn setup(mut q: ResMut<CurveCompressSettings>) {
+    q.compress_after_total_points = 50_000;
+    q.compress_to_points = 5_000;
+    q.keep_recent_fraction = 0.2;
+}
+```
+
+### Pipeline (telemetry → graph)
+
+Roughly:
+
+```mermaid
+flowchart LR
+  subgraph ingest
+    PKT[pkts / table updates]
+  end
+  subgraph plot
+    CG[CollectedGraphData]
+    LH[Line handles]
+    LT[LineTree chunks]
+    HC[Hamann-Chen on LineTree]
+    GPU[GPU index buffers]
+  end
+  PKT --> CG
+  CG --> LH
+  LH --> LT
+  LT -->|optional compress| HC
+  LT --> GPU
+```
+
+1. **Ingest** — graph/table handlers append samples into **`LineTree`** (timestamped `f32` chunks).
+2. **Threshold** — when `total_points > compress_after_total_points`, **`maybe_compress_all_graph_lines`** runs.
+3. **2D graphs** — each axis is a separate `Line`; **`LineTree::compress_time_value_hamann`** calls `select_time_value_indices` (with optional recent tail preserved via `keep_recent_fraction`).
+4. **3D plot (one logical curve)** — three `Line` assets (X, Y, Z) are compressed **jointly**: samples are aligned on the X-axis timestamps; **`select_polyline3_indices`** on `Vec3` built from the three values, then each line is rebuilt with the same index set (same tail behavior).
+
+### Limits (by design today)
+
+- **In-memory series** — simplification rewrites the stored chunks for that line; there is no separate “disk archive vs RAM window” split.
+- **Heuristic 3D joint path** — joint mode uses 3D polyline curvature; the `(t, ‖p‖)` variant exists in this crate for aligned multi-axis series when that model fits better.
+
+## Reference
+
+Implementation notes and citation context: [gist / reference port](https://gist.github.com/shanecelis/2e0ffd790e31507fba04dd56f806667a).

--- a/libs/hamann-chen-line/README.md
+++ b/libs/hamann-chen-line/README.md
@@ -1,29 +1,88 @@
 # `hamann-chen-line`
 
-Rust implementation of **Hamann–Chen (1994)** curvature-based polyline simplification: pick `n` vertices that approximate the shape of a long polyline or time series.
+**Hamann–Chen (1994)**-style **curvature-based polyline simplification** in Rust: given a long polyline (or a time series viewed as a polyline in \((t,y)\)), pick about **`m` vertices** so the reduced polyline keeps the visually important bends.
 
-## Library API
+This crate is intentionally **small and deterministic**: it returns **indices into your original arrays**; you copy `(x,y)`, `(t,y)`, or `(x,y,z)` yourself. No allocations of full geometry beyond internal working buffers.
 
-Add the path dependency (as in this repo) or publish name TBD.
+---
 
-| Function | Input | Role |
-|----------|--------|------|
-| [`select_polyline2_indices`](src/lib.rs) | `&[Vec2]`, target `n` | Planar polyline |
-| [`select_polyline3_indices`](src/lib.rs) | `&[Vec3]`, target `n` | 3D spatial polyline (per-vertex local frame, same curvature idea) |
-| [`select_time_value_indices`](src/lib.rs) | `t: &[f32]`, `y: &[f32]`, `n` | Graph / telemetry: polyline in the `(t, y)` plane |
-| [`select_trajectory_time_norm_indices`](src/lib.rs) | `t`, positions, `n` | One shared index set from `(t, ‖p‖)` so **X/Y/Z lines stay time-aligned** (not full 3D curvature on each axis separately) |
+## Provenance and reference implementation
 
-All return **indices into the original arrays** (sorted, first and last included when possible). Downstream code copies `(t, y)` or `Vec3` by those indices.
+The numerical pipeline matches the **curvature sampling → `xbars` / arc-length `ss` / filtered `ki` → cumulative curvature → interval walk → vertex pick** structure from **Hamann–Chen**.
 
-## CLI
+The Rust code is a **direct port** of the algorithm expressed in Shane Celis’s C# file  
+[**`PiecewiseLinearCurveApproximation.cs`**](https://gist.github.com/shanecelis/2e0ffd790e31507fba04dd56f806667a) (gist). That gist is the **authoritative reference** for the discrete steps this crate implements.
 
-The package builds a binary with the same name:
+**Deliberate differences from the C# gist (same math, different numerics):**
+
+- **Inverting cumulative curvature along arc length** — the gist uses Math.NET `LinearSpline` plus `RobustNewtonRaphson`. Here we use **trapezoidal integration** on `s` with respect to `ki`, build a cumulative table, and **linearly interpolate** in `s` at the target cumulative curvature. Same idea, simpler dependencies, stable for `f32`.
+- **3D polylines** — each interior vertex is projected into a **local 2D triangle** \((p_{i-1}, p_i, p_{i+1})\); the same 2D curvature machinery runs on that triangle, then the result is folded back into the 3D index picker (see crate rustdoc on `select_polyline3_indices`).
+
+If you need to **diff behaviour** against another port, start from the gist and the paper’s construction, then compare index sets for identical inputs and `m`.
+
+---
+
+## When to use which entry point
+
+| Situation | Function | What it optimizes |
+|-----------|----------|-------------------|
+| Planar path, columns \((x,y)\) | [`select_polyline2_indices`](src/lib.rs) | Shape in the **\(xy\)** plane. |
+| Telemetry / graph, columns \((t,y)\) | [`select_time_value_indices`](src/lib.rs) | Shape in the **\((t,y)\)** plane (time on one axis). |
+| Spatial path, columns \((x,y,z)\) | [`select_polyline3_indices`](src/lib.rs) | **3D** curvature via a local 2D frame at each vertex (heavier, geometry-faithful). |
+| Many parallel streams **must share one index set** (e.g. X/Y/Z lines with identical timestamps) and you want a **cheap** shared simplification | [`select_trajectory_time_norm_indices`](src/lib.rs) | A **2D** polyline in \((t, \|p\|)\) — keeps axes **time-aligned** but does **not** preserve full 3D turning behaviour. |
+
+**Contract (all functions above):**
+
+- `m` is the **desired** vertex budget (algorithm aims for ≤ `m` indices after dedup).
+- Returned indices are **sorted**, typically include **first and last** original indices when `m ≥ 2` and the series is long enough.
+- Empty or degenerate input returns an empty vector or a short prefix of indices (see tests).
+
+**Legacy alias:** [`select_point_indices`](src/lib.rs) = `select_polyline2_indices`.
+
+---
+
+## Algorithm sketch (intuition)
+
+1. **Curvature samples** along the polyline (2D, or 3D via local triangle flattening).
+2. **Filter** vertices where curvature is negligible or non-finite (the `xbars` / `ki` idea from the gist).
+3. **Arc-length parameter `s`** along the retained vertices; integrate curvature along `s` (trapezoidal rule here).
+4. **Pick** `m−2` interior targets spaced in **integrated curvature**, map each target back to an original vertex index (interval walk + nearest-point tie-break, as in the gist’s structure).
+5. **Sort, dedup**, force endpoints when possible.
+
+This favours **keeping points where the curve bends**, not uniform resampling in index space.
+
+---
+
+## Using the crate in another Rust project
+
+Path dependency (as in this monorepo):
+
+```toml
+hamann-chen-line = { path = "libs/hamann-chen-line" }
+```
+
+Then:
+
+```rust
+use glam::{Vec2, Vec3};
+use hamann_chen_line::{select_polyline2_indices, select_time_value_indices};
+
+let pts: Vec<Vec2> = /* ... */;
+let idx = select_polyline2_indices(&pts, 500);
+let simplified: Vec<Vec2> = idx.iter().map(|&i| pts[i]).collect();
+```
+
+For time series, `times` and `values` must have the same logical length (the function uses `min(len)`).
+
+---
+
+## CLI (optional)
+
+The package also builds a small binary for **CSV experiments** (comma-separated floats, **no header**; `-` = stdin/stdout):
 
 ```bash
 cargo run -p hamann-chen-line -- --help
 ```
-
-Examples (CSV: comma-separated floats, **no header**; `-` = stdin/stdout):
 
 ```bash
 # 2D polyline: columns x,y
@@ -35,26 +94,30 @@ cargo run -p hamann-chen-line -- -n 200 --kind time-value -i series.csv -o reduc
 # 3D path: columns x,y,z
 cargo run -p hamann-chen-line -- -n 150 --kind polyline3 -i traj.csv -o out.csv
 
-# Trajectory t,x,y,z → indices from (t, ‖p‖)
+# Trajectory t,x,y,z → one index set from (t, ‖p‖)
 cargo run -p hamann-chen-line -- -n 150 --kind trajectory-time-norm -i traj4.csv -o out.csv
 ```
 
 `-n` / `--target` is the desired vertex count (≥ 2).
 
-## Use inside Elodin (Editor)
+---
 
-The Editor does **not** call the CLI; it uses the crate from `libs/elodin-editor` and applies simplification to **live `Line` assets** (chunked time series) when buffers grow large.
+## Elodin Editor integration
 
-### Settings
+The **Editor does not shell out to this CLI**. It links the library from [`libs/elodin-editor`](../elodin-editor/Cargo.toml) and applies simplification to **live `Line` / `LineTree` telemetry** when series grow large, so graphs and `line_3d` trails stay within **CPU RAM** and **GPU index-buffer** budgets.
 
-[`CurveCompressSettings`](../elodin-editor/src/ui/plot/data.rs) is a Bevy `Resource` (default initialized in `PlotPlugin`):
+### Bevy resource: `CurveCompressSettings`
 
-- **`enabled`** — master switch.
-- **`compress_after_total_points`** — run simplification once a line’s total point count exceeds this.
-- **`compress_to_points`** — target total points after a pass (Hamann–Chen `n`).
-- **`keep_recent_fraction`** — e.g. `0.2` keeps roughly the **last 20 %** of samples **uncompressed**; Hamann–Chen runs only on the older prefix so the recent window stays full resolution. `0.0` = compress the whole series (still capped by `compress_to_points`).
+Defined in [`data.rs`](../elodin-editor/src/ui/plot/data.rs), registered in `PlotPlugin`:
 
-At runtime you can override the resource, for example:
+| Field | Role |
+|--------|------|
+| **`enabled`** | Master switch for Hamann–Chen passes on ingested graph data. |
+| **`compress_after_total_points`** | Trigger compression when **total** stored points in a line exceed this. |
+| **`compress_to_points`** | Target budget **`m`** for a simplification pass (per line, or joint 3-line path). |
+| **`keep_recent_fraction`** | Keep a **suffix** of the newest samples uncompressed (e.g. `0.2` ≈ last 20%); Hamann–Chen runs on the leading prefix only. `0.0` compresses the whole series (still capped by `compress_to_points`). |
+
+Override at runtime, for example:
 
 ```rust
 use elodin_editor::ui::plot::CurveCompressSettings;
@@ -66,9 +129,7 @@ fn setup(mut q: ResMut<CurveCompressSettings>) {
 }
 ```
 
-### Pipeline (telemetry → graph)
-
-Roughly:
+### Data flow (telemetry → GPU)
 
 ```mermaid
 flowchart LR
@@ -89,16 +150,26 @@ flowchart LR
   LT --> GPU
 ```
 
-1. **Ingest** — graph/table handlers append samples into **`LineTree`** (timestamped `f32` chunks).
-2. **Threshold** — when `total_points > compress_after_total_points`, **`maybe_compress_all_graph_lines`** runs.
-3. **2D graphs** — each axis is a separate `Line`; **`LineTree::compress_time_value_hamann`** calls `select_time_value_indices` (with optional recent tail preserved via `keep_recent_fraction`).
-4. **3D plot (one logical curve)** — three `Line` assets (X, Y, Z) are compressed **jointly**: samples are aligned on the X-axis timestamps; **`select_polyline3_indices`** on `Vec3` built from the three values, then each line is rebuilt with the same index set (same tail behavior).
+1. **Ingest** — handlers append samples into **`LineTree`** (timestamped `f32` chunks).
+2. **Threshold** — after each relevant packet, **`maybe_compress_all_graph_lines`** runs if `enabled` and counts exceed **`compress_after_total_points`**.
+3. **2D graphs** — each scalar channel is its own `Line`; **`compress_time_value_hamann`** calls **`select_time_value_indices`** (optional **`keep_recent_fraction`** split).
+4. **`line_3d`** — three `Line` assets (X, Y, Z). If timestamps **match** across all three, **`try_joint_triline_compress`** builds a **`Vec3`** path and calls **`select_polyline3_indices`**, then **rebuilds all three lines with the same index set** so the 3D trail does not shear apart.
 
-### Limits (by design today)
+### Editor-only rendering limits (separate from this crate)
 
-- **In-memory series** — simplification rewrites the stored chunks for that line; there is no separate “disk archive vs RAM window” split.
-- **Heuristic 3D joint path** — joint mode uses 3D polyline curvature; the `(t, ‖p‖)` variant exists in this crate for aligned multi-axis series when that model fits better.
+Even after in-memory compression, **GPU line strips** use a fixed **`INDEX_BUFFER_LEN`**. The 3D renderer may **increase the index sampling step in lockstep on X/Y/Z** so the strip fits the buffer without clipping the **tail** of the trail. That logic lives in `elodin-editor` (`plot_3d`), not in `hamann-chen-line`.
 
-## Reference
+---
 
-Implementation notes and citation context: [gist / reference port](https://gist.github.com/shanecelis/2e0ffd790e31507fba04dd56f806667a).
+## Design limits (today)
+
+- **In-memory only** — simplification **rewrites** stored chunks for that line; there is no separate on-disk archive vs RAM window.
+- **Joint `line_3d` mode** is a **3D polyline** heuristic; for some multi-axis data, [`select_trajectory_time_norm_indices`](src/lib.rs) (2D on \((t,\|p\|)\)) may be a better conceptual fit — it is exposed from this crate for experiments and optional future wiring.
+- **Not a Douglas–Peucker implementation** — different error metric and different vertex picks; do not expect identical results to RDP.
+
+---
+
+## Further reading
+
+- **Reference port (C#):** [Shane Celis — `PiecewiseLinearCurveApproximation.cs` gist](https://gist.github.com/shanecelis/2e0ffd790e31507fba04dd56f806667a)  
+- **Paper:** Hamann & Chen (1994), *curvature-based vertex sampling* (cite the original publication in academic work).

--- a/libs/hamann-chen-line/README.md
+++ b/libs/hamann-chen-line/README.md
@@ -117,6 +117,19 @@ Defined in [`data.rs`](../elodin-editor/src/ui/plot/data.rs), registered in `Plo
 | **`compress_to_points`** | Target budget **`m`** for a simplification pass (per line, or joint 3-line path). |
 | **`keep_recent_fraction`** | Keep a **suffix** of the newest samples uncompressed (e.g. `0.2` ≈ last 20%); Hamann–Chen runs on the leading prefix only. `0.0` compresses the whole series (still capped by `compress_to_points`). |
 
+**Defaults** (`impl Default` in `data.rs`, tied to `CHUNK_COUNT` × `CHUNK_LEN`):
+
+Let `cap = CHUNK_COUNT * CHUNK_LEN` (currently **1024 × 3072 = 3145728** — max points budget for one `LineTree`).
+
+| Field | Default |
+|--------|---------|
+| **`enabled`** | `true` |
+| **`compress_after_total_points`** | `cap * 3 / 4` → **2359296** |
+| **`compress_to_points`** | `cap / 2` → **1572864** |
+| **`keep_recent_fraction`** | **0.0** |
+
+If `CHUNK_COUNT` / `CHUNK_LEN` change, these numbers change with them; the formulas above stay the source of truth.
+
 Override at runtime, for example:
 
 ```rust

--- a/libs/hamann-chen-line/examples/Makefile
+++ b/libs/hamann-chen-line/examples/Makefile
@@ -1,0 +1,11 @@
+all: sine_hamann_grid.png
+
+.PHONY: sine_hamann_grid.png
+
+sine_hamann_grid.png:
+	cargo run --example sine_csv
+	gnuplot sine_hamann_plot.gnu
+
+clean:
+	$(RM) sine_hamann_grid.png
+	$(RM) -r sine_plot_out

--- a/libs/hamann-chen-line/examples/sine_csv.rs
+++ b/libs/hamann-chen-line/examples/sine_csv.rs
@@ -1,0 +1,51 @@
+//! Generate `sin(x)` on `[0, π]` (100 samples), write CSVs, and Hamann–Chen downsample to 49 / 24 / 9 vertices.
+//!
+//! Output directory: `examples/sine_plot_out/` (under this crate). Then run gnuplot from the crate root:
+//! `gnuplot examples/sine_hamann_plot.gnu`
+
+use std::fs;
+use std::path::PathBuf;
+
+use hamann_chen_line::select_time_value_indices;
+
+const N: usize = 100;
+
+fn main() -> anyhow::Result<()> {
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR")?);
+    let out_dir = manifest_dir.join("examples/sine_plot_out");
+    fs::create_dir_all(&out_dir)?;
+
+    let mut t = Vec::with_capacity(N);
+    let mut y = Vec::with_capacity(N);
+    for i in 0..N {
+        let x = (i as f32) * 2.0 * std::f32::consts::PI / ((N - 1) as f32);
+        t.push(x);
+        y.push(x.sin());
+    }
+
+    write_csv(&out_dir.join("sine_full.csv"), &t, &y)?;
+
+    for (m, name) in [
+        (49, "sine_m49.csv"),
+        (24, "sine_m24.csv"),
+        (9, "sine_m9.csv"),
+    ] {
+        let idx = select_time_value_indices(&t, &y, m);
+        let (tt, yy): (Vec<f32>, Vec<f32>) = idx.iter().map(|&i| (t[i], y[i])).unzip();
+        write_csv(&out_dir.join(name), &tt, &yy)?;
+        eprintln!("m={m}: {} vertices written to {name}", tt.len());
+    }
+
+    eprintln!("Wrote CSVs under {}", out_dir.display());
+    Ok(())
+}
+
+fn write_csv(path: &std::path::Path, t: &[f32], y: &[f32]) -> anyhow::Result<()> {
+    debug_assert_eq!(t.len(), y.len());
+    let mut s = String::new();
+    for i in 0..t.len() {
+        s.push_str(&format!("{},{}\n", t[i], y[i]));
+    }
+    fs::write(path, s)?;
+    Ok(())
+}

--- a/libs/hamann-chen-line/examples/sine_hamann_plot.gnu
+++ b/libs/hamann-chen-line/examples/sine_hamann_plot.gnu
@@ -1,0 +1,40 @@
+# Hamann–Chen sine demo: 2×2 grid (full curve + three vertex budgets).
+#
+# From this crate root (libs/hamann-chen-line), after:
+#   cargo run --example sine_csv
+# run:
+#   gnuplot examples/sine_hamann_plot.gnu
+#
+# Writes examples/sine_plot_out/sine_hamann_grid.png (needs pngcairo).
+
+set terminal pngcairo size 900, 900 enhanced font "Helvetica,11"
+set output "sine_hamann_grid.png"
+set datafile separator comma
+
+data = "sine_plot_out"
+
+set xrange [0:2*pi + 0.01]
+set yrange [-1.2:1.2]
+set samples 300
+ref(x) = sin(x)
+
+set multiplot layout 2, 2 title "sin(x) on [0, {/Symbol p}]: Hamann–Chen curvature-based subsampling" font ",13"
+
+set title "Reference: 100 samples (dense polyline)" font ",11"
+plot ref(x) with lines lc rgb "#888888" dt 2 title "sin(x)", \
+     data."/sine_full.csv" using 1:2 with linespoints lw 2 pt 7 ps 0.6 lc rgb "#0066cc" title "subsample"
+
+set title "Hamann–Chen: m = 49 vertices"
+plot ref(x) with lines lc rgb "#888888" dt 2 title "sin(x)", \
+     data."/sine_m49.csv" using 1:2 with linespoints lw 2 pt 7 ps 0.6 lc rgb "#cc4400" title "subsample"
+
+set title "Hamann–Chen: m = 24 vertices"
+plot ref(x) with lines lc rgb "#888888" dt 2 title "sin(x)", \
+     data."/sine_m24.csv" using 1:2 with linespoints lw 2 pt 7 ps 0.7 lc rgb "#228822" title "subsample"
+
+set title "Hamann–Chen: m = 9 vertices"
+plot ref(x) with lines lc rgb "#888888" dt 2 title "sin(x)", \
+     data."/sine_m9.csv" using 1:2 with linespoints lw 2 pt 7 ps 0.9 lc rgb "#880088" title "subsample"
+
+unset multiplot
+unset output

--- a/libs/hamann-chen-line/src/lib.rs
+++ b/libs/hamann-chen-line/src/lib.rs
@@ -1,0 +1,406 @@
+//! Hamann–Chen (1994) curvature-based polyline sampling.
+//!
+//! - **2D** — [`select_polyline2_indices`] for a planar polyline, and [`select_time_value_indices`]
+//!   for `(t, y)` graph data (same algorithm in the `(t,y)` plane).
+//! - **3D** — [`select_polyline3_indices`] for a spatial polyline (local osculating 2D frame per
+//!   vertex, then the same curvature construction as in the reference).
+//!
+//! Reference: <https://gist.github.com/shanecelis/2e0ffd790e31507fba04dd56f806667a>
+
+use glam::{Vec2, Vec3};
+
+fn approx_zero(x: f32) -> bool {
+    x.abs() <= f32::EPSILON * 8.0
+}
+
+fn linear_solve(a: Vec2, b: Vec2, c: Vec2) -> Vec2 {
+    let det = a.x * b.y - a.y * b.x;
+    if !det.is_finite() || det.abs() < 1e-20 {
+        return Vec2::ZERO;
+    }
+    Vec2::new((c.x * b.y - c.y * b.x) / det, (a.x * c.y - a.y * c.x) / det)
+}
+
+/// Hamann–Chen curvature samples for a 2D polyline (same length as `points`).
+fn curvature_samples_polyline2(points: &[Vec2]) -> Vec<f32> {
+    let n = points.len();
+    if n < 3 {
+        return vec![0.0; n];
+    }
+    let mut seq = Vec::with_capacity(n);
+    for i in 1..n - 1 {
+        let d1 = (points[i - 1] - points[i]).normalize_or_zero();
+        let d2 = (points[i + 1] - points[i]).normalize_or_zero();
+        let mut b2 = (d1 + d2).normalize_or_zero();
+        let b1 = if !approx_zero(d1.length())
+            && !approx_zero(d2.length())
+            && !approx_zero(b2.length())
+        {
+            Vec2::new(b2.y, -b2.x)
+        } else {
+            let t = (points[i + 1] - points[i]).normalize_or_zero();
+            b2 = Vec2::new(-t.y, t.x);
+            t
+        };
+        let alpha = d1.dot(b1);
+        let beta = d1.dot(b2);
+        let gamma = d2.dot(b1);
+        let delta = d2.dot(b2);
+        let soln = linear_solve(
+            Vec2::new(alpha, gamma),
+            Vec2::new(alpha * alpha, gamma * gamma),
+            Vec2::new(beta, delta),
+        );
+        let a1 = soln.x;
+        let a2 = soln.y;
+        if i == 1 {
+            let e = a1 + 2.0 * a2 * alpha;
+            let k0 = 2.0 * a2 / (1.0 + e * e).powf(1.5);
+            seq.push(k0);
+        }
+        let ki = 2.0 * a2 / (1.0 + a1 * a1).powf(1.5);
+        seq.push(ki);
+        if i == n - 2 {
+            let e = a1 + 2.0 * a2 * beta;
+            let kn = 2.0 * a2 / (1.0 + e * e).powf(1.5);
+            seq.push(kn);
+        }
+    }
+    debug_assert_eq!(seq.len(), n);
+    seq
+}
+
+/// Map `(p_{i-1}, p_i, p_{i+1})` to 2D coordinates with `p_i` at the origin and `p_{i-1}` on −x.
+fn triangle_to_local_xy(p_im1: Vec3, p_i: Vec3, p_ip1: Vec3) -> [Vec2; 3] {
+    let a3 = p_im1 - p_i;
+    let w = p_ip1 - p_i;
+    let u = a3.normalize_or_zero();
+    let a = a3.length();
+    let x = w.dot(u);
+    let y_sq = (w.length_squared() - x * x).max(0.0);
+    let y = y_sq.sqrt();
+    [Vec2::new(-a, 0.0), Vec2::ZERO, Vec2::new(x, y)]
+}
+
+/// Per-vertex curvature for a 3D polyline (length `n`), via the planar triangle at each interior vertex.
+fn curvature_samples_polyline3(points: &[Vec3]) -> Vec<f32> {
+    let n = points.len();
+    if n < 3 {
+        return vec![0.0; n];
+    }
+    let mut ks = vec![0.0_f32; n];
+    for i in 1..n - 1 {
+        let tri = triangle_to_local_xy(points[i - 1], points[i], points[i + 1]);
+        let k3 = curvature_samples_polyline2(&tri);
+        ks[i] = if k3.len() >= 2 { k3[1] } else { 0.0 };
+        if !ks[i].is_finite() {
+            ks[i] = 0.0;
+        }
+    }
+    ks[0] = ks[1];
+    ks[n - 1] = ks[n - 2];
+    ks
+}
+
+fn cumulative_integral_trapezoid(ss: &[f32], ki: &[f32]) -> Vec<f32> {
+    debug_assert_eq!(ss.len(), ki.len());
+    let mut cum = vec![0.0_f32; ss.len()];
+    for i in 0..ss.len().saturating_sub(1) {
+        let ds = ss[i + 1] - ss[i];
+        let seg = ds * (ki[i] + ki[i + 1]) * 0.5;
+        cum[i + 1] = cum[i] + seg;
+    }
+    cum
+}
+
+fn invert_cum_integral(ss: &[f32], cum: &[f32], target: f32) -> f32 {
+    if ss.is_empty() {
+        return 0.0;
+    }
+    if target <= cum[0] {
+        return ss[0];
+    }
+    let last = cum.len() - 1;
+    if target >= cum[last] {
+        return ss[last];
+    }
+    let j = cum.partition_point(|&v| v < target);
+    let j = j.min(last);
+    let j0 = j.saturating_sub(1);
+    let (c0, c1) = (cum[j0], cum[j]);
+    let (s0, s1) = (ss[j0], ss[j]);
+    if (c1 - c0).abs() < 1e-30 {
+        return s0;
+    }
+    let t = ((target - c0) / (c1 - c0)).clamp(0.0, 1.0);
+    s0 + t * (s1 - s0)
+}
+
+fn nearest_point_index2(points: &[Vec2], q: Vec2) -> usize {
+    points
+        .iter()
+        .enumerate()
+        .min_by(|(_, a), (_, b)| {
+            let da = (*a - q).length_squared();
+            let db = (*b - q).length_squared();
+            da.total_cmp(&db)
+        })
+        .map(|(i, _)| i)
+        .unwrap_or(0)
+}
+
+fn nearest_point_index3(points: &[Vec3], q: Vec3) -> usize {
+    points
+        .iter()
+        .enumerate()
+        .min_by(|(_, a), (_, b)| {
+            let da = (*a - q).length_squared();
+            let db = (*b - q).length_squared();
+            da.total_cmp(&db)
+        })
+        .map(|(i, _)| i)
+        .unwrap_or(0)
+}
+
+fn uniform_indices(n: usize, m: usize) -> Vec<usize> {
+    if m < 2 {
+        return vec![0];
+    }
+    let mut out = Vec::with_capacity(m);
+    for j in 0..m {
+        let idx = ((j as f64) * (n.saturating_sub(1) as f64) / ((m - 1) as f64)).round() as usize;
+        out.push(idx.min(n - 1));
+    }
+    out.sort_unstable();
+    out.dedup();
+    out
+}
+
+fn select_indices_curvature2(points: &[Vec2], ks: &[f32], m: usize) -> Vec<usize> {
+    let n = points.len();
+    debug_assert_eq!(ks.len(), n);
+    if m < 2 || n <= 2 {
+        return (0..n.min(m.max(1))).collect();
+    }
+    if n <= m {
+        return (0..n).collect();
+    }
+
+    let xbars_ks: Vec<(Vec2, f32)> = points
+        .iter()
+        .copied()
+        .zip(ks.iter().copied())
+        .filter(|&(_, k)| !k.is_nan() && !approx_zero(k))
+        .collect();
+
+    if xbars_ks.len() < 2 {
+        return uniform_indices(n, m);
+    }
+
+    let xbars: Vec<Vec2> = xbars_ks.iter().map(|&(p, _)| p).collect();
+    let ki: Vec<f32> = xbars_ks.iter().map(|&(_, k)| k).collect();
+
+    let si: Vec<f32> = xbars.windows(2).map(|w| (w[1] - w[0]).length()).collect();
+    let mut ss = Vec::with_capacity(xbars.len());
+    ss.push(0.0);
+    for seg in &si {
+        ss.push(*ss.last().unwrap_or(&0.0) + seg);
+    }
+
+    if ss.len() != ki.len() {
+        return uniform_indices(n, m);
+    }
+
+    let cum_k = cumulative_integral_trapezoid(&ss, &ki);
+    let k_total = *cum_k.last().unwrap_or(&0.0);
+    if !k_total.is_finite() || k_total.abs() < 1e-30 {
+        return uniform_indices(n, m);
+    }
+
+    let mut picked = Vec::with_capacity(m);
+    picked.push(0);
+
+    for j in 1..m - 1 {
+        let target = (j as f32) * k_total / (m as f32);
+        let s_t = invert_cum_integral(&ss, &cum_k, target);
+        let mut l = 0usize;
+        let mut found = false;
+        while l + 1 < ss.len() {
+            let sl = ss[l];
+            let sl_1 = ss[l + 1];
+            if s_t > sl && s_t < sl_1 {
+                let pick = if (s_t - sl).abs() <= (s_t - sl_1).abs() {
+                    nearest_point_index2(points, xbars[l + 1])
+                } else {
+                    nearest_point_index2(points, xbars[l + 2])
+                };
+                picked.push(pick);
+                found = true;
+                break;
+            }
+            l += 1;
+        }
+        if !found {
+            picked.push(nearest_point_index2(
+                points,
+                xbars[xbars.len().saturating_sub(1)],
+            ));
+        }
+    }
+
+    picked.push(n - 1);
+    picked.sort_unstable();
+    picked.dedup();
+    picked
+}
+
+fn select_indices_curvature3(points: &[Vec3], ks: &[f32], m: usize) -> Vec<usize> {
+    let n = points.len();
+    debug_assert_eq!(ks.len(), n);
+    if m < 2 || n <= 2 {
+        return (0..n.min(m.max(1))).collect();
+    }
+    if n <= m {
+        return (0..n).collect();
+    }
+
+    let xbars_ks: Vec<(Vec3, f32)> = points
+        .iter()
+        .copied()
+        .zip(ks.iter().copied())
+        .filter(|&(_, k)| !k.is_nan() && !approx_zero(k))
+        .collect();
+
+    if xbars_ks.len() < 2 {
+        return uniform_indices(n, m);
+    }
+
+    let xbars: Vec<Vec3> = xbars_ks.iter().map(|&(p, _)| p).collect();
+    let ki: Vec<f32> = xbars_ks.iter().map(|&(_, k)| k).collect();
+
+    let si: Vec<f32> = xbars.windows(2).map(|w| (w[1] - w[0]).length()).collect();
+    let mut ss = Vec::with_capacity(xbars.len());
+    ss.push(0.0);
+    for seg in &si {
+        ss.push(*ss.last().unwrap_or(&0.0) + seg);
+    }
+
+    if ss.len() != ki.len() {
+        return uniform_indices(n, m);
+    }
+
+    let cum_k = cumulative_integral_trapezoid(&ss, &ki);
+    let k_total = *cum_k.last().unwrap_or(&0.0);
+    if !k_total.is_finite() || k_total.abs() < 1e-30 {
+        return uniform_indices(n, m);
+    }
+
+    let mut picked = Vec::with_capacity(m);
+    picked.push(0);
+
+    for j in 1..m - 1 {
+        let target = (j as f32) * k_total / (m as f32);
+        let s_t = invert_cum_integral(&ss, &cum_k, target);
+        let mut l = 0usize;
+        let mut found = false;
+        while l + 1 < ss.len() {
+            let sl = ss[l];
+            let sl_1 = ss[l + 1];
+            if s_t > sl && s_t < sl_1 {
+                let pick = if (s_t - sl).abs() <= (s_t - sl_1).abs() {
+                    nearest_point_index3(points, xbars[l + 1])
+                } else {
+                    nearest_point_index3(points, xbars[l + 2])
+                };
+                picked.push(pick);
+                found = true;
+                break;
+            }
+            l += 1;
+        }
+        if !found {
+            picked.push(nearest_point_index3(
+                points,
+                xbars[xbars.len().saturating_sub(1)],
+            ));
+        }
+    }
+
+    picked.push(n - 1);
+    picked.sort_unstable();
+    picked.dedup();
+    picked
+}
+
+/// **2D planar polyline** — indices into `points` (≤ `m`), always including endpoints.
+#[inline]
+pub fn select_polyline2_indices(points: &[Vec2], m: usize) -> Vec<usize> {
+    let ks = curvature_samples_polyline2(points);
+    select_indices_curvature2(points, &ks, m)
+}
+
+/// **2D graph / time series** — `(t, y)` rows as a polyline in the `(t,y)` plane.
+#[inline]
+pub fn select_time_value_indices(times: &[f32], values: &[f32], m: usize) -> Vec<usize> {
+    let n = times.len().min(values.len());
+    if n == 0 {
+        return Vec::new();
+    }
+    let pts: Vec<Vec2> = (0..n).map(|i| Vec2::new(times[i], values[i])).collect();
+    select_polyline2_indices(&pts, m)
+}
+
+/// **3D spatial polyline** — indices into `points` (≤ `m`), always including endpoints.
+#[inline]
+pub fn select_polyline3_indices(points: &[Vec3], m: usize) -> Vec<usize> {
+    let ks = curvature_samples_polyline3(points);
+    select_indices_curvature3(points, &ks, m)
+}
+
+/// Joint downsampling of `(t, x, y, z)` using one index set from `(t, ‖p‖)` (fast, not full 3D shape).
+pub fn select_trajectory_time_norm_indices(times: &[f32], pos: &[Vec3], m: usize) -> Vec<usize> {
+    let n = times.len().min(pos.len());
+    if n == 0 {
+        return Vec::new();
+    }
+    let pts: Vec<Vec2> = (0..n)
+        .map(|i| Vec2::new(times[i], pos[i].length()))
+        .collect();
+    select_polyline2_indices(&pts, m)
+}
+
+/// Alias for [`select_polyline2_indices`] (legacy name).
+#[inline]
+pub fn select_point_indices(points: &[Vec2], m: usize) -> Vec<usize> {
+    select_polyline2_indices(points, m)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endpoints_preserved_polyline2() {
+        let pts: Vec<Vec2> = (0..100)
+            .map(|i| Vec2::new(i as f32, (i as f32) * 0.01))
+            .collect();
+        let idx = select_polyline2_indices(&pts, 8);
+        assert_eq!(idx.first().copied(), Some(0));
+        assert_eq!(idx.last().copied(), Some(99));
+        assert!(idx.len() <= 8);
+    }
+
+    #[test]
+    fn endpoints_preserved_polyline3() {
+        let pts: Vec<Vec3> = (0..50)
+            .map(|i| {
+                let t = i as f32;
+                Vec3::new(t.cos(), t.sin(), t * 0.05)
+            })
+            .collect();
+        let idx = select_polyline3_indices(&pts, 12);
+        assert_eq!(idx.first().copied(), Some(0));
+        assert_eq!(idx.last().copied(), Some(49));
+        assert!(idx.len() <= 12);
+    }
+}

--- a/libs/hamann-chen-line/src/lib.rs
+++ b/libs/hamann-chen-line/src/lib.rs
@@ -1,11 +1,15 @@
 //! Hamann–Chen (1994) curvature-based polyline sampling.
 //!
+//! Implementation is a direct port of the algorithm in Shane Celis’s C#
+//! [`PiecewiseLinearCurveApproximation.cs`](https://gist.github.com/shanecelis/2e0ffd790e31507fba04dd56f806667a)
+//! (curvature samples, `xbars` / `ss` / `ki` filtering, interval walk, endpoints). Inverting
+//! cumulative curvature along arc length uses trapezoidal integration on `s` and linear
+//! interpolation instead of Math.NET `LinearSpline` + `RobustNewtonRaphson` from that gist.
+//!
 //! - **2D** — [`select_polyline2_indices`] for a planar polyline, and [`select_time_value_indices`]
 //!   for `(t, y)` graph data (same algorithm in the `(t,y)` plane).
 //! - **3D** — [`select_polyline3_indices`] for a spatial polyline (local osculating 2D frame per
-//!   vertex, then the same curvature construction as in the reference).
-//!
-//! Reference: <https://gist.github.com/shanecelis/2e0ffd790e31507fba04dd56f806667a>
+//!   vertex, then the same 2D curvature construction as above on each triangle).
 
 use glam::{Vec2, Vec3};
 

--- a/libs/hamann-chen-line/src/lib.rs
+++ b/libs/hamann-chen-line/src/lib.rs
@@ -34,6 +34,7 @@
 //! `Cargo.toml`.
 
 use glam::{Vec2, Vec3};
+use std::ops::Sub;
 
 fn approx_zero(x: f32) -> bool {
     x.abs() <= f32::EPSILON * 8.0
@@ -162,26 +163,17 @@ fn invert_cum_integral(ss: &[f32], cum: &[f32], target: f32) -> f32 {
     s0 + t * (s1 - s0)
 }
 
-fn nearest_point_index2(points: &[Vec2], q: Vec2) -> usize {
+fn nearest_point_index<V>(points: &[V], q: V, dot: fn(V,V) -> f32) -> usize
+where
+    V: Copy + Sub<Output = V>,
+{
     points
         .iter()
         .enumerate()
         .min_by(|(_, a), (_, b)| {
-            let da = (*a - q).length_squared();
-            let db = (*b - q).length_squared();
-            da.total_cmp(&db)
-        })
-        .map(|(i, _)| i)
-        .unwrap_or(0)
-}
-
-fn nearest_point_index3(points: &[Vec3], q: Vec3) -> usize {
-    points
-        .iter()
-        .enumerate()
-        .min_by(|(_, a), (_, b)| {
-            let da = (*a - q).length_squared();
-            let db = (*b - q).length_squared();
+            // Compute distance squared.
+            let da = dot(**a - q, **a - q);
+            let db = dot(**b - q, **b - q);
             da.total_cmp(&db)
         })
         .map(|(i, _)| i)
@@ -202,7 +194,10 @@ fn uniform_indices(n: usize, m: usize) -> Vec<usize> {
     out
 }
 
-fn select_indices_curvature2(points: &[Vec2], ks: &[f32], m: usize) -> Vec<usize> {
+fn select_indices_curvature<V>(points: &[V], ks: &[f32], m: usize, dot: fn(V,V) -> f32) -> Vec<usize>
+where
+    V: Copy + Sub<Output = V>,
+{
     let n = points.len();
     debug_assert_eq!(ks.len(), n);
     if m < 2 || n <= 2 {
@@ -212,7 +207,7 @@ fn select_indices_curvature2(points: &[Vec2], ks: &[f32], m: usize) -> Vec<usize
         return (0..n).collect();
     }
 
-    let xbars_ks: Vec<(Vec2, f32)> = points
+    let xbars_ks: Vec<(V, f32)> = points
         .iter()
         .copied()
         .zip(ks.iter().copied())
@@ -223,10 +218,15 @@ fn select_indices_curvature2(points: &[Vec2], ks: &[f32], m: usize) -> Vec<usize
         return uniform_indices(n, m);
     }
 
-    let xbars: Vec<Vec2> = xbars_ks.iter().map(|&(p, _)| p).collect();
+    let xbars: Vec<V> = xbars_ks.iter().map(|&(p, _)| p).collect();
     let ki: Vec<f32> = xbars_ks.iter().map(|&(_, k)| k).collect();
 
-    let si: Vec<f32> = xbars.windows(2).map(|w| (w[1] - w[0]).length()).collect();
+    let si: Vec<f32> = xbars.windows(2).map(|w| {
+        let a = w[1] - w[0];
+        let length_squared = dot(a, a);
+        let length = length_squared.sqrt();
+        length
+    }).collect();
     let mut ss = Vec::with_capacity(xbars.len());
     ss.push(0.0);
     for seg in &si {
@@ -243,7 +243,8 @@ fn select_indices_curvature2(points: &[Vec2], ks: &[f32], m: usize) -> Vec<usize
         return uniform_indices(n, m);
     }
 
-    let mut picked = Vec::with_capacity(m);
+    // The algorithm may pick more than m points because of picking duplicate indices.
+    let mut picked = Vec::with_capacity(2 * m);
     picked.push(0);
 
     for j in 1..m - 1 {
@@ -258,11 +259,12 @@ fn select_indices_curvature2(points: &[Vec2], ks: &[f32], m: usize) -> Vec<usize
                 // `ss` and `xbars` have the same length; the last valid interval has `l == xbars.len() - 2`,
                 // so `l + 2 == xbars.len()` would be out of bounds — clamp to `l + 1` on that edge.
                 let pick = if (s_t - sl).abs() <= (s_t - sl_1).abs() {
-                    nearest_point_index2(points, xbars[l + 1])
+                    // nearest_point_index2(points, xbars[l + 1])
+                    nearest_point_index(points, xbars[l + 1], dot)
                 } else if l + 2 < xbars.len() {
-                    nearest_point_index2(points, xbars[l + 2])
+                    nearest_point_index(points, xbars[l + 2], dot)
                 } else {
-                    nearest_point_index2(points, xbars[l + 1])
+                    nearest_point_index(points, xbars[l + 1], dot)
                 };
                 picked.push(pick);
                 found = true;
@@ -271,9 +273,10 @@ fn select_indices_curvature2(points: &[Vec2], ks: &[f32], m: usize) -> Vec<usize
             l += 1;
         }
         if !found {
-            picked.push(nearest_point_index2(
+            picked.push(nearest_point_index(
                 points,
                 xbars[xbars.len().saturating_sub(1)],
+                dot,
             ));
         }
     }
@@ -281,86 +284,8 @@ fn select_indices_curvature2(points: &[Vec2], ks: &[f32], m: usize) -> Vec<usize
     picked.push(n - 1);
     picked.sort_unstable();
     picked.dedup();
-    picked
-}
-
-fn select_indices_curvature3(points: &[Vec3], ks: &[f32], m: usize) -> Vec<usize> {
-    let n = points.len();
-    debug_assert_eq!(ks.len(), n);
-    if m < 2 || n <= 2 {
-        return (0..n.min(m.max(1))).collect();
-    }
-    if n <= m {
-        return (0..n).collect();
-    }
-
-    let xbars_ks: Vec<(Vec3, f32)> = points
-        .iter()
-        .copied()
-        .zip(ks.iter().copied())
-        .filter(|&(_, k)| !k.is_nan() && !approx_zero(k))
-        .collect();
-
-    if xbars_ks.len() < 2 {
-        return uniform_indices(n, m);
-    }
-
-    let xbars: Vec<Vec3> = xbars_ks.iter().map(|&(p, _)| p).collect();
-    let ki: Vec<f32> = xbars_ks.iter().map(|&(_, k)| k).collect();
-
-    let si: Vec<f32> = xbars.windows(2).map(|w| (w[1] - w[0]).length()).collect();
-    let mut ss = Vec::with_capacity(xbars.len());
-    ss.push(0.0);
-    for seg in &si {
-        ss.push(*ss.last().unwrap_or(&0.0) + seg);
-    }
-
-    if ss.len() != ki.len() {
-        return uniform_indices(n, m);
-    }
-
-    let cum_k = cumulative_integral_trapezoid(&ss, &ki);
-    let k_total = *cum_k.last().unwrap_or(&0.0);
-    if !k_total.is_finite() || k_total.abs() < 1e-30 {
-        return uniform_indices(n, m);
-    }
-
-    let mut picked = Vec::with_capacity(m);
-    picked.push(0);
-
-    for j in 1..m - 1 {
-        let target = (j as f32) * k_total / (m as f32);
-        let s_t = invert_cum_integral(&ss, &cum_k, target);
-        let mut l = 0usize;
-        let mut found = false;
-        while l + 1 < ss.len() {
-            let sl = ss[l];
-            let sl_1 = ss[l + 1];
-            if s_t > sl && s_t < sl_1 {
-                let pick = if (s_t - sl).abs() <= (s_t - sl_1).abs() {
-                    nearest_point_index3(points, xbars[l + 1])
-                } else if l + 2 < xbars.len() {
-                    nearest_point_index3(points, xbars[l + 2])
-                } else {
-                    nearest_point_index3(points, xbars[l + 1])
-                };
-                picked.push(pick);
-                found = true;
-                break;
-            }
-            l += 1;
-        }
-        if !found {
-            picked.push(nearest_point_index3(
-                points,
-                xbars[xbars.len().saturating_sub(1)],
-            ));
-        }
-    }
-
-    picked.push(n - 1);
-    picked.sort_unstable();
-    picked.dedup();
+    //picked.truncate(m - 1);
+    assert!(picked.len() <= m, "Tried to return {} points, which is more than the {} points requested", picked.len(), m);
     picked
 }
 
@@ -374,7 +299,7 @@ fn select_indices_curvature3(points: &[Vec3], ks: &[f32], m: usize) -> Vec<usize
 #[inline]
 pub fn select_polyline2_indices(points: &[Vec2], m: usize) -> Vec<usize> {
     let ks = curvature_samples_polyline2(points);
-    select_indices_curvature2(points, &ks, m)
+    select_indices_curvature(points, &ks, m, Vec2::dot)
 }
 
 /// Same as [`select_polyline2_indices`] on points `(t_i, y_i)` built by zipping `times` and
@@ -402,7 +327,7 @@ pub fn select_time_value_indices(times: &[f32], values: &[f32], m: usize) -> Vec
 #[inline]
 pub fn select_polyline3_indices(points: &[Vec3], m: usize) -> Vec<usize> {
     let ks = curvature_samples_polyline3(points);
-    select_indices_curvature3(points, &ks, m)
+    select_indices_curvature(points, &ks, m, Vec3::dot)
 }
 
 /// **Joint** simplification: builds a 2D polyline `(t_i, ‖p_i‖)` and returns indices from

--- a/libs/hamann-chen-line/src/lib.rs
+++ b/libs/hamann-chen-line/src/lib.rs
@@ -1,15 +1,37 @@
-//! Hamann–Chen (1994) curvature-based polyline sampling.
+//! # Hamann–Chen (1994) curvature-based polyline sampling
 //!
-//! Implementation is a direct port of the algorithm in Shane Celis’s C#
-//! [`PiecewiseLinearCurveApproximation.cs`](https://gist.github.com/shanecelis/2e0ffd790e31507fba04dd56f806667a)
-//! (curvature samples, `xbars` / `ss` / `ki` filtering, interval walk, endpoints). Inverting
-//! cumulative curvature along arc length uses trapezoidal integration on `s` and linear
-//! interpolation instead of Math.NET `LinearSpline` + `RobustNewtonRaphson` from that gist.
+//! This crate reduces a long polyline to about **`m` vertices** by **sampling where curvature
+//! concentrates**, instead of uniform decimation in index space. It is **not** Douglas–Peucker.
 //!
-//! - **2D** — [`select_polyline2_indices`] for a planar polyline, and [`select_time_value_indices`]
-//!   for `(t, y)` graph data (same algorithm in the `(t,y)` plane).
-//! - **3D** — [`select_polyline3_indices`] for a spatial polyline (local osculating 2D frame per
-//!   vertex, then the same 2D curvature construction as above on each triangle).
+//! ## Reference implementation (C#)
+//!
+//! The control flow matches the algorithm laid out in Shane Celis’s C#
+//! [`PiecewiseLinearCurveApproximation.cs`](https://gist.github.com/shanecelis/2e0ffd790e31507fba04dd56f806667a):
+//! curvature along the polyline, filter low-curvature vertices (`xbars` / `ki`), build arc length
+//! `ss`, integrate curvature, walk intervals, pick indices, sort/dedup/endpoints.
+//!
+//! ## Differences from that gist
+//!
+//! - **Inverting cumulative curvature** — the gist uses Math.NET `LinearSpline` and
+//!   `RobustNewtonRaphson`. This port uses **trapezoidal integration** on `s` with respect to
+//!   `ki`, stores cumulative curvature, then **linear interpolation in `s`** at each target
+//!   fraction of total integrated curvature (same idea, no extra numerics crates).
+//! - **3D** — [`select_polyline3_indices`] flattens each vertex neighborhood to a **planar
+//!   triangle** `(p_{i-1}, p_i, p_{i+1})`, runs the **same 2D** curvature pipeline on that
+//!   triangle, and maps picks back to indices in the original 3D vertex list.
+//!
+//! ## Public API (pick one)
+//!
+//! | Use case | Entry point |
+//! |----------|-------------|
+//! | Planar `(x, y)` path | [`select_polyline2_indices`] |
+//! | Telemetry / graph `(t, y)` | [`select_time_value_indices`] |
+//! | Spatial `(x, y, z)` path | [`select_polyline3_indices`] |
+//! | One **shared** index set for aligned `(t, x, y, z)` (cheap, not full 3D shape) | [`select_trajectory_time_norm_indices`] |
+//!
+//! All return **sorted indices** into your slices (you copy data out yourself). Long-form docs,
+//! CLI examples, and Elodin Editor integration live in **`README.md`** next to this crate’s
+//! `Cargo.toml`.
 
 use glam::{Vec2, Vec3};
 
@@ -342,14 +364,25 @@ fn select_indices_curvature3(points: &[Vec3], ks: &[f32], m: usize) -> Vec<usize
     picked
 }
 
-/// **2D planar polyline** — indices into `points` (≤ `m`), always including endpoints.
+/// Simplifies a **planar** polyline (2D positions).
+///
+/// - **`m`** — desired vertex budget (after internal dedup, length is typically ≤ `m`).
+/// - **Endpoints** — when `m ≥ 2` and `points.len() ≥ 2`, the first and last original indices are
+///   kept when the generic picker succeeds.
+/// - **Fallback** — if curvature is everywhere negligible or degenerate, falls back to **uniform**
+///   index spacing (see tests).
 #[inline]
 pub fn select_polyline2_indices(points: &[Vec2], m: usize) -> Vec<usize> {
     let ks = curvature_samples_polyline2(points);
     select_indices_curvature2(points, &ks, m)
 }
 
-/// **2D graph / time series** — `(t, y)` rows as a polyline in the `(t,y)` plane.
+/// Same as [`select_polyline2_indices`] on points `(t_i, y_i)` built by zipping `times` and
+/// `values`.
+///
+/// Only `min(times.len(), values.len())` samples are considered. Empty input returns an empty
+/// vector. Use this for **telemetry graphs** where the visual is the curve in **time–value**
+/// space, not distance along the index axis.
 #[inline]
 pub fn select_time_value_indices(times: &[f32], values: &[f32], m: usize) -> Vec<usize> {
     let n = times.len().min(values.len());
@@ -360,14 +393,25 @@ pub fn select_time_value_indices(times: &[f32], values: &[f32], m: usize) -> Vec
     select_polyline2_indices(&pts, m)
 }
 
-/// **3D spatial polyline** — indices into `points` (≤ `m`), always including endpoints.
+/// Simplifies a **spatial** polyline in 3D using per-vertex **local 2D** curvature
+/// (triangle at each interior vertex), then the same integrated-curvature sampler as 2D.
+///
+/// Prefer this when the **geometry in 3D** matters (e.g. a flight path). For **three synchronized
+/// scalar streams** (X/Y/Z vs time) where you need **one index set** but a lighter model is OK, see
+/// [`select_trajectory_time_norm_indices`].
 #[inline]
 pub fn select_polyline3_indices(points: &[Vec3], m: usize) -> Vec<usize> {
     let ks = curvature_samples_polyline3(points);
     select_indices_curvature3(points, &ks, m)
 }
 
-/// Joint downsampling of `(t, x, y, z)` using one index set from `(t, ‖p‖)` (fast, not full 3D shape).
+/// **Joint** simplification: builds a 2D polyline `(t_i, ‖p_i‖)` and returns indices from
+/// [`select_polyline2_indices`].
+///
+/// Guarantees **one shared index list** for time-aligned `x/y/z` (copy each component by the same
+/// indices). Does **not** use full 3D turning curvature; the reduced series may miss detail that
+/// [`select_polyline3_indices`] would keep. Useful when speed and **axis alignment** matter more
+/// than exact 3D shape fidelity.
 pub fn select_trajectory_time_norm_indices(times: &[f32], pos: &[Vec3], m: usize) -> Vec<usize> {
     let n = times.len().min(pos.len());
     if n == 0 {
@@ -379,7 +423,7 @@ pub fn select_trajectory_time_norm_indices(times: &[f32], pos: &[Vec3], m: usize
     select_polyline2_indices(&pts, m)
 }
 
-/// Alias for [`select_polyline2_indices`] (legacy name).
+/// Alias for [`select_polyline2_indices`] (legacy name; “points” meant `Vec2` vertices).
 #[inline]
 pub fn select_point_indices(points: &[Vec2], m: usize) -> Vec<usize> {
     select_polyline2_indices(points, m)

--- a/libs/hamann-chen-line/src/lib.rs
+++ b/libs/hamann-chen-line/src/lib.rs
@@ -163,7 +163,7 @@ fn invert_cum_integral(ss: &[f32], cum: &[f32], target: f32) -> f32 {
     s0 + t * (s1 - s0)
 }
 
-fn nearest_point_index<V>(points: &[V], q: V, dot: fn(V,V) -> f32) -> usize
+fn nearest_point_index<V>(points: &[V], q: V, dot: fn(V, V) -> f32) -> usize
 where
     V: Copy + Sub<Output = V>,
 {
@@ -194,7 +194,12 @@ fn uniform_indices(n: usize, m: usize) -> Vec<usize> {
     out
 }
 
-fn select_indices_curvature<V>(points: &[V], ks: &[f32], m: usize, dot: fn(V,V) -> f32) -> Vec<usize>
+fn select_indices_curvature<V>(
+    points: &[V],
+    ks: &[f32],
+    m: usize,
+    dot: fn(V, V) -> f32,
+) -> Vec<usize>
 where
     V: Copy + Sub<Output = V>,
 {
@@ -221,12 +226,13 @@ where
     let xbars: Vec<V> = xbars_ks.iter().map(|&(p, _)| p).collect();
     let ki: Vec<f32> = xbars_ks.iter().map(|&(_, k)| k).collect();
 
-    let si: Vec<f32> = xbars.windows(2).map(|w| {
-        let a = w[1] - w[0];
-        let length_squared = dot(a, a);
-        let length = length_squared.sqrt();
-        length
-    }).collect();
+    let si: Vec<f32> = xbars
+        .windows(2)
+        .map(|w| {
+            let a = w[1] - w[0];
+            dot(a, a).sqrt()
+        })
+        .collect();
     let mut ss = Vec::with_capacity(xbars.len());
     ss.push(0.0);
     for seg in &si {
@@ -285,7 +291,12 @@ where
     picked.sort_unstable();
     picked.dedup();
     //picked.truncate(m - 1);
-    assert!(picked.len() <= m, "Tried to return {} points, which is more than the {} points requested", picked.len(), m);
+    assert!(
+        picked.len() <= m,
+        "Tried to return {} points, which is more than the {} points requested",
+        picked.len(),
+        m
+    );
     picked
 }
 

--- a/libs/hamann-chen-line/src/lib.rs
+++ b/libs/hamann-chen-line/src/lib.rs
@@ -233,10 +233,14 @@ fn select_indices_curvature2(points: &[Vec2], ks: &[f32], m: usize) -> Vec<usize
             let sl = ss[l];
             let sl_1 = ss[l + 1];
             if s_t > sl && s_t < sl_1 {
+                // `ss` and `xbars` have the same length; the last valid interval has `l == xbars.len() - 2`,
+                // so `l + 2 == xbars.len()` would be out of bounds — clamp to `l + 1` on that edge.
                 let pick = if (s_t - sl).abs() <= (s_t - sl_1).abs() {
                     nearest_point_index2(points, xbars[l + 1])
-                } else {
+                } else if l + 2 < xbars.len() {
                     nearest_point_index2(points, xbars[l + 2])
+                } else {
+                    nearest_point_index2(points, xbars[l + 1])
                 };
                 picked.push(pick);
                 found = true;
@@ -313,8 +317,10 @@ fn select_indices_curvature3(points: &[Vec3], ks: &[f32], m: usize) -> Vec<usize
             if s_t > sl && s_t < sl_1 {
                 let pick = if (s_t - sl).abs() <= (s_t - sl_1).abs() {
                     nearest_point_index3(points, xbars[l + 1])
-                } else {
+                } else if l + 2 < xbars.len() {
                     nearest_point_index3(points, xbars[l + 2])
+                } else {
+                    nearest_point_index3(points, xbars[l + 1])
                 };
                 picked.push(pick);
                 found = true;
@@ -406,5 +412,32 @@ mod tests {
         assert_eq!(idx.first().copied(), Some(0));
         assert_eq!(idx.last().copied(), Some(49));
         assert!(idx.len() <= 12);
+    }
+
+    #[test]
+    fn downsample_indices_stay_in_bounds() {
+        let pts2: Vec<Vec2> = (0..40)
+            .map(|i| {
+                let t = i as f32;
+                Vec2::new(t, t.sin() * 10.0)
+            })
+            .collect();
+        for m in 3..=18 {
+            let idx = select_polyline2_indices(&pts2, m);
+            assert!(idx.len() >= 2);
+            assert!(idx.iter().all(|&i| i < pts2.len()));
+        }
+
+        let pts3: Vec<Vec3> = (0..35)
+            .map(|i| {
+                let t = i as f32;
+                Vec3::new(t.cos() * 2.0, t.sin() * 2.0, t * 0.1)
+            })
+            .collect();
+        for m in 3..=16 {
+            let idx = select_polyline3_indices(&pts3, m);
+            assert!(idx.len() >= 2);
+            assert!(idx.iter().all(|&i| i < pts3.len()));
+        }
     }
 }

--- a/libs/hamann-chen-line/src/main.rs
+++ b/libs/hamann-chen-line/src/main.rs
@@ -1,0 +1,157 @@
+//! CLI to exercise Hamann–Chen simplification on CSV data.
+
+use std::io::{self, BufRead, Write};
+
+use clap::{Parser, ValueEnum};
+use glam::{Vec2, Vec3};
+use hamann_chen_line::{
+    select_polyline2_indices, select_polyline3_indices, select_time_value_indices,
+    select_trajectory_time_norm_indices,
+};
+
+#[derive(Copy, Clone, Debug, ValueEnum)]
+#[clap(rename_all = "kebab-case")]
+enum Kind {
+    /// Columns: `x,y` — planar 2D polyline
+    Polyline2,
+    /// Columns: `x,y,z` — 3D spatial polyline
+    Polyline3,
+    /// Columns: `t,y` — time series (polyline in the `(t,y)` plane)
+    TimeValue,
+    /// Columns: `t,x,y,z` — one index set from `(t, ‖p‖)` (aligned axes, not full 3D curvature)
+    TrajectoryTimeNorm,
+}
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "hamann-chen-line",
+    about = "Hamann–Chen polyline simplification (CSV in/out)"
+)]
+struct Args {
+    /// How many vertices to keep (≥ 2)
+    #[arg(short = 'n', long, default_value_t = 100)]
+    target: usize,
+
+    /// Row format (comma-separated floats, no header)
+    #[arg(long, value_enum, default_value = "polyline2")]
+    kind: Kind,
+
+    /// Input file (`-` = stdin)
+    #[arg(short, long, default_value = "-")]
+    input: String,
+
+    /// Output file (`-` = stdout)
+    #[arg(short, long, default_value = "-")]
+    output: String,
+}
+
+fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    if args.target < 2 {
+        anyhow::bail!("target must be at least 2");
+    }
+
+    let rows = read_csv_rows(&args.input)?;
+    if rows.is_empty() {
+        anyhow::bail!("no data rows");
+    }
+
+    let idx = match args.kind {
+        Kind::Polyline2 => {
+            let pts: Vec<Vec2> = rows
+                .iter()
+                .filter_map(|r| {
+                    if r.len() >= 2 {
+                        Some(Vec2::new(r[0], r[1]))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            if pts.len() < 2 {
+                anyhow::bail!("need at least two valid x,y rows");
+            }
+            select_polyline2_indices(&pts, args.target)
+        }
+        Kind::Polyline3 => {
+            let pts: Vec<Vec3> = rows
+                .iter()
+                .filter_map(|r| {
+                    if r.len() >= 3 {
+                        Some(Vec3::new(r[0], r[1], r[2]))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            if pts.len() < 2 {
+                anyhow::bail!("need at least two valid x,y,z rows");
+            }
+            select_polyline3_indices(&pts, args.target)
+        }
+        Kind::TimeValue => {
+            if rows.iter().any(|r| r.len() < 2) {
+                anyhow::bail!("time-value rows need at least two columns: t,y");
+            }
+            let t: Vec<f32> = rows.iter().map(|r| r[0]).collect();
+            let y: Vec<f32> = rows.iter().map(|r| r[1]).collect();
+            select_time_value_indices(&t, &y, args.target)
+        }
+        Kind::TrajectoryTimeNorm => {
+            if rows.iter().any(|r| r.len() < 4) {
+                anyhow::bail!("trajectory rows need four columns: t,x,y,z");
+            }
+            let t: Vec<f32> = rows.iter().map(|r| r[0]).collect();
+            let p: Vec<Vec3> = rows.iter().map(|r| Vec3::new(r[1], r[2], r[3])).collect();
+            select_trajectory_time_norm_indices(&t, &p, args.target)
+        }
+    };
+
+    let out_rows: Vec<Vec<f32>> = idx.iter().map(|&i| rows[i].clone()).collect();
+    write_csv_rows(&args.output, &out_rows)?;
+    Ok(())
+}
+
+fn read_csv_rows(path: &str) -> anyhow::Result<Vec<Vec<f32>>> {
+    let reader: Box<dyn BufRead> = if path == "-" {
+        Box::new(io::BufReader::new(io::stdin()))
+    } else {
+        Box::new(io::BufReader::new(
+            std::fs::File::open(path).map_err(|e| anyhow::anyhow!("open {path}: {e}"))?,
+        ))
+    };
+
+    let mut out = Vec::new();
+    for line in reader.lines() {
+        let line = line?;
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let row: Vec<f32> = line
+            .split(',')
+            .map(|s| s.trim().parse::<f32>())
+            .collect::<Result<_, _>>()
+            .map_err(|e| anyhow::anyhow!("parse float in {line:?}: {e}"))?;
+        out.push(row);
+    }
+    Ok(out)
+}
+
+fn write_csv_rows(path: &str, rows: &[Vec<f32>]) -> anyhow::Result<()> {
+    let mut w: Box<dyn Write> = if path == "-" {
+        Box::new(io::stdout())
+    } else {
+        Box::new(std::fs::File::create(path).map_err(|e| anyhow::anyhow!("create {path}: {e}"))?)
+    };
+    for row in rows {
+        for (i, v) in row.iter().enumerate() {
+            if i > 0 {
+                write!(w, ",")?;
+            }
+            write!(w, "{v}")?;
+        }
+        writeln!(w)?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Adds **`hamann-chen-line`**, a small Rust crate implementing **Hamann–Chen (1994)**-style polyline / time-series simplification (returns **indices** into the original data). The Elodin **Editor** uses it to **downsample very long live telemetry** so graphs and 3D trails stay within memory and GPU limits.

Also hardens **GPU index strip** generation (bounds-safe writes, better sampling when there are many chunks, and coordinated step scaling for **3D lines** so trails are not clipped before the latest sample).

---

## How `line_3d` uses the crate

A `line_3d` in the schematic is three **`Line`** assets (X, Y, Z) fed from the same component with **aligned timestamps**.

When a plotted component has **exactly three** lines and timestamps **match across all three**:

1. Build a 3D polyline \((x_i, y_i, z_i)\).
2. Call **`select_polyline3_indices`** from `hamann-chen-line`.
3. **Rebuild** all three `LineTree`s with the **same** timestamp array and **same** index set so the trail stays a coherent 3D curve.

If joint mode does not apply, each line is simplified alone using the 2D path below.

---

## How this affects **graphs** (2D)

Each scalar channel is one **`Line`** (time vs value). Simplification uses **`select_time_value_indices`**: same idea as a polyline, in the \((t, y)\) plane.

Optionally, **`keep_recent_fraction`** leaves the **newest** portion of the series uncompressed so recent detail stays sharp while older data is thinned.

---

## Controls and internal limits

### Tunable (Bevy `Resource`)

**`CurveCompressSettings`** (default from `PlotPlugin`, overridable at runtime):

| Field | Role |
|--------|------|
| **`enabled`** | Master switch for compression. |
| **`compress_after_total_points`** | Run only when total stored points exceed this. |
| **`compress_to_points`** | Target point count after a pass (the `n` passed into Hamann–Chen). |
| **`keep_recent_fraction`** | Fraction of the **tail** (by time) kept at full resolution; `0.0` = compress the whole series (still capped by `compress_to_points`). |

Compression is triggered from **`maybe_compress_all_graph_lines`** after graph/table packets update `Line` data (shared path for 2D graphs and the lines backing `line_3d`).

### Fixed / internal (not user-facing)

- **`CHUNK_COUNT`**, **`CHUNK_LEN`** — used to derive default thresholds in `CurveCompressSettings::default()` (capacity-style defaults for when to compress / target size).
- **`INDEX_BUFFER_LEN`** — max `u32`s per GPU index buffer for line strips. For **3D** extraction, if the strip would not fit, the renderer **doubles the sampling step in lockstep on X, Y, Z** (up to a bounded number of iterations) so indices fit and the trail still reaches the current end of the data.
- **`index_sampling_step`** uses an internal **`PER_CHUNK_OVERHEAD`** constant when estimating stride so very large chunk counts do not fall back to an unsafe step of `1`.

---

## Crate layout

- **`libs/hamann-chen-line/`** — algorithm + optional CLI.