### PR TITLE
Feat: Add elodin-py to aleph image

### DIFF
--- a/aleph/flake.lock
+++ b/aleph/flake.lock
@@ -25,6 +25,48 @@
         "type": "github"
       }
     },
+    "elodin": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": [
+          "rust-overlay"
+        ],
+        "systems": "systems"
+      },
+      "locked": {
+        "path": "..",
+        "type": "path"
+      },
+      "original": {
+        "path": "..",
+        "type": "path"
+      },
+      "parent": []
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": [
+          "elodin",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "jetpack": {
       "inputs": {
         "cuda-legacy": "cuda-legacy",
@@ -81,6 +123,7 @@
     },
     "root": {
       "inputs": {
+        "elodin": "elodin",
         "jetpack": "jetpack",
         "nixpkgs": "nixpkgs",
         "nixpkgs-unstable": "nixpkgs-unstable",
@@ -104,6 +147,21 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/aleph/flake.nix
+++ b/aleph/flake.nix
@@ -14,6 +14,13 @@
 
     jetpack.inputs.nixpkgs.follows = "nixpkgs";
     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+    # Monorepo: parent is the Elodin flake root. For an `aleph/`-only tree use
+    # `github:elodin-sys/elodin` (root) instead of path:..
+    elodin = {
+      url = "path:..";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.rust-overlay.follows = "rust-overlay";
+    };
   };
   outputs = {
     self,
@@ -21,6 +28,7 @@
     nixpkgs-unstable,
     jetpack,
     rust-overlay,
+    elodin,
   }: let
     # Separate Aleph's fixed NixOS target from host-scoped flake outputs
     alephSystem = "aarch64-linux";
@@ -43,13 +51,33 @@
           gitJSONOverlay);
       });
     };
+    # JAX pulls jax-cuda12-plugin when cudaSupport is true; that hits NCCL stubs
+    # jetpack marks unavailable on Orin. Elodin-py only needs CPU JAX on Aleph.
+    jetsonJaxCpuOverlay = final: prev:
+      prev.lib.optionalAttrs (prev.stdenv.hostPlatform.system == "aarch64-linux") {
+        python313Packages = prev.python313Packages.override {
+          overrides = self: super: {
+            jax = super.jax.override {cudaSupport = false;};
+          };
+        };
+      };
     overlay = final: prev:
       (prev.lib.packagesFromDirectoryRecursive {
         directory = ./pkgs;
         callPackage = path: args: final.callPackage path (args // {inherit rustToolchain;});
       })
       // (rust-overlay.overlays.default final prev)
-      // (gitReposOverlay final prev);
+      // (gitReposOverlay final prev)
+      // (jetsonJaxCpuOverlay final prev)
+      // (elodin.overlays.default final prev);
+
+    elodinPythonStack = [
+      ./modules/elodin-py.nix
+      ({lib, ...}: {
+        services.elodin-py.enable = lib.mkDefault true;
+        services.elodin-py.editor = false;
+      })
+    ];
 
     baseModules = {
       default = defaultModule;
@@ -125,7 +153,8 @@
     baseConfigurationModules =
       builtins.attrValues baseModules
       ++ builtins.attrValues fswModules
-      ++ builtins.attrValues devModules;
+      ++ builtins.attrValues devModules
+      ++ elodinPythonStack;
 
     # Create a NixOS system configuration from the shared base modules plus any extra modules.
     mkConfiguration = extraModules:
@@ -158,7 +187,14 @@
       });
     }
     // rec {
-      nixosModules = baseModules // fswModules // stmModules // stmConfigurationModules // devModules // configurationPresets;
+      nixosModules =
+        baseModules
+        // fswModules
+        // stmModules
+        // stmConfigurationModules
+        // devModules
+        // configurationPresets
+        // {elodin-py = ./modules/elodin-py.nix;};
       overlays.default = overlay;
       overlays.jetpack = jetpack.overlays.default;
       overlays.gitRepos = gitReposOverlay;

--- a/aleph/modules/elodin-py.nix
+++ b/aleph/modules/elodin-py.nix
@@ -1,0 +1,40 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.services.elodin-py;
+  pythonWithElodin = pkgs.python313.withPackages (_: [pkgs.elodin.elodin-py.py]);
+  elodinPython = pkgs.writeShellScriptBin "elodin-python" ''
+    export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=16384
+    exec ${lib.getExe pythonWithElodin} "$@"
+  '';
+in {
+  options.services.elodin-py = {
+    enable = lib.mkEnableOption ''
+      Elodin Python SDK: Python 3.13 with the `elodin` package (nox-py extension + JAX stack).
+      Installs `python` and `elodin-python` with glibc static-TLS tuning for the extension.
+    '';
+    editor = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Also install the Elodin editor CLI (`elodin` binary, Bevy + GPU stack).
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages =
+      [
+        pythonWithElodin
+        elodinPython
+        (pkgs.writeShellScriptBin "python" ''
+          export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=16384
+          exec ${lib.getExe pythonWithElodin} "$@"
+        '')
+      ]
+      ++ lib.optional cfg.editor pkgs.elodin.elodin-cli;
+  };
+}

