### PR TITLE
Fix manual docs deployment from GitHub Actions.

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -72,9 +72,9 @@ jobs:
           path: gh-pages
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      # For main branch pushes or manual runs: Build and deploy production
+      # For main branch pushes or manual runs on main: Build and deploy production
       - name: Build production site
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
         run: |
           cd docs/public
           echo "🔨 Building production site..."
@@ -117,7 +117,7 @@ jobs:
 
       # Commit and push changes
       - name: Deploy to GitHub Pages
-        if: github.event.action != 'closed' || (github.event_name == 'pull_request' && github.event.action == 'closed')
+        if: github.event_name == 'pull_request' || ((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main')
         run: |
           cd gh-pages
           
@@ -202,7 +202,7 @@ jobs:
   # Verify deployment (only for production)
   verify:
     needs: build-and-deploy
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Verify deployment

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -72,9 +72,9 @@ jobs:
           path: gh-pages
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      # For main branch: Build and deploy production
+      # For main branch pushes or manual runs: Build and deploy production
       - name: Build production site
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
         run: |
           cd docs/public
           echo "🔨 Building production site..."
@@ -128,7 +128,7 @@ jobs:
           # Commit changes
           git add -A
           
-          if [[ "${{ github.event_name }}" == "push" ]]; then
+          if [[ "${{ github.event_name }}" == "push" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             git commit -m "Deploy documentation from ${{ github.sha }}" || echo "No changes to commit"
           elif [[ "${{ github.event.action }}" == "closed" ]]; then
             git commit -m "Remove preview for PR #${{ github.event.pull_request.number }}" || echo "No changes to commit"
@@ -202,7 +202,7 @@ jobs:
   # Verify deployment (only for production)
   verify:
     needs: build-and-deploy
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Verify deployment

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,7 +29,6 @@ on:
     types: [opened, synchronize, reopened, closed]
     paths:
       - 'docs/public/**'
-      - '.github/workflows/deploy-docs.yml'
   
   # Allow manual trigger from GitHub UI
   workflow_dispatch:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -127,16 +127,20 @@ jobs:
           # Commit changes
           git add -A
           
-          if [[ "${{ github.event_name }}" == "push" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            git commit -m "Deploy documentation from ${{ github.sha }}" || echo "No changes to commit"
-          elif [[ "${{ github.event.action }}" == "closed" ]]; then
-            git commit -m "Remove preview for PR #${{ github.event.pull_request.number }}" || echo "No changes to commit"
-          else
-            git commit -m "Deploy preview for PR #${{ github.event.pull_request.number }}" || echo "No changes to commit"
-          fi
+          case "${{ github.event_name }}:${{ github.event.action }}" in
+            push:*|workflow_dispatch:*)
+              git commit -m "Deploy documentation from ${{ github.sha }}" || echo "No changes to commit"
+              ;;
+            pull_request:closed)
+              git commit -m "Remove preview for PR #${{ github.event.pull_request.number }}" || echo "No changes to commit"
+              ;;
+            pull_request:*)
+              git commit -m "Deploy preview for PR #${{ github.event.pull_request.number }}" || echo "No changes to commit"
+              ;;
+          esac
           
-            git pull --rebase origin gh-pages
-            git push origin gh-pages
+          git pull --rebase origin gh-pages
+          git push origin gh-pages
 
       # Comment on PR with preview link
       - name: Comment PR with preview link
@@ -165,7 +169,7 @@ jobs:
             The preview will be removed when this PR is closed or merged.
             
             ---
-            <sub>Preview deployment started at ${new Date().toUTCString()}</sub>`;
+            <sub>Preview deployment updated at ${new Date().toUTCString()}</sub>`;
             
             if (botComment) {
               await github.rest.issues.updateComment({


### PR DESCRIPTION
## Summary
This started because `v0.17.1` was not showing up on the live docs site at `https://docs.elodin.systems/releases/changelog/`, even though `docs/public/content/releases/changelog.md` on `main` already had the right content.
I tried to rerun **Deploy Documentation** manually from GitHub Actions, but the workflow completed without actually rebuilding and publishing the production docs. The production deploy steps only ran on `push` to `main`, not on `workflow_dispatch`.
This PR fixes that and tightens the deployment rules.
## What changed
- Manual `Deploy Documentation` runs from `main` now rebuild and publish the production docs.
- Manual runs from non-`main` branches do not deploy production.
- Production verification also only runs for `main` production deploys.
- PR preview docs now only run for changes under `docs/public/**`.
- Workflow-only PRs no longer create preview docs sites.
- Existing PR preview cleanup behavior is preserved for docs PRs when they are closed or merged.