### PR TITLE
Centralize Dynamic Array Broadcasting in `nox` .

### DIFF
--- a/.cursor/skills/bevy/SKILL.md
+++ b/.cursor/skills/bevy/SKILL.md
@@ -647,3 +647,74 @@ app
                           c,
                           d).chain());
 ```
+
+## Avoid unnecessary allocations with `Cow`
+
+Suppose you have a return type of `Result<T, String>`, In many cases the error string is static and you would prefer to use `Result<T, &'static str>` but there is a case where it's important to provide specific information in the error that seems to require allocating a string. You can have the best of both worlds by using `Cow<'static, str>`: a `Cow` can hold a reference `&'static str` or an owned `String` and it's transparent to the user; they both deref to `&str`.
+
+Note: a `String` error type is not recommended; use `thiserror` crate and an enumeration instead. See its usage below.
+
+### Before
+Here is a contrived example of a function that converts an unsigned byte to a boolean. It has two static error messages and one dynamic one.
+```rust
+fn convert_to_bool(a: u8) -> Result<bool, String> {
+    match a {
+        0 => Ok(false),
+        1 => Ok(true),
+        2 => Err(String::from("not trinary")), // Allocates.
+        42 => Err(String::from("thanks for all the fish")), // Allocates.
+        x => Err(format!("got unexpected value {x}")) // Allocates.
+    }
+}
+```
+
+### After using Cow
+Using `Cow` we can avoid allocating the static error messages and use their static strings directly.
+```rust
+fn convert_to_bool(a: u8) -> Result<bool, Cow<'static, str>> {
+    match a {
+        0 => Ok(false),
+        1 => Ok(true),
+        2 => Err(Cow::from("not trinary")), // No allocation.
+        42 => Err(Cow::from("thanks for all the fish")), // No allocation.
+        x => Err(Cow::from(format!("got unexpected value {x}"))) // Allocates.
+    }
+}
+```
+
+### After using `thiserror`
+Using `thiserror` we can avoid doing any allocations for the error.
+
+```rust
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("not trinary")]
+    NoTrinarySupport,
+    #[error("thanks for all the fish")]
+    TheAnswerToTheUniverseAndEverything,
+    #[error("got unexpected value {0}")]
+    UnexpectedValue(u8)
+}
+
+fn convert_to_bool(a: u8) -> Result<bool, Error> {
+    match a {
+        0 => Ok(false),
+        1 => Ok(true),
+        2 => Err(Error::NoTrinarySupport), // No allocation.
+        42 => Err(Error::TheAnswerToTheUniverseAndEverything), // No allocation.
+        x => Err(Error::UnexpectedValue(x)) // No allocation.
+    }
+}
+```
+
+## My Kingdom for a `Cow`
+
+Truth be told, `Cow` is one of those humble data structures that made me see Rust as something special. In most languages, you have to commit in your API to a reference or an owned value and often you have to commit to the most general type, which is the owned value. But take a look at Rust's regex [`replace_all`](https://docs.rs/regex/latest/regex/struct.Regex.html#method.replace_all) function:
+```rust
+pub fn replace_all<'h, R: Replacer>(&self, haystack: &'h str, rep: R) -> Cow<'h, str>
+```
+In a less careful implementation you'd probably get this:
+```rust
+pub fn replace_all<'h, R: Replacer>(&self, haystack: &'h str, rep: R) -> String
+```
+That's the general case. When you substitute a string, you have to create a new string. But Rust's `replace_all` handles the specific case where no substitutions happen and it can simply return back to you the string you gave it: `Cow::Borrowed(haystack)`. No allocation necessary and the API remains ergonomic.

