### PR TITLE
Enable bevy/debug feature when tracing

### DIFF
--- a/apps/elodin/Cargo.toml
+++ b/apps/elodin/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["sascha@elodin.systems", "akhil@elodin.systems", "van@elodin.systems"
 cargo-clippy = []
 inspector = ["elodin-editor/inspector"]
 debug = ["elodin-editor/debug"]
-tracy = ["elodin-editor/tracy", "bevy/trace_tracy", "dep:tracing-tracy"]
+tracy = ["elodin-editor/tracy", "bevy/trace_tracy", "bevy/debug", "dep:tracing-tracy"]
 
 [dependencies]
 thiserror = "2.0"

--- a/libs/elodin-editor/Cargo.toml
+++ b/libs/elodin-editor/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 cargo-clippy = []
 inspector = ["dep:bevy-inspector-egui", "bevy_geo_frames/inspector"]
 debug = ["big_space/debug"]
-tracy = ["bevy/trace_tracy"]
+tracy = ["bevy/trace_tracy", "bevy/debug"]
 
 [dependencies]
 # math


### PR DESCRIPTION
The [bevy profiling docs](https://github.com/bevyengine/bevy/blob/main/docs/profiling.md)  say this well enable bevy debug names in tracy. I haven't noticed a different when casually comparing, but I think we should enable it in case there's something useful that I'm just not noticing now because I'm not looking for it.