### PR TITLE
Fix: UI input pass-through with explicit pointer ownership.

### DIFF
--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::HashMap, ops::Range, sync::Arc, time::Duration};
 
-use crate::plugins::editor_cam_touch;
+use crate::plugins::{editor_cam_input, editor_cam_touch};
 #[cfg(feature = "big_space")]
 use crate::spatial::{FloatingOrigin, FloatingOriginSettings, GridCell};
 use bevy::{
@@ -227,7 +227,12 @@ impl Plugin for EditorPlugin {
                     .with_limiter(bevy_framepace::Limiter::Off),
             )
             //.add_plugins(DefaultPickingPlugins)
-            .add_plugins(bevy_editor_cam::DefaultEditorCamPlugins)
+            .add_plugins(
+                bevy_editor_cam::DefaultEditorCamPlugins
+                    .build()
+                    .disable::<bevy_editor_cam::input::DefaultInputPlugin>(),
+            )
+            .add_plugins(editor_cam_input::EditorCamInputPlugin)
             .add_plugins(EmbeddedAssetPlugin)
             .add_plugins(EguiPlugin::default())
             .add_plugins(bevy_infinite_grid::InfiniteGridPlugin)

--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -220,7 +220,6 @@ impl Plugin for EditorPlugin {
                 ..Default::default()
             })
             .insert_resource(winit_settings)
