### PR TITLE
`object_3d` EQL scalar-vector scale expressions.

### DIFF
--- a/docs/public/content/reference/python-api.md
+++ b/docs/public/content/reference/python-api.md
@@ -986,6 +986,27 @@ object_3d satellite.world_pos {
 ```
 
 The `scale` parameter accepts an EQL expression for dynamic sizing.
+It must evaluate to at least 3 values in meters. The expression can be a literal tuple, a vector component, indexed component values, scalar-vector math, or values from multiple components:
+
+```kdl
+object_3d vehicle.world_pos {
+    ellipsoid scale="2.0 * vehicle.pos_std_var" {
+        color 200 200 0
+    }
+}
+
+object_3d vehicle.world_pos {
+    ellipsoid scale="1.91*(vehicle.pos_std_var[1], vehicle.pos_std_var[0], vehicle.pos_std_var[2])" {
+        color 200 200 0
+    }
+}
+
+object_3d vehicle.world_pos {
+    ellipsoid scale="3.0 * (vehicle.pos_std_var[1], 0.0, target.pos_std_var[2])" {
+        color 200 200 0
+    }
+}
+```
 
 ### GLB Models
 

--- a/docs/public/content/reference/schematic.md
+++ b/docs/public/content/reference/schematic.md
@@ -78,9 +78,17 @@ order = 6
   - `box`: `x`, `y`, `z` (all required); `color` (default white).
   - `cylinder`: `radius`, `height` (both required); `color` (default white).
   - `plane`: `width`/`depth` (default `size` if set, else 10.0); optional `size` shorthand; `color` (default white).
-  - `ellipsoid`: , `color` (default white), `show_grid` (default `#false`).
+  - `ellipsoid`: `color` (default white), `show_grid` (default `#false`).
      - Physical measure
-        -`scale` an EQL string, e.g., `"(1, 1, 1)"` in meters
+        - `scale`: runtime EQL string that must evaluate to at least 3 values in meters. It can be a literal tuple, a vector component, indexed component values, scalar-vector math, or values from multiple components.
+          - Examples:
+            ```kdl
+            ellipsoid scale="(1, 1, 1)"
+            ellipsoid scale="vehicle.pos_std_var"
+            ellipsoid scale="2.0 * vehicle.pos_std_var"
+            ellipsoid scale="1.91*(vehicle.pos_std_var[1], vehicle.pos_std_var[0], vehicle.pos_std_var[2])"
+            ellipsoid scale="3.0 * (vehicle.pos_std_var[1], 0.0, target.pos_std_var[2])"
+            ```
      - Error measure
         - `error_covariance_cholesky` as an alternative to specifying the scale
           and rotation, one can specify the lower triangle cholesky L of the

--- a/docs/public/content/reference/schematic.md
+++ b/docs/public/content/reference/schematic.md
@@ -79,28 +79,28 @@ order = 6
   - `cylinder`: `radius`, `height` (both required); `color` (default white).
   - `plane`: `width`/`depth` (default `size` if set, else 10.0); optional `size` shorthand; `color` (default white).
   - `ellipsoid`: `color` (default white), `show_grid` (default `#false`).
-     - Physical measure
-        - `scale`: runtime EQL string that must evaluate to at least 3 values in meters. It can be a literal tuple, a vector component, indexed component values, scalar-vector math, or values from multiple components.
-          - Examples:
-            ```kdl
-            ellipsoid scale="(1, 1, 1)"
-            ellipsoid scale="vehicle.pos_std_var"
-            ellipsoid scale="2.0 * vehicle.pos_std_var"
-            ellipsoid scale="1.91*(vehicle.pos_std_var[1], vehicle.pos_std_var[0], vehicle.pos_std_var[2])"
-            ellipsoid scale="3.0 * (vehicle.pos_std_var[1], 0.0, target.pos_std_var[2])"
-            ```
-     - Error measure
-        - `error_covariance_cholesky` as an alternative to specifying the scale
-          and rotation, one can specify the lower triangle cholesky L of the
-          error covariance matrix P = LL^T. Example `"(a,b,c,d,e,f)"` which
-          describes a matrix that looks like this:
-          | a 0 0 |
-          | b c 0 |
-          | d e f |
-        - `error_confidence_interval` (default `70`) the percentage that if this
-          were repeated 100 times, we would expect that in 70 cases, the true
-          value would be within the bounds. In practice this means that the
-          larger the error confidence interval, the larger the ellipsoid.
+    - Physical measure
+      - `scale`: runtime EQL string that must evaluate to at least 3 values in meters. It can be a literal tuple, a vector component, indexed component values, scalar-vector math, or values from multiple components.
+        - Examples:
+          ```kdl
+          ellipsoid scale="(1, 1, 1)"
+          ellipsoid scale="vehicle.pos_std_var"
+          ellipsoid scale="2.0 * vehicle.pos_std_var"
+          ellipsoid scale="1.91*(vehicle.pos_std_var[1], vehicle.pos_std_var[0], vehicle.pos_std_var[2])"
+          ellipsoid scale="3.0 * (vehicle.pos_std_var[1], 0.0, target.pos_std_var[2])"
+          ```
+    - Error measure
+      - `error_covariance_cholesky` as an alternative to specifying the scale
+        and rotation, one can specify the lower triangle cholesky L of the
+        error covariance matrix P = LL^T. Example `"(a,b,c,d,e,f)"` which
+        describes a matrix that looks like this:
+        | a 0 0 |
+        | b c 0 |
+        | d e f |
+      - `error_confidence_interval` (default `70`) the percentage that if this
+        were repeated 100 times, we would expect that in 70 cases, the true
+        value would be within the bounds. In practice this means that the
+        larger the error confidence interval, the larger the ellipsoid.
 
   Mesh nodes support an optional `emissivity=<value>` property (0.0–1.0) to make the material glow (e.g., `sphere radius=0.2 emissivity=0.25 { color yellow }`).
 

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -2036,3 +2036,99 @@ mod joint_eql_cast_tests {
         assert!((buf[2] - 0.0).abs() < 1e-9);
     }
 }
