### PR TITLE
chore: Add git hash suffix to elodin python version.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
       };
       elodin = rec {
         elodin-py = final.callPackage ./nix/pkgs/elodin-py.nix {
-          inherit rustToolchain;
+          inherit rustToolchain gitRev;
           python = final.python313;
           pythonPackages = final.python313Packages;
         };

--- a/libs/build-common/git_inspect.rs
+++ b/libs/build-common/git_inspect.rs
@@ -17,12 +17,13 @@
 //! }
 //! ```
 
-/// Returns the short git hash and marks whether its a dirty tree.
+/// Returns the short git hash and, if the tree is dirty, appends `.dirty`.
+/// Suffix is PEP 440 / SemVer build-metadata safe (no `*`).
 ///
 /// ```rust, ignore
-/// assert_eq!(hash(), Some("123456"));  // Clean tree
-/// assert_eq!(hash(), Some("123456*")); // Dirty tree
-/// assert_eq!(hash(), None);            // Could not get hash.
+/// assert_eq!(hash(), Some("123456"));       // Clean tree
+/// assert_eq!(hash(), Some("123456.dirty")); // Dirty tree
+/// assert_eq!(hash(), None);                 // Could not get hash.
 /// ```
 pub fn short_hash() -> Option<String> {
     let mut hash = match std::env::var("GIT_HASH") {
@@ -48,7 +49,7 @@ pub fn short_hash() -> Option<String> {
             .status()
         && !status.success()
     {
-        hash.push('*');
+        hash.push_str(".dirty");
     }
     hash
 }

--- a/libs/nox-py/Cargo.toml
+++ b/libs/nox-py/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 edition = "2024"
 readme = "README.md"
 publish = false
+build = "build.rs"
 
 [features]
 publish = ["pyo3/extension-module", "pyo3/abi3-py310"]

--- a/libs/nox-py/build.rs
+++ b/libs/nox-py/build.rs
@@ -1,0 +1,12 @@
+#[path = "../build-common/git_inspect.rs"]
+mod git_inspect;
+fn main() {
+    let hash = git_inspect::short_hash();
+    println!(
+        "cargo:rustc-env=GIT_HASH={}",
+        hash.unwrap_or_else(|| "unknown".to_string())
+    );
+    if let Some(git_head_path) = git_inspect::head_path() {
+        println!("cargo:rerun-if-changed={}", &git_head_path);
+    }
+}

--- a/libs/nox-py/src/lib.rs
+++ b/libs/nox-py/src/lib.rs
@@ -164,7 +164,10 @@ pub fn elodin(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_six_dof, m)?)?;
     m.add_function(wrap_pyfunction!(skew, m)?)?;
     m.add_function(wrap_pyfunction!(_get_cache_dir, m)?)?;
-    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    m.add(
+        "__version__",
+        concat!(env!("CARGO_PKG_VERSION"), "+", env!("GIT_HASH")),
+    )?;
     s10::register(m)?;
     env_logger::init();
     // Safety: called during single-threaded module init before any threads are spawned

--- a/libs/nox-py/src/world_builder.rs
+++ b/libs/nox-py/src/world_builder.rs
@@ -62,7 +62,11 @@ fn install_signal_handlers(cancel_token: CancelToken) {
 }
 
 #[derive(Parser, Debug)]
-#[command(version, about, long_about = None)]
+#[command(
+    version = concat!(env!("CARGO_PKG_VERSION"), "+", env!("GIT_HASH")),
+    about,
+    long_about = None
+)]
 pub enum Args {
     Run {
         #[arg(default_value = "[::]:2240")]

--- a/nix/pkgs/elodin-py.nix
+++ b/nix/pkgs/elodin-py.nix
@@ -2,6 +2,7 @@
   pkgs,
   lib,
   rustToolchain,
+  gitRev ? "unknown",
   python,
   pythonPackages,
   ...
@@ -75,6 +76,8 @@
     OPENSSL_INCLUDE_DIR = "${pkgs.openssl.dev}/include/";
 
     NIX_LDFLAGS = lib.optionalString pkgs.stdenv.isDarwin "-lc++ -headerpad_max_install_names";
+
+    GIT_HASH = gitRev;
 
     doCheck = false;
 


### PR DESCRIPTION
Bring Elodin Python library to parity with rest of Elodin tools in showing version.

```sh
$ python -c "import elodin; print(elodin.__version__)"
0.16.3-alpha.0+c9175f29b*
```