-            .init_resource::<tiles::ViewportContainsPointer>()
             .add_plugins(bevy_framepace::FramepacePlugin)
             .insert_resource(
                 bevy_framepace::FramepaceSettings::default()

--- a/libs/elodin-editor/src/plugins/editor_cam_input.rs
+++ b/libs/elodin-editor/src/plugins/editor_cam_input.rs
@@ -17,7 +17,7 @@ use bevy_editor_cam::{
 };
 use bevy_picking::{
     PickingSystems,
-    pointer::{PointerAction, PointerId, PointerInput, PointerLocation},
+    pointer::{Location, PointerAction, PointerId, PointerInput, PointerLocation},
 };
 
 use crate::ui::{input_owner::UiInputOwners, window::window_entity_from_target};
@@ -59,10 +59,21 @@ pub fn gated_camera_inputs(
     let wheel_windows = mouse_wheel_windows(&mut mouse_wheel);
 
     if let Some(&camera) = pointer_map.get(&PointerId::Mouse) {
+        let mouse_location = pointer_location_for(&pointers, PointerId::Mouse);
         let camera_query = cameras.get(camera).ok();
         let owner_allows_camera = camera_query
             .map(|(entity, camera, _)| {
-                input_owners_permit_camera(&input_owners, &primary_window, camera, entity)
+                mouse_location
+                    .map(|location| {
+                        input_owners_permit_camera_at(
+                            &input_owners,
+                            &primary_window,
+                            camera,
+                            entity,
+                            location,
+                        )
+                    })
+                    .unwrap_or_default()
             })
             .unwrap_or_default();
         let is_in_zoom_mode = camera_query
@@ -95,11 +106,12 @@ pub fn gated_camera_inputs(
                 let Some((camera, camera_component, _)) =
                     cameras.iter().find(|(entity, camera, _)| {
                         pointer_location.is_in_viewport(camera, &primary_window)
-                            && input_owners_permit_camera(
+                            && input_owners_permit_camera_at(
                                 &input_owners,
                                 &primary_window,
                                 camera,
                                 *entity,
+                                pointer_location,
                             )
                     })
                 else {
@@ -141,6 +153,7 @@ pub fn send_gated_pointer_inputs(
     mut camera_map: ResMut<CameraPointerMap>,
     mut camera_controllers: Query<(Entity, &mut EditorCam, &Camera)>,
     primary_window: Query<Entity, With<PrimaryWindow>>,
+    pointers: Query<(&PointerId, &PointerLocation)>,
     input_owners: Res<UiInputOwners>,
     mut mouse_wheel: MessageReader<MouseWheel>,
     mut moves: MessageReader<PointerInput>,
@@ -165,7 +178,18 @@ pub fn send_gated_pointer_inputs(
             ended_pointers.push(pointer);
             continue;
         };
-        if !input_owners.permits_viewport(window_entity, entity) {
+        let Some(pointer_location) = pointer_location_for(&pointers, pointer) else {
+            camera_controller.end_move();
+            ended_pointers.push(pointer);
+            continue;
+        };
+        if !pointer_location.is_in_viewport(camera_component, &primary_window)
+            || !input_owners.permits_viewport_at(
+                window_entity,
+                entity,
+                pointer_location_pos(pointer_location),
+            )
+        {
             camera_controller.end_move();
             ended_pointers.push(pointer);
             continue;
@@ -199,15 +223,35 @@ pub fn send_gated_pointer_inputs(
     }
 }
 
-fn input_owners_permit_camera(
+fn input_owners_permit_camera_at(
     input_owners: &UiInputOwners,
     primary_window: &Query<Entity, With<PrimaryWindow>>,
     camera: &Camera,
     camera_entity: Entity,
+    pointer_location: &Location,
 ) -> bool {
     camera_window_entity(camera, primary_window)
-        .map(|window| input_owners.permits_viewport(window, camera_entity))
+        .map(|window| {
+            input_owners.permits_viewport_at(
+                window,
+                camera_entity,
+                pointer_location_pos(pointer_location),
+            )
+        })
         .unwrap_or_default()
+}
+
+fn pointer_location_for<'a>(
+    pointers: &'a Query<(&PointerId, &PointerLocation)>,
+    pointer: PointerId,
+) -> Option<&'a Location> {
+    pointers
+        .iter()
+        .find_map(|(id, loc)| (*id == pointer).then(|| loc.location()).flatten())
+}
+
+fn pointer_location_pos(pointer_location: &Location) -> bevy_egui::egui::Pos2 {
+    bevy_egui::egui::pos2(pointer_location.position.x, pointer_location.position.y)
 }
 
 fn camera_window_entity(

--- a/libs/elodin-editor/src/plugins/editor_cam_input.rs
+++ b/libs/elodin-editor/src/plugins/editor_cam_input.rs
@@ -42,6 +42,7 @@ impl Plugin for EditorCamInputPlugin {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn gated_camera_inputs(
     pointers: Query<(&PointerId, &PointerLocation)>,
     pointer_map: Res<CameraPointerMap>,

--- a/libs/elodin-editor/src/plugins/editor_cam_input.rs
+++ b/libs/elodin-editor/src/plugins/editor_cam_input.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use bevy::{
     app::{App, Plugin, PreUpdate},
-    camera::Camera,
+    camera::{Camera, RenderTarget},
     ecs::schedule::IntoScheduleConfigs,
     input::{
         ButtonInput,
@@ -49,7 +49,7 @@ pub fn gated_camera_inputs(
     mut controller: MessageWriter<EditorCamInputMessage>,
     mut mouse_wheel: MessageReader<MouseWheel>,
     mouse_input: Res<ButtonInput<MouseButton>>,
-    cameras: Query<(Entity, &Camera, &EditorCam)>,
+    cameras: Query<(Entity, &Camera, &RenderTarget, &EditorCam)>,
     primary_window: Query<Entity, With<PrimaryWindow>>,
     input_owners: Res<UiInputOwners>,
 ) {
@@ -62,13 +62,13 @@ pub fn gated_camera_inputs(
         let mouse_location = pointer_location_for(&pointers, PointerId::Mouse);
         let camera_query = cameras.get(camera).ok();
         let owner_allows_camera = camera_query
-            .map(|(entity, camera, _)| {
+            .map(|(entity, _camera, render_target, _)| {
                 mouse_location
                     .map(|location| {
                         input_owners_permit_camera_at(
                             &input_owners,
                             &primary_window,
-                            camera,
+                            render_target,
                             entity,
                             location,
                         )
@@ -77,10 +77,10 @@ pub fn gated_camera_inputs(
             })
             .unwrap_or_default();
         let is_in_zoom_mode = camera_query
-            .map(|(.., editor_cam)| editor_cam.current_motion.is_zooming_only())
+            .map(|(_, _, _, editor_cam)| editor_cam.current_motion.is_zooming_only())
             .unwrap_or_default();
         let zoom_amount_abs = camera_query
-            .and_then(|(.., editor_cam)| {
+            .and_then(|(_, _, _, editor_cam)| {
                 editor_cam
                     .current_motion
                     .inputs()
@@ -103,13 +103,13 @@ pub fn gated_camera_inputs(
     {
         match pointer {
             PointerId::Mouse => {
-                let Some((camera, camera_component, _)) =
-                    cameras.iter().find(|(entity, camera, _)| {
-                        pointer_location.is_in_viewport(camera, &primary_window)
+                let Some((camera, _camera_component, render_target, _)) =
+                    cameras.iter().find(|(entity, camera, render_target, _)| {
+                        pointer_location.is_in_viewport(camera, render_target, &primary_window)
                             && input_owners_permit_camera_at(
                                 &input_owners,
                                 &primary_window,
-                                camera,
+                                render_target,
                                 *entity,
                                 pointer_location,
                             )
@@ -118,7 +118,7 @@ pub fn gated_camera_inputs(
                     continue;
                 };
 
-                let Some(window_entity) = camera_window_entity(camera_component, &primary_window)
+                let Some(window_entity) = camera_window_entity(render_target, &primary_window)
                 else {
                     continue;
                 };
@@ -151,7 +151,7 @@ pub fn gated_camera_inputs(
 
 pub fn send_gated_pointer_inputs(
     mut camera_map: ResMut<CameraPointerMap>,
-    mut camera_controllers: Query<(Entity, &mut EditorCam, &Camera)>,
+    mut camera_controllers: Query<(Entity, &mut EditorCam, &Camera, &RenderTarget)>,
     primary_window: Query<Entity, With<PrimaryWindow>>,
     pointers: Query<(&PointerId, &PointerLocation)>,
     input_owners: Res<UiInputOwners>,
@@ -167,13 +167,13 @@ pub fn send_gated_pointer_inputs(
     let mut ended_pointers = Vec::new();
 
     for (pointer, camera) in active_pointers {
-        let Ok((entity, mut camera_controller, camera_component)) =
+        let Ok((entity, mut camera_controller, camera_component, render_target)) =
             camera_controllers.get_mut(camera)
         else {
             ended_pointers.push(pointer);
             continue;
         };
-        let Some(window_entity) = camera_window_entity(camera_component, &primary_window) else {
+        let Some(window_entity) = camera_window_entity(render_target, &primary_window) else {
             camera_controller.end_move();
             ended_pointers.push(pointer);
             continue;
@@ -183,7 +183,7 @@ pub fn send_gated_pointer_inputs(
             ended_pointers.push(pointer);
             continue;
         };
-        if !pointer_location.is_in_viewport(camera_component, &primary_window)
+        if !pointer_location.is_in_viewport(camera_component, render_target, &primary_window)
             || !input_owners.permits_viewport_at(
                 window_entity,
                 entity,
@@ -226,11 +226,11 @@ pub fn send_gated_pointer_inputs(
 fn input_owners_permit_camera_at(
     input_owners: &UiInputOwners,
     primary_window: &Query<Entity, With<PrimaryWindow>>,
-    camera: &Camera,
+    render_target: &RenderTarget,
     camera_entity: Entity,
     pointer_location: &Location,
 ) -> bool {
-    camera_window_entity(camera, primary_window)
+    camera_window_entity(render_target, primary_window)
         .map(|window| {
             input_owners.permits_viewport_at(
                 window,
@@ -255,11 +255,11 @@ fn pointer_location_pos(pointer_location: &Location) -> bevy_egui::egui::Pos2 {
 }
 
 fn camera_window_entity(
-    camera: &Camera,
+    render_target: &RenderTarget,
     primary_window: &Query<Entity, With<PrimaryWindow>>,
 ) -> Option<Entity> {
     let primary_entity = primary_window.single().ok()?;
-    window_entity_from_target(&camera.target, primary_entity)
+    window_entity_from_target(render_target, primary_entity)
 }
 
 fn mouse_wheel_windows(mouse_wheel: &mut MessageReader<MouseWheel>) -> HashMap<Entity, ()> {

--- a/libs/elodin-editor/src/plugins/editor_cam_input.rs
+++ b/libs/elodin-editor/src/plugins/editor_cam_input.rs
@@ -1,0 +1,245 @@
+use std::collections::HashMap;
+
+use bevy::{
+    app::{App, Plugin, PreUpdate},
+    camera::Camera,
+    ecs::schedule::IntoScheduleConfigs,
+    input::{
+        ButtonInput,
+        mouse::{MouseButton, MouseScrollUnit, MouseWheel},
+    },
+    prelude::{Entity, MessageReader, MessageWriter, Query, Res, ResMut, Vec2, With},
+    window::PrimaryWindow,
+};
+use bevy_editor_cam::{
+    controller::component::EditorCam,
+    input::{CameraPointerMap, EditorCamInputMessage, MotionKind},
+};
+use bevy_picking::{
+    PickingSystems,
+    pointer::{PointerAction, PointerId, PointerInput, PointerLocation},
+};
+
+use crate::ui::{input_owner::UiInputOwners, window::window_entity_from_target};
+
+pub struct EditorCamInputPlugin;
+
+impl Plugin for EditorCamInputPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_message::<EditorCamInputMessage>()
+            .init_resource::<CameraPointerMap>()
+            .add_systems(
+                PreUpdate,
+                (
+                    gated_camera_inputs,
+                    EditorCamInputMessage::receive_messages,
+                    send_gated_pointer_inputs,
+                )
+                    .chain()
+                    .after(PickingSystems::Last)
+                    .before(EditorCam::update_camera_positions),
+            );
+    }
+}
+
+pub fn gated_camera_inputs(
+    pointers: Query<(&PointerId, &PointerLocation)>,
+    pointer_map: Res<CameraPointerMap>,
+    mut controller: MessageWriter<EditorCamInputMessage>,
+    mut mouse_wheel: MessageReader<MouseWheel>,
+    mouse_input: Res<ButtonInput<MouseButton>>,
+    cameras: Query<(Entity, &Camera, &EditorCam)>,
+    primary_window: Query<Entity, With<PrimaryWindow>>,
+    input_owners: Res<UiInputOwners>,
+) {
+    let orbit_start = MouseButton::Right;
+    let pan_start = MouseButton::Left;
+    let zoom_stop = 0.0;
+    let wheel_windows = mouse_wheel_windows(&mut mouse_wheel);
+
+    if let Some(&camera) = pointer_map.get(&PointerId::Mouse) {
+        let camera_query = cameras.get(camera).ok();
+        let owner_allows_camera = camera_query
+            .map(|(entity, camera, _)| {
+                input_owners_permit_camera(&input_owners, &primary_window, camera, entity)
+            })
+            .unwrap_or_default();
+        let is_in_zoom_mode = camera_query
+            .map(|(.., editor_cam)| editor_cam.current_motion.is_zooming_only())
+            .unwrap_or_default();
+        let zoom_amount_abs = camera_query
+            .and_then(|(.., editor_cam)| {
+                editor_cam
+                    .current_motion
+                    .inputs()
+                    .map(|inputs| inputs.zoom_velocity_abs(editor_cam.smoothing.zoom.mul_f32(2.0)))
+            })
+            .unwrap_or(0.0);
+        let should_zoom_end = is_in_zoom_mode && zoom_amount_abs <= zoom_stop;
+
+        if !owner_allows_camera
+            || mouse_input.any_just_released([orbit_start, pan_start])
+            || should_zoom_end
+        {
+            controller.write(EditorCamInputMessage::End { camera });
+        }
+    }
+
+    for (&pointer, pointer_location) in pointers
+        .iter()
+        .filter_map(|(id, loc)| loc.location().map(|loc| (id, loc)))
+    {
+        match pointer {
+            PointerId::Mouse => {
+                let Some((camera, camera_component, _)) =
+                    cameras.iter().find(|(entity, camera, _)| {
+                        pointer_location.is_in_viewport(camera, &primary_window)
+                            && input_owners_permit_camera(
+                                &input_owners,
+                                &primary_window,
+                                camera,
+                                *entity,
+                            )
+                    })
+                else {
+                    continue;
+                };
+
+                let Some(window_entity) = camera_window_entity(camera_component, &primary_window)
+                else {
+                    continue;
+                };
+
+                if mouse_input.just_pressed(orbit_start) {
+                    controller.write(EditorCamInputMessage::Start {
+                        kind: MotionKind::OrbitZoom,
+                        camera,
+                        pointer,
+                    });
+                } else if mouse_input.just_pressed(pan_start) {
+                    controller.write(EditorCamInputMessage::Start {
+                        kind: MotionKind::PanZoom,
+                        camera,
+                        pointer,
+                    });
+                } else if wheel_windows.contains_key(&window_entity) {
+                    controller.write(EditorCamInputMessage::Start {
+                        kind: MotionKind::Zoom,
+                        camera,
+                        pointer,
+                    });
+                }
+            }
+            PointerId::Touch(_) => continue,
+            PointerId::Custom(_) => continue,
+        }
+    }
+}
+
+pub fn send_gated_pointer_inputs(
+    mut camera_map: ResMut<CameraPointerMap>,
+    mut camera_controllers: Query<(Entity, &mut EditorCam, &Camera)>,
+    primary_window: Query<Entity, With<PrimaryWindow>>,
+    input_owners: Res<UiInputOwners>,
+    mut mouse_wheel: MessageReader<MouseWheel>,
+    mut moves: MessageReader<PointerInput>,
+) {
+    let moves_list: Vec<_> = moves.read().collect();
+    let wheel_by_window = mouse_wheel_offsets_by_window(&mut mouse_wheel);
+    let active_pointers: Vec<_> = camera_map
+        .iter()
+        .map(|(&pointer, &camera)| (pointer, camera))
+        .collect();
+    let mut ended_pointers = Vec::new();
+
+    for (pointer, camera) in active_pointers {
+        let Ok((entity, mut camera_controller, camera_component)) =
+            camera_controllers.get_mut(camera)
+        else {
+            ended_pointers.push(pointer);
+            continue;
+        };
+        let Some(window_entity) = camera_window_entity(camera_component, &primary_window) else {
+            camera_controller.end_move();
+            ended_pointers.push(pointer);
+            continue;
+        };
+        if !input_owners.permits_viewport(window_entity, entity) {
+            camera_controller.end_move();
+            ended_pointers.push(pointer);
+            continue;
+        }
+
+        let screenspace_input: Vec2 = moves_list
+            .iter()
+            .filter(|m| m.pointer_id.eq(&pointer))
+            .filter_map(|m| match m.action {
+                PointerAction::Move { delta } => Some(delta),
+                PointerAction::Press { .. } => None,
+                PointerAction::Cancel => None,
+                _ => None,
+            })
+            .sum();
+
+        let zoom_amount = match pointer {
+            PointerId::Mouse => wheel_by_window
+                .get(&window_entity)
+                .copied()
+                .unwrap_or_default(),
+            _ => 0.0,
+        };
+
+        camera_controller.send_screenspace_input(screenspace_input);
+        camera_controller.send_zoom_input(zoom_amount);
+    }
+
+    for pointer in ended_pointers {
+        camera_map.remove(&pointer);
+    }
+}
+
+fn input_owners_permit_camera(
+    input_owners: &UiInputOwners,
+    primary_window: &Query<Entity, With<PrimaryWindow>>,
+    camera: &Camera,
+    camera_entity: Entity,
+) -> bool {
+    camera_window_entity(camera, primary_window)
+        .map(|window| input_owners.permits_viewport(window, camera_entity))
+        .unwrap_or_default()
+}
+
+fn camera_window_entity(
+    camera: &Camera,
+    primary_window: &Query<Entity, With<PrimaryWindow>>,
+) -> Option<Entity> {
+    let primary_entity = primary_window.single().ok()?;
+    window_entity_from_target(&camera.target, primary_entity)
+}
+
+fn mouse_wheel_windows(mouse_wheel: &mut MessageReader<MouseWheel>) -> HashMap<Entity, ()> {
+    let mut windows = HashMap::new();
+    for ev in mouse_wheel.read() {
+        if ev.y.abs() > 0.0 {
+            windows.insert(ev.window, ());
+        }
+    }
+    windows
+}
+
+fn mouse_wheel_offsets_by_window(
+    mouse_wheel: &mut MessageReader<MouseWheel>,
+) -> HashMap<Entity, f32> {
+    let mut offsets = HashMap::new();
+    for ev in mouse_wheel.read() {
+        let scroll_multiplier = match ev.unit {
+            MouseScrollUnit::Line => 150.0,
+            MouseScrollUnit::Pixel => 1.0,
+        };
+        offsets
+            .entry(ev.window)
+            .and_modify(|offset| *offset += ev.y * scroll_multiplier)
+            .or_insert(ev.y * scroll_multiplier);
+    }
+    offsets
+}

--- a/libs/elodin-editor/src/plugins/editor_cam_touch/mod.rs
+++ b/libs/elodin-editor/src/plugins/editor_cam_touch/mod.rs
@@ -10,7 +10,7 @@ use bevy::window::PrimaryWindow;
 use bevy_editor_cam::controller::component::EditorCam;
 
 use crate::ui::{
-    UiInputConsumerSet, input_owner::UiInputOwners, tiles, window::window_entity_from_target,
+    UiInputConsumerSet, input_owner::UiInputOwners, window::window_entity_from_target,
 };
 
 use super::camera_anchor::camera_anchor_from_transform;
@@ -176,7 +176,6 @@ pub fn touch_tracker(touches: Res<Touches>, mut touch_tracker: ResMut<TouchTrack
 pub fn touch_editor_cam(
     touch_tracker: Res<TouchTracker>,
     mut cams: Query<(Entity, &mut EditorCam, &Transform, &Camera, &RenderTarget)>,
-    viewport_contains_pointer: Res<tiles::ViewportContainsPointer>,
     input_owners: Res<UiInputOwners>,
     primary_window: Query<Entity, With<PrimaryWindow>>,
 ) {
@@ -199,7 +198,6 @@ pub fn touch_editor_cam(
             continue;
         };
         if !viewport_rect.contains(midpoint)
-            || !viewport_contains_pointer.0
             || !input_owners.permits_viewport_at(window_entity, entity, midpoint_pos)
         {
             continue;

--- a/libs/elodin-editor/src/plugins/editor_cam_touch/mod.rs
+++ b/libs/elodin-editor/src/plugins/editor_cam_touch/mod.rs
@@ -4,11 +4,14 @@ use bevy::ecs::schedule::IntoScheduleConfigs;
 use bevy::ecs::system::Query;
 use bevy::input::touch::Touch;
 use bevy::math::Vec2;
-use bevy::prelude::{Res, ResMut, Resource, Touches};
+use bevy::prelude::{Entity, Res, ResMut, Resource, Touches, With};
 use bevy::transform::components::Transform;
+use bevy::window::PrimaryWindow;
 use bevy_editor_cam::controller::component::EditorCam;
 
-use crate::ui::tiles;
+use crate::ui::{
+    UiInputConsumerSet, input_owner::UiInputOwners, tiles, window::window_entity_from_target,
+};
 
 use super::camera_anchor::camera_anchor_from_transform;
 
@@ -18,7 +21,12 @@ impl Plugin for EditorCamTouchPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<TouchTracker>()
             .add_systems(Update, touch_tracker)
-            .add_systems(Update, touch_editor_cam.after(touch_tracker));
+            .add_systems(
+                Update,
+                touch_editor_cam
+                    .after(touch_tracker)
+                    .in_set(UiInputConsumerSet),
+            );
     }
 }
 
@@ -167,20 +175,33 @@ pub fn touch_tracker(touches: Res<Touches>, mut touch_tracker: ResMut<TouchTrack
 
 pub fn touch_editor_cam(
     touch_tracker: Res<TouchTracker>,
-    mut cams: Query<(&mut EditorCam, &Transform, &Camera)>,
+    mut cams: Query<(Entity, &mut EditorCam, &Transform, &Camera)>,
     viewport_contains_pointer: Res<tiles::ViewportContainsPointer>,
+    input_owners: Res<UiInputOwners>,
+    primary_window: Query<Entity, With<PrimaryWindow>>,
 ) {
+    let Ok(primary_entity) = primary_window.single() else {
+        return;
+    };
     let touch_gestures = touch_tracker.get_touch_gestures();
     let midpoint = match touch_gestures {
         TouchGestures::OneFinger(one_finger) => one_finger.midpoint,
         TouchGestures::TwoFinger(two_finger) => two_finger.midpoint,
         _ => return,
     };
-    for (mut editor_cam, transform, cam) in cams.iter_mut() {
+    let midpoint_pos = bevy_egui::egui::pos2(midpoint.x, midpoint.y);
+
+    for (entity, mut editor_cam, transform, cam) in cams.iter_mut() {
+        let Some(window_entity) = window_entity_from_target(&cam.target, primary_entity) else {
+            continue;
+        };
         let Some(viewport_rect) = cam.logical_viewport_rect() else {
             continue;
         };
-        if !viewport_rect.contains(midpoint) || !viewport_contains_pointer.0 {
+        if !viewport_rect.contains(midpoint)
+            || !viewport_contains_pointer.0
+            || !input_owners.permits_viewport_at(window_entity, entity, midpoint_pos)
+        {
             continue;
         }
         let anchor = camera_anchor_from_transform(transform);

--- a/libs/elodin-editor/src/plugins/editor_cam_touch/mod.rs
+++ b/libs/elodin-editor/src/plugins/editor_cam_touch/mod.rs
@@ -1,5 +1,5 @@
 use bevy::app::{App, Plugin, Update};
-use bevy::camera::Camera;
+use bevy::camera::{Camera, RenderTarget};
 use bevy::ecs::schedule::IntoScheduleConfigs;
 use bevy::ecs::system::Query;
 use bevy::input::touch::Touch;
@@ -175,7 +175,7 @@ pub fn touch_tracker(touches: Res<Touches>, mut touch_tracker: ResMut<TouchTrack
 
 pub fn touch_editor_cam(
     touch_tracker: Res<TouchTracker>,
-    mut cams: Query<(Entity, &mut EditorCam, &Transform, &Camera)>,
+    mut cams: Query<(Entity, &mut EditorCam, &Transform, &Camera, &RenderTarget)>,
     viewport_contains_pointer: Res<tiles::ViewportContainsPointer>,
     input_owners: Res<UiInputOwners>,
     primary_window: Query<Entity, With<PrimaryWindow>>,
@@ -191,8 +191,8 @@ pub fn touch_editor_cam(
     };
     let midpoint_pos = bevy_egui::egui::pos2(midpoint.x, midpoint.y);
 
-    for (entity, mut editor_cam, transform, cam) in cams.iter_mut() {
-        let Some(window_entity) = window_entity_from_target(&cam.target, primary_entity) else {
+    for (entity, mut editor_cam, transform, cam, render_target) in cams.iter_mut() {
+        let Some(window_entity) = window_entity_from_target(render_target, primary_entity) else {
             continue;
         };
         let Some(viewport_rect) = cam.logical_viewport_rect() else {

--- a/libs/elodin-editor/src/plugins/mod.rs
+++ b/libs/elodin-editor/src/plugins/mod.rs
@@ -1,5 +1,6 @@
 mod asset_cache;
 pub(crate) mod camera_anchor;
+pub mod editor_cam_input;
 pub mod editor_cam_touch;
 pub(crate) mod env_asset_source;
 pub mod frustum;

--- a/libs/elodin-editor/src/plugins/navigation_gizmo/mod.rs
+++ b/libs/elodin-editor/src/plugins/navigation_gizmo/mod.rs
@@ -1,6 +1,8 @@
 use crate::{
-    MainCamera, plugins::camera_anchor::camera_anchor_from_transform, ui::ViewportRect,
-    ui::input_owner::UiInputOwners,
+    MainCamera,
+    plugins::camera_anchor::camera_anchor_from_transform,
+    ui::ViewportRect,
+    ui::input_owner::{PointerOwner, PointerOwnerPriority, UiInputOwners},
 };
 use bevy::animation::{AnimatedBy, AnimationTargetId, animated_field};
 use bevy::camera::{RenderTarget, Viewport};
@@ -10,7 +12,7 @@ use bevy::window::{PrimaryWindow, WindowRef};
 use bevy_editor_cam::controller::component::EditorCam;
 use bevy_editor_cam::extensions::look_to::LookToTrigger;
 use bevy_editor_cam::prelude::EnabledMotion;
-use bevy_egui::EguiContexts;
+use bevy_egui::{EguiContexts, egui};
 use std::{collections::HashMap, f32::consts};
 
 use super::render_layer_alloc::RenderLayerAllocator;
@@ -387,7 +389,7 @@ fn set_camera_viewport(
     mut main_editor_cam_query: Query<&mut EditorCam, (With<MainCamera>, Without<NavGizmoParent>)>,
     primary_query: Query<Entity, With<PrimaryWindow>>,
     mouse_buttons: Res<ButtonInput<MouseButton>>,
-    input_owners: Res<UiInputOwners>,
+    mut input_owners: ResMut<UiInputOwners>,
     mut anchor_state: ResMut<NavGizmoAnchorState>,
 ) {
     let margin = 8.0;
@@ -455,10 +457,31 @@ fn set_camera_viewport(
             window_size,
         );
 
+        let nav_gizmo_rect = egui::Rect::from_min_size(
+            egui::pos2(
+                nav_viewport_pos.x / scale_factor,
+                nav_viewport_pos.y / scale_factor,
+            ),
+            egui::vec2(side_length / scale_factor, side_length / scale_factor),
+        );
+        input_owners.register_rect(
+            window_entity,
+            nav_gizmo_rect,
+            PointerOwner::NavGizmo {
+                camera: parent.main_camera,
+            },
+            PointerOwnerPriority::Overlay,
+        );
+
+        let cursor_pos = window.physical_cursor_position();
+        let cursor_pos_logical =
+            cursor_pos.map(|pos| egui::pos2(pos.x / scale_factor, pos.y / scale_factor));
+        input_owners.resolve_window(window_entity, cursor_pos_logical);
+
         if mouse_buttons.just_pressed(MouseButton::Left)
             && anchor_state.active_drag.is_none()
-            && input_owners.permits_viewport(window_entity, parent.main_camera)
-            && let Some(cursor_pos) = window.physical_cursor_position()
+            && input_owners.permits_nav_gizmo(window_entity, parent.main_camera)
+            && let Some(cursor_pos) = cursor_pos
         {
             let drag_rect = Rect::from_corners(
                 nav_viewport_pos,

--- a/libs/elodin-editor/src/plugins/navigation_gizmo/mod.rs
+++ b/libs/elodin-editor/src/plugins/navigation_gizmo/mod.rs
@@ -1,4 +1,7 @@
-use crate::{MainCamera, plugins::camera_anchor::camera_anchor_from_transform, ui::ViewportRect};
+use crate::{
+    MainCamera, plugins::camera_anchor::camera_anchor_from_transform, ui::ViewportRect,
+    ui::input_owner::UiInputOwners,
+};
 use bevy::animation::{AnimatedBy, AnimationTargetId, animated_field};
 use bevy::camera::{RenderTarget, Viewport};
 use bevy::math::Dir3;
@@ -384,6 +387,7 @@ fn set_camera_viewport(
     mut main_editor_cam_query: Query<&mut EditorCam, (With<MainCamera>, Without<NavGizmoParent>)>,
     primary_query: Query<Entity, With<PrimaryWindow>>,
     mouse_buttons: Res<ButtonInput<MouseButton>>,
+    input_owners: Res<UiInputOwners>,
     mut anchor_state: ResMut<NavGizmoAnchorState>,
 ) {
     let margin = 8.0;
@@ -453,6 +457,7 @@ fn set_camera_viewport(
 
         if mouse_buttons.just_pressed(MouseButton::Left)
             && anchor_state.active_drag.is_none()
+            && input_owners.permits_viewport(window_entity, parent.main_camera)
             && let Some(cursor_pos) = window.physical_cursor_position()
         {
             let drag_rect = Rect::from_corners(

--- a/libs/elodin-editor/src/plugins/navigation_gizmo/mod.rs
+++ b/libs/elodin-editor/src/plugins/navigation_gizmo/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     MainCamera,
-    plugins::camera_anchor::camera_anchor_from_transform,
+    plugins::{camera_anchor::camera_anchor_from_transform, view_cube::ViewCubeCamera},
     ui::ViewportRect,
     ui::input_owner::{PointerOwner, PointerOwnerPriority, UiInputOwners},
 };
@@ -397,7 +397,12 @@ fn clamp_overlay_position(position: Vec2, side_length: f32, window_size: Vec2) -
 fn set_camera_viewport(
     windows: Query<(Entity, &Window, &bevy_egui::EguiContextSettings)>,
     _contexts: EguiContexts,
-    mut nav_camera_query: Query<(&mut Camera, &RenderTarget, &NavGizmoParent)>,
+    mut nav_camera_query: Query<(
+        &mut Camera,
+        &RenderTarget,
+        &NavGizmoParent,
+        Option<&ViewCubeCamera>,
+    )>,
     main_camera_query: Query<(&Camera, Option<&ViewportRect>), Without<NavGizmoParent>>,
     mut main_editor_cam_query: Query<&mut EditorCam, (With<MainCamera>, Without<NavGizmoParent>)>,
     primary_query: Query<Entity, With<PrimaryWindow>>,
@@ -417,7 +422,7 @@ fn set_camera_viewport(
         anchor_state.active_drag = None;
     }
 
-    for (mut nav_camera, render_target, parent) in nav_camera_query.iter_mut() {
+    for (mut nav_camera, render_target, parent, view_cube_camera) in nav_camera_query.iter_mut() {
         let Ok((main, viewport_rect)) = main_camera_query.get(parent.main_camera) else {
             continue;
         };
@@ -480,8 +485,14 @@ fn set_camera_viewport(
         input_owners.register_rect(
             window_entity,
             nav_gizmo_rect,
-            PointerOwner::NavGizmo {
-                camera: parent.main_camera,
+            if view_cube_camera.is_some() {
+                PointerOwner::ViewCube {
+                    camera: parent.main_camera,
+                }
+            } else {
+                PointerOwner::NavGizmo {
+                    camera: parent.main_camera,
+                }
             },
             PointerOwnerPriority::Overlay,
         );

--- a/libs/elodin-editor/src/plugins/navigation_gizmo/mod.rs
+++ b/libs/elodin-editor/src/plugins/navigation_gizmo/mod.rs
@@ -279,6 +279,7 @@ pub fn drag_nav_gizmo(
     nav_gizmo: Query<&NavGizmoParent>,
     mut query: Query<(&Transform, &mut EditorCam, &Camera), With<MainCamera>>,
     dragged_query: Query<(), With<DraggedMarker>>,
+    input_owners: Res<UiInputOwners>,
     mut commands: Commands,
 ) {
     let drag_target = drag.event().event_target();
@@ -289,6 +290,13 @@ pub fn drag_nav_gizmo(
     let Ok((transform, mut editor_cam, cam)) = query.get_mut(nav_gizmo.main_camera) else {
         return;
     };
+    if !input_owners.permits_nav_gizmo_location(nav_gizmo.main_camera, &drag.pointer_location) {
+        if dragged_query.get(drag_target).is_ok() {
+            editor_cam.end_move();
+            commands.entity(drag_target).remove::<DraggedMarker>();
+        }
+        return;
+    }
     let first_drag = dragged_query.get(drag_target).is_err();
     if first_drag {
         commands.entity(drag_target).insert(DraggedMarker);
@@ -330,12 +338,14 @@ fn side_clicked_cb(
     Query<(Entity, &Transform, &EditorCam), With<MainCamera>>,
     Query<&NavGizmoParent>,
     Query<&DraggedMarker>,
+    Res<UiInputOwners>,
     MessageWriter<LookToTrigger>,
 ) {
     move |click: On<Pointer<Click>>,
           query: Query<(Entity, &Transform, &EditorCam), With<MainCamera>>,
           nav_gizmo: Query<&NavGizmoParent>,
           drag_query: Query<&DraggedMarker>,
+          input_owners: Res<UiInputOwners>,
           mut look_to: MessageWriter<LookToTrigger>| {
         let target = click.event().event_target();
 
@@ -345,6 +355,9 @@ fn side_clicked_cb(
         let Ok((entity, transform, editor_cam)) = query.get(nav_gizmo.main_camera) else {
             return;
         };
+        if !input_owners.permits_nav_gizmo_location(entity, &click.pointer_location) {
+            return;
+        }
 
         if drag_query.get(target).is_ok() {
             return;

--- a/libs/elodin-editor/src/plugins/view_cube/interactions.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/interactions.rs
@@ -1076,7 +1076,7 @@ pub fn on_cube_click(
     let Ok(link) = lookup.root_links.get(source) else {
         return;
     };
-    if !input_owners.permits_viewport_location(link.main_camera, &trigger.pointer_location) {
+    if !input_owners.permits_view_cube_location(link.main_camera, &trigger.pointer_location) {
         return;
     }
 
@@ -1171,7 +1171,7 @@ pub fn on_cube_drag(
     let Ok((transform, mut editor_cam, camera)) = cameras.get_mut(link.main_camera) else {
         return;
     };
-    if !input_owners.permits_viewport_location(link.main_camera, &drag.pointer_location) {
+    if !input_owners.permits_view_cube_location(link.main_camera, &drag.pointer_location) {
         if dragging_roots.get(root).is_ok() {
             editor_cam.end_move();
             commands.entity(root).remove::<ViewCubeDragging>();
@@ -1340,7 +1340,7 @@ pub fn on_arrow_pressed(
     let Ok((_, link)) = root_query.get(source) else {
         return;
     };
-    if !input_owners.permits_viewport_location(link.main_camera, &trigger.pointer_location) {
+    if !input_owners.permits_view_cube_location(link.main_camera, &trigger.pointer_location) {
         return;
     }
 
@@ -1387,7 +1387,7 @@ pub fn on_action_button_click(
     let Ok((_, link)) = root_query.get(source) else {
         return;
     };
-    if !input_owners.permits_viewport_location(link.main_camera, &trigger.pointer_location) {
+    if !input_owners.permits_view_cube_location(link.main_camera, &trigger.pointer_location) {
         return;
     }
 

--- a/libs/elodin-editor/src/plugins/view_cube/interactions.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/interactions.rs
@@ -11,7 +11,7 @@ use super::components::*;
 use super::config::ViewCubeConfig;
 use super::events::ViewCubeEvent;
 use super::theme::ViewCubeColors;
-use crate::plugins::camera_anchor::camera_anchor_from_transform;
+use crate::{plugins::camera_anchor::camera_anchor_from_transform, ui::input_owner::UiInputOwners};
 
 #[derive(Clone)]
 struct ArrowHold {
@@ -1032,6 +1032,7 @@ pub fn on_cube_click(
     parents_query: Query<&ChildOf>,
     lookup: OnCubeClickLookup,
     hovered: Res<HoveredElement>,
+    input_owners: Res<UiInputOwners>,
     mut events: MessageWriter<ViewCubeEvent>,
 ) {
     if trigger.event().button != PointerButton::Primary {
@@ -1072,6 +1073,12 @@ pub fn on_cube_click(
     else {
         return;
     };
+    let Ok(link) = lookup.root_links.get(source) else {
+        return;
+    };
+    if !input_owners.permits_viewport_location(link.main_camera, &trigger.pointer_location) {
+        return;
+    }
 
     match element {
         CubeElement::Face(dir) => {
@@ -1143,6 +1150,7 @@ pub fn on_cube_drag(
     root_links: Query<&ViewCubeLink, With<ViewCubeRoot>>,
     mut cameras: Query<(&Transform, &mut EditorCam, &Camera), With<ViewCubeTargetCamera>>,
     dragging_roots: Query<(), With<ViewCubeDragging>>,
+    input_owners: Res<UiInputOwners>,
     mut commands: Commands,
 ) {
     if drag.button != PointerButton::Secondary {
@@ -1163,6 +1171,13 @@ pub fn on_cube_drag(
     let Ok((transform, mut editor_cam, camera)) = cameras.get_mut(link.main_camera) else {
         return;
     };
+    if !input_owners.permits_viewport_location(link.main_camera, &drag.pointer_location) {
+        if dragging_roots.get(root).is_ok() {
+            editor_cam.end_move();
+            commands.entity(root).remove::<ViewCubeDragging>();
+        }
+        return;
+    }
 
     if dragging_roots.get(root).is_err() {
         commands.entity(root).insert(ViewCubeDragging);
@@ -1293,12 +1308,14 @@ pub fn on_action_button_hover_end(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn on_arrow_pressed(
     trigger: On<Pointer<Press>>,
     arrows: Query<&RotationArrow>,
     parents_query: Query<&ChildOf>,
     camera_link_query: Query<&ViewCubeLink, With<ViewCubeCamera>>,
     root_query: Query<(Entity, &ViewCubeLink), With<ViewCubeRoot>>,
+    input_owners: Res<UiInputOwners>,
     mut hold: ResMut<ActiveArrowHold>,
     mut events: MessageWriter<ViewCubeEvent>,
 ) {
@@ -1320,6 +1337,12 @@ pub fn on_arrow_pressed(
     else {
         return;
     };
+    let Ok((_, link)) = root_query.get(source) else {
+        return;
+    };
+    if !input_owners.permits_viewport_location(link.main_camera, &trigger.pointer_location) {
+        return;
+    }
 
     // First step happens immediately on press.
     events.write(ViewCubeEvent::ArrowClicked {
@@ -1340,6 +1363,7 @@ pub fn on_action_button_click(
     parents_query: Query<&ChildOf>,
     camera_link_query: Query<&ViewCubeLink, With<ViewCubeCamera>>,
     root_query: Query<(Entity, &ViewCubeLink), With<ViewCubeRoot>>,
+    input_owners: Res<UiInputOwners>,
     mut events: MessageWriter<ViewCubeEvent>,
 ) {
     if trigger.event().button != PointerButton::Primary {
@@ -1360,6 +1384,12 @@ pub fn on_action_button_click(
     else {
         return;
     };
+    let Ok((_, link)) = root_query.get(source) else {
+        return;
+    };
+    if !input_owners.permits_viewport_location(link.main_camera, &trigger.pointer_location) {
+        return;
+    }
 
     events.write(ViewCubeEvent::ViewportActionClicked {
         action: *action,

--- a/libs/elodin-editor/src/ui/command_palette/mod.rs
+++ b/libs/elodin-editor/src/ui/command_palette/mod.rs
@@ -15,7 +15,9 @@ use crate::{
     plugins::LogicalKeyState,
     ui::{
         colors::{self, ColorExt, get_scheme, with_opacity},
-        images, theme,
+        images,
+        input_owner::{PointerOwnerPriority, UiBlocker},
+        register_window_input_blocker, theme,
         utils::{MarginSides, Shrink4},
     },
 };
@@ -216,11 +218,15 @@ impl RootWidgetSystem for PaletteWindow<'_, '_> {
         ctx: &mut egui::Context,
         args: Self::Args,
     ) -> Self::Output {
+        let Some(target_window) = args else {
+            return false;
+        };
+
         let (command_palette_icons, auto_open_none, just_opened) = {
             let state_mut = state.get_mut(world);
             let command_palette_state = state_mut.command_palette_state;
 
-            if command_palette_state.target_window != args {
+            if command_palette_state.target_window != Some(target_window) {
                 return false;
             }
 
@@ -240,6 +246,14 @@ impl RootWidgetSystem for PaletteWindow<'_, '_> {
         };
 
         let screen_rect = ctx.content_rect();
+        register_window_input_blocker(
+            world,
+            target_window,
+            screen_rect,
+            UiBlocker::CommandPalette,
+            PointerOwnerPriority::Modal,
+        );
+
         let palette_width = (screen_rect.width() / 2.0).clamp(500.0, 900.0);
         let palette_size = egui::vec2(palette_width, screen_rect.height() - 128.0);
         let palette_min = egui::pos2(screen_rect.center().x - palette_width / 2.0, 64.0);

--- a/libs/elodin-editor/src/ui/input_owner.rs
+++ b/libs/elodin-editor/src/ui/input_owner.rs
@@ -156,6 +156,11 @@ impl UiInputOwners {
             .unwrap_or(PointerOwner::None)
     }
 
+    pub fn owner_at(&self, window: Entity, pointer_pos: egui::Pos2) -> PointerOwner {
+        self.resolve_owner_at(window, pointer_pos)
+            .unwrap_or(PointerOwner::None)
+    }
+
     pub fn permits_viewport(&self, window: Entity, camera: Entity) -> bool {
         matches!(
             self.owner_for_window(window),
@@ -163,9 +168,29 @@ impl UiInputOwners {
         )
     }
 
+    pub fn permits_viewport_at(
+        &self,
+        window: Entity,
+        camera: Entity,
+        pointer_pos: egui::Pos2,
+    ) -> bool {
+        matches!(
+            self.owner_at(window, pointer_pos),
+            PointerOwner::Viewport { camera: owner_camera } if owner_camera == camera
+        )
+    }
+
     pub fn permits_graph(&self, window: Entity, graph: Entity) -> bool {
         matches!(
             self.owner_for_window(window),
+            PointerOwner::Graph { graph: owner_graph }
+                | PointerOwner::QueryPlot { graph: owner_graph } if owner_graph == graph
+        )
+    }
+
+    pub fn permits_graph_at(&self, window: Entity, graph: Entity, pointer_pos: egui::Pos2) -> bool {
+        matches!(
+            self.owner_at(window, pointer_pos),
             PointerOwner::Graph { graph: owner_graph }
                 | PointerOwner::QueryPlot { graph: owner_graph } if owner_graph == graph
         )
@@ -406,5 +431,29 @@ mod tests {
                 graph: second_graph,
             })
         );
+    }
+
+    #[test]
+    fn permits_at_uses_the_provided_position_without_resolving_window_state() {
+        let window = entity(1);
+        let graph = entity(2);
+        let camera = entity(3);
+        let mut owners = UiInputOwners::default();
+
+        owners.register_content_rect(
+            window,
+            rect(0.0, 0.0, 100.0, 50.0),
+            PointerOwner::Graph { graph },
+        );
+        owners.register_content_rect(
+            window,
+            rect(0.0, 50.0, 100.0, 100.0),
+            PointerOwner::Viewport { camera },
+        );
+
+        assert!(owners.permits_graph_at(window, graph, egui::pos2(50.0, 25.0)));
+        assert!(!owners.permits_graph_at(window, graph, egui::pos2(50.0, 75.0)));
+        assert!(owners.permits_viewport_at(window, camera, egui::pos2(50.0, 75.0)));
+        assert_eq!(owners.owner_for_window(window), PointerOwner::None);
     }
 }

--- a/libs/elodin-editor/src/ui/input_owner.rs
+++ b/libs/elodin-editor/src/ui/input_owner.rs
@@ -586,6 +586,28 @@ mod tests {
     }
 
     #[test]
+    fn timeline_over_viewport_blocks_viewport_input() {
+        let window = entity(1);
+        let camera = entity(2);
+        let mut owners = UiInputOwners::default();
+
+        owners.register_content_rect(
+            window,
+            rect(0.0, 0.0, 200.0, 200.0),
+            PointerOwner::Viewport { camera },
+        );
+        owners.register_blocker_rect(
+            window,
+            rect(0.0, 150.0, 200.0, 200.0),
+            UiBlocker::Timeline,
+            PointerOwnerPriority::Panel,
+        );
+
+        assert!(!owners.permits_viewport_at(window, camera, egui::pos2(100.0, 175.0)));
+        assert!(owners.permits_viewport_at(window, camera, egui::pos2(100.0, 75.0)));
+    }
+
+    #[test]
     fn permits_at_uses_the_provided_position_without_resolving_window_state() {
         let window = entity(1);
         let graph = entity(2);

--- a/libs/elodin-editor/src/ui/input_owner.rs
+++ b/libs/elodin-editor/src/ui/input_owner.rs
@@ -2,20 +2,25 @@ use bevy::prelude::{Entity, Resource};
 use bevy_egui::egui;
 use std::collections::HashMap;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
 pub enum PointerOwner {
+    #[default]
     None,
-    Viewport { camera: Entity },
-    Graph { graph: Entity },
-    QueryPlot { graph: Entity },
-    NavGizmo { camera: Entity },
-    BlockedByUi { blocker: UiBlocker },
-}
-
-impl Default for PointerOwner {
-    fn default() -> Self {
-        Self::None
-    }
+    Viewport {
+        camera: Entity,
+    },
+    Graph {
+        graph: Entity,
+    },
+    QueryPlot {
+        graph: Entity,
+    },
+    NavGizmo {
+        camera: Entity,
+    },
+    BlockedByUi {
+        blocker: UiBlocker,
+    },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]

--- a/libs/elodin-editor/src/ui/input_owner.rs
+++ b/libs/elodin-editor/src/ui/input_owner.rs
@@ -431,10 +431,7 @@ mod tests {
             owners.resolve_window(window, Some(egui::pos2(150.0, 50.0))),
             PointerOwner::ViewCube { camera }
         );
-        assert!(owners.permits_view_cube_location(
-            camera,
-            &location(window, 150.0, 50.0),
-        ));
+        assert!(owners.permits_view_cube_location(camera, &location(window, 150.0, 50.0),));
         assert!(!owners.permits_nav_gizmo(window, camera));
         assert!(!owners.permits_viewport(window, camera));
     }

--- a/libs/elodin-editor/src/ui/input_owner.rs
+++ b/libs/elodin-editor/src/ui/input_owner.rs
@@ -1,5 +1,10 @@
-use bevy::prelude::{Entity, Resource};
+use bevy::{
+    camera::NormalizedRenderTarget,
+    ecs::entity::ContainsEntity,
+    prelude::{Entity, Resource},
+};
 use bevy_egui::egui;
+use bevy_picking::pointer::Location;
 use std::collections::HashMap;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
@@ -185,6 +190,12 @@ impl UiInputOwners {
         )
     }
 
+    pub fn permits_viewport_location(&self, camera: Entity, location: &Location) -> bool {
+        pointer_window(location)
+            .map(|window| self.permits_viewport_at(window, camera, pointer_pos(location)))
+            .unwrap_or_default()
+    }
+
     pub fn permits_graph(&self, window: Entity, graph: Entity) -> bool {
         matches!(
             self.owner_for_window(window),
@@ -208,12 +219,41 @@ impl UiInputOwners {
         )
     }
 
+    pub fn permits_nav_gizmo_location(&self, camera: Entity, location: &Location) -> bool {
+        pointer_window(location)
+            .map(|window| self.permits_nav_gizmo_at(window, camera, pointer_pos(location)))
+            .unwrap_or_default()
+    }
+
+    pub fn permits_nav_gizmo_at(
+        &self,
+        window: Entity,
+        camera: Entity,
+        pointer_pos: egui::Pos2,
+    ) -> bool {
+        matches!(
+            self.owner_at(window, pointer_pos),
+            PointerOwner::NavGizmo { camera: owner_camera } if owner_camera == camera
+        )
+    }
+
     pub fn is_blocked_by_ui(&self, window: Entity) -> bool {
         matches!(
             self.owner_for_window(window),
             PointerOwner::BlockedByUi { .. }
         )
     }
+}
+
+fn pointer_window(location: &Location) -> Option<Entity> {
+    match &location.target {
+        NormalizedRenderTarget::Window(window) => Some(window.entity()),
+        _ => None,
+    }
+}
+
+fn pointer_pos(location: &Location) -> egui::Pos2 {
+    egui::pos2(location.position.x, location.position.y)
 }
 
 fn is_usable_rect(rect: egui::Rect) -> bool {
@@ -235,6 +275,17 @@ mod tests {
 
     fn rect(min_x: f32, min_y: f32, max_x: f32, max_y: f32) -> egui::Rect {
         egui::Rect::from_min_max(egui::pos2(min_x, min_y), egui::pos2(max_x, max_y))
+    }
+
+    fn location(window: Entity, x: f32, y: f32) -> Location {
+        Location {
+            target: NormalizedRenderTarget::Window(
+                bevy::window::WindowRef::Entity(window)
+                    .normalize(None)
+                    .expect("normalized window"),
+            ),
+            position: bevy::math::Vec2::new(x, y),
+        }
     }
 
     #[test]
@@ -335,6 +386,28 @@ mod tests {
         );
         assert!(owners.permits_nav_gizmo(window, camera));
         assert!(!owners.permits_viewport(window, camera));
+    }
+
+    #[test]
+    fn pointer_location_permissions_use_pointer_position() {
+        let window = entity(1);
+        let camera = entity(2);
+        let mut owners = UiInputOwners::default();
+
+        owners.register_content_rect(
+            window,
+            rect(0.0, 0.0, 200.0, 200.0),
+            PointerOwner::Viewport { camera },
+        );
+        owners.register_blocker_rect(
+            window,
+            rect(0.0, 0.0, 100.0, 200.0),
+            UiBlocker::Modal,
+            PointerOwnerPriority::Modal,
+        );
+
+        assert!(!owners.permits_viewport_location(camera, &location(window, 50.0, 50.0)));
+        assert!(owners.permits_viewport_location(camera, &location(window, 150.0, 50.0)));
     }
 
     #[test]

--- a/libs/elodin-editor/src/ui/input_owner.rs
+++ b/libs/elodin-editor/src/ui/input_owner.rs
@@ -312,6 +312,32 @@ mod tests {
     }
 
     #[test]
+    fn nav_gizmo_overlay_wins_over_underlying_viewport() {
+        let window = entity(1);
+        let camera = entity(2);
+        let mut owners = UiInputOwners::default();
+
+        owners.register_content_rect(
+            window,
+            rect(0.0, 0.0, 200.0, 200.0),
+            PointerOwner::Viewport { camera },
+        );
+        owners.register_rect(
+            window,
+            rect(100.0, 0.0, 200.0, 100.0),
+            PointerOwner::NavGizmo { camera },
+            PointerOwnerPriority::Overlay,
+        );
+
+        assert_eq!(
+            owners.resolve_window(window, Some(egui::pos2(150.0, 50.0))),
+            PointerOwner::NavGizmo { camera }
+        );
+        assert!(owners.permits_nav_gizmo(window, camera));
+        assert!(!owners.permits_viewport(window, camera));
+    }
+
+    #[test]
     fn later_region_wins_with_equal_priority() {
         let window = entity(1);
         let first = entity(2);

--- a/libs/elodin-editor/src/ui/input_owner.rs
+++ b/libs/elodin-editor/src/ui/input_owner.rs
@@ -72,6 +72,12 @@ impl UiInputOwners {
         self.next_order = 0;
     }
 
+    pub fn begin_window(&mut self, window: Entity) {
+        self.regions_by_window.remove(&window);
+        self.owners_by_window.remove(&window);
+        self.next_order = 0;
+    }
+
     pub fn register_rect(
         &mut self,
         window: Entity,
@@ -355,6 +361,50 @@ mod tests {
         assert_eq!(
             owners.resolve_owner_at(window, egui::pos2(50.0, 50.0)),
             None
+        );
+    }
+
+    #[test]
+    fn begin_window_clears_only_that_window() {
+        let first_window = entity(1);
+        let second_window = entity(2);
+        let first_graph = entity(3);
+        let second_graph = entity(4);
+        let mut owners = UiInputOwners::default();
+
+        owners.register_content_rect(
+            first_window,
+            rect(0.0, 0.0, 100.0, 100.0),
+            PointerOwner::Graph { graph: first_graph },
+        );
+        owners.register_content_rect(
+            second_window,
+            rect(0.0, 0.0, 100.0, 100.0),
+            PointerOwner::Graph {
+                graph: second_graph,
+            },
+        );
+        owners.resolve_window(first_window, Some(egui::pos2(50.0, 50.0)));
+        owners.resolve_window(second_window, Some(egui::pos2(50.0, 50.0)));
+
+        owners.begin_window(first_window);
+
+        assert_eq!(owners.owner_for_window(first_window), PointerOwner::None);
+        assert_eq!(
+            owners.resolve_owner_at(first_window, egui::pos2(50.0, 50.0)),
+            None
+        );
+        assert_eq!(
+            owners.owner_for_window(second_window),
+            PointerOwner::Graph {
+                graph: second_graph,
+            }
+        );
+        assert_eq!(
+            owners.resolve_owner_at(second_window, egui::pos2(50.0, 50.0)),
+            Some(PointerOwner::Graph {
+                graph: second_graph,
+            })
         );
     }
 }

--- a/libs/elodin-editor/src/ui/input_owner.rs
+++ b/libs/elodin-editor/src/ui/input_owner.rs
@@ -23,6 +23,9 @@ pub enum PointerOwner {
     NavGizmo {
         camera: Entity,
     },
+    ViewCube {
+        camera: Entity,
+    },
     BlockedByUi {
         blocker: UiBlocker,
     },
@@ -237,6 +240,24 @@ impl UiInputOwners {
         )
     }
 
+    pub fn permits_view_cube_location(&self, camera: Entity, location: &Location) -> bool {
+        pointer_window(location)
+            .map(|window| self.permits_view_cube_at(window, camera, pointer_pos(location)))
+            .unwrap_or_default()
+    }
+
+    pub fn permits_view_cube_at(
+        &self,
+        window: Entity,
+        camera: Entity,
+        pointer_pos: egui::Pos2,
+    ) -> bool {
+        matches!(
+            self.owner_at(window, pointer_pos),
+            PointerOwner::ViewCube { camera: owner_camera } if owner_camera == camera
+        )
+    }
+
     pub fn is_blocked_by_ui(&self, window: Entity) -> bool {
         matches!(
             self.owner_for_window(window),
@@ -385,6 +406,36 @@ mod tests {
             PointerOwner::NavGizmo { camera }
         );
         assert!(owners.permits_nav_gizmo(window, camera));
+        assert!(!owners.permits_viewport(window, camera));
+    }
+
+    #[test]
+    fn view_cube_overlay_wins_over_underlying_viewport() {
+        let window = entity(1);
+        let camera = entity(2);
+        let mut owners = UiInputOwners::default();
+
+        owners.register_content_rect(
+            window,
+            rect(0.0, 0.0, 200.0, 200.0),
+            PointerOwner::Viewport { camera },
+        );
+        owners.register_rect(
+            window,
+            rect(100.0, 0.0, 200.0, 100.0),
+            PointerOwner::ViewCube { camera },
+            PointerOwnerPriority::Overlay,
+        );
+
+        assert_eq!(
+            owners.resolve_window(window, Some(egui::pos2(150.0, 50.0))),
+            PointerOwner::ViewCube { camera }
+        );
+        assert!(owners.permits_view_cube_location(
+            camera,
+            &location(window, 150.0, 50.0),
+        ));
+        assert!(!owners.permits_nav_gizmo(window, camera));
         assert!(!owners.permits_viewport(window, camera));
     }
 

--- a/libs/elodin-editor/src/ui/input_owner.rs
+++ b/libs/elodin-editor/src/ui/input_owner.rs
@@ -1,0 +1,360 @@
+use bevy::prelude::{Entity, Resource};
+use bevy_egui::egui;
+use std::collections::HashMap;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum PointerOwner {
+    None,
+    Viewport { camera: Entity },
+    Graph { graph: Entity },
+    QueryPlot { graph: Entity },
+    NavGizmo { camera: Entity },
+    BlockedByUi { blocker: UiBlocker },
+}
+
+impl Default for PointerOwner {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum UiBlocker {
+    Monitor,
+    Inspector,
+    Timeline,
+    TabBar,
+    Popup,
+    Modal,
+    CommandPalette,
+    OtherPanel,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum PointerOwnerPriority {
+    Content,
+    Panel,
+    Overlay,
+    Modal,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct PointerOwnerRegion {
+    pub rect: egui::Rect,
+    pub owner: PointerOwner,
+    pub priority: PointerOwnerPriority,
+    order: u64,
+}
+
+impl PointerOwnerRegion {
+    fn contains(&self, pos: egui::Pos2) -> bool {
+        self.rect.contains(pos)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct WindowInputOwner {
+    pub pointer_pos: Option<egui::Pos2>,
+    pub owner: PointerOwner,
+}
+
+#[derive(Resource, Debug, Default)]
+pub struct UiInputOwners {
+    regions_by_window: HashMap<Entity, Vec<PointerOwnerRegion>>,
+    owners_by_window: HashMap<Entity, WindowInputOwner>,
+    next_order: u64,
+}
+
+impl UiInputOwners {
+    pub fn begin_frame(&mut self) {
+        self.regions_by_window.clear();
+        self.owners_by_window.clear();
+        self.next_order = 0;
+    }
+
+    pub fn register_rect(
+        &mut self,
+        window: Entity,
+        rect: egui::Rect,
+        owner: PointerOwner,
+        priority: PointerOwnerPriority,
+    ) {
+        if !is_usable_rect(rect) {
+            return;
+        }
+
+        let order = self.next_order;
+        self.next_order = self.next_order.saturating_add(1);
+        self.regions_by_window
+            .entry(window)
+            .or_default()
+            .push(PointerOwnerRegion {
+                rect,
+                owner,
+                priority,
+                order,
+            });
+    }
+
+    pub fn register_content_rect(&mut self, window: Entity, rect: egui::Rect, owner: PointerOwner) {
+        self.register_rect(window, rect, owner, PointerOwnerPriority::Content);
+    }
+
+    pub fn register_blocker_rect(
+        &mut self,
+        window: Entity,
+        rect: egui::Rect,
+        blocker: UiBlocker,
+        priority: PointerOwnerPriority,
+    ) {
+        self.register_rect(
+            window,
+            rect,
+            PointerOwner::BlockedByUi { blocker },
+            priority,
+        );
+    }
+
+    pub fn resolve_window(
+        &mut self,
+        window: Entity,
+        pointer_pos: Option<egui::Pos2>,
+    ) -> PointerOwner {
+        let owner = pointer_pos
+            .and_then(|pos| self.resolve_owner_at(window, pos))
+            .unwrap_or(PointerOwner::None);
+
+        self.owners_by_window
+            .insert(window, WindowInputOwner { pointer_pos, owner });
+        owner
+    }
+
+    pub fn resolve_owner_at(
+        &self,
+        window: Entity,
+        pointer_pos: egui::Pos2,
+    ) -> Option<PointerOwner> {
+        self.regions_by_window.get(&window).and_then(|regions| {
+            regions
+                .iter()
+                .filter(|region| region.contains(pointer_pos))
+                .max_by_key(|region| (region.priority, region.order))
+                .map(|region| region.owner)
+        })
+    }
+
+    pub fn owner_for_window(&self, window: Entity) -> PointerOwner {
+        self.owners_by_window
+            .get(&window)
+            .map(|owner| owner.owner)
+            .unwrap_or(PointerOwner::None)
+    }
+
+    pub fn permits_viewport(&self, window: Entity, camera: Entity) -> bool {
+        matches!(
+            self.owner_for_window(window),
+            PointerOwner::Viewport { camera: owner_camera } if owner_camera == camera
+        )
+    }
+
+    pub fn permits_graph(&self, window: Entity, graph: Entity) -> bool {
+        matches!(
+            self.owner_for_window(window),
+            PointerOwner::Graph { graph: owner_graph }
+                | PointerOwner::QueryPlot { graph: owner_graph } if owner_graph == graph
+        )
+    }
+
+    pub fn permits_nav_gizmo(&self, window: Entity, camera: Entity) -> bool {
+        matches!(
+            self.owner_for_window(window),
+            PointerOwner::NavGizmo { camera: owner_camera } if owner_camera == camera
+        )
+    }
+
+    pub fn is_blocked_by_ui(&self, window: Entity) -> bool {
+        matches!(
+            self.owner_for_window(window),
+            PointerOwner::BlockedByUi { .. }
+        )
+    }
+}
+
+fn is_usable_rect(rect: egui::Rect) -> bool {
+    rect.min.x.is_finite()
+        && rect.min.y.is_finite()
+        && rect.max.x.is_finite()
+        && rect.max.y.is_finite()
+        && rect.width() > 0.0
+        && rect.height() > 0.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entity(id: u64) -> Entity {
+        Entity::from_bits(id)
+    }
+
+    fn rect(min_x: f32, min_y: f32, max_x: f32, max_y: f32) -> egui::Rect {
+        egui::Rect::from_min_max(egui::pos2(min_x, min_y), egui::pos2(max_x, max_y))
+    }
+
+    #[test]
+    fn viewport_under_pointer_owns_input() {
+        let window = entity(1);
+        let camera = entity(2);
+        let mut owners = UiInputOwners::default();
+
+        owners.register_content_rect(
+            window,
+            rect(0.0, 0.0, 100.0, 100.0),
+            PointerOwner::Viewport { camera },
+        );
+
+        assert_eq!(
+            owners.resolve_window(window, Some(egui::pos2(50.0, 50.0))),
+            PointerOwner::Viewport { camera }
+        );
+        assert!(owners.permits_viewport(window, camera));
+    }
+
+    #[test]
+    fn monitor_over_viewport_blocks_viewport_input() {
+        let window = entity(1);
+        let camera = entity(2);
+        let mut owners = UiInputOwners::default();
+
+        owners.register_content_rect(
+            window,
+            rect(0.0, 0.0, 100.0, 100.0),
+            PointerOwner::Viewport { camera },
+        );
+        owners.register_blocker_rect(
+            window,
+            rect(0.0, 0.0, 100.0, 100.0),
+            UiBlocker::Monitor,
+            PointerOwnerPriority::Panel,
+        );
+
+        assert_eq!(
+            owners.resolve_window(window, Some(egui::pos2(50.0, 50.0))),
+            PointerOwner::BlockedByUi {
+                blocker: UiBlocker::Monitor,
+            }
+        );
+        assert!(!owners.permits_viewport(window, camera));
+        assert!(owners.is_blocked_by_ui(window));
+    }
+
+    #[test]
+    fn higher_priority_wins_even_if_registered_earlier() {
+        let window = entity(1);
+        let graph = entity(2);
+        let mut owners = UiInputOwners::default();
+
+        owners.register_blocker_rect(
+            window,
+            rect(0.0, 0.0, 100.0, 100.0),
+            UiBlocker::Popup,
+            PointerOwnerPriority::Overlay,
+        );
+        owners.register_content_rect(
+            window,
+            rect(0.0, 0.0, 100.0, 100.0),
+            PointerOwner::Graph { graph },
+        );
+
+        assert_eq!(
+            owners.resolve_window(window, Some(egui::pos2(50.0, 50.0))),
+            PointerOwner::BlockedByUi {
+                blocker: UiBlocker::Popup,
+            }
+        );
+        assert!(!owners.permits_graph(window, graph));
+    }
+
+    #[test]
+    fn later_region_wins_with_equal_priority() {
+        let window = entity(1);
+        let first = entity(2);
+        let second = entity(3);
+        let mut owners = UiInputOwners::default();
+
+        owners.register_content_rect(
+            window,
+            rect(0.0, 0.0, 100.0, 100.0),
+            PointerOwner::Graph { graph: first },
+        );
+        owners.register_content_rect(
+            window,
+            rect(0.0, 0.0, 100.0, 100.0),
+            PointerOwner::Graph { graph: second },
+        );
+
+        assert_eq!(
+            owners.resolve_window(window, Some(egui::pos2(50.0, 50.0))),
+            PointerOwner::Graph { graph: second }
+        );
+    }
+
+    #[test]
+    fn outside_registered_regions_has_no_owner() {
+        let window = entity(1);
+        let camera = entity(2);
+        let mut owners = UiInputOwners::default();
+
+        owners.register_content_rect(
+            window,
+            rect(0.0, 0.0, 100.0, 100.0),
+            PointerOwner::Viewport { camera },
+        );
+
+        assert_eq!(
+            owners.resolve_window(window, Some(egui::pos2(150.0, 150.0))),
+            PointerOwner::None
+        );
+        assert!(!owners.permits_viewport(window, camera));
+    }
+
+    #[test]
+    fn invalid_rects_are_ignored() {
+        let window = entity(1);
+        let graph = entity(2);
+        let mut owners = UiInputOwners::default();
+
+        owners.register_content_rect(
+            window,
+            rect(10.0, 10.0, 10.0, 20.0),
+            PointerOwner::Graph { graph },
+        );
+
+        assert_eq!(
+            owners.resolve_window(window, Some(egui::pos2(10.0, 15.0))),
+            PointerOwner::None
+        );
+    }
+
+    #[test]
+    fn begin_frame_clears_previous_state() {
+        let window = entity(1);
+        let graph = entity(2);
+        let mut owners = UiInputOwners::default();
+
+        owners.register_content_rect(
+            window,
+            rect(0.0, 0.0, 100.0, 100.0),
+            PointerOwner::Graph { graph },
+        );
+        owners.resolve_window(window, Some(egui::pos2(50.0, 50.0)));
+
+        owners.begin_frame();
+
+        assert_eq!(owners.owner_for_window(window), PointerOwner::None);
+        assert_eq!(
+            owners.resolve_owner_at(window, egui::pos2(50.0, 50.0)),
+            None
+        );
+    }
+}

--- a/libs/elodin-editor/src/ui/inspector/widgets.rs
+++ b/libs/elodin-editor/src/ui/inspector/widgets.rs
@@ -5,6 +5,7 @@ use impeller2_wkt::QueryType;
 use crate::ui::{
     button::{ECheckboxButton, EColorButton},
     colors::{self, ColorExt, EColor, get_scheme},
+    mark_egui_popup_hovered,
     theme::{self, configure_combo_box},
 };
 
@@ -121,7 +122,7 @@ pub fn eql_autocomplete(
             // These Popup settings were copied from the following URL after
             // popup_below_widget was deprecated:
             // https://github.com/emilk/egui/blob/af96e0373c18477b77236e2bfc89735af007b1c2/crates/egui/src/containers/old_popup.rs#L189
-            egui::Popup::from_response(target_res)
+            let popup_response = egui::Popup::from_response(target_res)
                 .layout(egui::Layout::top_down_justified(egui::Align::LEFT))
                 .open_memory(None)
                 .close_behavior(egui::PopupCloseBehavior::IgnoreClicks)
@@ -153,6 +154,11 @@ pub fn eql_autocomplete(
                             }
                         })
                 });
+            if let Some(inner) = &popup_response
+                && inner.response.contains_pointer()
+            {
+                mark_egui_popup_hovered(ui.ctx());
+            }
         });
         if !suggestions.is_empty() {
             egui::Popup::open_id(ui.ctx(), id);
@@ -173,7 +179,6 @@ pub fn color_popup(
     color_id: egui::Id,
     target_res: &egui::Response,
 ) -> Option<egui::Response> {
-    let popup_hovered_id = egui::Id::new("any_popup_hovered");
     let inner_response =
         egui::Popup::new(color_id, ui.ctx().clone(), target_res, target_res.layer_id)
             .kind(egui::PopupKind::Popup)
@@ -206,9 +211,7 @@ pub fn color_popup(
     if let Some(inner) = &inner_response
         && inner.response.contains_pointer()
     {
-        ui.ctx().data_mut(|data| {
-            data.insert_temp(popup_hovered_id, true);
-        });
+        mark_egui_popup_hovered(ui.ctx());
     }
 
     inner_response.map(|ir| ir.response)

--- a/libs/elodin-editor/src/ui/mod.rs
+++ b/libs/elodin-editor/src/ui/mod.rs
@@ -90,6 +90,7 @@ pub mod command_palette;
 pub mod data_overview;
 pub mod hierarchy;
 pub mod images;
+pub mod input_owner;
 pub mod inspector;
 pub mod label;
 pub mod log_stream;

--- a/libs/elodin-editor/src/ui/mod.rs
+++ b/libs/elodin-editor/src/ui/mod.rs
@@ -1,8 +1,3 @@
-use bevy::ecs::message::Messages;
-use bevy::input::{
-    ButtonInput,
-    mouse::{AccumulatedMouseMotion, AccumulatedMouseScroll, MouseButton, MouseMotion, MouseWheel},
-};
 use bevy::{
     camera::{RenderTarget, Viewport},
     ecs::{
@@ -293,51 +288,49 @@ pub struct UiPlugin;
 #[derive(Debug, PartialEq, Eq, Clone, Hash, SystemSet)]
 pub struct UiInputConsumerSet;
 
-// This system prevents UI events such as scroll and pan from passing through
-// egui modals and popups to whatever is behind them. The intention is for
-// modals to disable everything other than the modal, but popups allow
-// interactions with other things, except whatever is directly behind the
-// popup. The basic approach is for each popup to set a flag indicating if
-// the pointer is currently over it, then if any flags are true stop
-// propagating events.
-fn suppress_pointer_input_over_popups(
+#[derive(Resource, Debug, Default)]
+pub struct EguiOverlayInputBlockers {
+    modal_windows: HashSet<Entity>,
+    popup_windows: HashSet<Entity>,
+}
+
+impl EguiOverlayInputBlockers {
+    pub fn modal_blocks(&self, window: Entity) -> bool {
+        self.modal_windows.contains(&window)
+    }
+
+    pub fn popup_blocks(&self, window: Entity) -> bool {
+        self.popup_windows.contains(&window)
+    }
+}
+
+// egui modal and popup layers are not tile panes, so they do not naturally
+// register owner regions from tiles.rs. Capture them here and let tiles.rs fold
+// them into UiInputOwners instead of clearing Bevy input globally.
+fn update_egui_overlay_input_blockers(
     egui_wants_input: Res<EguiWantsInput>,
-    mut contexts: Query<&mut EguiContext>,
-    mut mouse_buttons: ResMut<ButtonInput<MouseButton>>,
-    mut mouse_motion_messages: ResMut<Messages<MouseMotion>>,
-    mut mouse_wheel_messages: ResMut<Messages<MouseWheel>>,
-    mut accumulated_motion: ResMut<AccumulatedMouseMotion>,
-    mut accumulated_scroll: ResMut<AccumulatedMouseScroll>,
+    mut contexts: Query<(Entity, &mut EguiContext)>,
+    mut blockers: ResMut<EguiOverlayInputBlockers>,
 ) {
-    let mut modal_open = false;
-    let mut pointer_over_popup = false;
-    for mut ctx in contexts.iter_mut() {
+    blockers.modal_windows.clear();
+    blockers.popup_windows.clear();
+
+    for (window, mut ctx) in contexts.iter_mut() {
         let ctx = ctx.get_mut();
         if ctx.memory(|mem| mem.top_modal_layer().is_some()) {
-            modal_open = true;
+            blockers.modal_windows.insert(window);
         }
 
         let popup_hovered_id = egui::Id::new("any_popup_hovered");
-        if ctx
+        let pointer_over_popup = ctx
             .data(|data| data.get_temp::<bool>(popup_hovered_id))
-            .unwrap_or(false)
-        {
-            pointer_over_popup = true;
+            .unwrap_or(false);
+        if egui_wants_input.is_popup_open() && pointer_over_popup {
+            blockers.popup_windows.insert(window);
         }
 
         ctx.data_mut(|data| data.insert_temp::<bool>(popup_hovered_id, false));
     }
-
-    let popup_active = egui_wants_input.is_popup_open() && pointer_over_popup;
-    if !(modal_open || popup_active) {
-        return;
-    }
-
-    mouse_motion_messages.clear();
-    mouse_wheel_messages.clear();
-    mouse_buttons.reset_all();
-    accumulated_motion.delta = Vec2::ZERO;
-    accumulated_scroll.delta = Vec2::ZERO;
 }
 
 impl Plugin for UiPlugin {
@@ -357,18 +350,19 @@ impl Plugin for UiPlugin {
             .init_resource::<HdrEnabled>()
             .init_resource::<FocusedWindow>()
             .init_resource::<input_owner::UiInputOwners>()
+            .init_resource::<EguiOverlayInputBlockers>()
             .init_resource::<timeline_slider::UITick>()
             .init_resource::<timeline::StreamTickOrigin>()
             .init_resource::<command_palette::CommandPaletteState>()
             .add_message::<DialogEvent>()
             .configure_sets(Update, UiInputConsumerSet)
+            .add_systems(
+                Update,
+                update_egui_overlay_input_blockers.before(render_layout),
+            )
             .add_systems(Update, timeline_slider::sync_ui_tick.before(render_layout))
             .add_systems(Update, actions::spawn_lua_actor)
             .add_systems(Update, update_focused_window)
-            .add_systems(
-                Update,
-                suppress_pointer_input_over_popups.before(UiInputConsumerSet),
-            )
             .add_systems(Update, shortcuts)
             .add_systems(
                 PreUpdate,

--- a/libs/elodin-editor/src/ui/mod.rs
+++ b/libs/elodin-editor/src/ui/mod.rs
@@ -545,6 +545,10 @@ pub fn render_layout(
     mut windows: Local<Vec<(Entity, WindowId)>>,
     mut widget_id: Local<String>,
 ) {
+    if let Some(mut input_owners) = world.get_resource_mut::<input_owner::UiInputOwners>() {
+        input_owners.begin_frame();
+    }
+
     windows.extend(
         world
             .query::<(Entity, &WindowId)>()

--- a/libs/elodin-editor/src/ui/mod.rs
+++ b/libs/elodin-editor/src/ui/mod.rs
@@ -16,7 +16,6 @@ use bevy_defer::AsyncPlugin;
 use bevy_egui::{
     EguiContext, EguiContexts, EguiPreUpdateSet,
     egui::{self, Color32, Label, RichText},
-    input::EguiWantsInput,
 };
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
@@ -288,49 +287,47 @@ pub struct UiPlugin;
 #[derive(Debug, PartialEq, Eq, Clone, Hash, SystemSet)]
 pub struct UiInputConsumerSet;
 
-#[derive(Resource, Debug, Default)]
-pub struct EguiOverlayInputBlockers {
-    modal_windows: HashSet<Entity>,
-    popup_windows: HashSet<Entity>,
+fn egui_popup_hovered_id() -> egui::Id {
+    egui::Id::new("any_popup_hovered")
 }
 
-impl EguiOverlayInputBlockers {
-    pub fn modal_blocks(&self, window: Entity) -> bool {
-        self.modal_windows.contains(&window)
-    }
-
-    pub fn popup_blocks(&self, window: Entity) -> bool {
-        self.popup_windows.contains(&window)
-    }
+pub(crate) fn mark_egui_popup_hovered(ctx: &egui::Context) {
+    ctx.data_mut(|data| data.insert_temp::<bool>(egui_popup_hovered_id(), true));
 }
 
-// egui modal and popup layers are not tile panes, so they do not naturally
-// register owner regions from tiles.rs. Capture them here and let tiles.rs fold
-// them into UiInputOwners instead of clearing Bevy input globally.
-fn update_egui_overlay_input_blockers(
-    egui_wants_input: Res<EguiWantsInput>,
-    mut contexts: Query<(Entity, &mut EguiContext)>,
-    mut blockers: ResMut<EguiOverlayInputBlockers>,
+pub(crate) fn register_window_input_blocker(
+    world: &mut World,
+    window: Entity,
+    rect: egui::Rect,
+    blocker: input_owner::UiBlocker,
+    priority: input_owner::PointerOwnerPriority,
 ) {
-    blockers.modal_windows.clear();
-    blockers.popup_windows.clear();
-
-    for (window, mut ctx) in contexts.iter_mut() {
-        let ctx = ctx.get_mut();
-        if ctx.memory(|mem| mem.top_modal_layer().is_some()) {
-            blockers.modal_windows.insert(window);
-        }
-
-        let popup_hovered_id = egui::Id::new("any_popup_hovered");
-        let pointer_over_popup = ctx
-            .data(|data| data.get_temp::<bool>(popup_hovered_id))
-            .unwrap_or(false);
-        if egui_wants_input.is_popup_open() && pointer_over_popup {
-            blockers.popup_windows.insert(window);
-        }
-
-        ctx.data_mut(|data| data.insert_temp::<bool>(popup_hovered_id, false));
+    if let Some(mut input_owners) = world.get_resource_mut::<input_owner::UiInputOwners>() {
+        input_owners.register_blocker_rect(window, rect, blocker, priority);
     }
+}
+
+fn resolve_input_owner_after_window_roots(world: &mut World, window: Entity, ctx: &egui::Context) {
+    let pointer_over_popup = ctx
+        .data(|data| data.get_temp::<bool>(egui_popup_hovered_id()))
+        .unwrap_or(false);
+
+    if ctx.is_popup_open() && pointer_over_popup {
+        register_window_input_blocker(
+            world,
+            window,
+            ctx.content_rect(),
+            input_owner::UiBlocker::Popup,
+            input_owner::PointerOwnerPriority::Overlay,
+        );
+    }
+
+    let pointer_pos = ctx.input(|input| input.pointer.latest_pos());
+    if let Some(mut input_owners) = world.get_resource_mut::<input_owner::UiInputOwners>() {
+        input_owners.resolve_window(window, pointer_pos);
+    }
+
+    ctx.data_mut(|data| data.insert_temp::<bool>(egui_popup_hovered_id(), false));
 }
 
 impl Plugin for UiPlugin {
@@ -350,16 +347,11 @@ impl Plugin for UiPlugin {
             .init_resource::<HdrEnabled>()
             .init_resource::<FocusedWindow>()
             .init_resource::<input_owner::UiInputOwners>()
-            .init_resource::<EguiOverlayInputBlockers>()
             .init_resource::<timeline_slider::UITick>()
             .init_resource::<timeline::StreamTickOrigin>()
             .init_resource::<command_palette::CommandPaletteState>()
             .add_message::<DialogEvent>()
             .configure_sets(Update, UiInputConsumerSet)
-            .add_systems(
-                Update,
-                update_egui_overlay_input_blockers.before(render_layout),
-            )
             .add_systems(Update, timeline_slider::sync_ui_tick.before(render_layout))
             .add_systems(Update, actions::spawn_lua_actor)
             .add_systems(Update, update_focused_window)
@@ -565,7 +557,7 @@ pub fn render_layout(
 
             world.add_root_widget_to::<ViewportOverlay>(id, "viewport_overlay", ());
 
-            world.add_root_widget_to::<modal::ModalWithSettings>(id, "modal_graph", ());
+            world.add_root_widget_to::<modal::ModalWithSettings>(id, "modal_graph", id);
 
             world.add_root_widget_to::<CommandPalette>(id, "command_palette", ());
         } else {
@@ -580,6 +572,9 @@ pub fn render_layout(
             let _ = write!(widget_id, "secondary_command_palette_{}", window_id.0);
         }
         world.add_root_widget_to::<command_palette::PaletteWindow>(id, &widget_id, Some(id));
+        world.egui_context_scope_for(id, |world, ctx| {
+            resolve_input_owner_after_window_roots(world, id, &ctx);
+        });
     }
 }
 

--- a/libs/elodin-editor/src/ui/mod.rs
+++ b/libs/elodin-editor/src/ui/mod.rs
@@ -388,7 +388,8 @@ impl Plugin for UiPlugin {
                     set_nav_gizmo_camera_orders,
                     warn_camera_order_ambiguities,
                 )
-                    .chain(),
+                    .chain()
+                    .before(UiInputConsumerSet),
             )
             .add_systems(First, fix_visibility_hierarchy)
             .add_systems(Update, sync_hdr)

--- a/libs/elodin-editor/src/ui/mod.rs
+++ b/libs/elodin-editor/src/ui/mod.rs
@@ -356,6 +356,7 @@ impl Plugin for UiPlugin {
             .init_resource::<SettingModalState>()
             .init_resource::<HdrEnabled>()
             .init_resource::<FocusedWindow>()
+            .init_resource::<input_owner::UiInputOwners>()
             .init_resource::<timeline_slider::UITick>()
             .init_resource::<timeline::StreamTickOrigin>()
             .init_resource::<command_palette::CommandPaletteState>()

--- a/libs/elodin-editor/src/ui/modal.rs
+++ b/libs/elodin-editor/src/ui/modal.rs
@@ -81,7 +81,13 @@ use bevy_egui::{EguiContexts, EguiTextureHandle, egui};
 
 use crate::ui::{
     Dialog, DialogAction, DialogButton, DialogEvent, FocusedWindow, SettingModal,
-    SettingModalState, colors::get_scheme, images, tiles::WindowState, utils::MarginSides,
+    SettingModalState,
+    colors::get_scheme,
+    images,
+    input_owner::{PointerOwnerPriority, UiBlocker},
+    register_window_input_blocker,
+    tiles::WindowState,
+    utils::MarginSides,
 };
 use bevy::prelude::*;
 
@@ -115,84 +121,97 @@ pub mod action {
 }
 
 impl RootWidgetSystem for ModalWithSettings<'_, '_> {
-    type Args = ();
+    type Args = Entity;
     type Output = ();
 
     fn ctx_system(
         world: &mut World,
         state: &mut SystemState<Self>,
         ctx: &mut egui::Context,
-        _args: Self::Args,
+        root_window: Self::Args,
     ) {
-        let state_mut = state.get_mut(world);
+        let Some((setting_modal_state, modal_rect, close_icon)) = ({
+            let state_mut = state.get_mut(world);
 
-        let mut contexts = state_mut.contexts;
-        let images = state_mut.images;
-        let window = state_mut.window;
-        let window_states = state_mut.window_states;
-        let focused_window = state_mut.focused_window;
-        let primary_window = state_mut.primary_window;
-        let setting_modal_state = state_mut.setting_modal_state;
+            let mut contexts = state_mut.contexts;
+            let images = state_mut.images;
+            let window = state_mut.window;
+            let window_states = state_mut.window_states;
+            let focused_window = state_mut.focused_window;
+            let primary_window = state_mut.primary_window;
+            let setting_modal_state = state_mut.setting_modal_state.0.clone();
 
-        let modal_size = egui::vec2(400.0, 480.0);
+            let modal_size = egui::vec2(400.0, 480.0);
 
-        let target_window = focused_window.0.or_else(|| primary_window.iter().next());
-        let inspector_anchor = target_window
-            .and_then(|entity| window_states.get(entity).ok())
-            .and_then(|state| state.ui_state.inspector_anchor.0);
+            let target_window = focused_window.0.or_else(|| primary_window.iter().next());
+            let inspector_anchor = target_window
+                .and_then(|entity| window_states.get(entity).ok())
+                .and_then(|state| state.ui_state.inspector_anchor.0);
 
-        let modal_rect = if let Some(inspector_anchor) = inspector_anchor {
-            egui::Rect::from_min_size(
-                egui::pos2(inspector_anchor.x - modal_size.x, inspector_anchor.y),
-                modal_size,
-            )
-        } else {
-            let window = target_window
-                .and_then(|entity| window.get(entity).ok())
-                .or_else(|| window.iter().next())
-                .expect("no window available");
-            egui::Rect::from_center_size(
-                egui::pos2(
-                    window.resolution.width() / 2.0,
-                    window.resolution.height() / 2.0,
-                ),
-                modal_size,
-            )
+            let modal_rect = if let Some(inspector_anchor) = inspector_anchor {
+                egui::Rect::from_min_size(
+                    egui::pos2(inspector_anchor.x - modal_size.x, inspector_anchor.y),
+                    modal_size,
+                )
+            } else {
+                let window = target_window
+                    .and_then(|entity| window.get(entity).ok())
+                    .or_else(|| window.iter().next())
+                    .expect("no window available");
+                egui::Rect::from_center_size(
+                    egui::pos2(
+                        window.resolution.width() / 2.0,
+                        window.resolution.height() / 2.0,
+                    ),
+                    modal_size,
+                )
+            };
+
+            let close_icon = contexts.add_image(EguiTextureHandle::Weak(images.icon_close.id()));
+            setting_modal_state
+                .map(|setting_modal_state| (setting_modal_state, modal_rect, close_icon))
+        }) else {
+            return;
         };
 
-        if let Some(setting_modal_state) = setting_modal_state.0.clone() {
-            let close_icon = contexts.add_image(EguiTextureHandle::Weak(images.icon_close.id()));
-            let modal_id = egui::Id::new("SETTING_MODAL");
-            let modal_area = egui::Area::new(modal_id)
-                .kind(egui::UiKind::Modal)
-                .fixed_pos(modal_rect.min)
-                .order(egui::Order::Foreground)
-                .interactable(true);
+        register_window_input_blocker(
+            world,
+            root_window,
+            ctx.content_rect(),
+            UiBlocker::Modal,
+            PointerOwnerPriority::Modal,
+        );
 
-            egui::Modal::new(modal_id)
-                .area(modal_area)
-                .backdrop_color(egui::Color32::TRANSPARENT)
-                .frame(egui::Frame {
-                    fill: get_scheme().bg_secondary,
-                    stroke: egui::Stroke {
-                        width: 1.0,
-                        color: get_scheme().text_secondary,
-                    },
-                    inner_margin: egui::Margin::same(16),
-                    outer_margin: egui::Margin::symmetric(4, 0),
-                    ..Default::default()
-                })
-                .show(ctx, |ui| {
-                    ui.set_min_size(modal_rect.size());
-                    ui.set_max_size(modal_rect.size());
-                    let SettingModal::Dialog(dialog) = setting_modal_state;
-                    ui.add_widget_with::<ModalDialog>(
-                        world,
-                        "modal_dialog",
-                        (close_icon, dialog.clone()),
-                    );
-                });
-        }
+        let modal_id = egui::Id::new("SETTING_MODAL");
+        let modal_area = egui::Area::new(modal_id)
+            .kind(egui::UiKind::Modal)
+            .fixed_pos(modal_rect.min)
+            .order(egui::Order::Foreground)
+            .interactable(true);
+
+        egui::Modal::new(modal_id)
+            .area(modal_area)
+            .backdrop_color(egui::Color32::TRANSPARENT)
+            .frame(egui::Frame {
+                fill: get_scheme().bg_secondary,
+                stroke: egui::Stroke {
+                    width: 1.0,
+                    color: get_scheme().text_secondary,
+                },
+                inner_margin: egui::Margin::same(16),
+                outer_margin: egui::Margin::symmetric(4, 0),
+                ..Default::default()
+            })
+            .show(ctx, |ui| {
+                ui.set_min_size(modal_rect.size());
+                ui.set_max_size(modal_rect.size());
+                let SettingModal::Dialog(dialog) = setting_modal_state;
+                ui.add_widget_with::<ModalDialog>(
+                    world,
+                    "modal_dialog",
+                    (close_icon, dialog.clone()),
+                );
+            });
     }
 }
 

--- a/libs/elodin-editor/src/ui/plot/widget.rs
+++ b/libs/elodin-editor/src/ui/plot/widget.rs
@@ -2006,7 +2006,7 @@ pub fn pretty_round(num: f64) -> f64 {
 }
 
 pub fn graph_touch(
-    mut query: Query<(Entity, &mut GraphState, &Camera)>,
+    mut query: Query<(Entity, &mut GraphState, &Camera, &RenderTarget)>,
     primary_window: Query<(Entity, &Window), With<PrimaryWindow>>,
     touch_tracker: Res<TouchTracker>,
     input_owners: Res<UiInputOwners>,
@@ -2023,8 +2023,8 @@ pub fn graph_touch(
     };
     let midpoint_pos = egui::pos2(midpoint.x, midpoint.y);
 
-    for (entity, mut graph_state, cam) in query.iter_mut() {
-        let Some(window_entity) = window_entity_from_target(&cam.target, primary_entity) else {
+    for (entity, mut graph_state, cam, render_target) in query.iter_mut() {
+        let Some(window_entity) = window_entity_from_target(render_target, primary_entity) else {
             continue;
         };
         if !input_owners.permits_graph_at(window_entity, entity, midpoint_pos) {

--- a/libs/elodin-editor/src/ui/plot/widget.rs
+++ b/libs/elodin-editor/src/ui/plot/widget.rs
@@ -1608,6 +1608,7 @@ pub fn zoom_graph(
 #[derive(Component)]
 pub struct LastPos(Option<Vec2>);
 
+#[allow(clippy::too_many_arguments)]
 pub fn pan_graph(
     mut query: Query<(
         Entity,

--- a/libs/elodin-editor/src/ui/plot/widget.rs
+++ b/libs/elodin-editor/src/ui/plot/widget.rs
@@ -867,7 +867,7 @@ impl TimeseriesPlot {
 
         // Only show time-related context menu for time-based plots
         if self.x_axis_mode.is_time_based() {
-            response.context_menu(|ui| {
+            let context_menu = response.context_menu(|ui| {
                 if ui.button("Set Time Range to Viewport Bounds").clicked() {
                     let (start, end) = if self.x_axis_mode.is_relative() {
                         // For relative time plots, bounds.min_x/max_x are in seconds
@@ -892,6 +892,12 @@ impl TimeseriesPlot {
                     };
                 }
             });
+            if context_menu
+                .as_ref()
+                .is_some_and(|inner| inner.response.contains_pointer())
+            {
+                crate::ui::mark_egui_popup_hovered(ui.ctx());
+            }
         }
 
         let mut font_id = egui::TextStyle::Monospace.resolve(ui.style());

--- a/libs/elodin-editor/src/ui/plot/widget.rs
+++ b/libs/elodin-editor/src/ui/plot/widget.rs
@@ -40,6 +40,7 @@ use crate::{
     ui::{
         SelectedObject,
         colors::{ColorExt, get_scheme, with_opacity},
+        input_owner::UiInputOwners,
         plot::{
             CollectedGraphData, GraphState, Line, OVERVIEW_MAX_POINTS,
             gpu::{LineBundle, LineConfig, LineUniform},
@@ -1522,11 +1523,12 @@ pub fn sync_locked_graphs(
 }
 
 pub fn zoom_graph(
-    mut query: Query<(&mut GraphState, &Camera, &RenderTarget)>,
+    mut query: Query<(Entity, &mut GraphState, &Camera, &RenderTarget)>,
     mut scroll_events: MessageReader<MouseWheel>,
     windows: Query<(Entity, &Window)>,
     primary_window: Query<Entity, With<PrimaryWindow>>,
     key_state: Res<LogicalKeyState>,
+    input_owners: Res<UiInputOwners>,
     mut xclock: ResMut<XSyncClock>,
 ) {
     let scroll_offsets = scroll_offsets_from_events(&mut scroll_events);
@@ -1538,13 +1540,16 @@ pub fn zoom_graph(
         return;
     };
 
-    for (mut graph_state, camera, render_target) in query.iter_mut() {
+    for (entity, mut graph_state, camera, render_target) in query.iter_mut() {
         let Some(window_entity) = window_entity_from_target(render_target, primary_entity) else {
             continue;
         };
         let Some(scroll_offset) = scroll_offsets.get(&window_entity) else {
             continue;
         };
+        if !input_owners.permits_graph(window_entity, entity) {
+            continue;
+        }
         let Ok((_, window)) = windows.get(window_entity) else {
             continue;
         };
@@ -1615,6 +1620,7 @@ pub fn pan_graph(
     windows: Query<(Entity, &Window)>,
     primary_window: Query<Entity, With<PrimaryWindow>>,
     key_state: Res<LogicalKeyState>,
+    input_owners: Res<UiInputOwners>,
     mut commands: Commands,
     mut xclock: ResMut<XSyncClock>,
 ) {
@@ -1629,6 +1635,12 @@ pub fn pan_graph(
             }
             continue;
         };
+        if !input_owners.permits_graph(window_entity, entity) {
+            if let Ok(mut e) = commands.get_entity(entity) {
+                e.try_insert(LastPos(None));
+            }
+            continue;
+        }
         let Ok((_, window)) = windows.get(window_entity) else {
             if let Ok(mut e) = commands.get_entity(entity) {
                 e.try_insert(LastPos(None));
@@ -1708,9 +1720,10 @@ pub fn pan_graph(
 pub fn reset_graph(
     mut last_click: Local<Option<Instant>>,
     mouse_buttons: Res<ButtonInput<MouseButton>>,
-    mut query: Query<(&mut GraphState, &Camera, &RenderTarget)>,
+    mut query: Query<(Entity, &mut GraphState, &Camera, &RenderTarget)>,
     windows: Query<(Entity, &Window)>,
     primary_window: Query<Entity, With<PrimaryWindow>>,
+    input_owners: Res<UiInputOwners>,
     mut xclock: ResMut<XSyncClock>,
 ) {
     if mouse_buttons.just_released(MouseButton::Left) {
@@ -1726,11 +1739,14 @@ pub fn reset_graph(
             return;
         };
 
-        for (mut graph_state, camera, render_target) in query.iter_mut() {
+        for (entity, mut graph_state, camera, render_target) in query.iter_mut() {
             let Some(window_entity) = window_entity_from_target(render_target, primary_entity)
             else {
                 continue;
             };
+            if !input_owners.permits_graph(window_entity, entity) {
+                continue;
+            }
             let Ok((_, window)) = windows.get(window_entity) else {
                 continue;
             };
@@ -1983,11 +1999,12 @@ pub fn pretty_round(num: f64) -> f64 {
 }
 
 pub fn graph_touch(
-    mut query: Query<(&mut GraphState, &Camera)>,
-    primary_window: Query<&Window, With<PrimaryWindow>>,
+    mut query: Query<(Entity, &mut GraphState, &Camera)>,
+    primary_window: Query<(Entity, &Window), With<PrimaryWindow>>,
     touch_tracker: Res<TouchTracker>,
+    input_owners: Res<UiInputOwners>,
 ) {
-    let Ok(window) = primary_window.single() else {
+    let Ok((primary_entity, window)) = primary_window.single() else {
         return;
     };
     let touch_gestures = touch_tracker.get_touch_gestures();
@@ -1997,8 +2014,15 @@ pub fn graph_touch(
         TouchGestures::TwoFinger(two_finger) => two_finger.midpoint,
         _ => return,
     };
+    let midpoint_pos = egui::pos2(midpoint.x, midpoint.y);
 
-    for (mut graph_state, cam) in query.iter_mut() {
+    for (entity, mut graph_state, cam) in query.iter_mut() {
+        let Some(window_entity) = window_entity_from_target(&cam.target, primary_entity) else {
+            continue;
+        };
+        if !input_owners.permits_graph_at(window_entity, entity, midpoint_pos) {
+            continue;
+        }
         let Some(viewport_rect) = cam.logical_viewport_rect() else {
             continue;
         };

--- a/libs/elodin-editor/src/ui/status_bar.rs
+++ b/libs/elodin-editor/src/ui/status_bar.rs
@@ -1,25 +1,33 @@
 use bevy::{
     diagnostic::{DiagnosticsStore, FrameTimeDiagnosticsPlugin},
     ecs::{
-        system::{Res, SystemParam, SystemState},
+        query::With,
+        system::{Query, Res, SystemParam, SystemState},
         world::World,
     },
+    prelude::Entity,
+    window::PrimaryWindow,
 };
 use impeller2_bevy::{ConnectionStatus, ThreadConnectionStatus};
 use impeller2_wkt::SimulationTimeStep;
 
-use crate::ui::colors::get_scheme;
+use crate::ui::{
+    colors::get_scheme,
+    input_owner::{PointerOwnerPriority, UiBlocker},
+    register_window_input_blocker,
+};
 
 use super::RootWidgetSystem;
 
 #[derive(SystemParam)]
-pub struct StatusBar<'w> {
+pub struct StatusBar<'w, 's> {
     tick_time: Res<'w, SimulationTimeStep>,
     diagnostics: Res<'w, DiagnosticsStore>,
     connection_status: Res<'w, ThreadConnectionStatus>,
+    primary_window: Query<'w, 's, Entity, With<PrimaryWindow>>,
 }
 
-impl RootWidgetSystem for StatusBar<'_> {
+impl RootWidgetSystem for StatusBar<'_, '_> {
     type Args = ();
     type Output = ();
 
@@ -30,11 +38,14 @@ impl RootWidgetSystem for StatusBar<'_> {
         _args: Self::Args,
     ) {
         let state_mut = state.get_mut(world);
+        let Ok(target_window) = state_mut.primary_window.single() else {
+            return;
+        };
 
         let tick_time = state_mut.tick_time;
         let diagnostics = state_mut.diagnostics;
 
-        egui::TopBottomPanel::bottom("status_bar")
+        let panel = egui::TopBottomPanel::bottom("status_bar")
             .frame(egui::Frame {
                 fill: get_scheme().bg_primary,
                 inner_margin: egui::Margin::symmetric(16, 4),
@@ -77,6 +88,14 @@ impl RootWidgetSystem for StatusBar<'_> {
                     ));
                 });
             });
+
+        register_window_input_blocker(
+            world,
+            target_window,
+            panel.response.rect,
+            UiBlocker::OtherPanel,
+            PointerOwnerPriority::Panel,
+        );
     }
 }
 

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -36,7 +36,7 @@ use winit::{
 };
 
 use super::{
-    EguiOverlayInputBlockers, PaneName, SelectedObject, ViewportRect, WindowUiState,
+    PaneName, SelectedObject, ViewportRect, WindowUiState,
     actions::{ActionTile, ActionTileWidget},
     button::{EImageButton, ETileButton},
     colors::{self, EColor, get_scheme, with_opacity},
@@ -2129,7 +2129,7 @@ impl egui_tiles::Behavior<Pane> for TreeBehavior<'_> {
 
         // Context menu on right-click
         let inspector_visible = self.inspector_visible;
-        response.context_menu(|ui| {
+        let context_menu = response.context_menu(|ui| {
             let scheme = get_scheme();
             ui.style_mut().spacing.item_spacing = egui::vec2(0.0, 4.0);
             ui.style_mut().visuals.widgets.hovered.bg_fill = scheme.highlight;
@@ -2162,6 +2162,12 @@ impl egui_tiles::Behavior<Pane> for TreeBehavior<'_> {
                     }
                 });
         });
+        if context_menu
+            .as_ref()
+            .is_some_and(|inner| inner.response.contains_pointer())
+        {
+            super::mark_egui_popup_hovered(ui.ctx());
+        }
 
         self.on_tab_button(tiles, tile_id, response)
     }
@@ -3349,27 +3355,6 @@ impl WidgetSystem for TileLayout<'_, '_> {
                     },
                 );
             });
-        }
-
-        let overlay_blocker =
-            world
-                .get_resource::<EguiOverlayInputBlockers>()
-                .and_then(|blockers| {
-                    if blockers.modal_blocks(target_window) {
-                        Some((UiBlocker::Modal, PointerOwnerPriority::Modal))
-                    } else if blockers.popup_blocks(target_window) {
-                        Some((UiBlocker::Popup, PointerOwnerPriority::Overlay))
-                    } else {
-                        None
-                    }
-                });
-        if let Some((blocker, priority)) = overlay_blocker {
-            register_ui_blocker(world, ui, target_window, ui.max_rect(), blocker, priority);
-        }
-
-        let pointer_pos = ui.input(|input| input.pointer.latest_pos());
-        if let Some(mut input_owners) = world.get_resource_mut::<UiInputOwners>() {
-            input_owners.resolve_window(target_window, pointer_pos);
         }
     }
 }

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -44,6 +44,7 @@ use super::{
     data_overview::{DataOverviewPane, DataOverviewWidget},
     hierarchy::{Hierarchy, HierarchyContent},
     images,
+    input_owner::{PointerOwner, PointerOwnerPriority, UiBlocker, UiInputOwners},
     inspector::{InspectorContent, InspectorIcons},
     monitor::{MonitorPane, MonitorWidget},
     plot::{GraphBundle, GraphState, PlotWidget},
@@ -1017,6 +1018,13 @@ impl Pane {
         match self {
             Pane::Graph(pane) => {
                 pane.rect = Some(content_rect);
+                register_content_owner(
+                    world,
+                    ui,
+                    target_window,
+                    content_rect,
+                    PointerOwner::Graph { graph: pane.id },
+                );
 
                 ui.add_widget_with::<PlotWidget>(
                     world,
@@ -1029,6 +1037,8 @@ impl Pane {
             Pane::Viewport(pane) => {
                 const MONITOR_HEIGHT: f32 = 36.0;
                 let mut show_monitor = false;
+                let mut viewport_owner_rect = None;
+                let mut monitor_owner_rect = None;
 
                 if let Some(cam) = pane.camera {
                     let mut state = SystemState::<(
@@ -1075,11 +1085,13 @@ impl Pane {
                                 egui::pos2(content_rect.max.x, content_rect.max.y - MONITOR_HEIGHT),
                             );
                             pane.rect = Some(viewport_rect);
+                            viewport_owner_rect = Some(viewport_rect);
 
                             let monitor_rect = egui::Rect::from_min_max(
                                 egui::pos2(content_rect.min.x, content_rect.max.y - MONITOR_HEIGHT),
                                 content_rect.max,
                             );
+                            monitor_owner_rect = Some(monitor_rect);
                             let scheme = super::colors::get_scheme();
                             ui.painter()
                                 .rect_filled(monitor_rect, 0.0, scheme.bg_secondary);
@@ -1121,20 +1133,76 @@ impl Pane {
 
                 if !show_monitor {
                     pane.rect = Some(content_rect);
+                    viewport_owner_rect = Some(content_rect);
+                }
+
+                if let Some(cam) = pane.camera {
+                    if let Some(rect) = viewport_owner_rect {
+                        register_content_owner(
+                            world,
+                            ui,
+                            target_window,
+                            rect,
+                            PointerOwner::Viewport { camera: cam },
+                        );
+                    }
+                } else {
+                    register_ui_blocker(
+                        world,
+                        ui,
+                        target_window,
+                        content_rect,
+                        UiBlocker::OtherPanel,
+                        PointerOwnerPriority::Panel,
+                    );
+                }
+
+                if let Some(rect) = monitor_owner_rect {
+                    register_ui_blocker(
+                        world,
+                        ui,
+                        target_window,
+                        rect,
+                        UiBlocker::Monitor,
+                        PointerOwnerPriority::Panel,
+                    );
                 }
 
                 egui_tiles::UiResponse::None
             }
             Pane::Monitor(pane) => {
+                register_ui_blocker(
+                    world,
+                    ui,
+                    target_window,
+                    content_rect,
+                    UiBlocker::Monitor,
+                    PointerOwnerPriority::Panel,
+                );
                 ui.add_widget_with::<MonitorWidget>(world, "monitor", pane.clone());
                 egui_tiles::UiResponse::None
             }
             Pane::QueryTable(pane) => {
+                register_ui_blocker(
+                    world,
+                    ui,
+                    target_window,
+                    content_rect,
+                    UiBlocker::OtherPanel,
+                    PointerOwnerPriority::Panel,
+                );
                 ui.add_widget_with::<QueryTableWidget>(world, "sql", pane.clone());
                 egui_tiles::UiResponse::None
             }
             Pane::QueryPlot(pane) => {
                 pane.rect = Some(content_rect);
+                register_content_owner(
+                    world,
+                    ui,
+                    target_window,
+                    content_rect,
+                    PointerOwner::QueryPlot { graph: pane.entity },
+                );
                 let mut pane_with_icon = pane.clone();
                 pane_with_icon.scrub_icon = Some(icons.scrub);
                 ui.add_widget_with::<super::query_plot::QueryPlotWidget>(
@@ -1145,10 +1213,26 @@ impl Pane {
                 egui_tiles::UiResponse::None
             }
             Pane::ActionTile(pane) => {
+                register_ui_blocker(
+                    world,
+                    ui,
+                    target_window,
+                    content_rect,
+                    UiBlocker::OtherPanel,
+                    PointerOwnerPriority::Panel,
+                );
                 ui.add_widget_with::<ActionTileWidget>(world, "action_tile", pane.entity);
                 egui_tiles::UiResponse::None
             }
             Pane::VideoStream(pane) | Pane::SensorView(pane) => {
+                register_ui_blocker(
+                    world,
+                    ui,
+                    target_window,
+                    content_rect,
+                    UiBlocker::OtherPanel,
+                    PointerOwnerPriority::Panel,
+                );
                 ui.add_widget_with::<super::video_stream::VideoStreamWidget>(
                     world,
                     "video_stream",
@@ -1160,6 +1244,14 @@ impl Pane {
                 egui_tiles::UiResponse::None
             }
             Pane::LogStream(pane) => {
+                register_ui_blocker(
+                    world,
+                    ui,
+                    target_window,
+                    content_rect,
+                    UiBlocker::OtherPanel,
+                    PointerOwnerPriority::Panel,
+                );
                 ui.add_widget_with::<super::log_stream::LogStreamWidget>(
                     world,
                     "log_stream",
@@ -1170,6 +1262,14 @@ impl Pane {
                 egui_tiles::UiResponse::None
             }
             Pane::SchematicTree(tree_pane) => {
+                register_ui_blocker(
+                    world,
+                    ui,
+                    target_window,
+                    content_rect,
+                    UiBlocker::OtherPanel,
+                    PointerOwnerPriority::Panel,
+                );
                 let tree_icons = super::schematic::tree::TreeIcons {
                     chevron: icons.chevron,
                     search: icons.search,
@@ -1185,6 +1285,14 @@ impl Pane {
                 egui_tiles::UiResponse::None
             }
             Pane::DataOverview(pane) => {
+                register_ui_blocker(
+                    world,
+                    ui,
+                    target_window,
+                    content_rect,
+                    UiBlocker::OtherPanel,
+                    PointerOwnerPriority::Panel,
+                );
                 let updated_pane = ui.add_widget_with::<DataOverviewWidget>(
                     world,
                     "data_overview",
@@ -1619,6 +1727,55 @@ fn main_content_rect(tree: &egui_tiles::Tree<Pane>) -> Option<egui::Rect> {
     tree.tiles.rect(root)
 }
 
+fn register_pointer_owner(
+    world: &mut World,
+    ui: &Ui,
+    target_window: Entity,
+    rect: egui::Rect,
+    owner: PointerOwner,
+    priority: PointerOwnerPriority,
+) {
+    let rect = rect.intersect(ui.clip_rect());
+    if let Some(mut input_owners) = world.get_resource_mut::<UiInputOwners>() {
+        input_owners.register_rect(target_window, rect, owner, priority);
+    }
+}
+
+fn register_content_owner(
+    world: &mut World,
+    ui: &Ui,
+    target_window: Entity,
+    rect: egui::Rect,
+    owner: PointerOwner,
+) {
+    register_pointer_owner(
+        world,
+        ui,
+        target_window,
+        rect,
+        owner,
+        PointerOwnerPriority::Content,
+    );
+}
+
+fn register_ui_blocker(
+    world: &mut World,
+    ui: &Ui,
+    target_window: Entity,
+    rect: egui::Rect,
+    blocker: UiBlocker,
+    priority: PointerOwnerPriority,
+) {
+    register_pointer_owner(
+        world,
+        ui,
+        target_window,
+        rect,
+        PointerOwner::BlockedByUi { blocker },
+        priority,
+    );
+}
+
 struct TreeBehavior<'w> {
     icons: TileIcons,
     tree_actions: SmallVec<[TreeAction; 4]>,
@@ -1810,6 +1967,14 @@ impl egui_tiles::Behavior<Pane> for TreeBehavior<'_> {
             }
             resp
         };
+        register_ui_blocker(
+            self.world,
+            ui,
+            self.target_window,
+            rect,
+            UiBlocker::TabBar,
+            PointerOwnerPriority::Panel,
+        );
 
         if !self.read_only && state.active && response.double_clicked() && !is_editing {
             ui.ctx()
@@ -2082,10 +2247,16 @@ impl egui_tiles::Behavior<Pane> for TreeBehavior<'_> {
         if !tab_add_visible(tiles, tabs) {
             return;
         }
-        let mut layout = SystemState::<TileLayout>::new(self.world);
-        let mut layout = layout.get_mut(self.world);
 
         let top_bar_rect = ui.available_rect_before_wrap();
+        register_ui_blocker(
+            self.world,
+            ui,
+            self.target_window,
+            top_bar_rect,
+            UiBlocker::TabBar,
+            PointerOwnerPriority::Panel,
+        );
         ui.painter().hline(
             top_bar_rect.x_range(),
             top_bar_rect.bottom(),
@@ -2097,6 +2268,8 @@ impl egui_tiles::Behavior<Pane> for TreeBehavior<'_> {
         ui.add_space(5.0);
         let resp = ui.add(EImageButton::new(self.icons.add).scale(1.4, 1.4));
         if resp.clicked() {
+            let mut layout = SystemState::<TileLayout>::new(self.world);
+            let mut layout = layout.get_mut(self.world);
             layout
                 .cmd_palette_state
                 .open_page_for_window(Some(self.target_window), move || {
@@ -2194,6 +2367,23 @@ impl<'w, 's> TileSystem<'w, 's> {
 
         egui_material_icons::initialize(ui.ctx());
 
+        if let Some(mut input_owners) = world.get_resource_mut::<UiInputOwners>() {
+            input_owners.begin_window(target_window);
+        }
+
+        let toolbar_rect = egui::Rect::from_min_size(
+            ui.available_rect_before_wrap().min,
+            vec2(ui.available_width(), 32.0),
+        );
+        register_ui_blocker(
+            world,
+            ui,
+            target_window,
+            toolbar_rect,
+            UiBlocker::OtherPanel,
+            PointerOwnerPriority::Panel,
+        );
+
         let toolbar_action =
             render_sidebar_toolbar(ui, left_sidebar_visible, right_sidebar_visible);
 
@@ -2243,6 +2433,14 @@ impl<'w, 's> TileSystem<'w, 's> {
                     ..Default::default()
                 })
                 .show_inside(ui, |ui| {
+                    register_ui_blocker(
+                        world,
+                        ui,
+                        target_window,
+                        ui.max_rect(),
+                        UiBlocker::OtherPanel,
+                        PointerOwnerPriority::Panel,
+                    );
                     let hierarchy_icons = Hierarchy {
                         search: icons.search,
                         entity: icons.entity,
@@ -2267,6 +2465,14 @@ impl<'w, 's> TileSystem<'w, 's> {
                     ..Default::default()
                 })
                 .show_inside(ui, |ui| {
+                    register_ui_blocker(
+                        world,
+                        ui,
+                        target_window,
+                        ui.max_rect(),
+                        UiBlocker::Inspector,
+                        PointerOwnerPriority::Panel,
+                    );
                     let inspector_icons = InspectorIcons {
                         chart: icons.chart,
                         subtract: icons.subtract,
@@ -3125,6 +3331,14 @@ impl WidgetSystem for TileLayout<'_, '_> {
         }
 
         if show_empty_overlay && let Some(rect) = empty_overlay_rect {
+            register_ui_blocker(
+                world,
+                ui,
+                target_window,
+                rect,
+                UiBlocker::OtherPanel,
+                PointerOwnerPriority::Panel,
+            );
             ui.scope_builder(UiBuilder::new().max_rect(rect), |ui| {
                 ui.add_widget_with::<TileLayoutEmpty>(
                     world,
@@ -3135,6 +3349,11 @@ impl WidgetSystem for TileLayout<'_, '_> {
                     },
                 );
             });
+        }
+
+        let pointer_pos = ui.input(|input| input.pointer.latest_pos());
+        if let Some(mut input_owners) = world.get_resource_mut::<UiInputOwners>() {
+            input_owners.resolve_window(target_window, pointer_pos);
         }
     }
 }

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -36,7 +36,7 @@ use winit::{
 };
 
 use super::{
-    PaneName, SelectedObject, ViewportRect, WindowUiState,
+    EguiOverlayInputBlockers, PaneName, SelectedObject, ViewportRect, WindowUiState,
     actions::{ActionTile, ActionTileWidget},
     button::{EImageButton, ETileButton},
     colors::{self, EColor, get_scheme, with_opacity},
@@ -3349,6 +3349,22 @@ impl WidgetSystem for TileLayout<'_, '_> {
                     },
                 );
             });
+        }
+
+        let overlay_blocker =
+            world
+                .get_resource::<EguiOverlayInputBlockers>()
+                .and_then(|blockers| {
+                    if blockers.modal_blocks(target_window) {
+                        Some((UiBlocker::Modal, PointerOwnerPriority::Modal))
+                    } else if blockers.popup_blocks(target_window) {
+                        Some((UiBlocker::Popup, PointerOwnerPriority::Overlay))
+                    } else {
+                        None
+                    }
+                });
+        if let Some((blocker, priority)) = overlay_blocker {
+            register_ui_blocker(world, ui, target_window, ui.max_rect(), blocker, priority);
         }
 
         let pointer_pos = ui.input(|input| input.pointer.latest_pos());

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -10,7 +10,7 @@ use bevy::{
 };
 use bevy_editor_cam::{
     controller::{component::Sensitivity, zoom::ZoomLimits},
-    prelude::{EditorCam, EnabledMotion, OrbitConstraint},
+    prelude::{EditorCam, OrbitConstraint},
 };
 use bevy_egui::{
     EguiContexts, EguiTextureHandle,
@@ -476,9 +476,6 @@ pub fn create_secondary_window(title: Option<String>) -> (WindowState, WindowId)
         id,
     )
 }
-
-#[derive(Resource, Default)]
-pub struct ViewportContainsPointer(pub bool);
 #[derive(Clone)]
 pub struct ActionTilePane {
     pub entity: Entity,
@@ -2725,8 +2722,6 @@ pub struct TileLayout<'w, 's> {
     meshes: ResMut<'w, Assets<Mesh>>,
     materials: ResMut<'w, Assets<StandardMaterial>>,
     render_layer_alloc: ResMut<'w, RenderLayerAllocator>,
-    viewport_contains_pointer: ResMut<'w, ViewportContainsPointer>,
-    editor_cam: Query<'w, 's, &'static mut EditorCam, With<MainCamera>>,
     primary_window: Single<'w, 's, Entity, With<PrimaryWindow>>,
     cmd_palette_state: ResMut<'w, CommandPaletteState>,
     eql_ctx: Res<'w, EqlContext>,
@@ -2832,15 +2827,6 @@ impl WidgetSystem for TileLayout<'_, '_> {
                 ..
             } = &mut *window_state;
             let _ = std::mem::replace(&mut tile_state.tree, tree);
-            state_mut.viewport_contains_pointer.0 = ui.ui_contains_pointer();
-
-            for mut editor_cam in state_mut.editor_cam.iter_mut() {
-                editor_cam.enabled_motion = EnabledMotion {
-                    pan: state_mut.viewport_contains_pointer.0,
-                    orbit: state_mut.viewport_contains_pointer.0,
-                    zoom: state_mut.viewport_contains_pointer.0,
-                }
-            }
 
             for diff in tree_actions.drain(..) {
                 if read_only && !matches!(diff, TreeAction::SelectTile(_)) {

--- a/libs/elodin-editor/src/ui/timeline/mod.rs
+++ b/libs/elodin-editor/src/ui/timeline/mod.rs
@@ -1,8 +1,9 @@
 use bevy::ecs::{
-    system::{Local, Res, SystemParam, SystemState},
+    system::{Local, Query, Res, SystemParam, SystemState},
     world::World,
 };
 use bevy::prelude::*;
+use bevy::window::PrimaryWindow;
 use bevy_egui::{EguiContexts, EguiTextureHandle, egui};
 use impeller2_bevy::CurrentStreamId;
 use impeller2_wkt::{
@@ -15,7 +16,12 @@ use timeline_slider::TimelineSlider;
 
 use crate::{
     FullTimeRange, SelectedTimeRange, TimeRangeBehavior,
-    ui::{colors::get_scheme, images},
+    ui::{
+        colors::get_scheme,
+        images,
+        input_owner::{PointerOwnerPriority, UiBlocker},
+        register_window_input_blocker,
+    },
 };
 
 use super::widgets::{WidgetSystem, WidgetSystemExt};
@@ -405,6 +411,7 @@ pub struct TimelinePanel<'w, 's> {
     selected_time_range: Res<'w, SelectedTimeRange>,
     full_time_range: Res<'w, FullTimeRange>,
     time_range_behavior: Res<'w, TimeRangeBehavior>,
+    primary_window: Query<'w, 's, Entity, With<PrimaryWindow>>,
 }
 
 impl WidgetSystem for TimelinePanel<'_, '_> {
@@ -418,6 +425,9 @@ impl WidgetSystem for TimelinePanel<'_, '_> {
         _args: Self::Args,
     ) {
         let state_mut = state.get_mut(world);
+        let Ok(target_window) = state_mut.primary_window.single() else {
+            return;
+        };
         let mut contexts = state_mut.contexts;
         let images = state_mut.images;
         let tick_time = state_mut.tick_time;
@@ -481,6 +491,14 @@ impl WidgetSystem for TimelinePanel<'_, '_> {
                         );
                     });
                 });
+
+                register_window_input_blocker(
+                    world,
+                    target_window,
+                    ui.max_rect(),
+                    UiBlocker::Timeline,
+                    PointerOwnerPriority::Panel,
+                );
             });
     }
 }


### PR DESCRIPTION
## Summary

`EditorCamInputPlugin` replaces `DefaultInputPlugin` of `bevy_editor_cam` and filters `Start`/`Move`/`Zoom` via `UiInputOwners` (`PreUpdate`).

## What Changed

Instead of globally clearing mouse / motion / wheel events when egui wants input, each input consumer now asks a more precise question:

> Does this pointer currently belong to me?

The new `ui/input_owner.rs` module tracks pointer ownership by window and region. It models owners like:

- `Viewport`
- `Graph`
- `QueryPlot`
- `NavGizmo`
- `BlockedByUi`

Regions also have priority:

- `Content`
- `Panel`
- `Overlay`
- `Modal`

This lets the topmost relevant UI region win, which prevents events from passing through to panels or viewports behind it.

## Scope

The same ownership model is now used by other sensitive input consumers:

- graph pan / zoom / reset / touch
- editor camera touch
- navigation gizmo
- view cube

The goal is a consistent rule across the editor: input should only be handled by the UI or scene element that owns the pointer.
