### PR TITLE
StepContext read a component data value at a specific timestamp

### DIFF
--- a/docs/public/content/reference/python-api.md
+++ b/docs/public/content/reference/python-api.md
@@ -146,15 +146,20 @@ Context object passed to `pre_step` and `post_step` callbacks, providing direct 
 
 #### Methods
 
-- `read_component(pair_name)` -> `numpy.ndarray`
+- `read_component(pair_name, timestamp=None)` -> `numpy.ndarray`
 
-    Read the latest component data from the database.
+    Read component data from the database.
 
     - `pair_name` : `string`, the full component name in "entity.component" format (e.g., `"drone.accel"`, `"drone.world_pos"`)
+    - `timestamp` : `int`, optional, microseconds since epoch. When `None` (the default), returns the most recent sample. When provided, returns the sample with the greatest timestamp `<=` the requested one (floor / sample-and-hold semantics). Timestamps past the most recent write clamp to the latest sample.
 
     Returns a NumPy array containing the component data. The array dtype matches the component schema and is always 1D; reshape if needed.
 
-    Raises `RuntimeError` if the component doesn't exist or has no data.
+    Raises `RuntimeError` if the component doesn't exist, has no data, or the requested `timestamp` is before the very first sample.
+
+    {% alert(kind="notice") %}
+    Historical reads use the same memory-mapped time-series that the latest-only path does, so the additional cost is one binary search over a contiguous timestamp index (a few hundred nanoseconds for typical histories). Use this to look up sensor values from earlier ticks (e.g. for finite-difference estimators) without leaving the simulation process.
+    {% end %}
 
 - `write_component(pair_name, data, timestamp=None)` -> None
 
@@ -170,18 +175,19 @@ Context object passed to `pre_step` and `post_step` callbacks, providing direct 
     Timestamps must be monotonically increasing per component. Writing with a timestamp less than the last write will raise a `TimeTravel` error.
     {% end %}
 
-- `component_batch_operation(reads=[], writes=None, write_timestamps=None)` -> `dict[str, numpy.ndarray]`
+- `component_batch_operation(reads=[], writes=None, write_timestamps=None, read_timestamps=None)` -> `dict[str, numpy.ndarray]`
 
     Perform multiple component reads and writes in a single database operation. This is more efficient than calling `read_component`/`write_component` multiple times, as it only acquires the database lock once for all operations.
 
     - `reads` : `list[str]`, list of component names to read (e.g., `["drone.accel", "drone.gyro"]`)
     - `writes` : `dict[str, numpy.ndarray]`, optional, dict mapping component names to numpy arrays to write
     - `write_timestamps` : `dict[str, int]`, optional, dict mapping component names to timestamps (microseconds since epoch). Components not in this dict use the current simulation timestamp.
+    - `read_timestamps` : `dict[str, int]`, optional, dict mapping component names to timestamps (microseconds since epoch). Components present in this dict are read with floor / sample-and-hold semantics; components not in this dict return the most recent sample. Past-the-end timestamps clamp to the latest sample.
 
     Returns a dict mapping read component names to their numpy array values.
 
     {% alert(kind="notice") %}
-    Use batch operations when reading or writing multiple components in a single callback for better performance at high tick rates.
+    Use batch operations when reading or writing multiple components in a single callback for better performance at high tick rates. `read_timestamps` lets you mix latest-only and historical reads in the same single-lock operation.
     {% end %}
 
 - `render_camera(camera_name)` -> `numpy.ndarray | None`

--- a/examples/ellipsoid/sim.py
+++ b/examples/ellipsoid/sim.py
@@ -139,3 +139,15 @@ def pre_step(tick, ctx):
 def post_step(tick, ctx):
     if tick % 4 == 0:
         ctx.render_camera(SENSOR_CAMERA_NAME)
+
+    # Exercise StepContext historical read: pull the current world_pos and the
+    # value from one tick earlier. The pre_step writes a fresh world_pos every
+    # tick, so consecutive samples should differ in shape-compatible ways.
+    pos_pair = f"{DRONE_NAME}.world_pos"
+    latest = ctx.read_component(pos_pair)
+    if tick > 0:
+        prev_ts = ctx.timestamp - int(1_000_000 / SIM_RATE)
+        prev = ctx.read_component(pos_pair, timestamp=prev_ts)
+        assert prev.shape == latest.shape, (
+            f"historical read shape mismatch: {prev.shape} vs {latest.shape}"
+        )