--- a/libs/nox-py/python/elodin/__main__.py
+++ b/libs/nox-py/python/elodin/__main__.py
@@ -1,12 +1,2 @@
 """Entry point for ``python -m elodin`` (interactive REPL with ``elodin`` imported)."""
 
-from __future__ import annotations
-
-# import code
-
-import elodin
-
-# code.interact(
-#     banner="Elodin: `elodin` is already imported. Exit with Ctrl-D or exit().",
-#     local={"elodin": elodin},
-# )

--- a/libs/nox-py/python/elodin/__main__.py
+++ b/libs/nox-py/python/elodin/__main__.py
@@ -1,0 +1,12 @@
+"""Entry point for ``python -m elodin`` (interactive REPL with ``elodin`` imported)."""
+
+from __future__ import annotations
+
+# import code
+
+import elodin
+
+# code.interact(
+#     banner="Elodin: `elodin` is already imported. Exit with Ctrl-D or exit().",
+#     local={"elodin": elodin},
+# )

--- a/libs/nox-py/python/elodin/__main__.py
+++ b/libs/nox-py/python/elodin/__main__.py
@@ -1,2 +1,1 @@
 """Entry point for ``python -m elodin`` (interactive REPL with ``elodin`` imported)."""
-

--- a/nix/pkgs/common.nix
+++ b/nix/pkgs/common.nix
@@ -2,7 +2,16 @@
   lib,
   pkgs,
   ...
-}: {
+}: let
+  mesaVulkanIcdFilenamesFor = pkgs: let
+    icdDir = "${pkgs.mesa}/share/vulkan/icd.d";
+    dir = builtins.readDir icdDir;
+    names =
+      lib.filter (n: dir.${n} == "regular" && lib.hasSuffix ".json" n)
+      (lib.attrNames dir);
+  in
+    lib.concatStringsSep ":" (map (n: "${icdDir}/${n}") (lib.sort lib.lessThan names));
+in {
   src = let
     includeSrc = orig_path: type: let
       path = toString orig_path;
@@ -139,7 +148,7 @@
     LIBGL_DRIVERS_PATH = "${pkgs.mesa}/lib/dri";
     __GLX_VENDOR_LIBRARY_NAME = "mesa";
     LIBVA_DRIVERS_PATH = "${pkgs.mesa}/lib/dri";
-    VK_ICD_FILENAMES = "${pkgs.mesa}/share/vulkan/icd.d/radeon_icd.x86_64.json:${pkgs.mesa}/share/vulkan/icd.d/intel_icd.x86_64.json:${pkgs.mesa}/share/vulkan/icd.d/lvp_icd.x86_64.json";
+    VK_ICD_FILENAMES = mesaVulkanIcdFilenamesFor pkgs;
     VK_LAYER_PATH = "${pkgs.vulkan-validation-layers}/share/vulkan/explicit_layer.d";
     ALSA_PLUGIN_DIR = "${pkgs.pipewire}/lib/alsa-lib";
   };
@@ -189,7 +198,7 @@
       --set LIBGL_DRIVERS_PATH "${pkgs.mesa}/lib/dri" \
       --set __GLX_VENDOR_LIBRARY_NAME "mesa" \
       --set LIBVA_DRIVERS_PATH "${pkgs.mesa}/lib/dri" \
-      --prefix VK_ICD_FILENAMES : "${pkgs.mesa}/share/vulkan/icd.d/radeon_icd.x86_64.json:${pkgs.mesa}/share/vulkan/icd.d/intel_icd.x86_64.json:${pkgs.mesa}/share/vulkan/icd.d/lvp_icd.x86_64.json" \
+      --prefix VK_ICD_FILENAMES : "${mesaVulkanIcdFilenamesFor pkgs}" \
       --prefix VK_LAYER_PATH : "${pkgs.vulkan-validation-layers}/share/vulkan/explicit_layer.d" \
       --set ALSA_PLUGIN_DIR "${pkgs.pipewire}/lib/alsa-lib"
     '';


### PR DESCRIPTION
# Problem

Only elodin-db is installed on aleph. We want to be able to run the Elodin Python module to exercise tests on device.

# Solution

Include the Elodin Python module in the aleph image.

To check if it's present, do the following:

```sh
$ python
import elodin
```