### PR TITLE
chore(aleph): clean-up aleph top level flake, deploy script

### DIFF
--- a/.cursor/skills/elodin-aleph/SKILL.md
+++ b/.cursor/skills/elodin-aleph/SKILL.md
@@ -18,7 +18,7 @@ ssh aleph-99a2.local                 # Hostname shown by `hostname` command
 
 # Deploy configuration changes
 ./deploy.sh                          # Default: $USER@fde1:2240:a1ef::1
-./deploy.sh --host aleph-99a2.local  # Custom host
+./deploy.sh root@aleph-99a2.local    # Custom SSH target
 
 # Build SD image for fresh install
 nix build --accept-flake-config .#packages.aarch64-linux.sdimage

--- a/aleph/README.md
+++ b/aleph/README.md
@@ -110,7 +110,16 @@ The deploy script will:
 - Activate the new configuration
 - Create a new bootloader entry
 
-When the default `c-blinky` module is enabled, activation also starts the `c-blinky-flash` one-shot service. That service flashes the packaged STM32 firmware from the deployed closure by driving `BOOT0` on carrier GPIO9, pulsing `NRST` on carrier GPIO11, and running `stm32flash` against `/dev/ttyTHS1` before `serial-bridge` starts. Once the STM32 boots back into the application, `serial-bridge` forwards the MCU log lines into Elodin-DB on the `aleph.stm32.log` message stream. The older custom expansion board reference used an I2C expander for reset; the open-source board uses the direct GPIO11 reset path instead.
+The default system configuration for Aleph flashes `sensor-fw` STM32 firmware and ensures 
+`serial-bridge` starts afterward so expansion-board sensor data can be streamed into Elodin-DB.
+To switch to a more "blink sketch", set `aleph.stm.firmware = "c-blinky"` in your configuration.
+All STM configurations start a `[firmware-name]-flash` one-shot service.
+The service flashes the packaged STM32 firmware from the deployed closure by driving `BOOT0` on 
+carrier GPIO9, pulsing `NRST` on carrier GPIO11, and running `stm32flash` against `/dev/ttyTHS1` 
+before `serial-bridge` starts.
+Once the STM32 boots back into the application, `serial-bridge` forwards the MCU log lines into 
+Elodin-DB on the `aleph.stm32.log` message stream. The older custom expansion board reference 
+used an I2C expander for reset; the open-source board uses the direct GPIO11 reset path instead.
 
 Useful verification commands on Aleph:
 

--- a/aleph/README.md
+++ b/aleph/README.md
@@ -78,15 +78,31 @@ This is the recommended development workflow for iterating on the NixOS configur
 
 2. Modify the NixOS configuration in `flake.nix`, `kernel/`, or `modules/`.
 
-3. Run `./deploy.sh` to deploy with default settings, or specify a custom host/user:
+3. Run `./deploy.sh` to deploy with default settings, or specify a custom `user@host` target:
    ```bash
    # Deploy using default settings ($USER@fde1:2240:a1ef::1)
    ./deploy.sh
-   # Deploy using custom host
-   ./deploy.sh --host aleph-99a2.local
+   # Deploy using a custom SSH target (also accepts a ssh alias if one is set)
+   ./deploy.sh root@aleph-99a2.local
+   # Pass raw SSH options with the -o option, for example a ssh key
+   ./deploy.sh -o "-i $HOME/.ssh/key_file -o StrictHostKeyChecking=no" root@aleph-99a2.local
+   # The deploy script also accepts ssh options via the NIX_SSHOPTS environment variable
+   NIX_SSHOPTS="-i $HOME/.ssh/key_file -o StrictHostKeyChecking=no" ./deploy.sh root@aleph-99a2.local
+   # Flash a custom configuration with the --config option (defaults to `sensor-fw` STM firmware):
+   ./deploy.sh root@aleph-99a2.local -c "base"        # base config; no STM firmware
+   ./deploy.sh root@aleph-99a2.local -c "c-blinky"    # base + c-blinky STM FW
+
    # Show all available options
    ./deploy.sh --help
    ```