--- a/libs/nox-py/python/elodin/elodin.pyi
+++ b/libs/nox-py/python/elodin/elodin.pyi
@@ -60,19 +60,30 @@ class StepContext:
             a timestamp less than the last write will raise an error (TimeTravel).
         """
         ...
-    def read_component(self, pair_name: str) -> jax.Array:
-        """Read the latest component data from the database.
+    def read_component(
+        self,
+        pair_name: str,
+        timestamp: Optional[int] = None,
+    ) -> jax.Array:
+        """Read component data from the database.
 
         Args:
             pair_name: The full component name in "entity.component" format
                       (e.g., "drone.accel", "drone.gyro", "drone.world_pos")
+            timestamp: Optional timestamp (microseconds since epoch). When None
+                       (the default), returns the most recent sample. When
+                       provided, returns the sample with the greatest timestamp
+                       <= the requested one (floor / sample-and-hold semantics).
+                       If the requested timestamp is past the most recent write,
+                       the latest sample is returned (clamp-to-latest).
 
         Returns:
             NumPy array containing the component data (dtype matches component schema).
             The array is always 1D; reshape if needed.
 
         Raises:
-            RuntimeError: If the component doesn't exist or has no data
+            RuntimeError: If the component doesn't exist, has no data, or the
+                          requested timestamp is before the very first sample.
         """
         ...
     def component_batch_operation(
@@ -80,6 +91,7 @@ class StepContext:
         reads: list[str] = [],
         writes: Optional[dict[str, jax.typing.ArrayLike]] = None,
         write_timestamps: Optional[dict[str, int]] = None,
+        read_timestamps: Optional[dict[str, int]] = None,
     ) -> dict[str, jax.Array]:
         """Perform multiple component reads and writes in a single DB operation.
 
@@ -93,17 +105,24 @@ class StepContext:
             write_timestamps: Optional dict mapping component names to timestamps
                              (microseconds since epoch). Components not in this dict
                              use the current simulation timestamp.
+            read_timestamps: Optional dict mapping component names to timestamps
+                            (microseconds since epoch). Components present in this
+                            dict are read with floor / sample-and-hold semantics
+                            (greatest sample with `ts' <= ts`); components not in
+                            this dict return the most recent sample. Past-the-end
+                            timestamps clamp to the latest sample.
 
         Returns:
             Dict mapping read component names to their numpy array values.
 
         Raises:
-            RuntimeError: If any component doesn't exist or has no data
+            RuntimeError: If any component doesn't exist, has no data, or a
+                          per-read timestamp is before the first sample.
             ValueError: If any write data size doesn't match the component schema
 
         Note:
-            Timestamps must be monotonically increasing per component. Writing with
-            a timestamp less than the last write will raise an error (TimeTravel).
+            Write timestamps must be monotonically increasing per component. Writing
+            with a timestamp less than the last write will raise an error (TimeTravel).
         """
         ...
     def truncate(self) -> None:

--- a/libs/nox-py/src/step_context.rs
+++ b/libs/nox-py/src/step_context.rs
@@ -685,14 +685,18 @@ impl StepContext {
                     })?;
 
                     let buf: &[u8] = match read_ts_map.get(name).copied() {
-                        None => component.time_series.latest().map(|(_, b)| b).ok_or_else(
-                            || {
-                                Error::PyO3(pyo3::exceptions::PyRuntimeError::new_err(format!(
-                                    "component '{}' has no data",
-                                    name
-                                )))
-                            },
-                        )?,
+                        None => {
+                            component
+                                .time_series
+                                .latest()
+                                .map(|(_, b)| b)
+                                .ok_or_else(|| {
+                                    Error::PyO3(pyo3::exceptions::PyRuntimeError::new_err(format!(
+                                        "component '{}' has no data",
+                                        name
+                                    )))
+                                })?
+                        }
                         Some(ts) => component
                             .time_series
                             .get_nearest(Timestamp(ts))

--- a/libs/nox-py/src/step_context.rs
+++ b/libs/nox-py/src/step_context.rs
@@ -307,21 +307,31 @@ impl StepContext {
         })
     }
 
-    /// Read the latest component data from the database as a numpy array.
+    /// Read component data from the database as a numpy array.
     ///
     /// Args:
     ///     pair_name: The full component name in "entity.component" format
     ///                (e.g., "drone.accel", "drone.gyro")
+    ///     timestamp: Optional timestamp (microseconds since epoch). When None,
+    ///                returns the most recent sample. When provided, returns the
+    ///                sample with the greatest timestamp <= the requested one
+    ///                (floor / sample-and-hold semantics). If the requested
+    ///                timestamp is past the most recent write the latest sample
+    ///                is returned.
     ///
     /// Returns:
-    ///     NumPy array containing the component data (dtype matches component schema)
+    ///     NumPy array containing the component data (dtype matches component schema).
+    ///     The array is always 1D; reshape if needed.
     ///
     /// Raises:
