### PR TITLE
ci: zig-wrapper-strip-rustc-crt (iteration number 7, test-musl-build.sh ok locally).

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,13 +167,10 @@ jobs:
               zig_target="x86_64-linux-musl"
               # cc-rs reads CC_/CXX_/AR_ with lowercase target (see cc docs)
               env_target="x86_64_unknown_linux_musl"
-              # cargo reads CARGO_TARGET_<TRIPLE>_LINKER with uppercase
-              cargo_env_target="X86_64_UNKNOWN_LINUX_MUSL"
               ;;
             aarch64-unknown-linux-musl)
               zig_target="aarch64-linux-musl"
               env_target="aarch64_unknown_linux_musl"
-              cargo_env_target="AARCH64_UNKNOWN_LINUX_MUSL"
               ;;
           esac
 
@@ -197,6 +194,8 @@ jobs:
           sudo mkdir -p /opt
           sudo tar -xJf "/tmp/${zig_tarball}" -C /opt
           zig_bin="/opt/${zig_dir}/zig"
+          echo "--- zig version ---"
+          "${zig_bin}" version
 
           # Wrappers needed because cc-rs treats CC_*/CXX_* as paths, not shell
           # commands, so we cannot inline `-target <triple>` in the env var.
@@ -252,6 +251,8 @@ jobs:
             "exec \"${zig_bin}\" ar \"\$@\"" \
             | sudo tee "${wrap_dir}/ar" >/dev/null
           sudo chmod +x "${wrap_dir}/cc" "${wrap_dir}/c++" "${wrap_dir}/ar"
