### PR TITLE
Move PyPI publish to end of release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,35 +351,6 @@ jobs:
           name: artifacts-macos-wheel
           path: dist
 
-  pypi-publish:
-    runs-on: "ubuntu-22.04"
-    needs:
-      - plan
-      - linux-wheel
-      - macos-wheel
-    if: ${{ needs.plan.outputs.publishing == 'true' }}
-    steps:
-      - name: Install Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-      - name: Download Linux wheel
-        uses: actions/download-artifact@v4
-        with:
-          name: artifacts-linux-wheel
-          path: dist
-      - name: Download macOS wheel
-        uses: actions/download-artifact@v4
-        with:
-          name: artifacts-macos-wheel
-          path: dist
-      - name: Publish to PyPI
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.UV_PUBLISH_TOKEN }}
-        run: |
-          pip install uv
-          echo "PyPI package for v0.17.0 was already published; skipping."
-
   # Determines if we should publish/announce
   host:
     needs:
@@ -388,10 +359,8 @@ jobs:
       - build-global-artifacts
       - linux-wheel
       - macos-wheel
-      - pypi-publish
     # Only run if we're "publishing", and only if local and global didn't fail (skipped is fine)
-    # Also require PyPI publish to succeed (it will be skipped if not publishing, which is fine)
-    if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') && (needs.pypi-publish.result == 'skipped' || needs.pypi-publish.result == 'success') }}
+    if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: "ubuntu-22.04-xl"
@@ -466,3 +435,33 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+
+  pypi-publish:
+    runs-on: "ubuntu-22.04"
+    needs:
+      - plan
+      - linux-wheel
+      - macos-wheel
+      - announce
+    if: ${{ always() && needs.plan.outputs.publishing == 'true' && needs.announce.result == 'success' }}
+    steps:
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Download Linux wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: artifacts-linux-wheel
+          path: dist
+      - name: Download macOS wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: artifacts-macos-wheel
+          path: dist
+      - name: Publish to PyPI
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.UV_PUBLISH_TOKEN }}
+        run: |
+          pip install uv
+          uv publish dist/*.whl --token "$UV_PUBLISH_TOKEN"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## unreleased
 
 ## v0.17
+### v0.17.1
+- **(fix)** Move PyPI publishing to the end of the release pipeline and keep release artifacts Windows-checkout safe. (#616)
+
 ### v0.17.0
 - **(feat)** So Long, IREE. Hello, Cranelift-MLIR! (#600)
 - **(feat)** Add `elodin-db query` subcommand. (#551)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-serial-bridge"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "blackbox",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-setup"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "fastrand 1.9.0",
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-status"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "db-macros",
@@ -2806,7 +2806,7 @@ dependencies = [
 
 [[package]]
 name = "blackbox"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "zerocopy",
 ]
@@ -3829,7 +3829,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-mlir"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -4754,7 +4754,7 @@ dependencies = [
 
 [[package]]
 name = "db-macros"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "convert_case 0.6.0",
  "darling 0.20.11",
@@ -5057,7 +5057,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elodin"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "base64 0.22.1",
  "bevy",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "elodin-db"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5166,7 +5166,7 @@ dependencies = [
 
 [[package]]
 name = "elodin-db-tests"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "arrow",
  "elodin-db",
@@ -5189,7 +5189,7 @@ dependencies = [
 
 [[package]]
 name = "elodin-editor"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "ab_glyph",
  "arc-swap",
@@ -5271,7 +5271,7 @@ dependencies = [
 
 [[package]]
 name = "elodin-macros"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "convert_case 0.6.0",
  "darling 0.20.11",
@@ -5467,7 +5467,7 @@ checksum = "5c4fbe202b6578d3d56428fa185cdf114a05e49da05f477b3c7f0fbb221f1862"
 
 [[package]]
 name = "eql"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "hifitime",
  "impeller2",
@@ -6584,7 +6584,7 @@ checksum = "36119f3a540b086b4e436bb2b588cf98a68863470e0e880f4d0842f112a3183a"
 
 [[package]]
 name = "gst-elodin-plugin"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "gst-plugin-version-helper",
@@ -6765,7 +6765,7 @@ dependencies = [
 
 [[package]]
 name = "hamann-chen-line"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "clap 4.6.0",
@@ -7340,7 +7340,7 @@ checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
 
 [[package]]
 name = "impeller2"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "bevy",
  "const-fnv1a-hash",
@@ -7362,7 +7362,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-bbq"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "bbq2",
  "impeller2",
@@ -7371,7 +7371,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-bevy"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "bbq2",
  "bevy",
@@ -7395,7 +7395,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-cli"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -7424,7 +7424,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-frame"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "cobs 0.2.3",
  "impeller2",
@@ -7432,7 +7432,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-kdl"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "bevy_geo_frames",
  "impeller2",
@@ -7445,7 +7445,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-stellar"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "bbq2",
  "fastrand 2.3.0",
@@ -7466,7 +7466,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-wkt"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "bevy",
  "bevy_geo_frames",
@@ -7483,7 +7483,7 @@ dependencies = [
 
 [[package]]
 name = "impeller_py"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "futures-lite",
@@ -7594,7 +7594,7 @@ checksum = "d57a1694cff80cdd6c8a4cae63984578e2617528d3c266e53f56dfd3e279e9f7"
 
 [[package]]
 name = "inscriber"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "clap 4.6.0",
@@ -8230,7 +8230,7 @@ dependencies = [
 
 [[package]]
 name = "lqr"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "clap 4.6.0",
@@ -8492,7 +8492,7 @@ dependencies = [
 
 [[package]]
 name = "mekf"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "clap 4.6.0",
@@ -9200,7 +9200,7 @@ dependencies = [
 
 [[package]]
 name = "nox"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "approx",
  "boxcar",
@@ -9228,14 +9228,14 @@ dependencies = [
 
 [[package]]
 name = "nox-array"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "zerocopy",
 ]
 
 [[package]]
 name = "nox-frames"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "approx",
  "hifitime",
@@ -9245,7 +9245,7 @@ dependencies = [
 
 [[package]]
 name = "nox-py"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "approx",
  "arrow",
@@ -10514,7 +10514,7 @@ dependencies = [
 
 [[package]]
 name = "postcard-c-codegen"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "clap 4.6.0",
  "convert_case 0.6.0",
@@ -11260,7 +11260,7 @@ dependencies = [
 
 [[package]]
 name = "rc-jet-controller"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "clap 4.6.0",
@@ -11456,7 +11456,7 @@ dependencies = [
 
 [[package]]
 name = "render-bridge"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "impeller2",
  "socket2 0.5.10",
@@ -11575,7 +11575,7 @@ dependencies = [
 
 [[package]]
 name = "roci"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "bbq2",
@@ -11601,7 +11601,7 @@ dependencies = [
 
 [[package]]
 name = "roci-adcs"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "approx",
  "nox",
@@ -11858,7 +11858,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s10"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "async-watcher",
  "cargo_metadata",
@@ -12516,7 +12516,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stellarator"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "blocking",
  "futures",
@@ -12544,11 +12544,11 @@ dependencies = [
 
 [[package]]
 name = "stellarator-buf"
-version = "0.17.0"
+version = "0.17.1"
 
 [[package]]
 name = "stellarator-macros"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -12956,7 +12956,7 @@ checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tegrastats-bridge"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "db-macros",
@@ -14045,7 +14045,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "video-streamer"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -14064,7 +14064,7 @@ dependencies = [
 
 [[package]]
 name = "video-toolbox"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "bitflags 2.11.0",
  "block2 0.6.2",
@@ -15465,7 +15465,7 @@ dependencies = [
 
 [[package]]
 name = "wmm"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "approx",
  "bindgen 0.70.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ members = [
 exclude = ["fsw/sensor-fw", "fsw/blackbox", "libs/muxide", "docs/memserve"]
 
 [workspace.package]
-version = "0.17.0"
+version = "0.17.1"
 edition = "2024"
 repository = "https://github.com/elodin-sys/elodin"
 

--- a/docs/public/config.toml
+++ b/docs/public/config.toml
@@ -45,7 +45,7 @@ github = "https://github.com/elodin-sys"
 twitter = "https://twitter.com/elodinsystems"
 email = "info@elodin.systems"
 ganalytics = ""
-version = "v0.17.0"
+version = "v0.17.1"
 
 # If running on netlify.app site, set to true
 is_netlify = false

--- a/docs/public/content/releases/changelog.md
+++ b/docs/public/content/releases/changelog.md
@@ -14,7 +14,8 @@ order = 1
 
 
 ## v0.17
-### v0.17.0
+
+### v0.17.1
 - **(feat)** So Long, IREE. Hello, Cranelift-MLIR! (#600)
 - **(feat)** Add `elodin-db query` subcommand. (#551)
 - **(feat)** Support NED and ECEF coordinate frames for positions (orientations still all ENU). (#352)


### PR DESCRIPTION
## Summary
- Move `pypi-publish` after `announce` so PyPI is the final publishing side effect.
- Bump the release version and docs/changelog to v0.17.1.