--- a/libs/db/eql/src/lib.rs
+++ b/libs/db/eql/src/lib.rs
@@ -770,7 +770,7 @@ pub(crate) fn parse_duration(duration_str: &str) -> Result<hifitime::Duration, E
     ))
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, Clone)]
 pub enum Error {
     #[error("entity not found: {0}")]
     ComponentNotFound(String),

--- a/libs/elodin-editor/src/headless.rs
+++ b/libs/elodin-editor/src/headless.rs
@@ -190,7 +190,7 @@ fn load_headless_scene(
                 tracing::warn!("Failed to parse EQL for object_3d: {}", obj.eql);
                 continue;
             };
-            create_object_3d_entity(
+            let _ = create_object_3d_entity(
                 &mut commands,
                 obj.clone(),
                 expr,

--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -1077,7 +1077,7 @@ pub fn sync_object_3d(
             continue;
         };
 
-        let object_entity = create_object_3d_entity(
+        if let Ok(object_entity) = create_object_3d_entity(
             &mut commands,
             Object3D {
                 eql,
@@ -1094,8 +1094,9 @@ pub fn sync_object_3d(
             &mut mat3_material_assets,
             &assets,
             &geo_context,
-        );
-        synced_object_3d.0.insert(entity, object_entity);
+        ) {
+            synced_object_3d.0.insert(entity, object_entity);
+        }
     }
 }
 

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -21,12 +21,12 @@ use crate::iter::JoinDisplayExt;
 use crate::plugins::render_layer_alloc::RenderLayerLease;
 use crate::ui::tiles::ViewportConfig;
 use crate::{BevyExt, EqlContext, MainCamera, plugins::navigation_gizmo::NavGizmoCamera};
-use bevy_geo_frames::prelude::*;
-use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
-use std::borrow::Cow;
 use bevy::platform::hash::FixedHasher;
+use bevy_geo_frames::prelude::*;
+use std::borrow::Cow;
+use std::collections::{HashMap, HashSet};
 use std::hash::BuildHasher;
+use std::sync::Arc;
 type ImportedCameraFilter = (Added<Camera>, Without<NavGizmoCamera>, Without<MainCamera>);
 
 type ImportedCameraQuery<'w, 's> = Query<'w, 's, (Entity, &'static ChildOf), ImportedCameraFilter>;
@@ -123,7 +123,6 @@ pub enum CompileError {
     Parse(#[from] eql::Error),
 }
 
-
 #[derive(Debug, thiserror::Error, Hash, PartialEq, Eq, Clone)]
 pub enum ComponentError {
     #[error("binary operation requires arrays be broadcastable")]
@@ -164,7 +163,9 @@ pub enum ComponentError {
     RequireNumericArray,
     #[error("tuple elements must be numeric")]
     RequireNumericTuple,
-    #[error("Expected 3 elements for rotation_vector (axis direction with magnitude as angle in degrees), got {length}")]
+    #[error(
+        "Expected 3 elements for rotation_vector (axis direction with magnitude as angle in degrees), got {length}"
+    )]
     RequireThreeElements { length: usize },
     #[error("expression must yield at least {required} values, got {length}")]
     NotEnoughComponents { required: usize, length: usize },
@@ -398,8 +399,7 @@ fn promote_component_to_f64(value: ComponentValue) -> Result<Array<f64, nox::Dyn
         other => {
             let data = component_buf_as_f64_vec(&other)?;
             let shape_sv: SmallVec<[usize; 4]> = SmallVec::from_slice(other.shape());
-            Array::from_shape_vec(shape_sv, data)
-                .ok_or(ComponentError::InvalidPromotion)
+            Array::from_shape_vec(shape_sv, data).ok_or(ComponentError::InvalidPromotion)
         }
     }
 }
@@ -408,8 +408,7 @@ fn cast_dyn_array_from_field<T: nox::Field>(
     shape_sv: &smallvec::SmallVec<[usize; 4]>,
     flat: Vec<T>,
 ) -> Result<Array<T, nox::Dyn>, ComponentError> {
-    Array::from_shape_vec(shape_sv.clone(), flat)
-        .ok_or(ComponentError::ShapeMismatch)
+    Array::from_shape_vec(shape_sv.clone(), flat).ok_or(ComponentError::ShapeMismatch)
 }
 
 fn cast_component_value(
@@ -478,13 +477,18 @@ fn cast_component_value(
 }
 
 /// Compiles a formula expression into a runtime closure
-fn compile_formula(formula: Arc<dyn eql::Formula>, inner_expr: eql::Expr) -> Result<CompiledExpr, CompileError> {
+fn compile_formula(
+    formula: Arc<dyn eql::Formula>,
+    inner_expr: eql::Expr,
+) -> Result<CompiledExpr, CompileError> {
     if let Some(target) = formula.editor_cast_target() {
         let inner_compiled = compile_eql_expr(inner_expr)?;
-        return Ok(CompiledExpr::closure(move |entity_map, component_values| {
-            let v = inner_compiled.execute(entity_map, component_values)?;
-            cast_component_value(v, target)
-        }));
+        return Ok(CompiledExpr::closure(
+            move |entity_map, component_values| {
+                let v = inner_compiled.execute(entity_map, component_values)?;
+                cast_component_value(v, target)
+            },
+        ));
     }
 
     let n = formula.name();
@@ -710,7 +714,9 @@ pub fn compile_eql_expr(expression: eql::Expr) -> Result<CompiledExpr, CompileEr
         Expr::ComponentPart(component) => {
             let component_id = component.id;
             CompiledExpr::closure(move |entity_map, component_value| {
-                let entity_id = entity_map.get(&component_id).ok_or(ComponentError::NoComponent(component.name.clone()))?;
+                let entity_id = entity_map
+                    .get(&component_id)
+                    .ok_or(ComponentError::NoComponent(component.name.clone()))?;
                 component_value
                     .get(*entity_id)
                     .map_err(|_| ComponentError::NoComponentValue(component.name.clone()))
@@ -732,7 +738,7 @@ pub fn compile_eql_expr(expression: eql::Expr) -> Result<CompiledExpr, CompileEr
                         } else {
                             Err(ComponentError::OutOfBounds {
                                 index,
-                                length: data.len()
+                                length: data.len(),
                             })
                         }
                     }
@@ -744,10 +750,9 @@ pub fn compile_eql_expr(expression: eql::Expr) -> Result<CompiledExpr, CompileEr
                             let value = nox::Array::<_, ()> { buf: value }.to_dyn();
                             Ok(ComponentValue::F32(value))
                         } else {
-
                             Err(ComponentError::OutOfBounds {
                                 index,
-                                length: data.len()
+                                length: data.len(),
                             })
                         }
                     }
@@ -813,8 +818,7 @@ pub fn compile_scale_eql(scale: &str, ctx: &eql::Context) -> Result<CompiledExpr
         return Err(ComponentError::InvalidEmptyIn("scale expression").into());
     }
 
-    ctx.parse_str(trimmed)
-        .map(compile_eql_expr)?
+    ctx.parse_str(trimmed).map(compile_eql_expr)?
 }
 
 /// Compiles an EQL expression that must yield at least 6 floats (lower-triangular Cholesky L).
@@ -823,8 +827,7 @@ pub fn compile_cholesky_eql(expr: &str, ctx: &eql::Context) -> Result<CompiledEx
     if trimmed.is_empty() {
         return Err(ComponentError::InvalidEmptyIn("error_covariance_cholesky expression").into());
     }
-    ctx.parse_str(trimmed)
-        .map(compile_eql_expr)?
+    ctx.parse_str(trimmed).map(compile_eql_expr)?
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -834,7 +837,7 @@ pub enum ScaleEvalError {
     #[error("expression must yield an F32 or F64 array")]
     InvalidComponentType,
     #[error("Component error: {0}")]
-    ComponentError(#[from] ComponentError)
+    ComponentError(#[from] ComponentError),
 }
 
 const ELLIPSOID_OVERSIZED_THRESHOLD: f32 = 10_000.0;
@@ -1081,7 +1084,9 @@ fn component_value_to_axis_angle(value: &ComponentValue) -> Result<(Vec3, f32), 
                 Err(ComponentError::RequireThreeElements { length: data.len() })
             }
         }
-        _ => Err(ComponentError::InvalidComponentType { requires: "f32 or f64 rotation_vector rotation" })
+        _ => Err(ComponentError::InvalidComponentType {
+            requires: "f32 or f64 rotation_vector rotation",
+        }),
     }
 }
 
@@ -1316,8 +1321,7 @@ fn evaluate_scale(
     component_value_maps: &Query<&'static ComponentValue>,
 ) -> Result<Vec3, ComponentError> {
     if let Some(expr) = &state.scale_expr {
-        let value = expr
-            .execute(entity_map, component_value_maps)?;
+        let value = expr.execute(entity_map, component_value_maps)?;
         component_value_to_vec3(&value)
     } else {
         Ok(Vec3::ONE)
@@ -1332,7 +1336,10 @@ fn component_value_to_vec3(value: &ComponentValue) -> Result<Vec3, ComponentErro
             if data.len() >= 3 {
                 Ok(Vec3::new(data[0] as f32, data[1] as f32, data[2] as f32).abs())
             } else {
-                Err(ComponentError::NotEnoughComponents { required: 3, length: data.len() })
+                Err(ComponentError::NotEnoughComponents {
+                    required: 3,
+                    length: data.len(),
+                })
             }
         }
         ComponentValue::F32(array) => {
@@ -1340,10 +1347,15 @@ fn component_value_to_vec3(value: &ComponentValue) -> Result<Vec3, ComponentErro
             if data.len() >= 3 {
                 Ok(Vec3::new(data[0], data[1], data[2]).abs())
             } else {
-                Err(ComponentError::NotEnoughComponents { required: 3, length: data.len() })
+                Err(ComponentError::NotEnoughComponents {
+                    required: 3,
+                    length: data.len(),
+                })
             }
         }
-        _ => Err(ComponentError::InvalidComponentType { requires: "f32 or f64 array" }),
+        _ => Err(ComponentError::InvalidComponentType {
+            requires: "f32 or f64 array",
+        }),
     }
 }
 

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -37,7 +37,7 @@ pub const ELLIPSOID_RENDER_LAYER: usize = 29;
 pub struct Object3DState {
     pub compiled_expr: Option<CompiledExpr>,
     pub scale_expr: Option<CompiledExpr>,
-    pub scale_error: Option<String>,
+    pub scale_error: Option<CompileError>,
     /// When set, ellipsoid shape is driven by error covariance (Mat3 path); evaluated each frame.
     pub error_covariance_cholesky_expr: Option<CompiledExpr>,
     pub joint_animations: Vec<(String, String)>, // (joint_name, eql_expr) - compiled in attach_joint_animations
@@ -112,7 +112,7 @@ pub enum CompiledExpr {
     Value(ComponentValue),
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, Hash, PartialEq, Eq, Clone)]
 pub enum ComponentError {
     #[error("binary operation requires arrays be broadcastable")]
     BinaryBroadcastError,
@@ -122,6 +122,8 @@ pub enum ComponentError {
     InvalidPromotion,
     #[error("cannot be empty")]
     InvalidEmpty,
+    #[error("{0} cannot be empty")]
+    InvalidEmptyIn(&'static str),
     #[error("requires a spatial transform")]
     RequiresTransform,
     #[error("requires 7-element array, got {0}")]
@@ -150,8 +152,12 @@ pub enum ComponentError {
     RequireNumericArray,
     #[error("tuple elements must be numeric")]
     RequireNumericTuple,
-    #[error("{0:?} can't be converted to a component value")]
-    CannotConvert(Expr),
+    #[error("Expected 3 elements for rotation_vector (axis direction with magnitude as angle in degrees), got {length}")]
+    RequireThreeElements { length: usize },
+    #[error("expression must yield at least {required} values, got {length}")]
+    NotEnoughComponents { required: usize, length: usize },
+    #[error("expression must yield an {requires}")]
+    InvalidComponentType { requires: &'static str },
     #[error("{0}")]
     Message(Cow<'static, str>),
 }
@@ -460,17 +466,17 @@ fn cast_component_value(
 }
 
 /// Compiles a formula expression into a runtime closure
-fn compile_formula(formula: Arc<dyn eql::Formula>, inner_expr: eql::Expr) -> CompiledExpr {
+fn compile_formula(formula: Arc<dyn eql::Formula>, inner_expr: eql::Expr) -> Result<CompiledExpr, CompileError> {
     if let Some(target) = formula.editor_cast_target() {
-        let inner_compiled = compile_eql_expr(inner_expr);
-        return CompiledExpr::closure(move |entity_map, component_values| {
+        let inner_compiled = compile_eql_expr(inner_expr)?;
+        return Ok(CompiledExpr::closure(move |entity_map, component_values| {
             let v = inner_compiled.execute(entity_map, component_values)?;
             cast_component_value(v, target)
-        });
+        }));
     }
 
     let n = formula.name();
-    match n {
+    Ok(match n {
         // Single-axis rotation formulas (body and world frame)
         "rotate_x" | "rotate_y" | "rotate_z" | "rotate_world_x" | "rotate_world_y"
         | "rotate_world_z" => {
@@ -485,14 +491,14 @@ fn compile_formula(formula: Arc<dyn eql::Formula>, inner_expr: eql::Expr) -> Com
             };
 
             let eql::Expr::Tuple(elements) = inner_expr else {
-                return CompiledExpr::closure(move |_, _| Err(ComponentError::RequiresTuple(n)));
+                return Err(ComponentError::RequiresTuple(n).into());
             };
             if elements.len() != 2 {
-                return CompiledExpr::closure(move |_, _| Err(ComponentError::RequiresReceiverAndAngle(n)));
+                return Err(ComponentError::RequiresReceiverAndAngle(n).into());
             }
 
-            let receiver_compiled = compile_eql_expr(elements[0].clone());
-            let angle_compiled = compile_eql_expr(elements[1].clone());
+            let receiver_compiled = compile_eql_expr(elements[0].clone())?;
+            let angle_compiled = compile_eql_expr(elements[1].clone())?;
 
             CompiledExpr::closure(move |entity_map, component_values| {
                 let spatial = receiver_compiled.execute(entity_map, component_values)?;
@@ -522,16 +528,16 @@ fn compile_formula(formula: Arc<dyn eql::Formula>, inner_expr: eql::Expr) -> Com
             };
 
             let eql::Expr::Tuple(elements) = inner_expr else {
-                return CompiledExpr::closure(move |_, _| Err(ComponentError::RequiresTuple(n)));
+                return Err(ComponentError::RequiresTuple(n).into());
             };
             if elements.len() != 4 {
-                return CompiledExpr::closure(move |_, _| Err(ComponentError::RequiresReceiverAndThreeAngles(n)));
+                return Err(ComponentError::RequiresReceiverAndThreeAngles(n).into());
             }
 
-            let receiver_compiled = compile_eql_expr(elements[0].clone());
-            let x_angle_compiled = compile_eql_expr(elements[1].clone());
-            let y_angle_compiled = compile_eql_expr(elements[2].clone());
-            let z_angle_compiled = compile_eql_expr(elements[3].clone());
+            let receiver_compiled = compile_eql_expr(elements[0].clone())?;
+            let x_angle_compiled = compile_eql_expr(elements[1].clone())?;
+            let y_angle_compiled = compile_eql_expr(elements[2].clone())?;
+            let z_angle_compiled = compile_eql_expr(elements[3].clone())?;
 
             CompiledExpr::closure(move |entity_map, component_values| {
                 let spatial = receiver_compiled.execute(entity_map, component_values)?;
@@ -575,14 +581,14 @@ fn compile_formula(formula: Arc<dyn eql::Formula>, inner_expr: eql::Expr) -> Com
             };
 
             let eql::Expr::Tuple(elements) = inner_expr else {
-                return CompiledExpr::closure(move |_, _| Err(ComponentError::RequiresTuple(n)));
+                return Err(ComponentError::RequiresTuple(n).into());
             };
             if elements.len() != 2 {
-                return CompiledExpr::closure(move |_, _| Err(ComponentError::RequiresReceiverAndDistance(n)));
+                return Err(ComponentError::RequiresReceiverAndDistance(n).into());
             }
 
-            let receiver_compiled = compile_eql_expr(elements[0].clone());
-            let distance_compiled = compile_eql_expr(elements[1].clone());
+            let receiver_compiled = compile_eql_expr(elements[0].clone())?;
+            let distance_compiled = compile_eql_expr(elements[1].clone())?;
 
             CompiledExpr::closure(move |entity_map, component_values| {
                 let spatial = receiver_compiled.execute(entity_map, component_values)?;
@@ -620,16 +626,16 @@ fn compile_formula(formula: Arc<dyn eql::Formula>, inner_expr: eql::Expr) -> Com
             };
 
             let eql::Expr::Tuple(elements) = inner_expr else {
-                return CompiledExpr::closure(move |_, _| Err(ComponentError::RequiresTuple(n)));
+                return Err(ComponentError::RequiresTuple(n).into());
             };
             if elements.len() != 4 {
-                return CompiledExpr::closure(move |_, _| Err(ComponentError::RequiresReceiverAndThreeDistances(n)));
+                return Err(ComponentError::RequiresReceiverAndThreeDistances(n).into());
             }
 
-            let receiver_compiled = compile_eql_expr(elements[0].clone());
-            let x_dist_compiled = compile_eql_expr(elements[1].clone());
-            let y_dist_compiled = compile_eql_expr(elements[2].clone());
-            let z_dist_compiled = compile_eql_expr(elements[3].clone());
+            let receiver_compiled = compile_eql_expr(elements[0].clone())?;
+            let x_dist_compiled = compile_eql_expr(elements[1].clone())?;
+            let y_dist_compiled = compile_eql_expr(elements[2].clone())?;
+            let z_dist_compiled = compile_eql_expr(elements[3].clone())?;
 
             CompiledExpr::closure(move |entity_map, component_values| {
                 let spatial = receiver_compiled.execute(entity_map, component_values)?;
@@ -657,16 +663,16 @@ fn compile_formula(formula: Arc<dyn eql::Formula>, inner_expr: eql::Expr) -> Com
         // direction(x, y, z): body-frame direction transformed to world frame (returns 3-vector)
         "direction" => {
             let eql::Expr::Tuple(elements) = inner_expr else {
-                return CompiledExpr::closure(move |_, _| Err(ComponentError::RequiresTuple(n)));
+                return Err(ComponentError::RequiresTuple(n).into());
             };
             if elements.len() != 4 {
-                return CompiledExpr::closure(move |_, _| Err(ComponentError::RequiresReceiverAndThreeComponents(n)));
+                return Err(ComponentError::RequiresReceiverAndThreeComponents(n).into());
             }
 
-            let receiver_compiled = compile_eql_expr(elements[0].clone());
-            let x_compiled = compile_eql_expr(elements[1].clone());
-            let y_compiled = compile_eql_expr(elements[2].clone());
-            let z_compiled = compile_eql_expr(elements[3].clone());
+            let receiver_compiled = compile_eql_expr(elements[0].clone())?;
+            let x_compiled = compile_eql_expr(elements[1].clone())?;
+            let y_compiled = compile_eql_expr(elements[2].clone())?;
+            let z_compiled = compile_eql_expr(elements[3].clone())?;
 
             CompiledExpr::closure(move |entity_map, component_values| {
                 let spatial = receiver_compiled.execute(entity_map, component_values)?;
@@ -681,16 +687,24 @@ fn compile_formula(formula: Arc<dyn eql::Formula>, inner_expr: eql::Expr) -> Com
         }
 
         _ => {
-            CompiledExpr::closure(move |_, _| Err(ComponentError::EditorNotSupported(n)))
+            return Err(ComponentError::EditorNotSupported(n).into());
         }
-    }
+    })
+}
+
+#[derive(thiserror::Error, Debug, Clone)]
+pub enum CompileError {
+    #[error("{0:?} can't be converted to a component value")]
+    CannotConvert(Expr),
+    #[error("component error: {0}")]
+    ComponentError(#[from] ComponentError),
+    #[error("parse error: {0}")]
+    Parse(#[from] eql::Error),
 }
 
 /// Compiles an EQL expression into a closure-based form
-///
-/// TODO: Consider making this return a `Result<CompiledExpr, CompiledExprError or Expr>`.
-pub fn compile_eql_expr(expression: eql::Expr) -> CompiledExpr {
-    match expression {
+pub fn compile_eql_expr(expression: eql::Expr) -> Result<CompiledExpr, CompileError> {
+    Ok(match expression {
         Expr::ComponentPart(component) => {
             let component_id = component.id;
             CompiledExpr::closure(move |entity_map, component_value| {
@@ -702,7 +716,7 @@ pub fn compile_eql_expr(expression: eql::Expr) -> CompiledExpr {
             })
         }
         Expr::ArrayAccess(expr, index) => {
-            let compiled_expr = compile_eql_expr(*expr);
+            let compiled_expr = compile_eql_expr(*expr)?;
             CompiledExpr::closure(move |entity_map, component_value_maps| {
                 let resolved_expr = compiled_expr.execute(entity_map, component_value_maps)?;
                 match resolved_expr {
@@ -740,8 +754,9 @@ pub fn compile_eql_expr(expression: eql::Expr) -> CompiledExpr {
             })
         }
         Expr::Tuple(exprs) => {
-            let compiled_exprs: Vec<CompiledExpr> =
+            let compiled_exprs: Result<Vec<CompiledExpr>, CompileError> =
                 exprs.into_iter().map(compile_eql_expr).collect();
+            let compiled_exprs = compiled_exprs?;
             CompiledExpr::closure(move |entity_map, component_value_maps| {
                 use nox::ArrayBuf;
                 let mut values = Vec::new();
@@ -763,8 +778,8 @@ pub fn compile_eql_expr(expression: eql::Expr) -> CompiledExpr {
             })
         }
         Expr::BinaryOp(left, right, op) => {
-            let left_compiled = compile_eql_expr(*left);
-            let right_compiled = compile_eql_expr(*right);
+            let left_compiled = compile_eql_expr(*left)?;
+            let right_compiled = compile_eql_expr(*right)?;
             CompiledExpr::closure(move |entity_map, component_value_maps| {
                 let left_val = left_compiled.execute(entity_map, component_value_maps)?;
                 let right_val = right_compiled.execute(entity_map, component_value_maps)?;
@@ -783,56 +798,41 @@ pub fn compile_eql_expr(expression: eql::Expr) -> CompiledExpr {
             })
         }
         Expr::FloatLiteral(f) => CompiledExpr::Value(ComponentValue::F64(nox::array!(f).to_dyn())),
-        Expr::Formula(formula, inner_expr) => compile_formula(formula, *inner_expr),
+        Expr::Formula(formula, inner_expr) => compile_formula(formula, *inner_expr)?,
         expr => {
-            CompiledExpr::closure(move |_, _| Err(ComponentError::CannotConvert(expr.clone())))
+            return Err(CompileError::CannotConvert(expr));
         }
-    }
+    })
 }
 
-pub fn compile_scale_eql(scale: &str, ctx: &eql::Context) -> Result<CompiledExpr, String> {
+pub fn compile_scale_eql(scale: &str, ctx: &eql::Context) -> Result<CompiledExpr, CompileError> {
     let trimmed = scale.trim();
     if trimmed.is_empty() {
-        return Err("scale expression cannot be empty".to_string());
+        return Err(ComponentError::InvalidEmptyIn("scale expression").into());
     }
 
     ctx.parse_str(trimmed)
-        .map(compile_eql_expr)
-        .map_err(|err| err.to_string())
+        .map(compile_eql_expr)?
 }
 
 /// Compiles an EQL expression that must yield at least 6 floats (lower-triangular Cholesky L).
-pub fn compile_cholesky_eql(expr: &str, ctx: &eql::Context) -> Result<CompiledExpr, String> {
+pub fn compile_cholesky_eql(expr: &str, ctx: &eql::Context) -> Result<CompiledExpr, CompileError> {
     let trimmed = expr.trim();
     if trimmed.is_empty() {
-        return Err("error_covariance_cholesky expression cannot be empty".to_string());
+        return Err(ComponentError::InvalidEmptyIn("error_covariance_cholesky expression").into());
     }
     ctx.parse_str(trimmed)
-        .map(compile_eql_expr)
-        .map_err(|err| err.to_string())
+        .map(compile_eql_expr)?
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum ScaleEvalError {
-    #[error("{0}")]
-    Expr(String),
-    #[error("scale expression must yield at least 3 values, got {len}")]
-    NotEnoughComponents { len: usize },
-    #[error("scale expression must yield an F32 or F64 array")]
+    #[error("expression must yield at least {required} values, got {length}")]
+    NotEnoughComponents { required: usize, length: usize },
+    #[error("expression must yield an F32 or F64 array")]
     InvalidComponentType,
     #[error("Component error: {0}")]
-    ComponentError(ComponentError)
-}
-
-impl From<String> for ScaleEvalError {
-    fn from(value: String) -> Self {
-        Self::Expr(value)
-    }
-}
-impl From<ComponentError> for ScaleEvalError {
-    fn from(value: ComponentError) -> Self {
-        Self::ComponentError(value)
-    }
+    ComponentError(#[from] ComponentError)
 }
 
 const ELLIPSOID_OVERSIZED_THRESHOLD: f32 = 10_000.0;
@@ -1027,7 +1027,7 @@ pub fn update_object_3d_system(
                     }
                 }
                 Err(err) => {
-                    object_3d.scale_error = Some(err.to_string());
+                    object_3d.scale_error = Some(err.into());
                     ellipse.oversized = false;
                     ellipse.max_extent = 0.0;
                 }
@@ -1040,7 +1040,7 @@ pub fn update_object_3d_system(
 ///
 /// Input: 3-element vector where direction is axis and magnitude is angle in DEGREES
 /// Output: (normalized axis, angle in radians)
-fn component_value_to_axis_angle(value: &ComponentValue) -> Result<(Vec3, f32), String> {
+fn component_value_to_axis_angle(value: &ComponentValue) -> Result<(Vec3, f32), ComponentError> {
     use nox::ArrayBuf;
     match value {
         ComponentValue::F64(array) => {
@@ -1058,10 +1058,7 @@ fn component_value_to_axis_angle(value: &ComponentValue) -> Result<(Vec3, f32), 
                 let angle_rad = angle_deg.to_radians();
                 Ok((normalized_axis, angle_rad))
             } else {
-                Err(format!(
-                    "Expected 3 elements for rotation_vector (axis direction with magnitude as angle in degrees), got {}",
-                    data.len()
-                ))
+                Err(ComponentError::RequireThreeElements { length: data.len() })
             }
         }
         ComponentValue::F32(array) => {
@@ -1079,13 +1076,10 @@ fn component_value_to_axis_angle(value: &ComponentValue) -> Result<(Vec3, f32), 
                 let angle_rad = angle_deg.to_radians();
                 Ok((normalized_axis, angle_rad))
             } else {
-                Err(format!(
-                    "Expected 3 elements for rotation_vector (axis direction with magnitude as angle in degrees), got {}",
-                    data.len()
-                ))
+                Err(ComponentError::RequireThreeElements { length: data.len() })
             }
         }
-        _ => Err("Invalid component type for rotation_vector rotation".to_string()),
+        _ => Err(ComponentError::InvalidComponentType { requires: "f32 or f64 rotation_vector rotation" })
     }
 }
 
@@ -1149,14 +1143,13 @@ pub fn attach_joint_animations(
                             ctx.0
                                 .parse_str(eql_expr)
                                 .map(compile_eql_expr)
-                                .map_err(|err| {
+                                .inspect_err(|err| {
                                     warn!(
                                         joint = %joint_name,
                                         eql = %eql_expr,
                                         error = %err,
                                         "Failed to compile EQL expression for joint animation."
                                     );
-                                    err
                                 })
                                 .ok()
                         } else {
@@ -1173,6 +1166,9 @@ pub fn attach_joint_animations(
             if existing_components.contains(joint_entity) {
                 continue;
             }
+            let Ok(compiled_expr) = compiled_expr else {
+                continue;
+            };
 
             // Get the original transform to preserve the bone's initial rotation.
             let original_transform = transforms
@@ -1220,6 +1216,7 @@ pub fn update_joint_animations(
     mut joint_query: Query<(&mut Transform, &JointAnimationComponent)>,
     entity_map: Res<EntityMap>,
     component_value_maps: Query<&'static ComponentValue>,
+    mut errors: Local<HashSet<ComponentError>>,
 ) {
     for (mut joint_transform, joint_anim) in joint_query.iter_mut() {
         // Evaluate the EQL expression
@@ -1229,10 +1226,12 @@ pub fn update_joint_animations(
         {
             Ok(value) => value,
             Err(err) => {
-                warn!(
-                    error = %err,
-                    "Failed to evaluate EQL expression for joint animation"
-                );
+                if errors.insert(err) {
+                    warn!(
+                        error = %err,
+                        "Failed to evaluate EQL expression for joint animation"
+                    );
+                }
                 continue;
             }
         };
@@ -1241,10 +1240,12 @@ pub fn update_joint_animations(
         let (axis, angle) = match component_value_to_axis_angle(&component_value) {
             Ok(result) => result,
             Err(err) => {
-                warn!(
-                    error = %err,
-                    "Failed to convert EQL result to axis-angle rotation for joint animation"
-                );
+                if errors.insert(err) {
+                    warn!(
+                        error = %err,
+                        "Failed to convert EQL result to axis-angle rotation for joint animation"
+                    );
+                }
                 continue;
             }
         };
@@ -1310,18 +1311,17 @@ fn evaluate_scale(
     state: &Object3DState,
     entity_map: &EntityMap,
     component_value_maps: &Query<&'static ComponentValue>,
-) -> Result<Vec3, ScaleEvalError> {
+) -> Result<Vec3, ComponentError> {
     if let Some(expr) = &state.scale_expr {
         let value = expr
-            .execute(entity_map, component_value_maps)
-            .map_err(ScaleEvalError::from)?;
+            .execute(entity_map, component_value_maps)?;
         component_value_to_vec3(&value)
     } else {
         Ok(Vec3::ONE)
     }
 }
 
-fn component_value_to_vec3(value: &ComponentValue) -> Result<Vec3, ScaleEvalError> {
+fn component_value_to_vec3(value: &ComponentValue) -> Result<Vec3, ComponentError> {
     use nox::ArrayBuf;
     match value {
         ComponentValue::F64(array) => {
@@ -1329,7 +1329,7 @@ fn component_value_to_vec3(value: &ComponentValue) -> Result<Vec3, ScaleEvalErro
             if data.len() >= 3 {
                 Ok(Vec3::new(data[0] as f32, data[1] as f32, data[2] as f32).abs())
             } else {
-                Err(ScaleEvalError::NotEnoughComponents { len: data.len() })
+                Err(ComponentError::NotEnoughComponents { required: 3, length: data.len() })
             }
         }
         ComponentValue::F32(array) => {
@@ -1337,10 +1337,10 @@ fn component_value_to_vec3(value: &ComponentValue) -> Result<Vec3, ScaleEvalErro
             if data.len() >= 3 {
                 Ok(Vec3::new(data[0], data[1], data[2]).abs())
             } else {
-                Err(ScaleEvalError::NotEnoughComponents { len: data.len() })
+                Err(ComponentError::NotEnoughComponents { required: 3, length: data.len() })
             }
         }
-        _ => Err(ScaleEvalError::InvalidComponentType),
+        _ => Err(ComponentError::InvalidComponentType { requires: "f32 or f64 array" }),
     }
 }
 
@@ -1441,7 +1441,7 @@ pub fn create_object_3d_entity(
     mat3_material_assets: &mut Assets<Mat3Material>,
     assets: &AssetServer,
     geo_context: &GeoContext,
-) -> Entity {
+) -> Result<Entity, CompileError> {
     let (scale_expr, scale_error) = match &data.mesh {
         impeller2_wkt::Object3DMesh::Ellipsoid {
             scale,
@@ -1488,7 +1488,7 @@ pub fn create_object_3d_entity(
     let entity_id = commands
         .spawn((
             Object3DState {
-                compiled_expr: Some(compile_eql_expr(expr)),
+                compiled_expr: Some(compile_eql_expr(expr)?),
                 scale_expr,
                 scale_error,
                 error_covariance_cholesky_expr,
@@ -1523,7 +1523,7 @@ pub fn create_object_3d_entity(
         mat3_material_assets,
         assets,
     );
-    entity_id
+    Ok(entity_id)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -31,6 +31,7 @@ type ImportedCameraFilter = (Added<Camera>, Without<NavGizmoCamera>, Without<Mai
 type ImportedCameraQuery<'w, 's> = Query<'w, 's, (Entity, &'static ChildOf), ImportedCameraFilter>;
 
 pub const ELLIPSOID_RENDER_LAYER: usize = 29;
+const BINARY_BROADCAST_ERROR: &str = "binary operation requires arrays be broadcastable";
 
 /// ExprObject3D component that holds an EQL expression for dynamic positioning
 #[derive(Component)]
@@ -753,7 +754,7 @@ pub fn compile_eql_expr(expression: eql::Expr) -> CompiledExpr {
                     eql::BinaryOp::Mul => left.try_mul(&right),
                     eql::BinaryOp::Div => left.try_div(&right),
                 }
-                .map_err(|_| "binary operation requires arrays be broadcastable".to_string())?;
+                .map_err(|_| BINARY_BROADCAST_ERROR.to_string())?;
 
                 Ok(ComponentValue::F64(result))
             })
@@ -2119,7 +2120,7 @@ mod ellipsoid_scale_eql_tests {
             .execute(&entity_map, &component_values)
             .expect_err("incompatible shapes should not be flattened together");
 
-        assert_eq!(err, "binary operation requires arrays be broadcastable");
+        assert_eq!(err, super::BINARY_BROADCAST_ERROR);
     }
 
     #[test]

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -25,7 +25,8 @@ use bevy_geo_frames::prelude::*;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::borrow::Cow;
-
+use bevy::platform::hash::FixedHasher;
+use std::hash::BuildHasher;
 type ImportedCameraFilter = (Added<Camera>, Without<NavGizmoCamera>, Without<MainCamera>);
 
 type ImportedCameraQuery<'w, 's> = Query<'w, 's, (Entity, &'static ChildOf), ImportedCameraFilter>;
@@ -111,6 +112,17 @@ pub enum CompiledExpr {
     Closure(Box<ExprFn>),
     Value(ComponentValue),
 }
+
+#[derive(thiserror::Error, Debug, Clone)]
+pub enum CompileError {
+    #[error("{0:?} can't be converted to a component value")]
+    CannotConvert(Expr),
+    #[error("component error: {0}")]
+    ComponentError(#[from] ComponentError),
+    #[error("parse error: {0}")]
+    Parse(#[from] eql::Error),
+}
+
 
 #[derive(Debug, thiserror::Error, Hash, PartialEq, Eq, Clone)]
 pub enum ComponentError {
@@ -692,16 +704,6 @@ fn compile_formula(formula: Arc<dyn eql::Formula>, inner_expr: eql::Expr) -> Res
     })
 }
 
-#[derive(thiserror::Error, Debug, Clone)]
-pub enum CompileError {
-    #[error("{0:?} can't be converted to a component value")]
-    CannotConvert(Expr),
-    #[error("component error: {0}")]
-    ComponentError(#[from] ComponentError),
-    #[error("parse error: {0}")]
-    Parse(#[from] eql::Error),
-}
-
 /// Compiles an EQL expression into a closure-based form
 pub fn compile_eql_expr(expression: eql::Expr) -> Result<CompiledExpr, CompileError> {
     Ok(match expression {
@@ -1216,8 +1218,9 @@ pub fn update_joint_animations(
     mut joint_query: Query<(&mut Transform, &JointAnimationComponent)>,
     entity_map: Res<EntityMap>,
     component_value_maps: Query<&'static ComponentValue>,
-    mut errors: Local<HashSet<ComponentError>>,
+    mut errors: Local<HashSet<u64>>,
 ) {
+    let hasher = FixedHasher;
     for (mut joint_transform, joint_anim) in joint_query.iter_mut() {
         // Evaluate the EQL expression
         let component_value = match joint_anim
@@ -1226,7 +1229,7 @@ pub fn update_joint_animations(
         {
             Ok(value) => value,
             Err(err) => {
-                if errors.insert(err) {
+                if errors.insert(hasher.hash_one(&err)) {
                     warn!(
                         error = %err,
                         "Failed to evaluate EQL expression for joint animation"
@@ -1240,7 +1243,7 @@ pub fn update_joint_animations(
         let (axis, angle) = match component_value_to_axis_angle(&component_value) {
             Ok(result) => result,
             Err(err) => {
-                if errors.insert(err) {
+                if errors.insert(hasher.hash_one(&err)) {
                     warn!(
                         error = %err,
                         "Failed to convert EQL result to axis-angle rotation for joint animation"

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -830,16 +830,6 @@ pub fn compile_cholesky_eql(expr: &str, ctx: &eql::Context) -> Result<CompiledEx
     ctx.parse_str(trimmed).map(compile_eql_expr)?
 }
 
-#[derive(Debug, thiserror::Error)]
-pub enum ScaleEvalError {
-    #[error("expression must yield at least {required} values, got {length}")]
-    NotEnoughComponents { required: usize, length: usize },
-    #[error("expression must yield an F32 or F64 array")]
-    InvalidComponentType,
-    #[error("Component error: {0}")]
-    ComponentError(#[from] ComponentError),
-}
-
 const ELLIPSOID_OVERSIZED_THRESHOLD: f32 = 10_000.0;
 
 /// Chi-squared quantile for 3 degrees of freedom (confidence as fraction 0..1).
@@ -1359,7 +1349,7 @@ fn component_value_to_vec3(value: &ComponentValue) -> Result<Vec3, ComponentErro
     }
 }
 
-fn component_value_to_6floats(value: &ComponentValue) -> Result<[f32; 6], String> {
+fn component_value_to_6floats(value: &ComponentValue) -> Result<[f32; 6], ComponentError> {
     use nox::ArrayBuf;
     match value {
         ComponentValue::F64(array) => {
@@ -1374,10 +1364,10 @@ fn component_value_to_6floats(value: &ComponentValue) -> Result<[f32; 6], String
                     data[5] as f32,
                 ])
             } else {
-                Err(format!(
-                    "error_covariance_cholesky must yield at least 6 values, got {}",
-                    data.len()
-                ))
+                Err(ComponentError::NotEnoughComponents {
+                    required: 6,
+                    length: data.len(),
+                })
             }
         }
         ComponentValue::F32(array) => {
@@ -1385,13 +1375,15 @@ fn component_value_to_6floats(value: &ComponentValue) -> Result<[f32; 6], String
             if data.len() >= 6 {
                 Ok([data[0], data[1], data[2], data[3], data[4], data[5]])
             } else {
-                Err(format!(
-                    "error_covariance_cholesky must yield at least 6 values, got {}",
-                    data.len()
-                ))
+                Err(ComponentError::NotEnoughComponents {
+                    required: 6,
+                    length: data.len(),
+                })
             }
         }
-        _ => Err("error_covariance_cholesky must yield an F32 or F64 array".to_string()),
+        _ => Err(ComponentError::InvalidComponentType {
+            requires: "F32 or F64 array",
+        }),
     }
 }
 

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -23,15 +23,14 @@ use crate::ui::tiles::ViewportConfig;
 use crate::{BevyExt, EqlContext, MainCamera, plugins::navigation_gizmo::NavGizmoCamera};
 use bevy_geo_frames::prelude::*;
 use std::collections::{HashMap, HashSet};
-use std::fmt;
 use std::sync::Arc;
+use std::borrow::Cow;
 
 type ImportedCameraFilter = (Added<Camera>, Without<NavGizmoCamera>, Without<MainCamera>);
 
 type ImportedCameraQuery<'w, 's> = Query<'w, 's, (Entity, &'static ChildOf), ImportedCameraFilter>;
 
 pub const ELLIPSOID_RENDER_LAYER: usize = 29;
-const BINARY_BROADCAST_ERROR: &str = "binary operation requires arrays be broadcastable";
 
 /// ExprObject3D component that holds an EQL expression for dynamic positioning
 #[derive(Component)]
@@ -104,7 +103,7 @@ pub struct WorldPosReceived;
 type ExprFn = dyn for<'a, 'b> Fn(
         &'a EntityMap,
         &'a Query<'b, 'b, &'static ComponentValue>,
-    ) -> Result<ComponentValue, String>
+    ) -> Result<ComponentValue, ComponentError>
     + Send
     + Sync;
 
@@ -113,13 +112,57 @@ pub enum CompiledExpr {
     Value(ComponentValue),
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum ComponentError {
+    #[error("binary operation requires arrays be broadcastable")]
+    BinaryBroadcastError,
+    #[error("cast: shape does not match data length")]
+    ShapeMismatch,
+    #[error("invalid array shape when promoting to f64")]
+    InvalidPromotion,
+    #[error("cannot be empty")]
+    InvalidEmpty,
+    #[error("requires a spatial transform")]
+    RequiresTransform,
+    #[error("requires 7-element array, got {0}")]
+    RequiresSevenElements(usize),
+    #[error("{0} requires tuple expression")]
+    RequiresTuple(&'static str),
+    #[error("{0} requires receiver and angle")]
+    RequiresReceiverAndAngle(&'static str),
+    #[error("{0} requires receiver and three angles (x, y, z)")]
+    RequiresReceiverAndThreeAngles(&'static str),
+    #[error("{0} requires receiver and distance")]
+    RequiresReceiverAndDistance(&'static str),
+    #[error("{0} requires receiver and three distances (x, y, z)")]
+    RequiresReceiverAndThreeDistances(&'static str),
+    #[error("{0} requires receiver and three components (x, y, z)")]
+    RequiresReceiverAndThreeComponents(&'static str),
+    #[error("formula '{0}' is not supported in editor runtime")]
+    EditorNotSupported(&'static str),
+    #[error("component '{0}' not found in entity map")]
+    NoComponent(String),
+    #[error("no component value map found for component '{0}'")]
+    NoComponentValue(String),
+    #[error("array index {index} out of bounds (length {length})")]
+    OutOfBounds { index: usize, length: usize },
+    #[error("array access can only be applied to numeric arrays")]
+    RequireNumericArray,
+    #[error("tuple elements must be numeric")]
+    RequireNumericTuple,
+    #[error("{0:?} can't be converted to a component value")]
+    CannotConvert(Expr),
+    #[error("{0}")]
+    Message(Cow<'static, str>),
+}
+
 impl CompiledExpr {
     pub fn closure<F>(closure: F) -> Self
     where
         F: for<'a, 'b> Fn(
                 &'a EntityMap,
                 &'a Query<'b, 'b, &'static ComponentValue>,
-            ) -> Result<ComponentValue, String>
+            ) -> Result<ComponentValue, ComponentError>
             + Send
             + Sync
             + 'static,
@@ -132,7 +175,7 @@ impl CompiledExpr {
         &'a self,
         entity_map: &'a EntityMap,
         values: &'a Query<'b, 'b, &'static ComponentValue>,
-    ) -> Result<ComponentValue, String> {
+    ) -> Result<ComponentValue, ComponentError> {
         match self {
             Self::Closure(c) => (c)(entity_map, values),
             Self::Value(value) => Ok(value.clone()),
@@ -194,14 +237,14 @@ fn rotate_vector_by_quat(q: (f64, f64, f64, f64), v: (f64, f64, f64)) -> (f64, f
 }
 
 /// Extract spatial transform data (qx, qy, qz, qw, px, py, pz), validating it has 7 elements
-fn extract_spatial(val: ComponentValue) -> Result<[f64; 7], String> {
+fn extract_spatial(val: ComponentValue) -> Result<[f64; 7], ComponentError> {
     use nox::ArrayBuf;
     let ComponentValue::F64(array) = val else {
-        return Err("requires a spatial transform".to_string());
+        return Err(ComponentError::RequiresTransform);
     };
     let data = array.buf.as_buf();
     if data.len() < 7 {
-        return Err(format!("requires 7-element array, got {}", data.len()));
+        return Err(ComponentError::RequiresSevenElements(data.len()));
     }
     Ok([
         data[0], data[1], data[2], data[3], data[4], data[5], data[6],
@@ -209,84 +252,84 @@ fn extract_spatial(val: ComponentValue) -> Result<[f64; 7], String> {
 }
 
 /// Extract a scalar f64 from component value
-fn extract_scalar(val: ComponentValue) -> Result<f64, String> {
+fn extract_scalar(val: ComponentValue) -> Result<f64, ComponentError> {
     use nox::ArrayBuf;
-    let empty = || Err("cannot be empty".to_string());
+    let empty = Err(ComponentError::InvalidEmpty);
     let v = match val {
         ComponentValue::F64(arr) => {
             let d = arr.buf.as_buf();
             if d.is_empty() {
-                return empty();
+                return empty;
             }
             d[0]
         }
         ComponentValue::F32(arr) => {
             let d = arr.buf.as_buf();
             if d.is_empty() {
-                return empty();
+                return empty;
             }
             d[0] as f64
         }
         ComponentValue::U8(arr) => {
             let d = arr.buf.as_buf();
             if d.is_empty() {
-                return empty();
+                return empty;
             }
             d[0] as f64
         }
         ComponentValue::U16(arr) => {
             let d = arr.buf.as_buf();
             if d.is_empty() {
-                return empty();
+                return empty;
             }
             d[0] as f64
         }
         ComponentValue::U32(arr) => {
             let d = arr.buf.as_buf();
             if d.is_empty() {
-                return empty();
+                return empty;
             }
             d[0] as f64
         }
         ComponentValue::U64(arr) => {
             let d = arr.buf.as_buf();
             if d.is_empty() {
-                return empty();
+                return empty;
             }
             d[0] as f64
         }
         ComponentValue::I8(arr) => {
             let d = arr.buf.as_buf();
             if d.is_empty() {
-                return empty();
+                return empty;
             }
             d[0] as f64
         }
         ComponentValue::I16(arr) => {
             let d = arr.buf.as_buf();
             if d.is_empty() {
-                return empty();
+                return empty;
             }
             d[0] as f64
         }
         ComponentValue::I32(arr) => {
             let d = arr.buf.as_buf();
             if d.is_empty() {
-                return empty();
+                return empty;
             }
             d[0] as f64
         }
         ComponentValue::I64(arr) => {
             let d = arr.buf.as_buf();
             if d.is_empty() {
-                return empty();
+                return empty;
             }
             d[0] as f64
         }
         ComponentValue::Bool(arr) => {
             let d = arr.buf.as_buf();
             if d.is_empty() {
-                return empty();
+                return empty;
             }
             if d[0] { 1.0 } else { 0.0 }
         }
@@ -308,7 +351,7 @@ fn build_vec3_result(v: (f64, f64, f64)) -> ComponentValue {
     ComponentValue::F64(result_array)
 }
 
-fn component_buf_as_f64_vec(value: &ComponentValue) -> Result<Vec<f64>, String> {
+fn component_buf_as_f64_vec(value: &ComponentValue) -> Result<Vec<f64>, ComponentError> {
     use nox::ArrayBuf;
     Ok(match value {
         ComponentValue::U8(a) => a.buf.as_buf().iter().map(|&x| x as f64).collect(),
@@ -330,7 +373,7 @@ fn component_buf_as_f64_vec(value: &ComponentValue) -> Result<Vec<f64>, String> 
     })
 }
 
-fn promote_component_to_f64(value: ComponentValue) -> Result<Array<f64, nox::Dyn>, String> {
+fn promote_component_to_f64(value: ComponentValue) -> Result<Array<f64, nox::Dyn>, ComponentError> {
     use smallvec::SmallVec;
     match value {
         ComponentValue::F64(arr) => Ok(arr),
@@ -338,7 +381,7 @@ fn promote_component_to_f64(value: ComponentValue) -> Result<Array<f64, nox::Dyn
             let data = component_buf_as_f64_vec(&other)?;
             let shape_sv: SmallVec<[usize; 4]> = SmallVec::from_slice(other.shape());
             Array::from_shape_vec(shape_sv, data)
-                .ok_or_else(|| "invalid array shape when promoting to f64".to_string())
+                .ok_or(ComponentError::InvalidPromotion)
         }
     }
 }
@@ -346,15 +389,15 @@ fn promote_component_to_f64(value: ComponentValue) -> Result<Array<f64, nox::Dyn
 fn cast_dyn_array_from_field<T: nox::Field>(
     shape_sv: &smallvec::SmallVec<[usize; 4]>,
     flat: Vec<T>,
-) -> Result<Array<T, nox::Dyn>, String> {
+) -> Result<Array<T, nox::Dyn>, ComponentError> {
     Array::from_shape_vec(shape_sv.clone(), flat)
-        .ok_or_else(|| "cast: shape does not match data length".to_string())
+        .ok_or(ComponentError::ShapeMismatch)
 }
 
 fn cast_component_value(
     value: ComponentValue,
     target: eql::CastTarget,
-) -> Result<ComponentValue, String> {
+) -> Result<ComponentValue, ComponentError> {
     use nox::ArrayBuf;
     use smallvec::SmallVec;
     let sh = value.shape();
@@ -442,12 +485,10 @@ fn compile_formula(formula: Arc<dyn eql::Formula>, inner_expr: eql::Expr) -> Com
             };
 
             let eql::Expr::Tuple(elements) = inner_expr else {
-                let error = format!("{n} requires tuple expression");
-                return CompiledExpr::closure(move |_, _| Err(error.clone()));
+                return CompiledExpr::closure(move |_, _| Err(ComponentError::RequiresTuple(n)));
             };
             if elements.len() != 2 {
-                let error = format!("{n} requires receiver and angle");
-                return CompiledExpr::closure(move |_, _| Err(error.clone()));
+                return CompiledExpr::closure(move |_, _| Err(ComponentError::RequiresReceiverAndAngle(n)));
             }
 
             let receiver_compiled = compile_eql_expr(elements[0].clone());
@@ -481,12 +522,10 @@ fn compile_formula(formula: Arc<dyn eql::Formula>, inner_expr: eql::Expr) -> Com
             };
 
             let eql::Expr::Tuple(elements) = inner_expr else {
-                let error = format!("{n} requires tuple expression");
-                return CompiledExpr::closure(move |_, _| Err(error.clone()));
+                return CompiledExpr::closure(move |_, _| Err(ComponentError::RequiresTuple(n)));
             };
             if elements.len() != 4 {
-                let error = format!("{n} requires receiver and three angles (x, y, z)");
-                return CompiledExpr::closure(move |_, _| Err(error.clone()));
+                return CompiledExpr::closure(move |_, _| Err(ComponentError::RequiresReceiverAndThreeAngles(n)));
             }
 
             let receiver_compiled = compile_eql_expr(elements[0].clone());
@@ -536,12 +575,10 @@ fn compile_formula(formula: Arc<dyn eql::Formula>, inner_expr: eql::Expr) -> Com
             };
 
             let eql::Expr::Tuple(elements) = inner_expr else {
-                let error = format!("{n} requires tuple expression");
-                return CompiledExpr::closure(move |_, _| Err(error.clone()));
+                return CompiledExpr::closure(move |_, _| Err(ComponentError::RequiresTuple(n)));
             };
             if elements.len() != 2 {
-                let error = format!("{n} requires receiver and distance");
-                return CompiledExpr::closure(move |_, _| Err(error.clone()));
+                return CompiledExpr::closure(move |_, _| Err(ComponentError::RequiresReceiverAndDistance(n)));
             }
 
             let receiver_compiled = compile_eql_expr(elements[0].clone());
@@ -583,12 +620,10 @@ fn compile_formula(formula: Arc<dyn eql::Formula>, inner_expr: eql::Expr) -> Com
             };
 
             let eql::Expr::Tuple(elements) = inner_expr else {
-                let error = format!("{n} requires tuple expression");
-                return CompiledExpr::closure(move |_, _| Err(error.clone()));
+                return CompiledExpr::closure(move |_, _| Err(ComponentError::RequiresTuple(n)));
             };
             if elements.len() != 4 {
-                let error = format!("{n} requires receiver and three distances (x, y, z)");
-                return CompiledExpr::closure(move |_, _| Err(error.clone()));
+                return CompiledExpr::closure(move |_, _| Err(ComponentError::RequiresReceiverAndThreeDistances(n)));
             }
 
             let receiver_compiled = compile_eql_expr(elements[0].clone());
@@ -622,14 +657,10 @@ fn compile_formula(formula: Arc<dyn eql::Formula>, inner_expr: eql::Expr) -> Com
         // direction(x, y, z): body-frame direction transformed to world frame (returns 3-vector)
         "direction" => {
             let eql::Expr::Tuple(elements) = inner_expr else {
-                return CompiledExpr::closure(move |_, _| {
-                    Err("direction requires tuple (receiver, x, y, z)".to_string())
-                });
+                return CompiledExpr::closure(move |_, _| Err(ComponentError::RequiresTuple(n)));
             };
             if elements.len() != 4 {
-                return CompiledExpr::closure(move |_, _| {
-                    Err("direction requires receiver and three components (x, y, z)".to_string())
-                });
+                return CompiledExpr::closure(move |_, _| Err(ComponentError::RequiresReceiverAndThreeComponents(n)));
             }
 
             let receiver_compiled = compile_eql_expr(elements[0].clone());
@@ -650,30 +681,23 @@ fn compile_formula(formula: Arc<dyn eql::Formula>, inner_expr: eql::Expr) -> Com
         }
 
         _ => {
-            let error = format!("formula '{n}' is not supported in editor runtime");
-            CompiledExpr::closure(move |_, _| Err(error.clone()))
+            CompiledExpr::closure(move |_, _| Err(ComponentError::EditorNotSupported(n)))
         }
     }
 }
 
 /// Compiles an EQL expression into a closure-based form
+///
+/// TODO: Consider making this return a `Result<CompiledExpr, CompiledExprError or Expr>`.
 pub fn compile_eql_expr(expression: eql::Expr) -> CompiledExpr {
     match expression {
         Expr::ComponentPart(component) => {
             let component_id = component.id;
             CompiledExpr::closure(move |entity_map, component_value| {
-                let entity_id = entity_map.get(&component_id).ok_or_else(|| {
-                    format!("component '{}' not found in entity map", component.name)
-                })?;
-
+                let entity_id = entity_map.get(&component_id).ok_or(ComponentError::NoComponent(component.name.clone()))?;
                 component_value
                     .get(*entity_id)
-                    .map_err(|_| {
-                        format!(
-                            "no component value map found for component '{}'",
-                            component.name
-                        )
-                    })
+                    .map_err(|_| ComponentError::NoComponentValue(component.name.clone()))
                     .cloned()
             })
         }
@@ -690,11 +714,10 @@ pub fn compile_eql_expr(expression: eql::Expr) -> CompiledExpr {
                             let value = nox::Array::<_, ()> { buf: value }.to_dyn();
                             Ok(ComponentValue::F64(value))
                         } else {
-                            Err(format!(
-                                "array index {} out of bounds (length: {})",
+                            Err(ComponentError::OutOfBounds {
                                 index,
-                                data.len()
-                            ))
+                                length: data.len()
+                            })
                         }
                     }
                     ComponentValue::F32(array) => {
@@ -705,14 +728,14 @@ pub fn compile_eql_expr(expression: eql::Expr) -> CompiledExpr {
                             let value = nox::Array::<_, ()> { buf: value }.to_dyn();
                             Ok(ComponentValue::F32(value))
                         } else {
-                            Err(format!(
-                                "array index {} out of bounds (length: {})",
+
+                            Err(ComponentError::OutOfBounds {
                                 index,
-                                data.len()
-                            ))
+                                length: data.len()
+                            })
                         }
                     }
-                    _ => Err("array access can only be applied to numeric arrays".to_string()),
+                    _ => Err(ComponentError::RequireNumericArray),
                 }
             })
         }
@@ -732,7 +755,7 @@ pub fn compile_eql_expr(expression: eql::Expr) -> CompiledExpr {
                             let f32_data = array.buf.as_buf();
                             values.extend(f32_data.iter().map(|&x| x as f64));
                         }
-                        _ => return Err("tuple elements must be numeric".to_string()),
+                        _ => return Err(ComponentError::RequireNumericTuple),
                     }
                 }
                 let tuple_array = Array::from_shape_vec(smallvec![values.len()], values).unwrap();
@@ -754,7 +777,7 @@ pub fn compile_eql_expr(expression: eql::Expr) -> CompiledExpr {
                     eql::BinaryOp::Mul => left.try_mul(&right),
                     eql::BinaryOp::Div => left.try_div(&right),
                 }
-                .map_err(|_| BINARY_BROADCAST_ERROR.to_string())?;
+                .map_err(|_| ComponentError::BinaryBroadcastError)?;
 
                 Ok(ComponentValue::F64(result))
             })
@@ -762,8 +785,7 @@ pub fn compile_eql_expr(expression: eql::Expr) -> CompiledExpr {
         Expr::FloatLiteral(f) => CompiledExpr::Value(ComponentValue::F64(nox::array!(f).to_dyn())),
         Expr::Formula(formula, inner_expr) => compile_formula(formula, *inner_expr),
         expr => {
-            let error = format!("{:?} can't be converted to a component value", expr);
-            CompiledExpr::closure(move |_, _| Err(error.clone()))
+            CompiledExpr::closure(move |_, _| Err(ComponentError::CannotConvert(expr.clone())))
         }
     }
 }
@@ -790,27 +812,16 @@ pub fn compile_cholesky_eql(expr: &str, ctx: &eql::Context) -> Result<CompiledEx
         .map_err(|err| err.to_string())
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ScaleEvalError {
+    #[error("{0}")]
     Expr(String),
+    #[error("scale expression must yield at least 3 values, got {len}")]
     NotEnoughComponents { len: usize },
+    #[error("scale expression must yield an F32 or F64 array")]
     InvalidComponentType,
-}
-
-impl fmt::Display for ScaleEvalError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Expr(err) => write!(f, "{}", err),
-            Self::NotEnoughComponents { len } => write!(
-                f,
-                "scale expression must yield at least 3 values, got {}",
-                len
-            ),
-            Self::InvalidComponentType => {
-                f.write_str("scale expression must yield an F32 or F64 array")
-            }
-        }
-    }
+    #[error("Component error: {0}")]
+    ComponentError(ComponentError)
 }
 
 impl From<String> for ScaleEvalError {
@@ -818,8 +829,11 @@ impl From<String> for ScaleEvalError {
         Self::Expr(value)
     }
 }
-
-impl std::error::Error for ScaleEvalError {}
+impl From<ComponentError> for ScaleEvalError {
+    fn from(value: ComponentError) -> Self {
+        Self::ComponentError(value)
+    }
+}
 
 const ELLIPSOID_OVERSIZED_THRESHOLD: f32 = 10_000.0;
 

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -2051,6 +2051,7 @@ mod joint_eql_cast_tests {
             SystemState::new(&mut world);
         let (q,) = system_state.get(&world);
         let out = compiled
+            .expect("compiled expr")
             .execute(&entity_map, &q)
             .expect("editor EQL runtime evaluation");
 
@@ -2149,7 +2150,7 @@ mod ellipsoid_scale_eql_tests {
             .execute(&entity_map, &component_values)
             .expect_err("incompatible shapes should not be flattened together");
 
-        assert_eq!(err, super::BINARY_BROADCAST_ERROR);
+        assert_eq!(err, crate::object_3d::ComponentError::BinaryBroadcastError);
     }
 
     #[test]

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -342,159 +342,6 @@ fn promote_component_to_f64(value: ComponentValue) -> Result<Array<f64, nox::Dyn
     }
 }
 
-// Keep object_3d runtime EQL binary operations shape-based.
-// TODO: move this into nox once dynamic broadcasting is fixed there. Today,
-// nox::Array binary ops can panic on equal-rank incompatible shapes and can
-// iterate dynamic broadcasts incorrectly when the left rank is greater than the right
-// rank. The editor keeps the broadcast local so runtime EQL returns a clean
-// error and preserves expected array shapes.
-fn broadcast_shape(
-    left: &[usize],
-    right: &[usize],
-) -> Result<smallvec::SmallVec<[usize; 4]>, String> {
-    let rank = left.len().max(right.len());
-    let mut shape = smallvec::SmallVec::with_capacity(rank);
-
-    for axis in 0..rank {
-        let left_axis = axis
-            .checked_sub(rank - left.len())
-            .map(|i| left[i])
-            .unwrap_or(1);
-        let right_axis = axis
-            .checked_sub(rank - right.len())
-            .map(|i| right[i])
-            .unwrap_or(1);
-
-        if left_axis == right_axis {
-            shape.push(left_axis);
-        } else if left_axis == 1 {
-            shape.push(right_axis);
-        } else if right_axis == 1 {
-            shape.push(left_axis);
-        } else {
-            return Err("binary operation requires arrays be broadcastable".to_string());
-        }
-    }
-
-    Ok(shape)
-}
-
-fn row_major_strides(shape: &[usize]) -> smallvec::SmallVec<[usize; 4]> {
-    let mut strides = smallvec::SmallVec::from_elem(0, shape.len());
-    let mut stride = 1;
-    for axis in (0..shape.len()).rev() {
-        strides[axis] = stride;
-        stride *= shape[axis];
-    }
-    strides
-}
-
-fn broadcast_strides(
-    output_shape: &[usize],
-    input_shape: &[usize],
-    input_strides: &[usize],
-) -> smallvec::SmallVec<[usize; 4]> {
-    debug_assert!(output_shape.len() >= input_shape.len());
-    debug_assert_eq!(input_shape.len(), input_strides.len());
-
-    let leading_axes = output_shape.len() - input_shape.len();
-    output_shape
-        .iter()
-        .enumerate()
-        .map(|(axis, _)| {
-            if axis < leading_axes {
-                0
-            } else {
-                let input_axis = axis - leading_axes;
-                if input_shape[input_axis] == 1 {
-                    0
-                } else {
-                    input_strides[input_axis]
-                }
-            }
-        })
-        .collect()
-}
-
-fn advance_broadcast_offsets(
-    index: &mut [usize],
-    shape: &[usize],
-    left_strides: &[usize],
-    right_strides: &[usize],
-    left_offset: &mut usize,
-    right_offset: &mut usize,
-) {
-    debug_assert_eq!(index.len(), shape.len());
-    debug_assert_eq!(left_strides.len(), shape.len());
-    debug_assert_eq!(right_strides.len(), shape.len());
-
-    for axis in (0..shape.len()).rev() {
-        index[axis] += 1;
-        *left_offset += left_strides[axis];
-        *right_offset += right_strides[axis];
-
-        if index[axis] < shape[axis] {
-            break;
-        }
-
-        *left_offset -= index[axis] * left_strides[axis];
-        *right_offset -= index[axis] * right_strides[axis];
-        index[axis] = 0;
-    }
-}
-
-fn apply_binary_op(
-    left: &Array<f64, nox::Dyn>,
-    right: &Array<f64, nox::Dyn>,
-    op: eql::BinaryOp,
-) -> Result<Array<f64, nox::Dyn>, String> {
-    use nox::ArrayBuf;
-
-    let left_data = left.buf.as_buf();
-    let right_data = right.buf.as_buf();
-    let output_shape = broadcast_shape(left.shape(), right.shape())?;
-    let output_len = output_shape.iter().product();
-    let left_strides = broadcast_strides(
-        &output_shape,
-        left.shape(),
-        &row_major_strides(left.shape()),
-    );
-    let right_strides = broadcast_strides(
-        &output_shape,
-        right.shape(),
-        &row_major_strides(right.shape()),
-    );
-
-    let apply = |left: f64, right: f64| match op {
-        eql::BinaryOp::Add => left + right,
-        eql::BinaryOp::Sub => left - right,
-        eql::BinaryOp::Mul => left * right,
-        eql::BinaryOp::Div => left / right,
-    };
-
-    let mut index = smallvec::SmallVec::<[usize; 4]>::from_elem(0, output_shape.len());
-    let mut left_offset = 0;
-    let mut right_offset = 0;
-    let mut values = Vec::with_capacity(output_len);
-    for flat_index in 0..output_len {
-        values.push(apply(left_data[left_offset], right_data[right_offset]));
-
-        if flat_index + 1 < output_len {
-            advance_broadcast_offsets(
-                &mut index,
-                &output_shape,
-                &left_strides,
-                &right_strides,
-                &mut left_offset,
-                &mut right_offset,
-            );
-        }
-    }
-
-    Array::from_shape_vec(output_shape, values)
-        .ok_or_else(|| "invalid array shape after binary operation".to_string())
-}
-
 fn cast_dyn_array_from_field<T: nox::Field>(
     shape_sv: &smallvec::SmallVec<[usize; 4]>,
     flat: Vec<T>,
@@ -900,7 +747,13 @@ pub fn compile_eql_expr(expression: eql::Expr) -> CompiledExpr {
 
                 let left = promote_component_to_f64(left_val)?;
                 let right = promote_component_to_f64(right_val)?;
-                let result = apply_binary_op(&left, &right, op)?;
+                let result = match op {
+                    eql::BinaryOp::Add => left.try_add(&right),
+                    eql::BinaryOp::Sub => left.try_sub(&right),
+                    eql::BinaryOp::Mul => left.try_mul(&right),
+                    eql::BinaryOp::Div => left.try_div(&right),
+                }
+                .map_err(|_| "binary operation requires arrays be broadcastable".to_string())?;
 
                 Ok(ComponentValue::F64(result))
             })
@@ -2193,22 +2046,32 @@ mod ellipsoid_scale_eql_tests {
     use impeller2::types::{ComponentId, PrimType, Timestamp};
     use impeller2_bevy::EntityMap;
     use impeller2_wkt::ComponentValue;
-    use nox::{Array, ArrayBuf};
+    use nox::Array;
 
-    use super::{apply_binary_op, compile_scale_eql, component_value_to_vec3};
+    use super::{compile_scale_eql, component_value_to_vec3};
 
     fn pos_std_var_component(name: &str) -> Arc<eql::Component> {
+        f64_component(name, &[3])
+    }
+
+    fn f64_component(name: &str, shape: &[u64]) -> Arc<eql::Component> {
         Arc::new(eql::Component::new(
             name.to_string(),
             ComponentId::new(name),
-            Schema::new(PrimType::F64, vec![3u64]).unwrap(),
+            Schema::new(PrimType::F64, shape.to_vec()).unwrap(),
         ))
     }
 
     fn f64_component_value(values: [f64; 3]) -> ComponentValue {
+        f64_component_value_with_shape(smallvec::smallvec![3], values.to_vec())
+    }
+
+    fn f64_component_value_with_shape(
+        shape: smallvec::SmallVec<[usize; 4]>,
+        values: Vec<f64>,
+    ) -> ComponentValue {
         ComponentValue::F64(
-            Array::<f64, nox::Dyn>::from_shape_vec(smallvec::smallvec![3], values.to_vec())
-                .expect("f64 telemetry buffer"),
+            Array::<f64, nox::Dyn>::from_shape_vec(shape, values).expect("f64 telemetry buffer"),
         )
     }
 
@@ -2221,56 +2084,39 @@ mod ellipsoid_scale_eql_tests {
     }
 
     #[test]
-    fn apply_binary_op_broadcasts_arrays_with_different_ranks() {
-        let left =
-            Array::<f64, nox::Dyn>::from_shape_vec(smallvec::smallvec![3], vec![1.0, 2.0, 3.0])
-                .expect("left array");
-        let right = Array::<f64, nox::Dyn>::from_shape_vec(
-            smallvec::smallvec![2, 3],
-            vec![10.0, 20.0, 30.0, 40.0, 50.0, 60.0],
-        )
-        .expect("right array");
-
-        let result = apply_binary_op(&left, &right, eql::BinaryOp::Add).expect("broadcasted add");
-
-        assert_eq!(result.shape(), &[2, 3]);
-        assert_eq!(result.buf.as_buf(), &[11.0, 22.0, 33.0, 41.0, 52.0, 63.0]);
-    }
-
-    #[test]
-    fn apply_binary_op_supports_sub_and_div_with_broadcasting() {
-        let left = Array::<f64, nox::Dyn>::from_shape_vec(
-            smallvec::smallvec![2, 3],
-            vec![10.0, 20.0, 30.0, 40.0, 50.0, 60.0],
-        )
-        .expect("left array");
-        let right =
-            Array::<f64, nox::Dyn>::from_shape_vec(smallvec::smallvec![3], vec![1.0, 2.0, 5.0])
-                .expect("right array");
-
-        let sub = apply_binary_op(&left, &right, eql::BinaryOp::Sub).expect("broadcasted sub");
-        let div = apply_binary_op(&left, &right, eql::BinaryOp::Div).expect("broadcasted div");
-
-        assert_eq!(sub.shape(), &[2, 3]);
-        assert_eq!(sub.buf.as_buf(), &[9.0, 18.0, 25.0, 39.0, 48.0, 55.0]);
-        assert_eq!(div.shape(), &[2, 3]);
-        assert_eq!(div.buf.as_buf(), &[10.0, 10.0, 6.0, 40.0, 25.0, 12.0]);
-    }
-
-    #[test]
     fn object_3d_eql_binary_ops_reject_same_len_incompatible_shapes() {
-        let left = Array::<f64, nox::Dyn>::from_shape_vec(
-            smallvec::smallvec![2, 3],
-            vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
-        )
-        .expect("left array");
-        let right = Array::<f64, nox::Dyn>::from_shape_vec(
-            smallvec::smallvec![3, 2],
-            vec![10.0, 20.0, 30.0, 40.0, 50.0, 60.0],
-        )
-        .expect("right array");
+        let left = f64_component("left", &[2, 3]);
+        let right = f64_component("right", &[3, 2]);
+        let left_id = left.id;
+        let right_id = right.id;
+        let ctx =
+            eql::Context::from_leaves([left.clone(), right.clone()], Timestamp(0), Timestamp(1000));
 
-        let err = apply_binary_op(&left, &right, eql::BinaryOp::Add)
+        let mut world = World::new();
+        let left_entity = world
+            .spawn(f64_component_value_with_shape(
+                smallvec::smallvec![2, 3],
+                vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            ))
+            .id();
+        let right_entity = world
+            .spawn(f64_component_value_with_shape(
+                smallvec::smallvec![3, 2],
+                vec![10.0, 20.0, 30.0, 40.0, 50.0, 60.0],
+            ))
+            .id();
+        let entity_map = EntityMap(HashMap::from([
+            (left_id, left_entity),
+            (right_id, right_entity),
+        ]));
+
+        let mut system_state: SystemState<(Query<'static, 'static, &ComponentValue>,)> =
+            SystemState::new(&mut world);
+        let (component_values,) = system_state.get(&world);
+        let compiled = compile_scale_eql("left + right", &ctx).expect("expression should compile");
+
+        let err = compiled
+            .execute(&entity_map, &component_values)
             .expect_err("incompatible shapes should not be flattened together");
 
         assert_eq!(err, "binary operation requires arrays be broadcastable");

--- a/libs/elodin-editor/src/ui/command_palette/palette_items.rs
+++ b/libs/elodin-editor/src/ui/command_palette/palette_items.rs
@@ -1177,7 +1177,7 @@ fn create_object_3d_with_color(eql: String, expr: eql::Expr, mesh: Mesh) -> Pale
                     material: Material::color(r, g, b),
                 };
 
-                crate::object_3d::create_object_3d_entity(
+                let _ = crate::object_3d::create_object_3d_entity(
                     &mut commands,
                     Object3D {
                         eql: eql.clone(),
@@ -1263,7 +1263,7 @@ pub fn create_3d_object() -> PaletteItem {
                                                 | {
                                                 let obj = impeller2_wkt::Object3DMesh::glb(gltf_path.trim());
 
-                                                crate::object_3d::create_object_3d_entity(
+                                                let _ = crate::object_3d::create_object_3d_entity(
                                                     &mut commands,
                                                     Object3D { eql: eql.clone(), mesh: obj, icon: None, mesh_visibility_range: None, frame: None, node_id: Default::default() },
                                                     expr.clone(),

--- a/libs/elodin-editor/src/ui/command_palette/palette_items.rs
+++ b/libs/elodin-editor/src/ui/command_palette/palette_items.rs
@@ -1212,7 +1212,7 @@ fn parse_color(
     component_value_maps: Query<&'static ComponentValue>,
 ) -> Option<(f32, f32, f32)> {
     let expr = ctx.parse_str(expr).ok()?;
-    let expr = crate::object_3d::compile_eql_expr(expr);
+    let expr = crate::object_3d::compile_eql_expr(expr).ok()?;
     let val = expr.execute(entity_map, &component_value_maps).ok()?;
 
     let ComponentValue::F64(array) = val else {

--- a/libs/elodin-editor/src/ui/inspector/object3d.rs
+++ b/libs/elodin-editor/src/ui/inspector/object3d.rs
@@ -122,7 +122,7 @@ impl WidgetSystem for InspectorObject3D<'_, '_> {
                 match eql_context.0.parse_str(&object_3d_state.data.eql) {
                     Ok(expr) => {
                         object_3d_state.compiled_expr =
-                            Some(crate::object_3d::compile_eql_expr(expr));
+                            Some(crate::object_3d::compile_eql_expr(expr)?);
                     }
                     Err(err) => {
                         ui.colored_label(get_scheme().error, err.to_string());

--- a/libs/elodin-editor/src/ui/inspector/object3d.rs
+++ b/libs/elodin-editor/src/ui/inspector/object3d.rs
@@ -15,7 +15,8 @@ use impeller2_wkt::{
 use smallvec::SmallVec;
 
 use crate::object_3d::{
-    EllipsoidVisual, Object3DMeshChild, compile_cholesky_eql, compile_scale_eql, spawn_mesh, CompileError, ComponentError,
+    CompileError, ComponentError, EllipsoidVisual, Object3DMeshChild, compile_cholesky_eql,
+    compile_scale_eql, spawn_mesh,
 };
 use crate::ui::inspector::{eql_textfield, node_color_picker};
 use crate::{
@@ -243,8 +244,9 @@ impl WidgetSystem for InspectorObject3D<'_, '_> {
 
             ui.separator();
 
-            let mut scale_expr_update: Option<Result<crate::object_3d::CompiledExpr, CompileError>> =
-                None;
+            let mut scale_expr_update: Option<
+                Result<crate::object_3d::CompiledExpr, CompileError>,
+            > = None;
             let mut cholesky_expr_update: Option<Option<crate::object_3d::CompiledExpr>> = None;
             let scale_error_display = object_3d_state.scale_error.clone();
 
@@ -461,8 +463,10 @@ impl WidgetSystem for InspectorObject3D<'_, '_> {
                         let response = eql_textfield(ui, true, &eql_context.0, scale);
                         if response.changed() {
                             if scale.trim().is_empty() {
-                                scale_expr_update =
-                                    Some(Err(ComponentError::InvalidEmptyIn("scale expression").into()));
+                                scale_expr_update = Some(Err(ComponentError::InvalidEmptyIn(
+                                    "scale expression",
+                                )
+                                .into()));
                             } else {
                                 scale_expr_update = Some(compile_scale_eql(scale, &eql_context.0));
                             }

--- a/libs/elodin-editor/src/ui/inspector/object3d.rs
+++ b/libs/elodin-editor/src/ui/inspector/object3d.rs
@@ -15,7 +15,7 @@ use impeller2_wkt::{
 use smallvec::SmallVec;
 
 use crate::object_3d::{
-    EllipsoidVisual, Object3DMeshChild, compile_cholesky_eql, compile_scale_eql, spawn_mesh,
+    EllipsoidVisual, Object3DMeshChild, compile_cholesky_eql, compile_scale_eql, spawn_mesh, CompileError, ComponentError,
 };
 use crate::ui::inspector::{eql_textfield, node_color_picker};
 use crate::{
@@ -122,7 +122,7 @@ impl WidgetSystem for InspectorObject3D<'_, '_> {
                 match eql_context.0.parse_str(&object_3d_state.data.eql) {
                     Ok(expr) => {
                         object_3d_state.compiled_expr =
-                            Some(crate::object_3d::compile_eql_expr(expr)?);
+                            crate::object_3d::compile_eql_expr(expr).ok();
                     }
                     Err(err) => {
                         ui.colored_label(get_scheme().error, err.to_string());
@@ -243,7 +243,7 @@ impl WidgetSystem for InspectorObject3D<'_, '_> {
 
             ui.separator();
 
-            let mut scale_expr_update: Option<Result<crate::object_3d::CompiledExpr, String>> =
+            let mut scale_expr_update: Option<Result<crate::object_3d::CompiledExpr, CompileError>> =
                 None;
             let mut cholesky_expr_update: Option<Option<crate::object_3d::CompiledExpr>> = None;
             let scale_error_display = object_3d_state.scale_error.clone();
@@ -462,14 +462,14 @@ impl WidgetSystem for InspectorObject3D<'_, '_> {
                         if response.changed() {
                             if scale.trim().is_empty() {
                                 scale_expr_update =
-                                    Some(Err("scale expression cannot be empty".to_string()));
+                                    Some(Err(ComponentError::InvalidEmptyIn("scale expression").into()));
                             } else {
                                 scale_expr_update = Some(compile_scale_eql(scale, &eql_context.0));
                             }
                         }
 
                         if let Some(err) = &scale_error_display {
-                            ui.colored_label(get_scheme().error, err);
+                            ui.colored_label(get_scheme().error, format!("{}", err));
                         }
                         if ui
                             .button("Use error covariance (Cholesky) instead")
@@ -477,7 +477,7 @@ impl WidgetSystem for InspectorObject3D<'_, '_> {
                         {
                             *error_covariance_cholesky = Some("(1, 0, 1, 0, 0, 1)".to_string());
                             *error_confidence_interval = default_ellipsoid_confidence_interval();
-                            scale_expr_update = Some(Err("".to_string()));
+                            scale_expr_update = None;
                             cholesky_expr_update = Some(
                                 compile_cholesky_eql("(1, 0, 1, 0, 0, 1)", &eql_context.0).ok(),
                             );
@@ -506,7 +506,7 @@ impl WidgetSystem for InspectorObject3D<'_, '_> {
                     }
                     Err(err) => {
                         object_3d_state.scale_expr = None;
-                        object_3d_state.scale_error = if err.is_empty() { None } else { Some(err) };
+                        object_3d_state.scale_error = Some(err);
                     }
                 }
             }

--- a/libs/elodin-editor/src/ui/inspector/viewport.rs
+++ b/libs/elodin-editor/src/ui/inspector/viewport.rs
@@ -428,7 +428,7 @@ fn eql_input(ui: &mut egui::Ui, editable_expr: &mut EditableEQL, ctx: &eql::Cont
             }
             match ctx.parse_str(&editable_expr.eql) {
                 Ok(expr) => {
-                    editable_expr.compiled_expr = Some(compile_eql_expr(expr));
+                    editable_expr.compiled_expr = compile_eql_expr(expr).ok();
                 }
                 Err(err) => {
                     ui.colored_label(get_scheme().error, err.to_string());

--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -16,6 +16,7 @@ use std::{
     collections::{BTreeMap, HashMap},
     path::{Path, PathBuf},
 };
+use crate::object_3d::CompileError;
 
 #[cfg(not(target_os = "macos"))]
 use crate::tiles::WindowRelayout;
@@ -592,7 +593,7 @@ impl LoadSchematicParams<'_, '_> {
         };
         let icon = object_3d.icon.clone();
         let mesh_vr = object_3d.mesh_visibility_range.clone();
-        let entity = crate::object_3d::create_object_3d_entity(
+        let result = crate::object_3d::create_object_3d_entity(
             &mut self.commands,
             object_3d.clone(),
             expr,
@@ -603,19 +604,26 @@ impl LoadSchematicParams<'_, '_> {
             &self.asset_server,
             &self.geo_context,
         );
-        self.commands.entity(entity).insert(SchematicSpawned);
-        if let Some(icon) = &icon {
-            crate::object_3d::spawn_billboard_icon(
-                &mut self.commands,
-                entity,
-                icon,
-                mesh_vr.as_ref(),
-                &mut self.materials,
-                &mut self.meshes,
-                &mut self.images,
-                &self.asset_server,
-                &mut self.icon_cache,
-            );
+        match result {
+            Ok(entity) => {
+                self.commands.entity(entity).insert(SchematicSpawned);
+                if let Some(icon) = &icon {
+                    crate::object_3d::spawn_billboard_icon(
+                        &mut self.commands,
+                        entity,
+                        icon,
+                        mesh_vr.as_ref(),
+                        &mut self.materials,
+                        &mut self.meshes,
+                        &mut self.images,
+                        &self.asset_server,
+                        &mut self.icon_cache,
+                    );
+                }
+            }
+            Err(err) => {
+                warn!("Unable to spawn object 3d due to eql compile error: {err}");
+            }
         }
     }
 
@@ -645,14 +653,17 @@ impl LoadSchematicParams<'_, '_> {
             .eql
             .0
             .parse_str(&vector_arrow.vector)
-            .map(compile_eql_expr)
+            .map_err(CompileError::Parse)
+            .and_then(compile_eql_expr)
             .ok();
 
         let origin_expr = vector_arrow
             .origin
             .as_ref()
-            .and_then(|origin| self.eql.0.parse_str(origin).ok())
-            .map(compile_eql_expr);
+            .and_then(|origin| self.eql.0.parse_str(origin)
+                      .map_err(CompileError::Parse)
+                      .and_then(compile_eql_expr)
+                      .ok());
 
         let frame = vector_arrow.frame;
         let mut spawn = self.commands.spawn((

--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -1,4 +1,5 @@
 use crate::icon_rasterizer::IconTextureCache;
+use crate::object_3d::CompileError;
 use bevy::{ecs::system::SystemParam, prelude::*, window::PrimaryWindow};
 #[cfg(target_os = "macos")]
 use bevy_defer::AsyncCommandsExtension;
@@ -16,7 +17,6 @@ use std::{
     collections::{BTreeMap, HashMap},
     path::{Path, PathBuf},
 };
-use crate::object_3d::CompileError;
 
 #[cfg(not(target_os = "macos"))]
 use crate::tiles::WindowRelayout;
@@ -657,13 +657,14 @@ impl LoadSchematicParams<'_, '_> {
             .and_then(compile_eql_expr)
             .ok();
 
-        let origin_expr = vector_arrow
-            .origin
-            .as_ref()
-            .and_then(|origin| self.eql.0.parse_str(origin)
-                      .map_err(CompileError::Parse)
-                      .and_then(compile_eql_expr)
-                      .ok());
+        let origin_expr = vector_arrow.origin.as_ref().and_then(|origin| {
+            self.eql
+                .0
+                .parse_str(origin)
+                .map_err(CompileError::Parse)
+                .and_then(compile_eql_expr)
+                .ok()
+        });
 
         let frame = vector_arrow.frame;
         let mut spawn = self.commands.spawn((

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -55,7 +55,7 @@ use super::{
 };
 use crate::{
     EqlContext, GridHandle, MainCamera,
-    object_3d::{ELLIPSOID_RENDER_LAYER, EditableEQL, compile_eql_expr, CompileError},
+    object_3d::{CompileError, ELLIPSOID_RENDER_LAYER, EditableEQL, compile_eql_expr},
     plugins::{
         LogicalKeyState,
         gizmos::GIZMO_RENDER_LAYER,
@@ -1327,13 +1327,15 @@ impl ViewportPane {
             .pos
             .as_ref()
             .map(|eql| {
-                let compiled_expr = eql_ctx.parse_str(eql)
-                    .inspect_err(|e|
+                let compiled_expr = eql_ctx
+                    .parse_str(eql)
+                    .inspect_err(|e| {
                         bevy::log::error!(
                             "Failed to parse viewport pos expression '{}': {}",
                             eql,
                             e
-                        ))
+                        )
+                    })
                     .map_err(CompileError::Parse)
                     .and_then(compile_eql_expr)
                     .ok();
@@ -1347,13 +1349,15 @@ impl ViewportPane {
             .look_at
             .as_ref()
             .map(|eql| {
-                let compiled_expr = eql_ctx.parse_str(eql)
-                    .inspect_err(|e|
+                let compiled_expr = eql_ctx
+                    .parse_str(eql)
+                    .inspect_err(|e| {
                         bevy::log::error!(
                             "Failed to parse viewport look_at expression '{}': {}",
                             eql,
                             e
-                        ))
+                        )
+                    })
                     .map_err(CompileError::Parse)
                     .and_then(compile_eql_expr)
                     .ok();
@@ -1367,13 +1371,11 @@ impl ViewportPane {
             .up
             .as_ref()
             .map(|eql| {
-                let compiled_expr = eql_ctx.parse_str(eql)
-                    .inspect_err(|e|
-                        bevy::log::error!(
-                            "Failed to parse viewport up expression '{}': {}",
-                            eql,
-                            e
-                        ))
+                let compiled_expr = eql_ctx
+                    .parse_str(eql)
+                    .inspect_err(|e| {
+                        bevy::log::error!("Failed to parse viewport up expression '{}': {}", eql, e)
+                    })
                     .map_err(CompileError::Parse)
                     .and_then(compile_eql_expr)
                     .ok();

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -55,7 +55,7 @@ use super::{
 };
 use crate::{
     EqlContext, GridHandle, MainCamera,
-    object_3d::{ELLIPSOID_RENDER_LAYER, EditableEQL, compile_eql_expr},
+    object_3d::{ELLIPSOID_RENDER_LAYER, EditableEQL, compile_eql_expr, CompileError},
     plugins::{
         LogicalKeyState,
         gizmos::GIZMO_RENDER_LAYER,
@@ -1327,17 +1327,16 @@ impl ViewportPane {
             .pos
             .as_ref()
             .map(|eql| {
-                let compiled_expr = match eql_ctx.parse_str(eql) {
-                    Ok(expr) => Some(compile_eql_expr(expr)),
-                    Err(e) => {
+                let compiled_expr = eql_ctx.parse_str(eql)
+                    .inspect_err(|e|
                         bevy::log::error!(
                             "Failed to parse viewport pos expression '{}': {}",
                             eql,
                             e
-                        );
-                        None
-                    }
-                };
+                        ))
+                    .map_err(CompileError::Parse)
+                    .and_then(compile_eql_expr)
+                    .ok();
                 EditableEQL {
                     eql: eql.to_string(),
                     compiled_expr,
@@ -1348,17 +1347,16 @@ impl ViewportPane {
             .look_at
             .as_ref()
             .map(|eql| {
-                let compiled_expr = match eql_ctx.parse_str(eql) {
-                    Ok(expr) => Some(compile_eql_expr(expr)),
-                    Err(e) => {
+                let compiled_expr = eql_ctx.parse_str(eql)
+                    .inspect_err(|e|
                         bevy::log::error!(
                             "Failed to parse viewport look_at expression '{}': {}",
                             eql,
                             e
-                        );
-                        None
-                    }
-                };
+                        ))
+                    .map_err(CompileError::Parse)
+                    .and_then(compile_eql_expr)
+                    .ok();
                 EditableEQL {
                     eql: eql.to_string(),
                     compiled_expr,
@@ -1369,17 +1367,16 @@ impl ViewportPane {
             .up
             .as_ref()
             .map(|eql| {
-                let compiled_expr = match eql_ctx.parse_str(eql) {
-                    Ok(expr) => Some(compile_eql_expr(expr)),
-                    Err(e) => {
+                let compiled_expr = eql_ctx.parse_str(eql)
+                    .inspect_err(|e|
                         bevy::log::error!(
                             "Failed to parse viewport up expression '{}': {}",
                             eql,
                             e
-                        );
-                        None
-                    }
-                };
+                        ))
+                    .map_err(CompileError::Parse)
+                    .and_then(compile_eql_expr)
+                    .ok();
                 EditableEQL {
                     eql: eql.to_string(),
                     compiled_expr,

--- a/libs/nox/README.md
+++ b/libs/nox/README.md
@@ -20,30 +20,9 @@ Most users will **not depend on `nox` directly**. Instead, they will interact wi
 
 ## Dynamic array broadcasting
 
-Dynamic `nox::Array` binary operations (`add`, `sub`, `mul`, `div`) follow the same right-aligned broadcasting rule used by NumPy and JAX:
+Dynamic `nox::Array` binary operations (`add`, `sub`, `mul`, `div`) use right-aligned NumPy/JAX-style broadcasting. Fallible variants (`try_add`, `try_sub`, `try_mul`, `try_div`) return a controlled error for incompatible shapes, while the non-fallible methods remain compatibility wrappers.
 
-- A scalar shape `[]` broadcasts to any output shape.
-- Two dimensions are compatible when they are equal or one of them is `1`.
-- Shapes are compared from the trailing dimension toward the leading dimension.
-- Missing leading dimensions behave like `1`.
-- Fallible APIs (`try_add`, `try_sub`, `try_mul`, `try_div`) return a controlled error for incompatible shapes. The non-fallible APIs remain compatibility wrappers.
-
-The dynamic broadcasting tests in `src/array/mod.rs` document the expected behavior with concrete examples:
-
-| Scenario | Expected shape |
-| --- | --- |
-| `scalar * [3]` | `[3]` |
-| `[3] * scalar` | `[3]` |
-| `[3] + [2, 3]` | `[2, 3]` |
-| `[2, 3] + [3]` | `[2, 3]` |
-| `[2, 3] + [2, 1]` | `[2, 3]` |
-| `[2, 3] + [2, 3]` | `[2, 3]` |
-| `scalar * [2, 3]` | `[2, 3]` |
-| `[2, 3] * scalar` | `[2, 3]` |
-| `[1, 3] + [2, 1, 3]` | `[2, 1, 3]` |
-| `[2, 3] + [3, 2]` | error |
-
-`Array::zeroed([2, 3])` is also covered by tests and must allocate the product of the dimensions (`6` elements), not their sum.
+See [array/README.md](array/README.md) for the detailed rules and examples.
 
 
 ## Related crates and subsystems

--- a/libs/nox/README.md
+++ b/libs/nox/README.md
@@ -18,6 +18,33 @@ For a broader introduction to the project, see the [overview documentation](../.
 
 Most users will **not depend on `nox` directly**. Instead, they will interact with one of the specialized crates or subsystems built on top of it.
 
+## Dynamic array broadcasting
+
+Dynamic `nox::Array` binary operations (`add`, `sub`, `mul`, `div`) follow the same right-aligned broadcasting rule used by NumPy and JAX:
+
+- A scalar shape `[]` broadcasts to any output shape.
+- Two dimensions are compatible when they are equal or one of them is `1`.
+- Shapes are compared from the trailing dimension toward the leading dimension.
+- Missing leading dimensions behave like `1`.
+- Fallible APIs (`try_add`, `try_sub`, `try_mul`, `try_div`) return a controlled error for incompatible shapes. The non-fallible APIs remain compatibility wrappers.
+
+The dynamic broadcasting tests in `src/array/mod.rs` document the expected behavior with concrete examples:
+
+| Scenario | Expected shape |
+| --- | --- |
+| `scalar * [3]` | `[3]` |
+| `[3] * scalar` | `[3]` |
+| `[3] + [2, 3]` | `[2, 3]` |
+| `[2, 3] + [3]` | `[2, 3]` |
+| `[2, 3] + [2, 1]` | `[2, 3]` |
+| `[2, 3] + [2, 3]` | `[2, 3]` |
+| `scalar * [2, 3]` | `[2, 3]` |
+| `[2, 3] * scalar` | `[2, 3]` |
+| `[1, 3] + [2, 1, 3]` | `[2, 1, 3]` |
+| `[2, 3] + [3, 2]` | error |
+
+`Array::zeroed([2, 3])` is also covered by tests and must allocate the product of the dimensions (`6` elements), not their sum.
+
 
 ## Related crates and subsystems
 - [array](array) – array and tensor utilities.

--- a/libs/nox/array/README.md
+++ b/libs/nox/array/README.md
@@ -24,6 +24,34 @@ assert_eq!(view.shape(), &shape);
 - Safe but minimal: you must guarantee that `buf.len()` equals the product of dimensions in shape.
 - Adds pretty printing similar to how `NumPy` prints arrays, with ellipses for large arrays.
 
+## Dynamic broadcasting in `nox::Array`
+
+The parent `nox` crate uses dynamic array shapes for runtime tensor values. Binary operations on dynamic `nox::Array` values (`add`, `sub`, `mul`, `div`) follow the same right-aligned broadcasting rule used by NumPy and JAX:
+
+- A scalar shape `[]` broadcasts to any output shape.
+- Two dimensions are compatible when they are equal or one of them is `1`.
+- Shapes are compared from the trailing dimension toward the leading dimension.
+- Missing leading dimensions behave like `1`.
+- Fallible APIs (`try_add`, `try_sub`, `try_mul`, `try_div`) return a controlled error for incompatible shapes.
+- Non-fallible APIs (`add`, `sub`, `mul`, `div`) remain compatibility wrappers and expect the shapes to be broadcastable.
+
+The dynamic broadcasting tests in `../src/array/mod.rs` and `../src/array/broadcast.rs` document the expected behavior with concrete examples:
+
+| Scenario | Expected shape |
+| --- | --- |
+| `scalar * [3]` | `[3]` |
+| `[3] * scalar` | `[3]` |
+| `[3] + [2, 3]` | `[2, 3]` |
+| `[2, 3] + [3]` | `[2, 3]` |
+| `[2, 3] + [2, 1]` | `[2, 3]` |
+| `[2, 3] + [2, 3]` | `[2, 3]` |
+| `scalar * [2, 3]` | `[2, 3]` |
+| `[2, 3] * scalar` | `[2, 3]` |
+| `[1, 3] + [2, 1, 3]` | `[2, 1, 3]` |
+| `[2, 3] + [3, 2]` | error |
+
+Dynamic allocation uses the product of all dimensions. For example, `Array::zeroed([2, 3])` allocates `6` elements.
+
 ## More examples
 
 ### From raw bytes

--- a/libs/nox/src/array/broadcast.rs
+++ b/libs/nox/src/array/broadcast.rs
@@ -2,6 +2,12 @@ use smallvec::SmallVec;
 
 use crate::Error;
 
+/// Returns the right-aligned broadcast shape for two concrete array shapes.
+///
+/// Dimensions are compatible when they are equal or one side is `1`. Missing
+/// leading dimensions are treated as `1`, so scalars (`[]`) broadcast to any
+/// shape. Returns [`Error::BroadcastShapeMismatch`] when the shapes cannot be
+/// broadcast together.
 pub fn broadcast_shape(left: &[usize], right: &[usize]) -> Result<SmallVec<[usize; 4]>, Error> {
     let rank = left.len().max(right.len());
     let mut shape = SmallVec::with_capacity(rank);
@@ -33,10 +39,15 @@ pub fn broadcast_shape(left: &[usize], right: &[usize]) -> Result<SmallVec<[usiz
     Ok(shape)
 }
 
+/// Returns whether two concrete array shapes can be broadcast together.
 pub fn can_broadcast(left: &[usize], right: &[usize]) -> bool {
     broadcast_shape(left, right).is_ok()
 }
 
+/// Mutates `output` so it can hold the co-broadcasted shape with `other`.
+///
+/// This is retained for internal callers that already provide the candidate
+/// output shape.
 pub(crate) fn cobroadcast_dims(output: &mut [usize], other: &[usize]) -> bool {
     for (output, other) in output.iter_mut().rev().zip(other.iter().rev()) {
         if *output == *other || *other == 1 {

--- a/libs/nox/src/array/broadcast.rs
+++ b/libs/nox/src/array/broadcast.rs
@@ -36,3 +36,17 @@ pub fn broadcast_shape(left: &[usize], right: &[usize]) -> Result<SmallVec<[usiz
 pub fn can_broadcast(left: &[usize], right: &[usize]) -> bool {
     broadcast_shape(left, right).is_ok()
 }
+
+pub(crate) fn cobroadcast_dims(output: &mut [usize], other: &[usize]) -> bool {
+    for (output, other) in output.iter_mut().rev().zip(other.iter().rev()) {
+        if *output == *other || *other == 1 {
+            continue;
+        }
+        if *output == 1 {
+            *output = *other;
+        } else {
+            return false;
+        }
+    }
+    true
+}

--- a/libs/nox/src/array/broadcast.rs
+++ b/libs/nox/src/array/broadcast.rs
@@ -24,8 +24,8 @@ pub fn broadcast_shape(left: &[usize], right: &[usize]) -> Result<SmallVec<[usiz
             shape.push(left_axis);
         } else {
             return Err(Error::BroadcastShapeMismatch {
-                left: left.iter().copied().collect(),
-                right: right.iter().copied().collect(),
+                left: left.to_vec(),
+                right: right.to_vec(),
             });
         }
     }

--- a/libs/nox/src/array/broadcast.rs
+++ b/libs/nox/src/array/broadcast.rs
@@ -1,0 +1,38 @@
+use smallvec::SmallVec;
+
+use crate::Error;
+
+pub fn broadcast_shape(left: &[usize], right: &[usize]) -> Result<SmallVec<[usize; 4]>, Error> {
+    let rank = left.len().max(right.len());
+    let mut shape = SmallVec::with_capacity(rank);
+
+    for axis in 0..rank {
+        let left_axis = axis
+            .checked_sub(rank - left.len())
+            .map(|i| left[i])
+            .unwrap_or(1);
+        let right_axis = axis
+            .checked_sub(rank - right.len())
+            .map(|i| right[i])
+            .unwrap_or(1);
+
+        if left_axis == right_axis {
+            shape.push(left_axis);
+        } else if left_axis == 1 {
+            shape.push(right_axis);
+        } else if right_axis == 1 {
+            shape.push(left_axis);
+        } else {
+            return Err(Error::BroadcastShapeMismatch {
+                left: left.iter().copied().collect(),
+                right: right.iter().copied().collect(),
+            });
+        }
+    }
+
+    Ok(shape)
+}
+
+pub fn can_broadcast(left: &[usize], right: &[usize]) -> bool {
+    broadcast_shape(left, right).is_ok()
+}

--- a/libs/nox/src/array/broadcast.rs
+++ b/libs/nox/src/array/broadcast.rs
@@ -50,3 +50,35 @@ pub(crate) fn cobroadcast_dims(output: &mut [usize], other: &[usize]) -> bool {
     }
     true
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn broadcast_shape_handles_scalar_vector_matrix_and_higher_rank() {
+        assert_eq!(broadcast_shape(&[], &[3]).unwrap().as_slice(), &[3]);
+        assert_eq!(broadcast_shape(&[3], &[]).unwrap().as_slice(), &[3]);
+        assert_eq!(broadcast_shape(&[3], &[2, 3]).unwrap().as_slice(), &[2, 3]);
+        assert_eq!(broadcast_shape(&[2, 3], &[3]).unwrap().as_slice(), &[2, 3]);
+        assert_eq!(
+            broadcast_shape(&[2, 3], &[2, 1]).unwrap().as_slice(),
+            &[2, 3]
+        );
+        assert_eq!(
+            broadcast_shape(&[1, 3], &[2, 1, 3]).unwrap().as_slice(),
+            &[2, 1, 3]
+        );
+    }
+
+    #[test]
+    fn broadcast_shape_rejects_incompatible_shapes() {
+        let err = broadcast_shape(&[2, 3], &[3, 2]).unwrap_err();
+
+        assert!(matches!(
+            err,
+            crate::Error::BroadcastShapeMismatch { left, right }
+                if left == [2, 3] && right == [3, 2]
+        ));
+    }
+}

--- a/libs/nox/src/array/dynamic.rs
+++ b/libs/nox/src/array/dynamic.rs
@@ -51,7 +51,11 @@ impl<T: Elem> ArrayBuf<T> for DynArray<T, Vec<T>> {
     }
 
     fn default(dims: &[usize]) -> Self {
-        let len: usize = dims.iter().copied().sum();
+        let len: usize = if dims.is_empty() {
+            1
+        } else {
+            dims.iter().copied().product()
+        };
         let strides = crate::utils::calculate_strides(dims);
 
         let shape = SmallVec::from_slice(dims);

--- a/libs/nox/src/array/mod.rs
+++ b/libs/nox/src/array/mod.rs
@@ -29,7 +29,8 @@ mod broadcast;
 mod dynamic;
 mod repr;
 mod view;
-pub use broadcast::*;
+pub(crate) use broadcast::cobroadcast_dims;
+pub use broadcast::{broadcast_shape, can_broadcast};
 pub use repr::*;
 pub use view::*;
 
@@ -1311,20 +1312,6 @@ impl<D1: Dim, D2: Dim> MappableDim for (D1, D2) {
         D: Dim;
 
     type ElemDim = D2;
-}
-
-pub(crate) fn cobroadcast_dims(output: &mut [usize], other: &[usize]) -> bool {
-    for (output, other) in output.iter_mut().rev().zip(other.iter().rev()) {
-        if *output == *other || *other == 1 {
-            continue;
-        }
-        if *output == 1 {
-            *output = *other;
-        } else {
-            return false;
-        }
-    }
-    true
 }
 
 pub trait StridesIter {

--- a/libs/nox/src/array/mod.rs
+++ b/libs/nox/src/array/mod.rs
@@ -1718,6 +1718,20 @@ mod tests {
     }
 
     #[test]
+    fn test_dynamic_binary_ops_broadcast_sub_and_div() {
+        let left = dyn_array(&[2, 3], &[10.0, 20.0, 30.0, 40.0, 50.0, 60.0]);
+        let right = dyn_array(&[3], &[1.0, 2.0, 5.0]);
+
+        let sub = left.try_sub(&right).expect("[2, 3] - [3]");
+        assert_eq!(sub.shape(), &[2, 3]);
+        assert_eq!(sub.buf.as_buf(), &[9.0, 18.0, 25.0, 39.0, 48.0, 55.0]);
+
+        let div = left.try_div(&right).expect("[2, 3] / [3]");
+        assert_eq!(div.shape(), &[2, 3]);
+        assert_eq!(div.buf.as_buf(), &[10.0, 10.0, 6.0, 40.0, 25.0, 12.0]);
+    }
+
+    #[test]
     fn test_dynamic_binary_ops_broadcast_higher_rank() {
         let left = dyn_array(&[1, 3], &[10.0, 20.0, 30.0]);
         let right = dyn_array(&[2, 1, 3], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);

--- a/libs/nox/src/array/mod.rs
+++ b/libs/nox/src/array/mod.rs
@@ -344,7 +344,11 @@ impl<T1: Elem, D1: ArrayDim + TensorDim> Array<T1, D1> {
 macro_rules! impl_op {
     ($op:tt, $op_trait:tt, $fn_name:tt, $try_fn_name:tt) => {
         impl<T1: Elem, D1: ArrayDim + TensorDim  > Array<T1, D1> {
-            #[doc = concat!("This function attempts to perform the `", stringify!($op_trait), "` operation on two arrays.")]
+            #[doc = concat!("Fallibly performs element-wise `", stringify!($op_trait), "` with broadcasting.")]
+            ///
+            /// The output shape is computed with right-aligned dynamic
+            /// broadcasting. Returns [`Error::BroadcastShapeMismatch`] when the
+            /// two input shapes are not broadcastable.
             pub fn $try_fn_name<D2: ArrayDim + TensorDim>(
                 &self,
                 b: &Array<T1, D2>,
@@ -377,7 +381,10 @@ macro_rules! impl_op {
                 Ok(out)
             }
 
-            #[doc = concat!("This function performs the `", stringify!($op_trait), "` operation on two arrays.")]
+            #[doc = concat!("Performs element-wise `", stringify!($op_trait), "` with broadcasting.")]
+            ///
+            /// Compatibility wrapper around the fallible variant. Panics when
+            /// the input shapes are not broadcastable.
             pub fn $fn_name<D2: ArrayDim + TensorDim>(
                 &self,
                 b: &Array<T1, D2>,

--- a/libs/nox/src/array/mod.rs
+++ b/libs/nox/src/array/mod.rs
@@ -8,7 +8,7 @@ use crate::{Const, Dyn, ShapeConstraint};
 use alloc::{vec, vec::Vec};
 use approx::{AbsDiffEq, RelativeEq};
 use core::default::Default;
-use core::{cmp, fmt, iter};
+use core::{fmt, iter};
 use core::{
     marker::PhantomData,
     ops::{Add, Div, Mul, Neg, Sub},
@@ -52,7 +52,9 @@ pub mod dims {
     };
 }
 pub mod prelude {
-    pub use super::{Array, ArrayBuf, ArrayDim, ArrayRepr, ArrayView, Mat3, Vec3, dims::*};
+    pub use super::{
+        Array, ArrayBuf, ArrayDim, ArrayRepr, ArrayView, Mat3, Vec3, broadcast_shape, dims::*,
+    };
 }
 
 /// A struct representing an array with type-safe dimensions and element type.
@@ -337,8 +339,41 @@ impl<T1: Elem, D1: ArrayDim + TensorDim> Array<T1, D1> {
 }
 
 macro_rules! impl_op {
-    ($op:tt, $op_trait:tt, $fn_name:tt) => {
+    ($op:tt, $op_trait:tt, $fn_name:tt, $try_fn_name:tt) => {
         impl<T1: Elem, D1: ArrayDim + TensorDim  > Array<T1, D1> {
+            #[doc = concat!("This function attempts to perform the `", stringify!($op_trait), "` operation on two arrays.")]
+            pub fn $try_fn_name<D2: ArrayDim + TensorDim>(
+                &self,
+                b: &Array<T1, D2>,
+            ) -> Result<Array<T1, BroadcastedDim<D1, D2>>, Error>
+            where
+                T1: $op_trait<Output = T1>,
+                ShapeConstraint: BroadcastDim<D1, D2>,
+                <ShapeConstraint as BroadcastDim<D1, D2>>::Output: ArrayDim ,
+            {
+                let d1 = D1::array_shape(&self.buf);
+                let d2 = D2::array_shape(&b.buf);
+                let broadcast_dims = broadcast_shape(d1.as_ref(), d2.as_ref())?;
+                let mut out: Array<T1, BroadcastedDim<D1, D2>> =
+                    Array::zeroed(broadcast_dims.as_ref());
+                let left = self
+                    .broadcast_iter(broadcast_dims.clone())
+                    .ok_or_else(|| Error::BroadcastShapeMismatch {
+                        left: d1.as_ref().to_vec(),
+                        right: broadcast_dims.as_ref().to_vec(),
+                    })?;
+                let right = b
+                    .broadcast_iter(broadcast_dims.clone())
+                    .ok_or_else(|| Error::BroadcastShapeMismatch {
+                        left: d2.as_ref().to_vec(),
+                        right: broadcast_dims.as_ref().to_vec(),
+                    })?;
+                for ((a, b), out) in left.zip(right).zip(out.buf.as_mut_buf().iter_mut()) {
+                    *out = *a $op *b;
+                }
+                Ok(out)
+            }
+
             #[doc = concat!("This function performs the `", stringify!($op_trait), "` operation on two arrays.")]
             pub fn $fn_name<D2: ArrayDim + TensorDim>(
                 &self,
@@ -349,45 +384,8 @@ macro_rules! impl_op {
                 ShapeConstraint: BroadcastDim<D1, D2>,
                 <ShapeConstraint as BroadcastDim<D1, D2>>::Output: ArrayDim ,
             {
-                let d1 = D1::array_shape(&self.buf);
-                let d2 = D2::array_shape(&b.buf);
-
-                match d1.as_ref().len().cmp(&d2.as_ref().len()) {
-                    cmp::Ordering::Less | cmp::Ordering::Equal => {
-                        let mut out: Array<T1, BroadcastedDim<D1, D2>> =
-                            Array::zeroed(d2.as_ref());
-                        let mut broadcast_dims = d2.clone();
-                        if !cobroadcast_dims(broadcast_dims.as_mut(), d1.as_ref()) {
-                            todo!("handle unbroadcastble dims {:?} {:?}", broadcast_dims.as_mut(), d1.as_ref());
-                        }
-                        for ((a, b), out) in self
-                            .broadcast_iter(broadcast_dims.clone())
-                            .unwrap()
-                            .zip(b.broadcast_iter(broadcast_dims).unwrap())
-                            .zip(out.buf.as_mut_buf().iter_mut())
-                        {
-                            *out = *a $op *b;
-                        }
-                        out
-                    }
-                    cmp::Ordering::Greater => {
-                        let mut out: Array<T1, BroadcastedDim<D1, D2>> =
-                            Array::zeroed(d2.as_ref());
-                        let mut broadcast_dims = d1.clone();
-                        if !cobroadcast_dims(broadcast_dims.as_mut(), d2.as_ref()) {
-                            todo!("handle unbroadcastble dims {:?} {:?}", broadcast_dims.as_mut(), d2.as_ref());
-                        }
-                        for ((b, a), out) in b
-                            .broadcast_iter(broadcast_dims.clone())
-                            .unwrap()
-                            .zip(self.broadcast_iter(broadcast_dims).unwrap())
-                            .zip(out.buf.as_mut_buf().iter_mut())
-                        {
-                            *out = *a $op *b;
-                        }
-                        out
-                    }
-                }
+                self.$try_fn_name(b)
+                    .expect("array shapes must be broadcastable")
             }
 
         }
@@ -459,10 +457,10 @@ impl<T1: Elem, D1: Dim> Array<T1, D1> {
     }
 }
 
-impl_op!(*, Mul, mul);
-impl_op!(+, Add, add);
-impl_op!(-, Sub, sub);
-impl_op!(/, Div, div);
+impl_op!(*, Mul, mul, try_mul);
+impl_op!(+, Add, add, try_add);
+impl_op!(-, Sub, sub, try_sub);
+impl_op!(/, Div, div, try_div);
 
 macro_rules! impl_unary_op {
     ($op_trait:tt, $fn_name:tt) => {
@@ -1313,16 +1311,39 @@ impl<D1: Dim, D2: Dim> MappableDim for (D1, D2) {
     type ElemDim = D2;
 }
 
-pub fn can_broadcast(left: &[usize], right: &[usize]) -> bool {
-    for (left, right) in left.iter().rev().zip(right.iter().rev()) {
-        if *left == *right || *right == 1 {
-            continue;
-        }
-        if *left != 1 {
-            return false;
+pub fn broadcast_shape(left: &[usize], right: &[usize]) -> Result<SmallVec<[usize; 4]>, Error> {
+    let rank = left.len().max(right.len());
+    let mut shape = SmallVec::with_capacity(rank);
+
+    for axis in 0..rank {
+        let left_axis = axis
+            .checked_sub(rank - left.len())
+            .map(|i| left[i])
+            .unwrap_or(1);
+        let right_axis = axis
+            .checked_sub(rank - right.len())
+            .map(|i| right[i])
+            .unwrap_or(1);
+
+        if left_axis == right_axis {
+            shape.push(left_axis);
+        } else if left_axis == 1 {
+            shape.push(right_axis);
+        } else if right_axis == 1 {
+            shape.push(left_axis);
+        } else {
+            return Err(Error::BroadcastShapeMismatch {
+                left: left.to_vec(),
+                right: right.to_vec(),
+            });
         }
     }
-    true
+
+    Ok(shape)
+}
+
+pub fn can_broadcast(left: &[usize], right: &[usize]) -> bool {
+    broadcast_shape(left, right).is_ok()
 }
 
 pub(crate) fn cobroadcast_dims(output: &mut [usize], other: &[usize]) -> bool {
@@ -1683,6 +1704,93 @@ mod tests {
         let b = array![[[1.0, 1.0], [2.0, 2.0]], [[1.0, 1.0], [2.0, 2.0]]];
         let c: Array<f32, (Const<2>, Const<2>, Const<2>)> = a.add(&b);
         assert_eq!(c.buf, [[[2.0, 3.0], [3.0, 4.0]], [[2.0, 3.0], [3.0, 4.0]]]);
+    }
+
+    fn dyn_array(shape: &[usize], storage: &[f64]) -> Array<f64, Dyn> {
+        Array::from_shape_vec(SmallVec::from_slice(shape), storage.to_vec())
+            .expect("valid dynamic array")
+    }
+
+    #[test]
+    fn test_dynamic_binary_ops_broadcast_scalar_vector_and_matrix() {
+        let scalar = dyn_array(&[], &[2.0]);
+        let vector = dyn_array(&[3], &[1.0, 2.0, 3.0]);
+        let matrix = dyn_array(&[2, 3], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+        let out = scalar.try_mul(&vector).expect("scalar * vector");
+        assert_eq!(out.shape(), &[3]);
+        assert_eq!(out.buf.as_buf(), &[2.0, 4.0, 6.0]);
+
+        let out = vector.try_mul(&scalar).expect("vector * scalar");
+        assert_eq!(out.shape(), &[3]);
+        assert_eq!(out.buf.as_buf(), &[2.0, 4.0, 6.0]);
+
+        let out = scalar.try_mul(&matrix).expect("scalar * matrix");
+        assert_eq!(out.shape(), &[2, 3]);
+        assert_eq!(out.buf.as_buf(), &[2.0, 4.0, 6.0, 8.0, 10.0, 12.0]);
+
+        let out = matrix.try_mul(&scalar).expect("matrix * scalar");
+        assert_eq!(out.shape(), &[2, 3]);
+        assert_eq!(out.buf.as_buf(), &[2.0, 4.0, 6.0, 8.0, 10.0, 12.0]);
+    }
+
+    #[test]
+    fn test_dynamic_binary_ops_broadcast_vector_and_matrix() {
+        let vector = dyn_array(&[3], &[10.0, 20.0, 30.0]);
+        let matrix = dyn_array(&[2, 3], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+        let out = vector.try_add(&matrix).expect("vector + matrix");
+        assert_eq!(out.shape(), &[2, 3]);
+        assert_eq!(out.buf.as_buf(), &[11.0, 22.0, 33.0, 14.0, 25.0, 36.0]);
+
+        let out = matrix.try_add(&vector).expect("matrix + vector");
+        assert_eq!(out.shape(), &[2, 3]);
+        assert_eq!(out.buf.as_buf(), &[11.0, 22.0, 33.0, 14.0, 25.0, 36.0]);
+    }
+
+    #[test]
+    fn test_dynamic_binary_ops_broadcast_matrix_shapes() {
+        let left = dyn_array(&[2, 3], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        let column = dyn_array(&[2, 1], &[10.0, 20.0]);
+        let same = dyn_array(&[2, 3], &[6.0, 5.0, 4.0, 3.0, 2.0, 1.0]);
+
+        let out = left.try_add(&column).expect("[2, 3] + [2, 1]");
+        assert_eq!(out.shape(), &[2, 3]);
+        assert_eq!(out.buf.as_buf(), &[11.0, 12.0, 13.0, 24.0, 25.0, 26.0]);
+
+        let out = left.try_add(&same).expect("[2, 3] + [2, 3]");
+        assert_eq!(out.shape(), &[2, 3]);
+        assert_eq!(out.buf.as_buf(), &[7.0, 7.0, 7.0, 7.0, 7.0, 7.0]);
+    }
+
+    #[test]
+    fn test_dynamic_binary_ops_broadcast_higher_rank() {
+        let left = dyn_array(&[1, 3], &[10.0, 20.0, 30.0]);
+        let right = dyn_array(&[2, 1, 3], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+        let out = left.try_add(&right).expect("[1, 3] + [2, 1, 3]");
+        assert_eq!(out.shape(), &[2, 1, 3]);
+        assert_eq!(out.buf.as_buf(), &[11.0, 22.0, 33.0, 14.0, 25.0, 36.0]);
+    }
+
+    #[test]
+    fn test_dynamic_binary_ops_reject_incompatible_shapes() {
+        let left = dyn_array(&[2, 3], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        let right = dyn_array(&[3, 2], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+
+        let err = left
+            .try_add(&right)
+            .expect_err("[2, 3] + [3, 2] should fail");
+
+        assert!(matches!(err, Error::BroadcastShapeMismatch { .. }));
+    }
+
+    #[test]
+    fn test_dynamic_zeroed_multidimensional_allocates_product() {
+        let arr = Array::<f64, Dyn>::zeroed(&[2, 3]);
+
+        assert_eq!(arr.shape(), &[2, 3]);
+        assert_eq!(arr.buf.as_buf().len(), 6);
     }
 
     #[test]

--- a/libs/nox/src/array/mod.rs
+++ b/libs/nox/src/array/mod.rs
@@ -25,9 +25,11 @@ use faer::{
 };
 use smallvec::SmallVec;
 
+mod broadcast;
 mod dynamic;
 mod repr;
 mod view;
+pub use broadcast::*;
 pub use repr::*;
 pub use view::*;
 
@@ -1309,41 +1311,6 @@ impl<D1: Dim, D2: Dim> MappableDim for (D1, D2) {
         D: Dim;
 
     type ElemDim = D2;
-}
-
-pub fn broadcast_shape(left: &[usize], right: &[usize]) -> Result<SmallVec<[usize; 4]>, Error> {
-    let rank = left.len().max(right.len());
-    let mut shape = SmallVec::with_capacity(rank);
-
-    for axis in 0..rank {
-        let left_axis = axis
-            .checked_sub(rank - left.len())
-            .map(|i| left[i])
-            .unwrap_or(1);
-        let right_axis = axis
-            .checked_sub(rank - right.len())
-            .map(|i| right[i])
-            .unwrap_or(1);
-
-        if left_axis == right_axis {
-            shape.push(left_axis);
-        } else if left_axis == 1 {
-            shape.push(right_axis);
-        } else if right_axis == 1 {
-            shape.push(left_axis);
-        } else {
-            return Err(Error::BroadcastShapeMismatch {
-                left: left.to_vec(),
-                right: right.to_vec(),
-            });
-        }
-    }
-
-    Ok(shape)
-}
-
-pub fn can_broadcast(left: &[usize], right: &[usize]) -> bool {
-    broadcast_shape(left, right).is_ok()
 }
 
 pub(crate) fn cobroadcast_dims(output: &mut [usize], other: &[usize]) -> bool {

--- a/libs/nox/src/error.rs
+++ b/libs/nox/src/error.rs
@@ -1,7 +1,7 @@
 //! Provides error definitions.
 use thiserror::Error;
 
-use alloc::borrow::Cow;
+use alloc::{borrow::Cow, vec::Vec};
 /// Enumerates possible error types that can occur within the Nox tensor operations.
 #[derive(Error, Debug)]
 pub enum Error {
@@ -63,6 +63,10 @@ pub enum Error {
 
     #[error("concat dim failed with dims")]
     InvalidConcatDims,
+
+    /// Error when array shapes cannot be broadcast together.
+    #[error("array shapes {left:?} and {right:?} are not broadcastable")]
+    BroadcastShapeMismatch { left: Vec<usize>, right: Vec<usize> },
 
     /// Error when matrix inversion failed
     #[error("matrix cholesky failed with {0} arg illegal")]

--- a/libs/nox/src/error.rs
+++ b/libs/nox/src/error.rs
@@ -64,7 +64,7 @@ pub enum Error {
     #[error("concat dim failed with dims")]
     InvalidConcatDims,
 
-    /// Error when array shapes cannot be broadcast together.
+    /// Error when two concrete array shapes cannot be broadcast together.
     #[error("array shapes {left:?} and {right:?} are not broadcastable")]
     BroadcastShapeMismatch { left: Vec<usize>, right: Vec<usize> },
 


### PR DESCRIPTION
## Summary
- Added `libs/nox/src/array/broadcast.rs`:
   - `broadcast_shape`
   - `can_broadcast`
   - `cobroadcast_dims`
- Added fallible `nox::Array` APIs:
   - `try_add`
   - `try_sub`
   - `try_mul`
   - `try_div`
- Kept existing `add`/`sub`/`mul`/`div` as compatibility wrappers.
- Fixed dynamic output allocation to use the broadcasted shape.
- Fixed `DynArray::default([2, 3])` to allocate 6 elements instead of 5.
- Added `Error::BroadcastShapeMismatch`.
- Removed Editor-local broadcasting helpers from `object_3d`.
- Updated Editor runtime EQL to call `nox` array ops directly.
- Added focused `broadcast_shape` unit tests.
- Added dynamic array broadcasting tests for scalar/vector/matrix/higher-rank/error cases.
- Added README documentation for dynamic broadcasting rules.

--- 

## RFD

- [#632](https://github.com/elodin-sys/elodin/discussions/632)