+
+#[cfg(test)]
+mod ellipsoid_scale_eql_tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use bevy::ecs::system::SystemState;
+    use bevy::prelude::{Query, Vec3, World};
+    use impeller2::schema::Schema;
+    use impeller2::types::{ComponentId, PrimType, Timestamp};
+    use impeller2_bevy::EntityMap;
+    use impeller2_wkt::ComponentValue;
+    use nox::Array;
+
+    use super::{compile_scale_eql, component_value_to_vec3};
+
+    fn pos_std_var_component(name: &str) -> Arc<eql::Component> {
+        Arc::new(eql::Component::new(
+            name.to_string(),
+            ComponentId::new(name),
+            Schema::new(PrimType::F64, vec![3u64]).unwrap(),
+        ))
+    }
+
+    fn f64_component_value(values: [f64; 3]) -> ComponentValue {
+        ComponentValue::F64(
+            Array::<f64, nox::Dyn>::from_shape_vec(smallvec::smallvec![3], values.to_vec())
+                .expect("f64 telemetry buffer"),
+        )
+    }
+
+    fn assert_vec3_close(actual: Vec3, expected: Vec3) {
+        let delta = (actual - expected).abs();
+        assert!(
+            delta.max_element() < 1e-5,
+            "expected {expected:?}, got {actual:?}"
+        );
+    }
+
+    #[test]
+    fn ellipsoid_scale_eql_accepts_scalar_tuple_and_component_expressions() {
+        let vehicle = pos_std_var_component("vehicle.pos_std_var");
+        let target = pos_std_var_component("target.pos_std_var");
+        let vehicle_id = vehicle.id;
+        let target_id = target.id;
+        let ctx = eql::Context::from_leaves(
+            [vehicle.clone(), target.clone()],
+            Timestamp(0),
+            Timestamp(1000),
+        );
+
+        let mut world = World::new();
+        let vehicle_entity = world
+            .spawn(f64_component_value([10.0, 20.0, 30.0]))
+            .id();
+        let target_entity = world
+            .spawn(f64_component_value([100.0, 200.0, 300.0]))
+            .id();
+        let entity_map = EntityMap(HashMap::from([
+            (vehicle_id, vehicle_entity),
+            (target_id, target_entity),
+        ]));
+
+        let mut system_state: SystemState<(Query<'static, 'static, &ComponentValue>,)> =
+            SystemState::new(&mut world);
+        let (component_values,) = system_state.get(&world);
+
+        for (scale_expr, expected) in [
+            (
+                "1.91*(vehicle.pos_std_var[1], vehicle.pos_std_var[0], vehicle.pos_std_var[2])",
+                Vec3::new(38.2, 19.1, 57.3),
+            ),
+            (
+                "(1.91*vehicle.pos_std_var[1], 1.91*vehicle.pos_std_var[0], 1.91*vehicle.pos_std_var[2])",
+                Vec3::new(38.2, 19.1, 57.3),
+            ),
+            (
+                "2.0 * vehicle.pos_std_var",
+                Vec3::new(20.0, 40.0, 60.0),
+            ),
+            (
+                "3.0 * (vehicle.pos_std_var[1], 0.0, target.pos_std_var[2])",
+                Vec3::new(60.0, 0.0, 900.0),
+            ),
+        ] {
+            let compiled =
+                compile_scale_eql(scale_expr, &ctx).expect("scale expression should compile");
+            let value = compiled
+                .execute(&entity_map, &component_values)
+                .expect("scale expression should evaluate");
+            let scale = component_value_to_vec3(&value).expect("scale should yield a Vec3");
+
+            assert_vec3_close(scale, expected);
+        }
+    }
+}

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -342,9 +342,12 @@ fn promote_component_to_f64(value: ComponentValue) -> Result<Array<f64, nox::Dyn
     }
 }
 