-    ///     RuntimeError: If the component doesn't exist or has no data
+    ///     RuntimeError: If the component doesn't exist, has no data, or the
+    ///                   requested timestamp is before the very first sample.
+    #[pyo3(signature = (pair_name, timestamp=None))]
     fn read_component<'py>(
         &self,
         py: Python<'py>,
         pair_name: &str,
+        timestamp: Option<i64>,
     ) -> Result<Bound<'py, PyAny>, Error> {
         let pair_id = ComponentId::new(pair_name);
 
@@ -333,91 +343,31 @@ impl StepContext {
                 )))
             })?;
 
-            let (_, buf) = component.time_series.latest().ok_or_else(|| {
-                Error::PyO3(pyo3::exceptions::PyRuntimeError::new_err(format!(
-                    "component '{}' has no data",
-                    pair_name
-                )))
-            })?;
+            let buf = match timestamp {
+                None => {
+                    let (_, buf) = component.time_series.latest().ok_or_else(|| {
+                        Error::PyO3(pyo3::exceptions::PyRuntimeError::new_err(format!(
+                            "component '{}' has no data",
+                            pair_name
+                        )))
+                    })?;
+                    buf
+                }
+                Some(ts) => {
+                    let (_, buf) = component
+                        .time_series
+                        .get_nearest(Timestamp(ts))
+                        .ok_or_else(|| {
+                            Error::PyO3(pyo3::exceptions::PyRuntimeError::new_err(format!(
+                                "component '{}' has no data at or before timestamp {}",
+                                pair_name, ts
+                            )))
+                        })?;
+                    buf
+                }
+            };
 
-            // Determine the numpy dtype based on the schema's primitive type
-            let prim_type = component.schema.prim_type;
-            let shape = component.schema.shape();
-
-            // Convert bytes to numpy array based on primitive type
-            // Note: We return a 1D array regardless of the component shape for simplicity.
-            // The Python side can reshape if needed.
-            let _ = shape; // Mark as intentionally unused
-            match prim_type {
-                PrimType::F64 => {
-                    let data: Vec<f64> = buf
-                        .chunks_exact(8)
-                        .map(|chunk| f64::from_le_bytes(chunk.try_into().unwrap()))
-                        .collect();
-                    Ok(PyArray1::from_vec(py, data).into_any())
-                }
-                PrimType::F32 => {
-                    let data: Vec<f32> = buf
-                        .chunks_exact(4)
-                        .map(|chunk| f32::from_le_bytes(chunk.try_into().unwrap()))
-                        .collect();
-                    Ok(PyArray1::from_vec(py, data).into_any())
-                }
-                PrimType::I64 => {
-                    let data: Vec<i64> = buf
-                        .chunks_exact(8)
-                        .map(|chunk| i64::from_le_bytes(chunk.try_into().unwrap()))
-                        .collect();
-                    Ok(PyArray1::from_vec(py, data).into_any())
-                }
-                PrimType::I32 => {
-                    let data: Vec<i32> = buf
-                        .chunks_exact(4)
-                        .map(|chunk| i32::from_le_bytes(chunk.try_into().unwrap()))
-                        .collect();
-                    Ok(PyArray1::from_vec(py, data).into_any())
-                }
-                PrimType::U64 => {
-                    let data: Vec<u64> = buf
-                        .chunks_exact(8)
-                        .map(|chunk| u64::from_le_bytes(chunk.try_into().unwrap()))
-                        .collect();
-                    Ok(PyArray1::from_vec(py, data).into_any())
-                }
-                PrimType::U32 => {
-                    let data: Vec<u32> = buf
-                        .chunks_exact(4)
-                        .map(|chunk| u32::from_le_bytes(chunk.try_into().unwrap()))
-                        .collect();
-                    Ok(PyArray1::from_vec(py, data).into_any())
-                }
-                PrimType::Bool => {
-                    let data: Vec<bool> = buf.iter().map(|&b| b != 0).collect();
-                    Ok(PyArray1::from_vec(py, data).into_any())
-                }
-                PrimType::U8 => {
-                    let data: Vec<u8> = buf.to_vec();
-                    Ok(PyArray1::from_vec(py, data).into_any())
-                }
-                PrimType::U16 => {
-                    let data: Vec<u16> = buf
-                        .chunks_exact(2)
-                        .map(|chunk| u16::from_le_bytes(chunk.try_into().unwrap()))
-                        .collect();
-                    Ok(PyArray1::from_vec(py, data).into_any())
-                }
-                PrimType::I8 => {
-                    let data: Vec<i8> = buf.iter().map(|&b| b as i8).collect();
-                    Ok(PyArray1::from_vec(py, data).into_any())
-                }
-                PrimType::I16 => {
-                    let data: Vec<i16> = buf
-                        .chunks_exact(2)
-                        .map(|chunk| i16::from_le_bytes(chunk.try_into().unwrap()))
-                        .collect();
-                    Ok(PyArray1::from_vec(py, data).into_any())
-                }
-            }
+            Ok(buf_to_numpy_array(py, buf, component.schema.prim_type))
         })
     }
 