+   **Note:** the custom configurations accepted by the deploy script are the variables named in
+   `customConfigurations` and `nixosConfigurations` in `flake.nix`.
+
+   The deploy script is also packaged and can be run as follows:
+   ```
+   nix run .#deploy -- -c "base" aleph-99a2.local
+   ```
+   **Note:** if calling the deploy script this way, you must pass options after the double-hyphen.
 
 The deploy script will:
 - Build the NixOS configuration

--- a/aleph/deploy.sh
+++ b/aleph/deploy.sh
@@ -2,119 +2,94 @@
 #! nix-shell -i bash -p gum nix-output-monitor
 set -eu
 
-# When run via `nix run`, $0 is a /nix/store path and the repo-relative path
-# math breaks. Fall back to "." so the script builds the caller's flake.
-if [[ "$0" == /nix/store/* ]]; then
-  flake_ref="."
-else
-  script_dir="$(cd "$(dirname "$0")" && pwd)"
-  repo_root="$(cd "$script_dir/.." && pwd)"
-  flake_ref="git+file://${repo_root}?dir=aleph"
-fi
-
-default_user="${USER}"
-default_host="fde1:2240:a1ef::1"
+# Default values
+default_target="${USER}@fde1:2240:a1ef::1"
 default_config="default"
-default_identity=""
-no_aleph_builder=false
+aleph_builder=false
 
 log_info() { gum log --level info "$*"; }
 log_warn() { gum log --level warn "$*"; }
-log_error() { gum log --level error "$*"; }
+
+check_system_aarch64_builder() {
+  ([ "$(uname -m)" = "aarch64" ] && [ "$(uname)" = "Linux" ]) ||
+    ([ -f /etc/nix/machines ] && grep -q 'aarch64-linux' /etc/nix/machines)
+}
 
 show_usage() {
-  echo "Usage: $0 [options]"
+  echo "Usage: $0 [options] [user@host]"
   echo
   echo "Options:"
-  echo "  -h, --host HOST       Specify the hostname or IP address (default: $default_host)"
-  echo "  -u, --user USER       Specify the SSH username (default: $default_user)"
-  echo "  -i, --identity PATH   Specify SSH private key path (optional)"
+  echo "  -o SSHOPTS            Set NIX_SSHOPTS to the provided SSH options string"
   echo "  -c, --config CONFIG   Specify the NixOS configuration (default: $default_config)"
-  echo "  --no-aleph-builder    Don't use Aleph as a remote builder (use local machine or"
-  echo "                         configured remote builders instead)"
+  echo "                        Valid values include: \"default\", \"base\", \"c-blinky\", \"sensor-fw\" "
+  echo "  --aleph-builder       Force build on Aleph/Jetson (slow!) "
   echo "  --help                Show this help message"
   echo
-  echo "Example:"
-  echo "  $0 -h fde1:2240:a1ef::1 -u myuser -i ./ssh/aleph-key -c my-custom-config"
-  exit 1
+  echo "Examples:"
+  echo "  $0"
+  echo "  $0 root@aleph-99a2.local"
+  echo "  $0 -o \"-i $HOME/.ssh/key_file -o StrictHostKeyChecking=no\" root@aleph-99a2.local"
+  exit "${1:-1}"
 }
 
 # Parse command line arguments
-user="$default_user"
-host="$default_host"
+deploy_target="$default_target"
 config="$default_config"
-identity="$default_identity"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    -h|--host)
-      host="$2"
-      shift 2
-      ;;
-    -u|--user)
-      user="$2"
-      shift 2
-      ;;
-    -i|--identity)
-      identity="$2"
+    -o)
+      export NIX_SSHOPTS="$2"
       shift 2
       ;;
     -c|--config)
       config="$2"
       shift 2
       ;;
-    --no-aleph-builder)
-      no_aleph_builder=true
+    --aleph-builder)
+      aleph_builder=true
       shift
       ;;
     --help)
-      show_usage
+      show_usage 0
+      ;;
+    -*)
+      log_warn "Unknown option: $1"
+      show_usage 1
       ;;
     *)
-      log_error "Unknown option: $1"
-      show_usage
+      deploy_target="$1"
+      break
       ;;
   esac
 done
 
 # Construct the target path with the selected configuration
-target="${flake_ref}#nixosConfigurations.$config.config.system.build.toplevel"
-store_url="ssh-ng://$user@$host"
-ssh_opts=()
+target=".#nixosConfigurations.$config.config.system.build.toplevel"
+ssh_store="ssh-ng://$deploy_target"
 
-if [ -n "$identity" ]; then
-  if [ ! -f "$identity" ]; then
-    log_error "Identity file not found: $identity"
+log_info "Using target: $deploy_target, configuration: $config"
+if [ "$aleph_builder" = true ]; then
+  build_cmd="nom build --accept-flake-config --eval-store auto --store $ssh_store $target --print-out-paths"
+  log_info "Using Aleph as a remote builder"
+  log_info "Running: $build_cmd"
+  out_path=$(eval "$build_cmd")
+else
+  if ! check_system_aarch64_builder; then
+    log_warn "No aarch64-linux builder found on this machine or in /etc/nix/machines"
+    log_warn "Re-run with --aleph-builder to build on your Jetson (slow)."
     exit 1
   fi
-  ssh_opts=(-i "$identity")
-  store_url="${store_url}?ssh-key=${identity}"
+
+  build_cmd="nom build --accept-flake-config $target --print-out-paths"
+  log_info "Running: $build_cmd"
+  out_path=$(eval "$build_cmd")
+  copy_cmd="nix copy --no-check-sigs --to $ssh_store $out_path"
+  log_info "Running: $copy_cmd"
+  eval "$copy_cmd"
 fi
 
-log_info "Using host: $host, user: $user, configuration: $config"
-if [ "$no_aleph_builder" = true ]; then
-  log_info "Not using Aleph as a remote builder"
-fi
-if [ -n "$identity" ]; then
-  log_info "Using SSH identity: $identity"
-fi
-
-if [ "$no_aleph_builder" = false ] && ! ( ([ "$(uname -m)" = "aarch64" ] && [ "$(uname)" = "Linux" ]) ||
-  ([ -f /etc/nix/machines ] && grep -q 'aarch64-linux' /etc/nix/machines)); then
-  log_warn "No aarch64-linux builder found, falling back to building on Aleph (slow)"
-  build_cmd=(nom build --accept-flake-config --eval-store auto --store "$store_url" "$target" --print-out-paths)
-  log_info "Running: ${build_cmd[*]}"
-  out_path="$("${build_cmd[@]}")"
-else
-  build_cmd=(nom build --accept-flake-config "$target" --print-out-paths)
-  log_info "Running: ${build_cmd[*]}"
-  out_path="$("${build_cmd[@]}")"
-  copy_cmd=(nix copy --no-check-sigs --to "$store_url" "$out_path")
-  log_info "Running: ${copy_cmd[*]}"
-  "${copy_cmd[@]}"
-fi
-
-log_info "Activating $out_path on $user@$host"
-ssh "${ssh_opts[@]}" "$user@$host" "sudo nix-env -p /nix/var/nix/profiles/system --set ${out_path} \
-  && sudo ${out_path}/bin/switch-to-configuration switch;"
+log_info "Activating $out_path on $deploy_target"
+remote_cmd="sudo nix-env -p /nix/var/nix/profiles/system --set ${out_path} && sudo ${out_path}/bin/switch-to-configuration switch;"
+eval "ssh ${NIX_SSHOPTS:-} \"$deploy_target\" \"$remote_cmd\""
 log_info "Deployment completed successfully"

--- a/aleph/flake.lock
+++ b/aleph/flake.lock
@@ -25,24 +25,6 @@
         "type": "github"
       }
     },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "jetpack": {
       "inputs": {
         "cuda-legacy": "cuda-legacy",
@@ -99,7 +81,6 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "jetpack": "jetpack",
         "nixpkgs": "nixpkgs",
         "nixpkgs-unstable": "nixpkgs-unstable",
@@ -123,21 +104,6 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
         "type": "github"
       }
     }

--- a/aleph/flake.nix
+++ b/aleph/flake.nix
@@ -22,11 +22,11 @@
     jetpack,
     rust-overlay,
   }: let
-    
     # Separate Aleph's fixed NixOS target from host-scoped flake outputs
     alephSystem = "aarch64-linux";
     supportedSystems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
-    forAllSystems = f:     # Equivalent to using flake-utils
+    forAllSystems = f:
+    # Equivalent to using flake-utils
       nixpkgs.lib.genAttrs supportedSystems (system: f nixpkgs.legacyPackages.${system});
 
     rustToolchain = p: p.rust-bin.fromRustupToolchainFile ../rust-toolchain.toml;
@@ -63,8 +63,6 @@
       wifi = ./modules/wifi.nix;
     };
     fswModules = {
-      c-blinky = ./modules/c-blinky.nix;
-      sensor-fw = ./modules/sensor-fw.nix;
       elodin-db = ./modules/elodin-db.nix;
       aleph-serial-bridge = ./modules/aleph-serial-bridge.nix;
       tegrastats-bridge = ./modules/tegrastats-bridge.nix;
@@ -73,6 +71,13 @@
       udp-component-broadcast = ./modules/udp-component-broadcast.nix;
       udp-component-receive = ./modules/udp-component-receive.nix;
       elodinsink = ./modules/elodinsink.nix;
+    };
+    stmModules = {
+      sensor-fw = ./modules/sensor-fw.nix;
+      c-blinky = ./modules/c-blinky.nix;
+    };
+    stmConfigurationModules = {
+      stm = ./modules/stm.nix;
     };
     devModules = {
       aleph-cuda = ./modules/aleph-cuda.nix;
@@ -96,6 +101,10 @@
       security.sudo.wheelNeedsPassword = false;
       users.users.root.password = "root";
     };
+
+    # A set of presets that flash different programs onto the expansion board STM
+    configurationPresets = import ./modules/custom-configurations.nix;
+
     installerSystem = module: let
       baseNixosConfig = nixpkgs.lib.nixosSystem {
         system = alephSystem;
@@ -113,6 +122,24 @@
           })
         ];
       };
+    baseConfigurationModules =
+      builtins.attrValues baseModules
+      ++ builtins.attrValues fswModules
+      ++ builtins.attrValues devModules;
+
+    # Create a NixOS system configuration from the shared base modules plus any extra modules.
+    mkConfiguration = extraModules:
+      nixpkgs.lib.nixosSystem {
+        system = alephSystem;
+        modules = baseConfigurationModules ++ extraModules;
+      };
+    customConfigurations = {
+      base = mkConfiguration [];
+      c-blinky = mkConfiguration [configurationPresets.preset-c-blinky];
+      sensor-fw = mkConfiguration [configurationPresets.preset-sensor-fw];
+      m10q = mkConfiguration [configurationPresets.preset-m10q];
+      m9n = mkConfiguration [configurationPresets.preset-m9n];
+    };
   in
     {
       devShells = forAllSystems (pkgs: {
@@ -131,53 +158,20 @@
       });
     }
     // rec {
-      nixosModules = baseModules // fswModules // devModules;
+      nixosModules = baseModules // fswModules // stmModules // stmConfigurationModules // devModules // configurationPresets;
       overlays.default = overlay;
       overlays.jetpack = jetpack.overlays.default;
       overlays.gitRepos = gitReposOverlay;
-      nixosConfigurations = {
-        default = nixpkgs.lib.nixosSystem {
-          system = alephSystem;
-          modules =
-            builtins.attrValues baseModules
-            ++ builtins.attrValues (builtins.removeAttrs fswModules ["c-blinky"])
-            ++ builtins.attrValues devModules;
-        };
-        m10q = nixpkgs.lib.nixosSystem {
-          system = alephSystem;
-          modules =
-            builtins.attrValues baseModules
-            ++ builtins.attrValues (builtins.removeAttrs fswModules ["c-blinky"])
-            ++ builtins.attrValues devModules
-            ++ [
-              ({...}: {
-                services.sensor-fw.gps.model = "m10q";
-              })
-            ];
-        };
-        m9n = nixpkgs.lib.nixosSystem {
-          system = alephSystem;
-          modules =
-            builtins.attrValues baseModules
-            ++ builtins.attrValues (builtins.removeAttrs fswModules ["c-blinky"])
-            ++ builtins.attrValues devModules
-            ++ [
-              ({...}: {
-                services.sensor-fw.gps.model = "m9n";
-              })
-            ];
-        };
-        c-blinky = nixpkgs.lib.nixosSystem {
-          system = alephSystem;
-          modules =
-            builtins.attrValues baseModules
-            ++ builtins.attrValues (builtins.removeAttrs fswModules ["sensor-fw"])
-            ++ builtins.attrValues devModules;
-        };
-        installer = installerSystem ({...}: {
-          imports = builtins.attrValues baseModules;
-        });
-      };
+      nixosConfigurations =
+        {
+          # .#nixosConfigurations.default.config.system.build.toplevel will apply the
+          # sensor-fw sketch onto the expansion board STM by default
+          default = mkConfiguration [configurationPresets.preset-sensor-fw];
+          installer = installerSystem ({...}: {
+            imports = builtins.attrValues baseModules;
+          });
+        }
+        // customConfigurations;
       packages.aarch64-linux = {
         toplevel = nixosConfigurations.default.config.system.build.toplevel;
         sdimage = nixosConfigurations.installer.config.system.build.sdImage;

--- a/aleph/flake.nix
+++ b/aleph/flake.nix
@@ -11,7 +11,6 @@
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
     jetpack.url = "github:anduril/jetpack-nixos/2c98c9d6c326d67ae5f4909db61238d31352e18c";
     rust-overlay.url = "github:oxalica/rust-overlay";
-    flake-utils.url = "github:numtide/flake-utils";
 
     jetpack.inputs.nixpkgs.follows = "nixpkgs";
     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
@@ -20,11 +19,16 @@
     self,
     nixpkgs,
     nixpkgs-unstable,
-    flake-utils,
     jetpack,
     rust-overlay,
   }: let
-    system = "aarch64-linux";
+    
+    # Separate Aleph's fixed NixOS target from host-scoped flake outputs
+    alephSystem = "aarch64-linux";
+    supportedSystems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
+    forAllSystems = f:     # Equivalent to using flake-utils
+      nixpkgs.lib.genAttrs supportedSystems (system: f nixpkgs.legacyPackages.${system});
+
     rustToolchain = p: p.rust-bin.fromRustupToolchainFile ../rust-toolchain.toml;
     gitJSONOverlay = builtins.fromJSON (builtins.readFile ./gitrepos.json);
     gitReposOverlay = final: prev: {
@@ -94,12 +98,12 @@
     };
     installerSystem = module: let
       baseNixosConfig = nixpkgs.lib.nixosSystem {
-        inherit system;
+        system = alephSystem;
         modules = [module];
       };
     in
       nixpkgs.lib.nixosSystem {
-        inherit system;
+        system = alephSystem;
         modules = [
           module
           ({...}: {
@@ -110,24 +114,22 @@
         ];
       };
   in
-    flake-utils.lib.eachDefaultSystem (
-      system: let
-        pkgs = nixpkgs.legacyPackages.${system};
-      in {
-        devShells = {
-          default = pkgs.mkShell {
-            buildInputs = with pkgs; [
-              just
-              zstd
-            ];
-          };
+    {
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            just
+            zstd
+          ];
         };
-        apps.deploy = {
+      });
+      apps = forAllSystems (pkgs: {
+        deploy = {
           type = "app";
           program = "${pkgs.writeScript "deploy" (builtins.readFile ./deploy.sh)}";
         };
-      }
-    )
+      });
+    }
     // rec {
       nixosModules = baseModules // fswModules // devModules;
       overlays.default = overlay;
@@ -135,14 +137,14 @@
       overlays.gitRepos = gitReposOverlay;
       nixosConfigurations = {
         default = nixpkgs.lib.nixosSystem {
-          inherit system;
+          system = alephSystem;
           modules =
             builtins.attrValues baseModules
             ++ builtins.attrValues (builtins.removeAttrs fswModules ["c-blinky"])
             ++ builtins.attrValues devModules;
         };
         m10q = nixpkgs.lib.nixosSystem {
-          inherit system;
+          system = alephSystem;
           modules =
             builtins.attrValues baseModules
             ++ builtins.attrValues (builtins.removeAttrs fswModules ["c-blinky"])
@@ -154,7 +156,7 @@
             ];
         };
         m9n = nixpkgs.lib.nixosSystem {
-          inherit system;
+          system = alephSystem;
           modules =
             builtins.attrValues baseModules
             ++ builtins.attrValues (builtins.removeAttrs fswModules ["c-blinky"])
@@ -166,7 +168,7 @@
             ];
         };
         c-blinky = nixpkgs.lib.nixosSystem {
-          inherit system;
+          system = alephSystem;
           modules =
             builtins.attrValues baseModules
             ++ builtins.attrValues (builtins.removeAttrs fswModules ["sensor-fw"])

--- a/aleph/modules/c-blinky.nix
+++ b/aleph/modules/c-blinky.nix
@@ -16,7 +16,7 @@ in {
   options.services.c-blinky = {
     enable = mkOption {
       type = types.bool;
-      default = true;
+      default = false;
       description = "Whether to deploy and flash c-blinky onto the Aleph STM32H7.";
     };
 

--- a/aleph/modules/custom-configurations.nix
+++ b/aleph/modules/custom-configurations.nix
@@ -1,0 +1,32 @@
+# Sample Aleph configuration presets for STM consumed by `flake.nix` when
+# building named `nixosConfigurations` variants. These are added to base config.
+#
+rec {
+  # Config preset for blinking led (similar to blink sketch)
+  preset-c-blinky = {...}: {
+    imports = [./stm.nix];
+
+    aleph.stm.firmware = "c-blinky";
+  };
+
+  # Config preset for streaming sensor data from expansion board to elodin-db
+  preset-sensor-fw = {...}: {
+    imports = [./stm.nix];
+
+    aleph.stm.firmware = "sensor-fw";
+  };
+
+  # Sensor-FW config preset + u-blox SAM-M10Q support
+  preset-m10q = {...}: {
+    imports = [preset-sensor-fw];
+
+    services.sensor-fw.gps.model = "m10q";
+  };
+
+  # Sensor-FW config preset + u-blox NEO-M9N support
+  preset-m9n = {...}: {
+    imports = [preset-sensor-fw];
+
+    services.sensor-fw.gps.model = "m9n";
+  };
+}

--- a/aleph/modules/sensor-fw.nix
+++ b/aleph/modules/sensor-fw.nix
@@ -16,7 +16,7 @@ in {
   options.services.sensor-fw = {
     enable = mkOption {
       type = types.bool;
-      default = true;
+      default = false;
       description = "Whether to deploy and flash sensor-fw onto the Aleph STM32H7.";
     };
 
@@ -84,13 +84,6 @@ in {
   };
 
   config = mkIf cfg.enable {
-    assertions = optionals (builtins.hasAttr "c-blinky" config.services) [
-      {
-        assertion = !config.services.c-blinky.enable;
-        message = "services.sensor-fw and services.c-blinky are mutually exclusive (both flash the STM32).";
-      }
-    ];
-
     services.sensor-fw.package = mkDefault (pkgs.sensor-fw.override {
       gpsBaudRate =
         if cfg.gps.model == "m9n"

--- a/aleph/modules/stm.nix
+++ b/aleph/modules/stm.nix
@@ -1,0 +1,34 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.aleph.stm;
+in {
+  imports = [
+    ./sensor-fw.nix
+    ./c-blinky.nix
+  ];
+
+  options.aleph.stm.firmware = lib.mkOption {
+    type = lib.types.enum ["sensor-fw" "c-blinky"];
+    default = "sensor-fw";
+    description = ''
+      Selects which STM32 firmware Aleph deploys and flashes by default. Options are:
+      "sensor-fw" which sets up streaming from expansion board IMU sensors into elodin-db.
+      "c-blinky" analagous to arduino blink sketch; blinks an LED on the expansion board.
+    '';
+  };
+
+  config = {
+    assertions = [
+      {
+        assertion = !(config.services.sensor-fw.enable && config.services.c-blinky.enable);
+        message = "services.sensor-fw and services.c-blinky are mutually exclusive (STM32 can only load one program at a time).";
+      }
+    ];
+
+    services.sensor-fw.enable = lib.mkDefault (cfg.firmware == "sensor-fw");
+    services.c-blinky.enable = lib.mkDefault (cfg.firmware == "c-blinky");
+  };
+}

--- a/aleph/template/flake.nix
+++ b/aleph/template/flake.nix
@@ -44,9 +44,8 @@
         aleph-dev # general on-device development tools like git, uv, editors, and Python
         # aleph-cuda # opt-in CUDA, cuDNN, TensorRT, DeepStream, and GPU Python tooling
 
-        # default fsw (pick one: sensor-fw OR c-blinky, they are mutually exclusive)
-        sensor-fw # full sensor firmware: streams IMU/mag/baro/GPS data to elodin-db
-        # c-blinky # deploy-time STM32 bring-up firmware flashed from the Orin during activation
+        # STM firmware selector (defaults to sensor-fw)
+        stm # set aleph.stm.firmware = "c-blinky" below for bring-up firmware
         mekf # a basic attitude mekf that runs on the sensor data from the expansion board
         msp-osd # MSP DisplayPort OSD for FPV goggles, displays attitude from MEKF
 
@@ -88,6 +87,9 @@
       # Uncomment ONE line to enable GPS-disciplined timestamping:
       # services.sensor-fw.gps.model = "m10q";   # SAM-M10Q (9600 baud)
       # services.sensor-fw.gps.model = "m9n";    # NEO-M9N / M9N-5883 (38400 baud)
+
+      # Alternate STM firmware selection (default: "sensor-fw")
+      # aleph.stm.firmware = "c-blinky";
 
       # Enable MSP OSD service (uses MEKF attitude output by default)
       services.msp-osd = {
@@ -187,9 +189,8 @@
     nixosModules.c-blinky = {config, ...}: {
       imports = [
         nixosModules.default
-        aleph.nixosModules.c-blinky
       ];
-      services.sensor-fw.enable = false;
+      aleph.stm.firmware = "c-blinky";
     };
     nixosConfigurations = {
       default = nixpkgs.lib.nixosSystem {


### PR DESCRIPTION
- f428a24dac8562abc9e381e93d25a51720424777 removes `flake-utils` and replaces with an equivalent, small boilerplate function. This is to reduce the flake input footprint, since we are only using that small feature of `flake-utils`.
- cf2a2a29b2494ed834284cfea1f9dec7c072cfd0 simplifies the logic of the deploy script. It now can accept arbitrary `ssh` options. the `--host` and `--user` options have been removed in favor of the `user@host` syntax used by `ssh`
- 9212f2f3566437e3769fc9bb7b51129520bf9e92 aggregates much of the stm firmware selection logic and moves it out of `flake.nix` into `modules/stm.nix` and `modules/custom-configurations.nix`. The existing workflow ergonomics have been preserved; this is a refactor.