+          echo "--- generated cc wrapper ---"
+          cat "${wrap_dir}/cc"
 
           {
             echo "CC_${env_target}=${wrap_dir}/cc"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,11 +212,26 @@ jobs:
           # Use `printf '%s\n'` line-by-line so each wrapper-script line is
           # a distinct printf arg — keeps the YAML block scalar valid even
           # though the generated script itself has no leading indentation.
+          # The wrapper strips:
+          #   1. --target=<rust-triple>  — Zig rejects this format
+          #      ("UnknownOperatingSystem"); we pass the Zig-flavoured
+          #      -target ourselves.
+          #   2. rustc self-contained CRT objects (rcrt1.o, crti.o,
+          #      crtbeginS.o, crtendS.o, crtn.o passed positionally) — Zig
+          #      adds its own CRT for -target *-linux-musl, so without this
+          #      filter we get duplicate _start / _start_c symbols at link
+          #      time. Filtering here (rather than via -C link-self-contained
+          #      =no in cargo config) is robust against `dist build` setting
+          #      its own RUSTFLAGS env var which would shadow our config.
           printf '%s\n' \
             '#!/bin/bash' \
             'args=()' \
             'for a in "$@"; do' \
-            '  case "$a" in --target=*) ;; *) args+=("$a") ;; esac' \
+            '  case "$a" in' \
+            '    --target=*) ;;' \
+            '    */self-contained/*crt*.o) ;;' \
+            '    *) args+=("$a") ;;' \
+            '  esac' \
             'done' \
             "exec \"${zig_bin}\" cc -target ${zig_target} \"\${args[@]}\"" \
             | sudo tee "${wrap_dir}/cc" >/dev/null
@@ -224,7 +239,11 @@ jobs:
             '#!/bin/bash' \
             'args=()' \
             'for a in "$@"; do' \
-            '  case "$a" in --target=*) ;; *) args+=("$a") ;; esac' \
+            '  case "$a" in' \
+            '    --target=*) ;;' \
+            '    */self-contained/*crt*.o) ;;' \
+            '    *) args+=("$a") ;;' \
+            '  esac' \
             'done' \
             "exec \"${zig_bin}\" c++ -target ${zig_target} \"\${args[@]}\"" \
             | sudo tee "${wrap_dir}/c++" >/dev/null

--- a/scripts/test-musl-build.sh
+++ b/scripts/test-musl-build.sh
@@ -103,11 +103,18 @@ build_one_target() {
   local wrap_dir="${session_dir}/zig-cc-${env_target}"
   mkdir -p "$wrap_dir"
 
+  # Wrapper strips:
+  #   --target=*                       (Zig rejects Rust triple format)
+  #   */self-contained/*crt*.o         (rustc CRT objects, Zig adds its own)
   printf '%s\n' \
     '#!/bin/bash' \
     'args=()' \
     'for a in "$@"; do' \
-    '  case "$a" in --target=*) ;; *) args+=("$a") ;; esac' \
+    '  case "$a" in' \
+    '    --target=*) ;;' \
+    '    */self-contained/*crt*.o) ;;' \
+    '    *) args+=("$a") ;;' \
+    '  esac' \
     'done' \
     "exec \"${zig_bin}\" cc -target ${zig_target} \"\${args[@]}\"" \
     > "${wrap_dir}/cc"
@@ -115,7 +122,11 @@ build_one_target() {
     '#!/bin/bash' \
     'args=()' \
     'for a in "$@"; do' \
-    '  case "$a" in --target=*) ;; *) args+=("$a") ;; esac' \
+    '  case "$a" in' \
+    '    --target=*) ;;' \
+    '    */self-contained/*crt*.o) ;;' \
+    '    *) args+=("$a") ;;' \
+    '  esac' \
     'done' \
     "exec \"${zig_bin}\" c++ -target ${zig_target} \"\${args[@]}\"" \
     > "${wrap_dir}/c++"

--- a/scripts/test-musl-build.sh
+++ b/scripts/test-musl-build.sh
@@ -33,7 +33,7 @@ else
 fi
 
 repo_root="$(git rev-parse --show-toplevel)"
-cd "$repo_root"
+cd "$repo_root" || { echo "error: cannot cd to repo root: $repo_root" >&2; exit 1; }
 
 if ! command -v zig >/dev/null 2>&1; then
   cat >&2 <<'EOF'
@@ -53,8 +53,16 @@ if ! command -v rustup >/dev/null 2>&1; then
 fi
 
 zig_bin="$(command -v zig)"
-echo "==> using zig: $zig_bin ($(zig version))"
-echo "==> targets:   ${TARGETS[*]}"
+echo "==> using zig:    $zig_bin ($(zig version))"
+echo "==> using cargo:  $(cargo --version)"
+echo "==> using rustc:  $(rustc --version)"
+echo "==> using rustup: $(rustup --version | head -1)"
+echo "==> targets:      ${TARGETS[*]}"
+
+zig_major_minor="$(zig version | awk -F. '{ print $1"."$2 }')"
+if [ "$zig_major_minor" != "0.16" ]; then
+  echo "warning: CI uses Zig 0.16.x; local Zig $zig_major_minor may produce different results" >&2
+fi
 
 cargo_config=".cargo/config.toml"
 session_dir="$(mktemp -d "${TMPDIR:-/tmp}/musl-test.XXXXXX")"
@@ -135,6 +143,8 @@ build_one_target() {
     "exec \"${zig_bin}\" ar \"\$@\"" \
     > "${wrap_dir}/ar"
   chmod +x "${wrap_dir}/cc" "${wrap_dir}/c++" "${wrap_dir}/ar"
+  echo "--- generated cc wrapper ---"
+  cat "${wrap_dir}/cc"
 
   # Restore original .cargo/config.toml then append fresh target section
   if [ "$had_config" = "1" ]; then


### PR DESCRIPTION
> See also: https://github.com/elodin-sys/elodin/issues/663

---

### Result
==> [x86_64-unknown-linux-musl] Finished release profile in 3m 27s → PASS ==> [aarch64-unknown-linux-musl] Finished release profile in 3m 36s → PASS real 7m04.822s

### What this validates
- Linux host build path (not just macOS)
- Zig 0.16.0 from `ziglang.org` resolves `-lstdc++` cleanly for both musl triples
- Wrapper filter strips rustc self-contained CRT objects + `--target=*` correctly
- `cc-rs` chain through `openh264-sys2` (C++) cross-compiles end-to-end
- `.cargo/config.toml` `[target.<triple>]` linker setting honored by cargo
- Reproducible from a clean checkout (no incremental cache hiding anything)

### Residual delta vs CI
- CI uses `dist build` (cargo-dist 0.28.0), we used `cargo build --release` directly.
  This was the cause of iter 6 failure (dist injects `RUSTFLAGS` that shadowed
  `.cargo/config.toml` rustflags). Iter 7 neutralizes this by filtering CRT objects
  at the linker wrapper level — independent of which `RUSTFLAGS` layer wins.
- `x86_64-unknown-linux-musl` runner in CI is x86_64 host (we tested as aarch64
  cross-compile). Wrapper is host-agnostic; identical behavior expected.