@@ -571,24 +521,31 @@ impl StepContext {
     ///     write_timestamps: Optional dict mapping component names to timestamps
     ///                       (microseconds since epoch). Components not in this dict
     ///                       use the current simulation timestamp.
+    ///     read_timestamps: Optional dict mapping component names to timestamps
+    ///                      (microseconds since epoch). Components present in this
+    ///                      dict are read with floor / sample-and-hold semantics
+    ///                      (greatest sample with `ts' <= ts`); components not in
+    ///                      this dict return the most recent sample.
     ///
     /// Returns:
     ///     Dict mapping read component names to their numpy array values
     ///
     /// Raises:
-    ///     RuntimeError: If any component doesn't exist or has no data
+    ///     RuntimeError: If any component doesn't exist, has no data, or a
+    ///                   per-read timestamp is before the first sample.
     ///     ValueError: If any write data size doesn't match the component schema
     ///
     /// Note:
-    ///     Timestamps must be monotonically increasing per component. Writing with
-    ///     a timestamp less than the last write will raise an error (TimeTravel).
-    #[pyo3(signature = (reads=vec![], writes=None, write_timestamps=None))]
+    ///     Write timestamps must be monotonically increasing per component. Writing
+    ///     with a timestamp less than the last write will raise an error (TimeTravel).
+    #[pyo3(signature = (reads=vec![], writes=None, write_timestamps=None, read_timestamps=None))]
     fn component_batch_operation<'py>(
         &self,
         py: Python<'py>,
         reads: Vec<String>,
         writes: Option<&Bound<'py, PyDict>>,
         write_timestamps: Option<&Bound<'py, PyDict>>,
+        read_timestamps: Option<&Bound<'py, PyDict>>,
     ) -> Result<Bound<'py, PyDict>, Error> {
         // Pre-parse all component IDs outside the lock
         let read_ids: Vec<(String, ComponentId)> = reads
@@ -609,6 +566,28 @@ impl StepContext {
                 let ts: i64 = value.extract().map_err(|e| {
                     Error::PyO3(pyo3::exceptions::PyValueError::new_err(format!(
                         "write_timestamps value for '{}' must be an integer: {}",
+                        name, e
+                    )))
+                })?;
+                ts_map.insert(name, ts);
+            }
+            ts_map
+        } else {
+            HashMap::new()
+        };
+
+        let read_ts_map: HashMap<String, i64> = if let Some(ts_dict) = read_timestamps {
+            let mut ts_map = HashMap::new();
+            for (key, value) in ts_dict.iter() {
+                let name: String = key.extract().map_err(|e| {
+                    Error::PyO3(pyo3::exceptions::PyValueError::new_err(format!(
+                        "read_timestamps key must be a string: {}",
+                        e
+                    )))
+                })?;
+                let ts: i64 = value.extract().map_err(|e| {
+                    Error::PyO3(pyo3::exceptions::PyValueError::new_err(format!(
+                        "read_timestamps value for '{}' must be an integer: {}",
                         name, e
                     )))
                 })?;
@@ -705,12 +684,26 @@ impl StepContext {
                         )))
                     })?;
 
-                    let (_, buf) = component.time_series.latest().ok_or_else(|| {
-                        Error::PyO3(pyo3::exceptions::PyRuntimeError::new_err(format!(
-                            "component '{}' has no data",
-                            name
-                        )))
-                    })?;
+                    let buf: &[u8] = match read_ts_map.get(name).copied() {
+                        None => component.time_series.latest().map(|(_, b)| b).ok_or_else(
+                            || {
+                                Error::PyO3(pyo3::exceptions::PyRuntimeError::new_err(format!(
+                                    "component '{}' has no data",
+                                    name
+                                )))
+                            },
+                        )?,
+                        Some(ts) => component
+                            .time_series
+                            .get_nearest(Timestamp(ts))
+                            .map(|(_, b)| b)
+                            .ok_or_else(|| {
+                                Error::PyO3(pyo3::exceptions::PyRuntimeError::new_err(format!(
+                                    "component '{}' has no data at or before timestamp {}",
+                                    name, ts
+                                )))
+                            })?,
+                    };
 
                     let prim_type = component.schema.prim_type;
                     results.insert(name.clone(), (buf.to_vec(), prim_type));


### PR DESCRIPTION
While all previous usages with the StepContext was reading and writing values in between simulation ticks, relative to the current tick, this was found limiting if you needed to read from data in the past. There's no performance implications for doing this, as the entire database is in memory during the request, so this was simple to add.