-// Keep object_3d runtime EQL binary operations shape-based. This mirrors the
-// intended nox broadcasting behavior while avoiding scalar dynamic-array edge
-// cases in editor-side expression evaluation.
+// Keep object_3d runtime EQL binary operations shape-based.
+// TODO: move this into nox once dynamic broadcasting is fixed there. Today,
+// nox::Array binary ops can panic on equal-rank incompatible shapes and can
+// mis-iterate dynamic broadcasts when the left rank is greater than the right
+// rank. The editor keeps the broadcast local so runtime EQL returns a clean
+// error and preserves expected array shapes.
 fn broadcast_shape(
     left: &[usize],
     right: &[usize],

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -345,7 +345,7 @@ fn promote_component_to_f64(value: ComponentValue) -> Result<Array<f64, nox::Dyn
 // Keep object_3d runtime EQL binary operations shape-based.
 // TODO: move this into nox once dynamic broadcasting is fixed there. Today,
 // nox::Array binary ops can panic on equal-rank incompatible shapes and can
-// mis-iterate dynamic broadcasts when the left rank is greater than the right
+// iterate dynamic broadcasts incorrectly when the left rank is greater than the right
 // rank. The editor keeps the broadcast local so runtime EQL returns a clean
 // error and preserves expected array shapes.
 fn broadcast_shape(

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -394,6 +394,9 @@ fn broadcast_strides(
     input_shape: &[usize],
     input_strides: &[usize],
 ) -> smallvec::SmallVec<[usize; 4]> {
+    debug_assert!(output_shape.len() >= input_shape.len());
+    debug_assert_eq!(input_shape.len(), input_strides.len());
+
     let leading_axes = output_shape.len() - input_shape.len();
     output_shape
         .iter()
@@ -421,6 +424,10 @@ fn advance_broadcast_offsets(
     left_offset: &mut usize,
     right_offset: &mut usize,
 ) {
+    debug_assert_eq!(index.len(), shape.len());
+    debug_assert_eq!(left_strides.len(), shape.len());
+    debug_assert_eq!(right_strides.len(), shape.len());
+
     for axis in (0..shape.len()).rev() {
         index[axis] += 1;
         *left_offset += left_strides[axis];

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -342,16 +342,84 @@ fn promote_component_to_f64(value: ComponentValue) -> Result<Array<f64, nox::Dyn
     }
 }
 
+// Keep object_3d runtime EQL binary operations shape-based. This mirrors the
+// intended nox broadcasting behavior while avoiding scalar dynamic-array edge
+// cases in editor-side expression evaluation.
+fn broadcast_shape(
+    left: &[usize],
+    right: &[usize],
+) -> Result<smallvec::SmallVec<[usize; 4]>, String> {
+    let rank = left.len().max(right.len());
+    let mut shape = smallvec::SmallVec::with_capacity(rank);
+
+    for axis in 0..rank {
+        let left_axis = axis
+            .checked_sub(rank - left.len())
+            .map(|i| left[i])
+            .unwrap_or(1);
+        let right_axis = axis
+            .checked_sub(rank - right.len())
+            .map(|i| right[i])
+            .unwrap_or(1);
+
+        if left_axis == right_axis {
+            shape.push(left_axis);
+        } else if left_axis == 1 {
+            shape.push(right_axis);
+        } else if right_axis == 1 {
+            shape.push(left_axis);
+        } else {
+            return Err("binary operation requires arrays be broadcastable".to_string());
+        }
+    }
+
+    Ok(shape)
+}
+
+fn row_major_strides(shape: &[usize]) -> smallvec::SmallVec<[usize; 4]> {
+    let mut strides = smallvec::SmallVec::from_elem(0, shape.len());
+    let mut stride = 1;
+    for axis in (0..shape.len()).rev() {
+        strides[axis] = stride;
+        stride *= shape[axis];
+    }
+    strides
+}
+
+fn broadcast_offset(
+    output_index: &[usize],
+    input_shape: &[usize],
+    input_strides: &[usize],
+) -> usize {
+    let leading_axes = output_index.len() - input_shape.len();
+    input_shape
+        .iter()
+        .zip(input_strides.iter())
+        .enumerate()
+        .map(|(axis, (&dim, &stride))| {
+            let index = if dim == 1 {
+                0
+            } else {
+                output_index[leading_axes + axis]
+            };
+            index * stride
+        })
+        .sum()
+}
+
 fn apply_binary_op(
     left: &Array<f64, nox::Dyn>,
     right: &Array<f64, nox::Dyn>,
     op: eql::BinaryOp,
 ) -> Result<Array<f64, nox::Dyn>, String> {
     use nox::ArrayBuf;
-    use smallvec::SmallVec;
 
     let left_data = left.buf.as_buf();
     let right_data = right.buf.as_buf();
+    let output_shape = broadcast_shape(left.shape(), right.shape())?;
+    let output_len = output_shape.iter().product();
+    let left_strides = row_major_strides(left.shape());
+    let right_strides = row_major_strides(right.shape());
 
     let apply = |left: f64, right: f64| match op {
         eql::BinaryOp::Add => left + right,
@@ -360,36 +428,21 @@ fn apply_binary_op(
         eql::BinaryOp::Div => left / right,
     };
 
-    let (shape, values) = if left_data.len() == 1 && right_data.len() != 1 {
-        (
-            SmallVec::from_slice(right.shape()),
-            right_data
-                .iter()
-                .map(|&right| apply(left_data[0], right))
-                .collect(),
-        )
-    } else if right_data.len() == 1 && left_data.len() != 1 {
-        (
-            SmallVec::from_slice(left.shape()),
-            left_data
-                .iter()
-                .map(|&left| apply(left, right_data[0]))
-                .collect(),
-        )
-    } else if left_data.len() == right_data.len() {
-        (
-            SmallVec::from_slice(left.shape()),
-            left_data
-                .iter()
-                .zip(right_data.iter())
-                .map(|(&left, &right)| apply(left, right))
-                .collect(),
-        )
-    } else {
-        return Err("binary operation requires arrays be broadcastable".to_string());
-    };
+    let mut output_index = smallvec::SmallVec::<[usize; 4]>::from_elem(0, output_shape.len());
+    let mut values = Vec::with_capacity(output_len);
+    for flat_index in 0..output_len {
+        let mut remaining = flat_index;
+        for axis in (0..output_shape.len()).rev() {
+            output_index[axis] = remaining % output_shape[axis];
+            remaining /= output_shape[axis];
+        }
 
-    Array::from_shape_vec(shape, values)
+        let left_offset = broadcast_offset(&output_index, left.shape(), &left_strides);
+        let right_offset = broadcast_offset(&output_index, right.shape(), &right_strides);
+        values.push(apply(left_data[left_offset], right_data[right_offset]));
+    }
+
+    Array::from_shape_vec(output_shape, values)
         .ok_or_else(|| "invalid array shape after binary operation".to_string())
 }
 
@@ -2091,9 +2144,9 @@ mod ellipsoid_scale_eql_tests {
     use impeller2::types::{ComponentId, PrimType, Timestamp};
     use impeller2_bevy::EntityMap;
     use impeller2_wkt::ComponentValue;
-    use nox::Array;
+    use nox::{Array, ArrayBuf};
 
-    use super::{compile_scale_eql, component_value_to_vec3};
+    use super::{apply_binary_op, compile_scale_eql, component_value_to_vec3};
 
     fn pos_std_var_component(name: &str) -> Arc<eql::Component> {
         Arc::new(eql::Component::new(
@@ -2116,6 +2169,42 @@ mod ellipsoid_scale_eql_tests {
             delta.max_element() < 1e-5,
             "expected {expected:?}, got {actual:?}"
         );
+    }
+
+    #[test]
+    fn object_3d_eql_binary_ops_preserve_nox_shape_broadcasting() {
+        let left =
+            Array::<f64, nox::Dyn>::from_shape_vec(smallvec::smallvec![1, 3], vec![1.0, 2.0, 3.0])
+                .expect("left array");
+        let right = Array::<f64, nox::Dyn>::from_shape_vec(
+            smallvec::smallvec![2, 3],
+            vec![10.0, 20.0, 30.0, 40.0, 50.0, 60.0],
+        )
+        .expect("right array");
+
+        let result = apply_binary_op(&left, &right, eql::BinaryOp::Add).expect("broadcasted add");
+
+        assert_eq!(result.shape(), &[2, 3]);
+        assert_eq!(result.buf.as_buf(), &[11.0, 22.0, 33.0, 41.0, 52.0, 63.0]);
+    }
+
+    #[test]
+    fn object_3d_eql_binary_ops_reject_same_len_incompatible_shapes() {
+        let left = Array::<f64, nox::Dyn>::from_shape_vec(
+            smallvec::smallvec![2, 3],
+            vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        )
+        .expect("left array");
+        let right = Array::<f64, nox::Dyn>::from_shape_vec(
+            smallvec::smallvec![3, 2],
+            vec![10.0, 20.0, 30.0, 40.0, 50.0, 60.0],
+        )
+        .expect("right array");
+
+        let err = apply_binary_op(&left, &right, eql::BinaryOp::Add)
+            .expect_err("incompatible shapes should not be flattened together");
+
+        assert_eq!(err, "binary operation requires arrays be broadcastable");
     }
 
     #[test]

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -2172,7 +2172,7 @@ mod ellipsoid_scale_eql_tests {
     }
 
     #[test]
-    fn object_3d_eql_binary_ops_preserve_nox_shape_broadcasting() {
+    fn apply_binary_op_broadcasts_arrays_with_different_ranks() {
         let left =
             Array::<f64, nox::Dyn>::from_shape_vec(smallvec::smallvec![1, 3], vec![1.0, 2.0, 3.0])
                 .expect("left array");

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -2231,6 +2231,26 @@ mod ellipsoid_scale_eql_tests {
     }
 
     #[test]
+    fn apply_binary_op_supports_sub_and_div_with_broadcasting() {
+        let left = Array::<f64, nox::Dyn>::from_shape_vec(
+            smallvec::smallvec![2, 3],
+            vec![10.0, 20.0, 30.0, 40.0, 50.0, 60.0],
+        )
+        .expect("left array");
+        let right =
+            Array::<f64, nox::Dyn>::from_shape_vec(smallvec::smallvec![3], vec![1.0, 2.0, 5.0])
+                .expect("right array");
+
+        let sub = apply_binary_op(&left, &right, eql::BinaryOp::Sub).expect("broadcasted sub");
+        let div = apply_binary_op(&left, &right, eql::BinaryOp::Div).expect("broadcasted div");
+
+        assert_eq!(sub.shape(), &[2, 3]);
+        assert_eq!(sub.buf.as_buf(), &[9.0, 18.0, 25.0, 39.0, 48.0, 55.0]);
+        assert_eq!(div.shape(), &[2, 3]);
+        assert_eq!(div.buf.as_buf(), &[10.0, 10.0, 6.0, 40.0, 25.0, 12.0]);
+    }
+
+    #[test]
     fn object_3d_eql_binary_ops_reject_same_len_incompatible_shapes() {
         let left = Array::<f64, nox::Dyn>::from_shape_vec(
             smallvec::smallvec![2, 3],

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -386,25 +386,51 @@ fn row_major_strides(shape: &[usize]) -> smallvec::SmallVec<[usize; 4]> {
     strides
 }
 
-fn broadcast_offset(
-    output_index: &[usize],
+fn broadcast_strides(
+    output_shape: &[usize],
     input_shape: &[usize],
     input_strides: &[usize],
-) -> usize {
-    let leading_axes = output_index.len() - input_shape.len();
-    input_shape
+) -> smallvec::SmallVec<[usize; 4]> {
+    let leading_axes = output_shape.len() - input_shape.len();
+    output_shape
         .iter()
-        .zip(input_strides.iter())
         .enumerate()
-        .map(|(axis, (&dim, &stride))| {
-            let index = if dim == 1 {
+        .map(|(axis, _)| {
+            if axis < leading_axes {
                 0
             } else {
-                output_index[leading_axes + axis]
-            };
-            index * stride
+                let input_axis = axis - leading_axes;
+                if input_shape[input_axis] == 1 {
+                    0
+                } else {
+                    input_strides[input_axis]
+                }
+            }
         })
-        .sum()
+        .collect()
+}
+
+fn advance_broadcast_offsets(
+    index: &mut [usize],
+    shape: &[usize],
+    left_strides: &[usize],
+    right_strides: &[usize],
+    left_offset: &mut usize,
+    right_offset: &mut usize,
+) {
+    for axis in (0..shape.len()).rev() {
+        index[axis] += 1;
+        *left_offset += left_strides[axis];
+        *right_offset += right_strides[axis];
+
+        if index[axis] < shape[axis] {
+            break;
+        }
+
+        *left_offset -= index[axis] * left_strides[axis];
+        *right_offset -= index[axis] * right_strides[axis];
+        index[axis] = 0;
+    }
 }
 
 fn apply_binary_op(
@@ -418,8 +444,16 @@ fn apply_binary_op(
     let right_data = right.buf.as_buf();
     let output_shape = broadcast_shape(left.shape(), right.shape())?;
     let output_len = output_shape.iter().product();
-    let left_strides = row_major_strides(left.shape());
-    let right_strides = row_major_strides(right.shape());
+    let left_strides = broadcast_strides(
+        &output_shape,
+        left.shape(),
+        &row_major_strides(left.shape()),
+    );
+    let right_strides = broadcast_strides(
+        &output_shape,
+        right.shape(),
+        &row_major_strides(right.shape()),
+    );
 
     let apply = |left: f64, right: f64| match op {
         eql::BinaryOp::Add => left + right,
@@ -428,18 +462,23 @@ fn apply_binary_op(
         eql::BinaryOp::Div => left / right,
     };
 
-    let mut output_index = smallvec::SmallVec::<[usize; 4]>::from_elem(0, output_shape.len());
+    let mut index = smallvec::SmallVec::<[usize; 4]>::from_elem(0, output_shape.len());
+    let mut left_offset = 0;
+    let mut right_offset = 0;
     let mut values = Vec::with_capacity(output_len);
     for flat_index in 0..output_len {
-        let mut remaining = flat_index;
-        for axis in (0..output_shape.len()).rev() {
-            output_index[axis] = remaining % output_shape[axis];
-            remaining /= output_shape[axis];
-        }
-
-        let left_offset = broadcast_offset(&output_index, left.shape(), &left_strides);
-        let right_offset = broadcast_offset(&output_index, right.shape(), &right_strides);
         values.push(apply(left_data[left_offset], right_data[right_offset]));
+
+        if flat_index + 1 < output_len {
+            advance_broadcast_offsets(
+                &mut index,
+                &output_shape,
+                &left_strides,
+                &right_strides,
+                &mut left_offset,
+                &mut right_offset,
+            );
+        }
     }
 
     Array::from_shape_vec(output_shape, values)
@@ -2174,7 +2213,7 @@ mod ellipsoid_scale_eql_tests {
     #[test]
     fn apply_binary_op_broadcasts_arrays_with_different_ranks() {
         let left =
-            Array::<f64, nox::Dyn>::from_shape_vec(smallvec::smallvec![1, 3], vec![1.0, 2.0, 3.0])
+            Array::<f64, nox::Dyn>::from_shape_vec(smallvec::smallvec![3], vec![1.0, 2.0, 3.0])
                 .expect("left array");
         let right = Array::<f64, nox::Dyn>::from_shape_vec(
             smallvec::smallvec![2, 3],

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -342,6 +342,57 @@ fn promote_component_to_f64(value: ComponentValue) -> Result<Array<f64, nox::Dyn
     }
 }
 
+fn apply_binary_op(
+    left: &Array<f64, nox::Dyn>,
+    right: &Array<f64, nox::Dyn>,
+    op: eql::BinaryOp,
+) -> Result<Array<f64, nox::Dyn>, String> {
+    use nox::ArrayBuf;
+    use smallvec::SmallVec;
+
+    let left_data = left.buf.as_buf();
+    let right_data = right.buf.as_buf();
+
+    let apply = |left: f64, right: f64| match op {
+        eql::BinaryOp::Add => left + right,
+        eql::BinaryOp::Sub => left - right,
+        eql::BinaryOp::Mul => left * right,
+        eql::BinaryOp::Div => left / right,
+    };
+
+    let (shape, values) = if left_data.len() == 1 && right_data.len() != 1 {
+        (
+            SmallVec::from_slice(right.shape()),
+            right_data
+                .iter()
+                .map(|&right| apply(left_data[0], right))
+                .collect(),
+        )
+    } else if right_data.len() == 1 && left_data.len() != 1 {
+        (
+            SmallVec::from_slice(left.shape()),
+            left_data
+                .iter()
+                .map(|&left| apply(left, right_data[0]))
+                .collect(),
+        )
+    } else if left_data.len() == right_data.len() {
+        (
+            SmallVec::from_slice(left.shape()),
+            left_data
+                .iter()
+                .zip(right_data.iter())
+                .map(|(&left, &right)| apply(left, right))
+                .collect(),
+        )
+    } else {
+        return Err("binary operation requires arrays be broadcastable".to_string());
+    };
+
+    Array::from_shape_vec(shape, values)
+        .ok_or_else(|| "invalid array shape after binary operation".to_string())
+}
+
 fn cast_dyn_array_from_field<T: nox::Field>(
     shape_sv: &smallvec::SmallVec<[usize; 4]>,
     flat: Vec<T>,
@@ -747,15 +798,7 @@ pub fn compile_eql_expr(expression: eql::Expr) -> CompiledExpr {
 
                 let left = promote_component_to_f64(left_val)?;
                 let right = promote_component_to_f64(right_val)?;
-                if !nox::array::can_broadcast(left.shape(), right.shape()) {
-                    return Err("binary operation requires arrays be broadcastable".to_string());
-                }
-                let result = match op {
-                    eql::BinaryOp::Add => left.add(&right),
-                    eql::BinaryOp::Sub => left.sub(&right),
-                    eql::BinaryOp::Mul => left.mul(&right),
-                    eql::BinaryOp::Div => left.div(&right),
-                };
+                let result = apply_binary_op(&left, &right, op)?;
 
                 Ok(ComponentValue::F64(result))
             })
@@ -2088,12 +2131,8 @@ mod ellipsoid_scale_eql_tests {
         );
 
         let mut world = World::new();
-        let vehicle_entity = world
-            .spawn(f64_component_value([10.0, 20.0, 30.0]))
-            .id();
-        let target_entity = world
-            .spawn(f64_component_value([100.0, 200.0, 300.0]))
-            .id();
+        let vehicle_entity = world.spawn(f64_component_value([10.0, 20.0, 30.0])).id();
+        let target_entity = world.spawn(f64_component_value([100.0, 200.0, 300.0])).id();
         let entity_map = EntityMap(HashMap::from([
             (vehicle_id, vehicle_entity),
             (target_id, target_entity),
@@ -2112,10 +2151,7 @@ mod ellipsoid_scale_eql_tests {
                 "(1.91*vehicle.pos_std_var[1], 1.91*vehicle.pos_std_var[0], 1.91*vehicle.pos_std_var[2])",
                 Vec3::new(38.2, 19.1, 57.3),
             ),
-            (
-                "2.0 * vehicle.pos_std_var",
-                Vec3::new(20.0, 40.0, 60.0),
-            ),
+            ("2.0 * vehicle.pos_std_var", Vec3::new(20.0, 40.0, 60.0)),
             (
                 "3.0 * (vehicle.pos_std_var[1], 0.0, target.pos_std_var[2])",
                 Vec3::new(60.0, 0.0, 900.0),


### PR DESCRIPTION
## Summary

This PR fixes runtime EQL binary expression evaluation for `object_3d` expressions in the Editor.

The user-facing issue appeared through `ellipsoid scale`, where expressions like `scalar * (x, y, z)` or `scalar * component_vector` did not evaluate correctly. The underlying fix is not ellipsoid-specific: it applies to the Editor's `object_3d` EQL runtime path.

The documentation focuses on `ellipsoid scale`.

## Changes

- Added shape-based binary operation handling in the Editor `object_3d` EQL runtime.
- Added support for scalar-vector and vector-scalar expressions such as:
  - `2.0 * vehicle.pos_std_var`
  - `1.91 * (x, y, z)`
- Preserved expected broadcasting behavior for compatible array shapes.
- Added regression coverage for incompatible shapes with the same flattened length.
- Added unit tests for dynamic ellipsoid scale expressions.
- Updated schematic and Python API documentation for `ellipsoid scale`.

## Unit Tests

The ellipsoid scale tests cover:

- Scalar multiplied by an indexed tuple:
```text
1.91*(vehicle.pos_std_var[1], vehicle.pos_std_var[0], vehicle.pos_std_var[2])
```

- Per-element scalar multiplication inside a tuple:
```text
(1.91*vehicle.pos_std_var[1], 1.91*vehicle.pos_std_var[0], 1.91*vehicle.pos_std_var[2])
```

- Scalar multiplied by a vector component:
```text
2.0 * vehicle.pos_std_var
```

- Expression combining values from two different components:
```text
3.0 * (vehicle.pos_std_var[1], 0.0, target.pos_std_var[2])
```