### PR TITLE
Require clients to consume db responses

### DIFF
--- a/examples/betaflight-sitl/config.py
+++ b/examples/betaflight-sitl/config.py
@@ -143,8 +143,8 @@ class DroneConfig:
     # --- Simulation Settings ---
 
     # Physics simulation rate in Hz (8kHz for high-performance Betaflight PID loop)
-    # simulation_rate: float = 8000.0  # 125µs
-    simulation_rate: float = 4000.0  # 250µs
+    simulation_rate: float = 8000.0  # 125µs
+    # simulation_rate: float = 4000.0  # 250µs
     # simulation_rate: float = 2000.0  # 500µs
     # simulation_rate: float = 1000.0  # 1000µs
 

--- a/examples/betaflight-sitl/config.py
+++ b/examples/betaflight-sitl/config.py
@@ -143,8 +143,8 @@ class DroneConfig:
     # --- Simulation Settings ---
 
     # Physics simulation rate in Hz (8kHz for high-performance Betaflight PID loop)
-    simulation_rate: float = 8000.0  # 125µs
-    # simulation_rate: float = 4000.0  # 250µs
+    # simulation_rate: float = 8000.0  # 125µs
+    simulation_rate: float = 4000.0  # 250µs
     # simulation_rate: float = 2000.0  # 500µs
     # simulation_rate: float = 1000.0  # 1000µs
 

--- a/examples/betaflight-sitl/main.py
+++ b/examples/betaflight-sitl/main.py
@@ -229,7 +229,7 @@ def sitl_post_step(tick: int, ctx: el.StepContext):
                 pass  # Expected during initial warmup
         print(f"[SITL] Warmup complete ({warmup_count} responses at {config.pid_rate:.0f}Hz)")
         print("[SITL] Bridge ready")
-        ctx.truncate()  # Clears all data, resets tick to 0
+        # ctx.truncate()  # Clears all data, resets tick to 0
 
     if start_time[0] is None:
         start_time[0] = time.time()
@@ -426,7 +426,7 @@ db_filename = next_filename("betaflight_dbXXX")
 world.run(
     system,
     simulation_rate=config.pid_rate,
-    generate_real_time=True,
+    # generate_real_time=True,
     max_ticks=config.total_sim_ticks,
     post_step=sitl_post_step,
     db_path=db_filename,

--- a/examples/betaflight-sitl/main.py
+++ b/examples/betaflight-sitl/main.py
@@ -229,7 +229,6 @@ def sitl_post_step(tick: int, ctx: el.StepContext):
                 pass  # Expected during initial warmup
         print(f"[SITL] Warmup complete ({warmup_count} responses at {config.pid_rate:.0f}Hz)")
         print("[SITL] Bridge ready")
-        # ctx.truncate()  # Clears all data, resets tick to 0
 
     if start_time[0] is None:
         start_time[0] = time.time()
@@ -426,7 +425,7 @@ db_filename = next_filename("betaflight_dbXXX")
 world.run(
     system,
     simulation_rate=config.pid_rate,
-    # generate_real_time=True,
+    generate_real_time=True,
     max_ticks=config.total_sim_ticks,
     post_step=sitl_post_step,
     db_path=db_filename,

--- a/fsw/tegrastats-bridge/src/main.rs
+++ b/fsw/tegrastats-bridge/src/main.rs
@@ -1,14 +1,14 @@
 use db_macros::{AsVTable, Metadatatize};
-use futures_concurrency::future::Join;
+use futures_concurrency::future::{Join, Race};
 use impeller2::types::{LenPacket, PacketId, Timestamp};
-use impeller2_stellar::Client;
 use impeller2_stellar::SinkExt;
+use impeller2_stellar::{PacketSink, PacketStream};
 use std::{
     mem,
     net::SocketAddr,
     time::{Duration, Instant},
 };
-use stellarator::{fs::File, rent};
+use stellarator::{fs::File, io::SplitExt, net::TcpStream, rent};
 use sysinfo::CpuRefreshKind;
 use zerocopy::{Immutable, IntoBytes};
 
@@ -27,11 +27,14 @@ pub struct Output {
 }
 
 async fn connect() -> anyhow::Result<Duration> {
-    let mut client = Client::connect(SocketAddr::new([127, 0, 0, 1].into(), 2240))
+    let stream = TcpStream::connect(SocketAddr::new([127, 0, 0, 1].into(), 2240))
         .await
         .map_err(anyhow::Error::from)?;
+    let (rx, tx) = stream.split();
+    let tx = PacketSink::new(tx);
+    let mut rx = PacketStream::new(rx);
     let id: PacketId = fastrand::u16(..).to_le_bytes();
-    client.init_world::<Output>(id).await?;
+    tx.init_world::<Output>(id).await?;
     let mut table = LenPacket::table(id, mem::size_of::<Output>());
     let thermal_zone = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         .map(|i| File::open(format!("/sys/devices/virtual/thermal/thermal_zone{i}/temp")))
@@ -53,38 +56,54 @@ async fn connect() -> anyhow::Result<Duration> {
     system.refresh_cpu_specifics(CpuRefreshKind::everything());
     let connected_at = Instant::now();
 
-    loop {
-        table.clear();
-        let thermal_zones = thermal_zone.each_ref().map(maybe_read_to_float).join();
-        let cpu_freq = cpu_freq.each_ref().map(maybe_read_to_float).join();
-        let gpu_load = read_to_float(&gpu_load);
-        let (thermal_zones, cpu_freq, gpu_load) = (thermal_zones, cpu_freq, gpu_load).join().await;
-        let thermal_zones = thermal_zones.map(|res| res.unwrap_or(f32::NAN) / 1000.0);
-        let cpu_freq = cpu_freq.map(|res| res.unwrap_or(f32::NAN));
-        let gpu_load = gpu_load.unwrap_or(f32::NAN) / 1000.0;
-        system.refresh_cpu_specifics(CpuRefreshKind::everything());
-        let mut cpu_usage = [f32::NAN; 8];
-        for (cpu, usage) in system.cpus().iter().zip(cpu_usage.iter_mut()) {
-            *usage = cpu.cpu_usage();
+    let drain_replies = async {
+        let mut buf = vec![0_u8; 256];
+        loop {
+            let pkt = rx.next_grow(buf).await?;
+            buf = pkt.into_buf().into_inner();
         }
+    };
 
-        let output = Output {
-            time: Timestamp::now().0,
-            thermal_zones,
-            cpu_usage,
-            gpu_usage: gpu_load,
-            cpu_freq,
-            _pad: 0,
-        };
-        table.extend_from_slice(output.as_bytes());
-        if let Err(err) = rent!(client.send(table).await, table) {
-            eprintln!(
-                "send failed after connected session {:?}: {err:?}",
-                connected_at.elapsed()
-            );
-            return Ok(connected_at.elapsed());
+    let send_metrics = async {
+        loop {
+            table.clear();
+            let thermal_zones = thermal_zone.each_ref().map(maybe_read_to_float).join();
+            let cpu_freq = cpu_freq.each_ref().map(maybe_read_to_float).join();
+            let gpu_load = read_to_float(&gpu_load);
+            let (thermal_zones, cpu_freq, gpu_load) =
+                (thermal_zones, cpu_freq, gpu_load).join().await;
+            let thermal_zones = thermal_zones.map(|res| res.unwrap_or(f32::NAN) / 1000.0);
+            let cpu_freq = cpu_freq.map(|res| res.unwrap_or(f32::NAN));
+            let gpu_load = gpu_load.unwrap_or(f32::NAN) / 1000.0;
+            system.refresh_cpu_specifics(CpuRefreshKind::everything());
+            let mut cpu_usage = [f32::NAN; 8];
+            for (cpu, usage) in system.cpus().iter().zip(cpu_usage.iter_mut()) {
+                *usage = cpu.cpu_usage();
+            }
+
+            let output = Output {
+                time: Timestamp::now().0,
+                thermal_zones,
+                cpu_usage,
+                gpu_usage: gpu_load,
+                cpu_freq,
+                _pad: 0,
+            };
+            table.extend_from_slice(output.as_bytes());
+            if let Err(err) = rent!(tx.send(table).await, table) {
+                eprintln!(
+                    "send failed after connected session {:?}: {err:?}",
+                    connected_at.elapsed()
+                );
+                return Ok::<Duration, impeller2_stellar::Error>(connected_at.elapsed());
+            }
+            stellarator::sleep(Duration::from_millis(1000)).await;
         }
-        stellarator::sleep(Duration::from_millis(1000)).await;
+    };
+
+    match (drain_replies, send_metrics).race().await {
+        Ok(duration) => Ok(duration),
+        Err(err) => Err(err.into()),
     }
 }
 

--- a/libs/db/cpp/helpers.hpp
+++ b/libs/db/cpp/helpers.hpp
@@ -77,7 +77,13 @@ class Msg {
 public:
     Msg(T p)
     {
-        auto packet_id = msg_id(T::TYPE_NAME);
+        auto packet_id = [] {
+            if constexpr (requires { T::PACKET_ID; }) {
+                return T::PACKET_ID;
+            } else {
+                return msg_id(T::TYPE_NAME);
+            }
+        }();
         header = PacketHeader {
             .len = 0,
             .ty = PacketType::MSG,
@@ -105,6 +111,23 @@ public:
         }
 
         return buf;
+    }
+};
+
+struct ConnectionSettings {
+    static constexpr std::string_view TYPE_NAME = "ConnectionSettings";
+    static constexpr std::array<uint8_t, 2> PACKET_ID = { 224, 39 };
+
+    bool silent = false;
+
+    size_t encoded_size() const
+    {
+        return postcard_size_bool();
+    }
+
+    postcard_error_t encode_raw(postcard_slice_t* slice) const
+    {
+        return postcard_encode_bool(slice, silent);
     }
 };
 

--- a/libs/db/cpp/helpers.hpp
+++ b/libs/db/cpp/helpers.hpp
@@ -4,7 +4,9 @@
 #include <array>
 #include <cstdint>
 #include <cstring>
+#include <iostream>
 #include <span>
+#include <string>
 #include <string_view>
 #include <vector>
 
@@ -130,6 +132,64 @@ struct ConnectionSettings {
         return postcard_encode_bool(slice, silent);
     }
 };
+
+inline std::string decode_error_response_payload(std::span<const uint8_t> payload)
+{
+    postcard_slice_t slice;
+    postcard_init_slice(&slice, const_cast<uint8_t*>(payload.data()), payload.size());
+
+    size_t description_len = 0;
+    auto res = postcard_decode_string_len(&slice, &description_len);
+    if (res != POSTCARD_SUCCESS) {
+        return "failed to decode ErrorResponse description length";
+    }
+
+    std::string description(description_len, '\0');
+    if (description_len > 0) {
+        res = postcard_decode_string(&slice, description.data(), description_len, description_len);
+        if (res != POSTCARD_SUCCESS) {
+            return "failed to decode ErrorResponse description";
+        }
+    }
+
+    return description;
+}
+
+inline void log_elodin_db_replies(
+    std::vector<uint8_t>& pending,
+    std::span<const uint8_t> bytes,
+    std::string_view label)
+{
+    static constexpr std::array<uint8_t, 2> ERROR_RESPONSE_ID = { 224, 29 };
+
+    pending.insert(pending.end(), bytes.begin(), bytes.end());
+
+    size_t offset = 0;
+    while (pending.size() - offset >= sizeof(PacketHeader)) {
+        uint32_t len = 0;
+        std::memcpy(&len, pending.data() + offset, sizeof(len));
+        const size_t packet_len = static_cast<size_t>(len) + sizeof(uint32_t);
+        if (pending.size() - offset < packet_len) {
+            break;
+        }
+
+        PacketHeader header;
+        std::memcpy(&header, pending.data() + offset, sizeof(header));
+        if (header.ty == PacketType::MSG && header.packet_id == ERROR_RESPONSE_ID) {
+            auto payload = std::span<const uint8_t>(
+                pending.data() + offset + sizeof(PacketHeader),
+                packet_len - sizeof(PacketHeader));
+            std::cerr << label << ": Elodin-DB error: "
+                      << decode_error_response_payload(payload) << std::endl;
+        }
+
+        offset += packet_len;
+    }
+
+    if (offset > 0) {
+        pending.erase(pending.begin(), pending.begin() + static_cast<std::ptrdiff_t>(offset));
+    }
+}
 
 SetComponentMetadata set_component_metadata(std::string name, const std::vector<std::string>& element_names = {})
 {

--- a/libs/db/examples/client-batched.cpp
+++ b/libs/db/examples/client-batched.cpp
@@ -103,6 +103,7 @@ public:
     void drain_replies(const char* label)
     {
         try {
+            auto pending = std::vector<uint8_t>();
             while (true) {
                 auto data = std::vector<uint8_t>(1024);
                 auto len = read(data.data(), data.size());
@@ -110,6 +111,7 @@ public:
                     std::println("{}: connection closed", label);
                     break;
                 }
+                log_elodin_db_replies(pending, std::span(data.data(), len), label);
             }
         } catch (const std::exception& e) {
             std::cerr << label << " error: " << e.what() << std::endl;

--- a/libs/db/examples/client-batched.cpp
+++ b/libs/db/examples/client-batched.cpp
@@ -17,6 +17,7 @@
 #include <cmath>
 #include <cstddef>
 #include <iostream>
+#include <memory>
 #include <print>
 #include <system_error>
 #include <thread>
@@ -99,6 +100,22 @@ public:
         return res;
     }
 
+    void drain_replies(const char* label)
+    {
+        try {
+            while (true) {
+                auto data = std::vector<uint8_t>(1024);
+                auto len = read(data.data(), data.size());
+                if (len == 0) {
+                    std::println("{}: connection closed", label);
+                    break;
+                }
+            }
+        } catch (const std::exception& e) {
+            std::cerr << label << " error: " << e.what() << std::endl;
+        }
+    }
+
 private:
     int fd_ = -1;
 };
@@ -132,7 +149,11 @@ try {
     const uint16_t port = 2240;
 
     std::println("Connecting writer socket (batched mode)");
-    auto sock = Socket(ip, port);
+    auto sock = std::make_shared<Socket>(ip, port);
+    std::thread writer_replies([sock] {
+        sock->drain_replies("Writer replies");
+    });
+    writer_replies.detach();
 
     // One VTable with all 6 sensor components sharing a single time source.
     // The server decomposes this into individual time series on write.
@@ -146,18 +167,19 @@ try {
         field<SensorData, &SensorData::humidity>(schema(PrimType::F32(), {}, timestamp(time, component("vehicle.humidity")))),
     });
 
-    sock.send(VTableMsg {
+    sock->send(VTableMsg {
         .id = { 2, 0 },
         .vtable = table,
     });
-    sock.send(set_component_metadata("vehicle.imu.mag", {"x", "y", "z"}));
-    sock.send(set_component_metadata("vehicle.imu.gyro", {"x", "y", "z"}));
-    sock.send(set_component_metadata("vehicle.imu.accel", {"x", "y", "z"}));
-    sock.send(set_component_metadata("vehicle.temp"));
-    sock.send(set_component_metadata("vehicle.pressure"));
-    sock.send(set_component_metadata("vehicle.humidity"));
+    sock->send(set_component_metadata("vehicle.imu.mag", {"x", "y", "z"}));
+    sock->send(set_component_metadata("vehicle.imu.gyro", {"x", "y", "z"}));
+    sock->send(set_component_metadata("vehicle.imu.accel", {"x", "y", "z"}));
+    sock->send(set_component_metadata("vehicle.temp"));
+    sock->send(set_component_metadata("vehicle.pressure"));
+    sock->send(set_component_metadata("vehicle.humidity"));
 
     std::thread reader(reader_thread_func, ip, port);
+    reader.detach();
 
     auto sensor_data = SensorData {
         .mag = { 0.0, 0.0, 0.0 },
@@ -181,12 +203,11 @@ try {
         sensor_data.time = system_clock::now().time_since_epoch() / microseconds(1);
         sensor_data.temp = std::sin(static_cast<double>(sensor_data.time) / 1000000.0);
 
-        sock.write_all(&table_header, sizeof(table_header));
-        sock.write_all(&sensor_data, sizeof(sensor_data));
+        sock->write_all(&table_header, sizeof(table_header));
+        sock->write_all(&sensor_data, sizeof(sensor_data));
         usleep(1000);
     }
 
-    reader.join();
     return 0;
 } catch (const std::exception& e) {
     std::cerr << "Error: " << e.what() << std::endl;

--- a/libs/db/examples/client-per-component.cpp
+++ b/libs/db/examples/client-per-component.cpp
@@ -100,6 +100,7 @@ public:
     void drain_replies(const std::string& label)
     {
         try {
+            auto pending = std::vector<uint8_t>();
             while (true) {
                 auto data = std::vector<uint8_t>(1024);
                 auto len = read(data.data(), data.size());
@@ -107,6 +108,7 @@ public:
                     std::println("[{}] replies closed", label);
                     break;
                 }
+                log_elodin_db_replies(pending, std::span(data.data(), len), label);
             }
         } catch (const std::exception& e) {
             std::cerr << "[" << label << "] reply drain error: " << e.what() << std::endl;

--- a/libs/db/examples/client-per-component.cpp
+++ b/libs/db/examples/client-per-component.cpp
@@ -23,6 +23,7 @@
 #include <cmath>
 #include <cstddef>
 #include <iostream>
+#include <memory>
 #include <print>
 #include <string>
 #include <system_error>
@@ -87,6 +88,31 @@ public:
         write_all(buf.data(), buf.size());
     }
 
+    size_t read(uint8_t* data, size_t len)
+    {
+        auto res = ::read(fd_, data, len);
+        if (res < 0) {
+            throw std::system_error(errno, std::generic_category(), "Failed to read");
+        }
+        return res;
+    }
+
+    void drain_replies(const std::string& label)
+    {
+        try {
+            while (true) {
+                auto data = std::vector<uint8_t>(1024);
+                auto len = read(data.data(), data.size());
+                if (len == 0) {
+                    std::println("[{}] replies closed", label);
+                    break;
+                }
+            }
+        } catch (const std::exception& e) {
+            std::cerr << "[" << label << "] reply drain error: " << e.what() << std::endl;
+        }
+    }
+
 private:
     int fd_ = -1;
 };
@@ -104,7 +130,11 @@ void component_writer(
 {
     try {
         std::println("[{}] connecting to {}:{}", component_name, ip, port);
-        auto sock = Socket(ip, port);
+        auto sock = std::make_shared<Socket>(ip, port);
+        std::thread reply_reader([sock, component_name] {
+            sock->drain_replies(component_name);
+        });
+        reply_reader.detach();
 
         auto time = builder::raw_table(0, 8);
         auto table = builder::vtable({
@@ -112,11 +142,11 @@ void component_writer(
                 schema(prim_type, dims, timestamp(time, component(component_name)))),
         });
 
-        sock.send(VTableMsg {
+        sock->send(VTableMsg {
             .id = { vtable_id, 0 },
             .vtable = table,
         });
-        sock.send(set_component_metadata(component_name, labels));
+        sock->send(set_component_metadata(component_name, labels));
 
         // Packet layout: [int64_t time][float values...]
         std::vector<uint8_t> buf(8 + value_bytes, 0);
@@ -137,10 +167,11 @@ void component_writer(
                 .packet_id = { vtable_id, 0 },
                 .request_id = 0,
             };
-            sock.write_all(&header, sizeof(header));
-            sock.write_all(buf.data(), buf.size());
+            sock->write_all(&header, sizeof(header));
+            sock->write_all(buf.data(), buf.size());
             usleep(1000);
         }
+
     } catch (const std::exception& e) {
         std::cerr << "[" << component_name << "] error: " << e.what() << std::endl;
     }

--- a/libs/db/examples/client-write-only.cpp
+++ b/libs/db/examples/client-write-only.cpp
@@ -1,0 +1,140 @@
+///$(which true);FLAGS="--std=c++23";THIS_FILE="$(cd "$(dirname "$0")"; pwd -P)/$(basename "$0")";OUT_FILE="/tmp/build-cache/$THIS_FILE";mkdir -p "$(dirname "$OUT_FILE")";test "$THIS_FILE" -ot "$OUT_FILE" || $(which clang++ || which g++) $FLAGS "$THIS_FILE" -o "$OUT_FILE" || exit $?;exec bash -c "exec -a \"$0\" \"$OUT_FILE\" $([ $# -eq 0 ] || printf ' "%s"' "$@")"
+//
+// Write-only pattern: opt into a silent connection and never read replies.
+// Use this only for pure ingest sockets. Query and stream requests are ignored
+// by the server on silent connections.
+
+#include <arpa/inet.h>
+#include <cstdint>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <iostream>
+#include <print>
+#include <system_error>
+
+#include "db.hpp"
+
+using namespace vtable;
+using namespace vtable::builder;
+using namespace std::chrono;
+
+struct SensorData {
+    int64_t time;
+    float gyro[3];
+    float accel[3];
+};
+
+class Socket {
+public:
+    Socket(const char* ip, uint16_t port)
+    {
+        fd_ = socket(AF_INET, SOCK_STREAM, 0);
+        if (fd_ < 0) {
+            throw std::system_error(
+                errno, std::generic_category(), "Failed to create socket");
+        }
+
+        struct sockaddr_in server_addr = { .sin_family = AF_INET,
+            .sin_port = htons(port),
+            .sin_addr = { .s_addr = inet_addr(ip) } };
+
+        if (::connect(fd_,
+                reinterpret_cast<struct sockaddr*>(&server_addr),
+                sizeof(server_addr))
+            < 0) {
+            throw std::system_error(
+                errno, std::generic_category(), "Failed to connect");
+        }
+    }
+
+    ~Socket()
+    {
+        if (fd_ >= 0) {
+            close(fd_);
+        }
+    }
+
+    void write_all(const void* data, size_t len)
+    {
+        auto ptr = static_cast<const uint8_t*>(data);
+        auto remaining = len;
+
+        while (remaining > 0) {
+            auto written = write(fd_, ptr, remaining);
+            if (written < 0) {
+                throw std::system_error(
+                    errno, std::generic_category(), "Failed to write");
+            }
+            ptr += written;
+            remaining -= written;
+        }
+    }
+
+    template <typename T>
+    void send(T msg)
+    {
+        auto buf = Msg(msg).encode_vec();
+        write_all(buf.data(), buf.size());
+    }
+
+private:
+    int fd_ = -1;
+};
+
+int main()
+try {
+    const char* ip = "127.0.0.1";
+    const uint16_t port = 2240;
+
+    std::println("Connecting write-only socket");
+    auto sock = Socket(ip, port);
+
+    // This must be the first packet on the connection. The server will apply
+    // writes but never send replies, errors, or streams on this socket.
+    sock.send(ConnectionSettings { .silent = true });
+
+    auto time = builder::raw_table(0, 8);
+    auto table = builder::vtable({
+        field<SensorData, &SensorData::gyro>(schema(PrimType::F32(), { 3 }, timestamp(time, component("vehicle.imu.gyro")))),
+        field<SensorData, &SensorData::accel>(schema(PrimType::F32(), { 3 }, timestamp(time, component("vehicle.imu.accel")))),
+    });
+
+    sock.send(VTableMsg {
+        .id = { 2, 0 },
+        .vtable = table,
+    });
+    sock.send(set_component_metadata("vehicle.imu.gyro", { "x", "y", "z" }));
+    sock.send(set_component_metadata("vehicle.imu.accel", { "x", "y", "z" }));
+
+    auto sensor_data = SensorData {
+        .gyro = { 0.0, 0.0, 0.0 },
+        .accel = { 0.0, 0.0, 0.0 },
+    };
+
+    while (true) {
+        auto table_header = PacketHeader {
+            .len = 4 + sizeof(sensor_data),
+            .ty = PacketType::TABLE,
+            .packet_id = { 2, 0 },
+            .request_id = 0,
+        };
+
+        sensor_data.time = system_clock::now().time_since_epoch() / microseconds(1);
+        sensor_data.gyro[2] = std::sin(static_cast<double>(sensor_data.time) / 1000000.0);
+        sensor_data.accel[2] = std::cos(static_cast<double>(sensor_data.time) / 1000000.0);
+
+        sock.write_all(&table_header, sizeof(table_header));
+        sock.write_all(&sensor_data, sizeof(sensor_data));
+        usleep(1000);
+    }
+
+    return 0;
+} catch (const std::exception& e) {
+    std::cerr << "Error: " << e.what() << std::endl;
+    return 1;
+}

--- a/libs/db/examples/db.hpp
+++ b/libs/db/examples/db.hpp
@@ -3836,7 +3836,9 @@ struct LogEntry {
 #include <array>
 #include <cstdint>
 #include <cstring>
+#include <iostream>
 #include <span>
+#include <string>
 #include <string_view>
 #include <vector>
 
@@ -3962,6 +3964,64 @@ struct ConnectionSettings {
         return postcard_encode_bool(slice, silent);
     }
 };
+
+inline std::string decode_error_response_payload(std::span<const uint8_t> payload)
+{
+    postcard_slice_t slice;
+    postcard_init_slice(&slice, const_cast<uint8_t*>(payload.data()), payload.size());
+
+    size_t description_len = 0;
+    auto res = postcard_decode_string_len(&slice, &description_len);
+    if (res != POSTCARD_SUCCESS) {
+        return "failed to decode ErrorResponse description length";
+    }
+
+    std::string description(description_len, '\0');
+    if (description_len > 0) {
+        res = postcard_decode_string(&slice, description.data(), description_len, description_len);
+        if (res != POSTCARD_SUCCESS) {
+            return "failed to decode ErrorResponse description";
+        }
+    }
+
+    return description;
+}
+
+inline void log_elodin_db_replies(
+    std::vector<uint8_t>& pending,
+    std::span<const uint8_t> bytes,
+    std::string_view label)
+{
+    static constexpr std::array<uint8_t, 2> ERROR_RESPONSE_ID = { 224, 29 };
+
+    pending.insert(pending.end(), bytes.begin(), bytes.end());
+
+    size_t offset = 0;
+    while (pending.size() - offset >= sizeof(PacketHeader)) {
+        uint32_t len = 0;
+        std::memcpy(&len, pending.data() + offset, sizeof(len));
+        const size_t packet_len = static_cast<size_t>(len) + sizeof(uint32_t);
+        if (pending.size() - offset < packet_len) {
+            break;
+        }
+
+        PacketHeader header;
+        std::memcpy(&header, pending.data() + offset, sizeof(header));
+        if (header.ty == PacketType::MSG && header.packet_id == ERROR_RESPONSE_ID) {
+            auto payload = std::span<const uint8_t>(
+                pending.data() + offset + sizeof(PacketHeader),
+                packet_len - sizeof(PacketHeader));
+            std::cerr << label << ": Elodin-DB error: "
+                      << decode_error_response_payload(payload) << std::endl;
+        }
+
+        offset += packet_len;
+    }
+
+    if (offset > 0) {
+        pending.erase(pending.begin(), pending.begin() + static_cast<std::ptrdiff_t>(offset));
+    }
+}
 
 SetComponentMetadata set_component_metadata(std::string name, const std::vector<std::string>& element_names = {})
 {

--- a/libs/db/examples/db.hpp
+++ b/libs/db/examples/db.hpp
@@ -3909,7 +3909,13 @@ class Msg {
 public:
     Msg(T p)
     {
-        auto packet_id = msg_id(T::TYPE_NAME);
+        auto packet_id = [] {
+            if constexpr (requires { T::PACKET_ID; }) {
+                return T::PACKET_ID;
+            } else {
+                return msg_id(T::TYPE_NAME);
+            }
+        }();
         header = PacketHeader {
             .len = 0,
             .ty = PacketType::MSG,
@@ -3937,6 +3943,23 @@ public:
         }
 
         return buf;
+    }
+};
+
+struct ConnectionSettings {
+    static constexpr std::string_view TYPE_NAME = "ConnectionSettings";
+    static constexpr std::array<uint8_t, 2> PACKET_ID = { 224, 39 };
+
+    bool silent = false;
+
+    size_t encoded_size() const
+    {
+        return postcard_size_bool();
+    }
+
+    postcard_error_t encode_raw(postcard_slice_t* slice) const
+    {
+        return postcard_encode_bool(slice, silent);
     }
 };
 

--- a/libs/db/examples/log-client.cpp
+++ b/libs/db/examples/log-client.cpp
@@ -82,6 +82,7 @@ public:
     void drain_replies(const char* label)
     {
         try {
+            auto pending = std::vector<uint8_t>();
             while (true) {
                 auto data = std::vector<uint8_t>(1024);
                 auto len = read(data.data(), data.size());
@@ -89,6 +90,7 @@ public:
                     std::println("{}: connection closed", label);
                     break;
                 }
+                log_elodin_db_replies(pending, std::span(data.data(), len), label);
             }
         } catch (const std::exception& e) {
             std::cerr << label << " error: " << e.what() << std::endl;

--- a/libs/db/examples/log-client.cpp
+++ b/libs/db/examples/log-client.cpp
@@ -9,9 +9,11 @@
 #include <chrono>
 #include <cstddef>
 #include <iostream>
+#include <memory>
 #include <print>
 #include <sstream>
 #include <system_error>
+#include <thread>
 #include <vector>
 
 #include "db.hpp"
@@ -68,6 +70,31 @@ public:
         write_all(data.data(), data.size());
     }
 
+    size_t read(uint8_t* data, size_t len)
+    {
+        auto res = ::read(fd_, data, len);
+        if (res < 0) {
+            throw std::system_error(errno, std::generic_category(), "Failed to read");
+        }
+        return res;
+    }
+
+    void drain_replies(const char* label)
+    {
+        try {
+            while (true) {
+                auto data = std::vector<uint8_t>(1024);
+                auto len = read(data.data(), data.size());
+                if (len == 0) {
+                    std::println("{}: connection closed", label);
+                    break;
+                }
+            }
+        } catch (const std::exception& e) {
+            std::cerr << label << " error: " << e.what() << std::endl;
+        }
+    }
+
 private:
     int fd_ = -1;
 };
@@ -83,11 +110,15 @@ try {
     if (argc >= 3) port = static_cast<uint16_t>(std::stoi(argv[2]));
 
     std::println("log-client: connecting to {}:{}", ip, port);
-    auto sock = Socket(ip, port);
+    auto sock = std::make_shared<Socket>(ip, port);
+    std::thread writer_replies([sock] {
+        sock->drain_replies("log-client replies");
+    });
+    writer_replies.detach();
 
     // Register the log metadata once at startup
     auto metadata_pkt = set_log_metadata_packet(LOG_NAME);
-    sock.send_raw(metadata_pkt);
+    sock->send_raw(metadata_pkt);
     std::println("log-client: registered log metadata for '{}'", LOG_NAME);
 
     // Simulated flight software log messages
@@ -140,7 +171,7 @@ try {
 
     std::println("log-client: sending boot sequence...");
     for (const auto& entry : boot_sequence) {
-        send_log(sock, LOG_NAME, entry.level, entry.message);
+        send_log(*sock, LOG_NAME, entry.level, entry.message);
         usleep(entry.delay_ms * 1000);
     }
 
@@ -150,7 +181,7 @@ try {
         for (const auto& entry : flight_messages) {
             std::ostringstream msg;
             msg << "[cycle " << cycle << "] " << entry.message;
-            send_log(sock, LOG_NAME, entry.level, msg.str());
+            send_log(*sock, LOG_NAME, entry.level, msg.str());
             usleep(entry.delay_ms * 1000);
         }
         cycle++;

--- a/libs/db/examples/rocket-client.cpp
+++ b/libs/db/examples/rocket-client.cpp
@@ -92,6 +92,7 @@ public:
     void drain_replies(const char* label)
     {
         try {
+            auto pending = std::vector<uint8_t>();
             while (true) {
                 auto data = std::vector<uint8_t>(1024);
                 auto len = read(data.data(), data.size());
@@ -99,6 +100,7 @@ public:
                     std::println("{}: connection closed", label);
                     break;
                 }
+                log_elodin_db_replies(pending, std::span(data.data(), len), label);
             }
         } catch (const std::exception& e) {
             std::cerr << label << " error: " << e.what() << std::endl;

--- a/libs/db/examples/rocket-client.cpp
+++ b/libs/db/examples/rocket-client.cpp
@@ -9,12 +9,13 @@
 #include <chrono>
 #include <cmath>
 #include <cstddef>
+#include <iomanip>
 #include <iostream>
+#include <memory>
 #include <print>
 #include <system_error>
 #include <thread>
 #include <vector>
-#include <iomanip>
 
 #include "db.hpp"
 
@@ -88,6 +89,22 @@ public:
         return res;
     }
 
+    void drain_replies(const char* label)
+    {
+        try {
+            while (true) {
+                auto data = std::vector<uint8_t>(1024);
+                auto len = read(data.data(), data.size());
+                if (len == 0) {
+                    std::println("{}: connection closed", label);
+                    break;
+                }
+            }
+        } catch (const std::exception& e) {
+            std::cerr << label << " error: " << e.what() << std::endl;
+        }
+    }
+
 private:
     int fd_ = -1;
 };
@@ -141,7 +158,11 @@ try {
     std::println("Global data size {}", sizeof(RocketData));
     // Connect the main socket for writing
     std::println("Main thread: connecting writer socket");
-    auto sock = Socket(ip, port);
+    auto sock = std::make_shared<Socket>(ip, port);
+    std::thread writer_replies([sock] {
+        sock->drain_replies("Writer replies");
+    });
+    writer_replies.detach();
     auto time = builder::raw_table(0, 8);
 
     auto table = builder::vtable({
@@ -164,7 +185,7 @@ try {
     //           timestamp_ns(time_ns, component("sensor.time_monotonic")))),
     //   });
 
-    sock.send(VTableMsg {
+    sock->send(VTableMsg {
         .id = { ID[0], ID[1] },
         .vtable = table,
     });
@@ -172,6 +193,7 @@ try {
     // Start the reader thread
     std::println("Main thread: starting reader thread");
     std::thread reader(reader_thread_func, ip, port);
+    reader.detach();
 
     auto rocket_data = RocketData {
     .commanded_deflect = 0.0,
@@ -192,13 +214,12 @@ try {
         // std::println("time orig  {}\ntime after {}", t, rocket_data.time);
         rocket_data.commanded_deflect = 0.1 * std::sin(static_cast<double>(t) / 1000000.0);
 
-        sock.write_all(&table_header, sizeof(table_header));
-        sock.write_all(&rocket_data, sizeof(rocket_data));
+        sock->write_all(&table_header, sizeof(table_header));
+        sock->write_all(&rocket_data, sizeof(rocket_data));
         usleep(1000);
     }
 
     // We should never reach here, but if we do:
-    reader.join();
     return 0;
 } catch (const std::exception& e) {
     std::cerr << "Main thread error: " << e.what() << std::endl;

--- a/libs/db/src/error.rs
+++ b/libs/db/src/error.rs
@@ -57,6 +57,8 @@ pub enum Error {
     FixTimestamps(String),
     #[error("operation cancelled")]
     Cancelled,
+    #[error("write timeout (client not reading)")]
+    WriteTimeout,
 }
 
 impl From<impeller2_stellar::Error> for Error {
@@ -80,6 +82,7 @@ impl From<stellarator::Error> for Error {
 impl Error {
     pub fn is_stream_closed(&self) -> bool {
         match self {
+            Error::WriteTimeout => true,
             Error::Stellar(stellarator::Error::EOF) => true,
             Error::Io(err)
                 if err.kind() == io::ErrorKind::BrokenPipe

--- a/libs/db/src/lib.rs
+++ b/libs/db/src/lib.rs
@@ -54,6 +54,8 @@ use zerocopy::IntoBytes;
 pub use error::Error;
 
 pub(crate) const COMPONENT_CREATION_INDEX_METADATA_KEY: &str = "_creation_index";
+pub const TX_WRITE_TIMEOUT: Duration = Duration::from_secs(2);
+const RESPONSE_PACKET_CAPACITY: usize = 8 * 1024 * 1024;
 
 pub mod append_log;
 mod arrow;
@@ -1510,7 +1512,7 @@ async fn handle_conn_inner<A: AsyncRead + AsyncWrite + Send + Sync + 'static>(
 ) -> Result<(), Error> {
     let _conn_span = tracing::info_span!("handle_conn").entered();
     let mut buf = vec![0u8; 8 * 1024 * 1024];
-    let mut resp_pkt = LenPacket::new(PacketTy::Msg, [0, 0], 8 * 1024 * 1024);
+    let mut resp_pkt = LenPacket::new(PacketTy::Msg, [0, 0], RESPONSE_PACKET_CAPACITY);
     loop {
         let pkt = rx.next(buf).await?;
         let req_id = pkt.req_id();
@@ -1542,6 +1544,7 @@ async fn handle_conn_inner<A: AsyncRead + AsyncWrite + Send + Sync + 'static>(
                 .await?;
                 return Ok(());
             }
+            Err(Error::WriteTimeout) => return Ok(()),
             Err(err) if err.is_stream_closed() => {}
             Err(err) => {
                 debug!(?err, "error handling packet");
@@ -1552,6 +1555,9 @@ async fn handle_conn_inner<A: AsyncRead + AsyncWrite + Send + Sync + 'static>(
                     .await
                 {
                     warn!(?err, "error sending err resp");
+                    if matches!(err, Error::WriteTimeout) {
+                        return Ok(());
+                    }
                 }
             }
         }
@@ -1587,6 +1593,31 @@ impl<A: AsyncWrite + 'static> Clone for PacketTx<A> {
     }
 }
 
+pub(crate) async fn send_with_timeout<A: AsyncWrite>(
+    tx: &Arc<Mutex<PacketSink<A>>>,
+    pkt: LenPacket,
+) -> Result<LenPacket, Error> {
+    enum SendOutcome {
+        Sent(stellarator::BufResult<(), LenPacket>),
+        TimedOut,
+    }
+
+    let send = async {
+        let tx = tx.lock().await;
+        SendOutcome::Sent(tx.send(pkt).await)
+    };
+    let timeout = async {
+        stellarator::sleep(TX_WRITE_TIMEOUT).await;
+        SendOutcome::TimedOut
+    };
+
+    match futures_lite::future::race(send, timeout).await {
+        SendOutcome::Sent((Ok(()), pkt)) => Ok(pkt),
+        SendOutcome::Sent((Err(err), _pkt)) => Err(Error::from(err)),
+        SendOutcome::TimedOut => Err(Error::WriteTimeout),
+    }
+}
+
 impl<A: AsyncWrite + 'static> PacketTx<A> {
     pub async fn send_msg<M: Msg>(&mut self, msg: &M) -> Result<(), Error> {
         let req_id = self.req_id;
@@ -1614,10 +1645,20 @@ impl<A: AsyncWrite + 'static> PacketTx<A> {
             return Err(err);
         }
         pkt.as_mut_packet().header.req_id = self.req_id;
-        let tx = self.tx.lock().await;
-        let res = rent!(tx.send(pkt).await, pkt);
-        self.pkt = Some(pkt);
-        res.map_err(Error::from)
+        match send_with_timeout(&self.tx, pkt).await {
+            Ok(pkt) => {
+                self.pkt = Some(pkt);
+                Ok(())
+            }
+            Err(err) => {
+                self.pkt = Some(LenPacket::new(
+                    PacketTy::Msg,
+                    [0, 0],
+                    RESPONSE_PACKET_CAPACITY,
+                ));
+                Err(err)
+            }
+        }
     }
 
     pub async fn send_time_series(
@@ -2301,10 +2342,9 @@ pub async fn handle_msg_stream<A: AsyncWrite>(
         let Some((_timestamp, msg)) = msg_log.latest() else {
             continue;
         };
-        let tx = tx.lock().await;
         pkt.clear();
         pkt.extend_from_slice(msg);
-        rent!(tx.send(pkt).await, pkt)?;
+        pkt = send_with_timeout(&tx, pkt).await?;
     }
 }
 
@@ -2322,11 +2362,10 @@ pub async fn handle_timestamped_msg_stream<A: AsyncWrite>(
         let Some((timestamp, msg)) = msg_log.latest() else {
             continue;
         };
-        let tx = tx.lock().await;
         pkt.clear();
         pkt.extend_from_slice(timestamp.as_bytes());
         pkt.extend_from_slice(msg);
-        rent!(tx.send(pkt).await, pkt)?;
+        pkt = send_with_timeout(&tx, pkt).await?;
     }
 }
 
@@ -2371,11 +2410,10 @@ pub async fn handle_fixed_rate_msg_stream<A: AsyncWrite + Send + Sync>(
         }
 
         {
-            let tx = tx.lock().await;
             pkt.clear();
             pkt.extend_from_slice(msg_timestamp.as_bytes());
             pkt.extend_from_slice(msg);
-            rent!(tx.send(pkt).await, pkt)?;
+            pkt = send_with_timeout(&tx, pkt).await?;
         }
         last_sent_timestamp = Some(msg_timestamp);
 
@@ -3113,5 +3151,38 @@ impl AtomicTimestampExt for AtomicCell<Timestamp> {
     fn update_min(&self, val: Timestamp) {
         self.value.fetch_min(val.0, atomic::Ordering::AcqRel);
         self.wait_queue.wake_all();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct PendingWrite;
+
+    impl AsyncWrite for PendingWrite {
+        fn write<B: stellarator::buf::IoBuf>(
+            &self,
+            buf: B,
+        ) -> impl std::future::Future<Output = stellarator::BufResult<usize, B>> {
+            async move {
+                stellarator::sleep(TX_WRITE_TIMEOUT + Duration::from_secs(30)).await;
+                (Ok(buf.init_len()), buf)
+            }
+        }
+    }
+
+    #[stellarator::test]
+    async fn send_with_timeout_fails_when_client_write_never_completes() {
+        let tx = Arc::new(Mutex::new(PacketSink::new(PendingWrite)));
+        let started = Instant::now();
+        let err = match send_with_timeout(&tx, LenPacket::msg([1, 0], 0)).await {
+            Ok(_) => panic!("send unexpectedly completed"),
+            Err(err) => err,
+        };
+
+        assert!(matches!(err, Error::WriteTimeout));
+        assert!(started.elapsed() >= TX_WRITE_TIMEOUT);
+        assert!(started.elapsed() < TX_WRITE_TIMEOUT + Duration::from_secs(10));
     }
 }

--- a/libs/db/src/lib.rs
+++ b/libs/db/src/lib.rs
@@ -1602,10 +1602,8 @@ pub(crate) async fn send_with_timeout<A: AsyncWrite>(
         TimedOut,
     }
 
-    let send = async {
-        let tx = tx.lock().await;
-        SendOutcome::Sent(tx.send(pkt).await)
-    };
+    let tx = tx.lock().await;
+    let send = async { SendOutcome::Sent(tx.send(pkt).await) };
     let timeout = async {
         stellarator::sleep(TX_WRITE_TIMEOUT).await;
         SendOutcome::TimedOut
@@ -3160,6 +3158,8 @@ mod tests {
 
     struct PendingWrite;
 
+    struct ReadyWrite;
+
     impl AsyncWrite for PendingWrite {
         fn write<B: stellarator::buf::IoBuf>(
             &self,
@@ -3169,6 +3169,15 @@ mod tests {
                 stellarator::sleep(TX_WRITE_TIMEOUT + Duration::from_secs(30)).await;
                 (Ok(buf.init_len()), buf)
             }
+        }
+    }
+
+    impl AsyncWrite for ReadyWrite {
+        fn write<B: stellarator::buf::IoBuf>(
+            &self,
+            buf: B,
+        ) -> impl std::future::Future<Output = stellarator::BufResult<usize, B>> {
+            async move { (Ok(buf.init_len()), buf) }
         }
     }
 
@@ -3184,5 +3193,37 @@ mod tests {
         assert!(matches!(err, Error::WriteTimeout));
         assert!(started.elapsed() >= TX_WRITE_TIMEOUT);
         assert!(started.elapsed() < TX_WRITE_TIMEOUT + Duration::from_secs(10));
+    }
+
+    #[stellarator::test]
+    async fn send_with_timeout_does_not_count_mutex_wait_time() {
+        enum Outcome {
+            Send(Result<LenPacket, Error>),
+            Released,
+        }
+
+        let tx = Arc::new(Mutex::new(PacketSink::new(ReadyWrite)));
+        let guard = tx.lock().await;
+        let mut send = Box::pin(send_with_timeout(&tx, LenPacket::msg([1, 0], 0)));
+
+        let outcome =
+            futures_lite::future::race(async { Outcome::Send(send.as_mut().await) }, async {
+                stellarator::sleep(TX_WRITE_TIMEOUT + Duration::from_millis(100)).await;
+                drop(guard);
+                Outcome::Released
+            })
+            .await;
+
+        match outcome {
+            Outcome::Send(Err(Error::WriteTimeout)) => {
+                panic!("timeout fired while waiting for tx mutex")
+            }
+            Outcome::Send(Err(err)) => panic!("send failed unexpectedly: {err:?}"),
+            Outcome::Send(Ok(_)) => panic!("send completed while tx mutex was held"),
+            Outcome::Released => {}
+        }
+
+        send.await
+            .expect("send should complete after mutex release");
     }
 }

--- a/libs/db/src/lib.rs
+++ b/libs/db/src/lib.rs
@@ -1512,6 +1512,7 @@ async fn handle_conn_inner<A: AsyncRead + AsyncWrite + Send + Sync + 'static>(
     let _conn_span = tracing::info_span!("handle_conn").entered();
     let mut buf = vec![0u8; 8 * 1024 * 1024];
     let mut resp_pkt = LenPacket::new(PacketTy::Msg, [0, 0], RESPONSE_PACKET_CAPACITY);
+    let mut silent = false;
     loop {
         let pkt = rx.next(buf).await?;
         let req_id = pkt.req_id();
@@ -1519,11 +1520,15 @@ async fn handle_conn_inner<A: AsyncRead + AsyncWrite + Send + Sync + 'static>(
             req_id,
             tx,
             pkt: Some(resp_pkt),
+            silent,
         };
-        let result = handle_packet(&pkt, &db, &mut pkt_tx).await;
+        let result = handle_packet(&pkt, &db, &mut pkt_tx, silent).await;
         buf = pkt.into_buf().into_inner();
         match result {
             Ok(PacketAction::Continue) => {}
+            Ok(PacketAction::SetSilent(new_silent)) => {
+                silent = new_silent;
+            }
             Ok(PacketAction::StartFollowStream {
                 target_packet_size,
                 req_id: follow_req_id,
@@ -1547,6 +1552,11 @@ async fn handle_conn_inner<A: AsyncRead + AsyncWrite + Send + Sync + 'static>(
             Err(err) if err.is_stream_closed() => {}
             Err(err) => {
                 debug!(?err, "error handling packet");
+                if silent {
+                    resp_pkt = pkt_tx.pkt.expect("len pkt taken and not given back");
+                    tx = pkt_tx.tx;
+                    continue;
+                }
                 if let Err(err) = pkt_tx
                     .send_msg(&ErrorResponse {
                         description: err.to_string(),
@@ -1569,6 +1579,7 @@ async fn handle_conn_inner<A: AsyncRead + AsyncWrite + Send + Sync + 'static>(
 /// should continue its normal read loop or switch to a special mode.
 enum PacketAction {
     Continue,
+    SetSilent(bool),
     /// Transition the connection into follow-stream mode.
     StartFollowStream {
         target_packet_size: u32,
@@ -1580,6 +1591,7 @@ pub struct PacketTx<A: AsyncWrite + 'static> {
     req_id: RequestId,
     tx: Arc<Mutex<PacketSink<OwnedWriter<A>>>>,
     pkt: Option<LenPacket>,
+    silent: bool,
 }
 
 impl<A: AsyncWrite + 'static> Clone for PacketTx<A> {
@@ -1588,6 +1600,7 @@ impl<A: AsyncWrite + 'static> Clone for PacketTx<A> {
             req_id: self.req_id,
             tx: self.tx.clone(),
             pkt: self.pkt.clone(),
+            silent: self.silent,
         }
     }
 }
@@ -1596,12 +1609,19 @@ pub(crate) async fn send_with_timeout<A: AsyncWrite>(
     tx: &Arc<Mutex<PacketSink<A>>>,
     pkt: LenPacket,
 ) -> Result<LenPacket, Error> {
+    let tx = tx.lock().await;
+    send_locked_with_timeout(&tx, pkt).await
+}
+
+async fn send_locked_with_timeout<A: AsyncWrite>(
+    tx: &PacketSink<A>,
+    pkt: LenPacket,
+) -> Result<LenPacket, Error> {
     enum SendOutcome {
         Sent(stellarator::BufResult<(), LenPacket>),
         TimedOut,
     }
 
-    let tx = tx.lock().await;
     let send = async { SendOutcome::Sent(tx.send(pkt).await) };
     let timeout = async {
         stellarator::sleep(TX_WRITE_TIMEOUT).await;
@@ -1635,6 +1655,9 @@ impl<A: AsyncWrite + 'static> PacketTx<A> {
         &mut self,
         builder: impl FnOnce(&mut LenPacket) -> Result<(), Error> + '_,
     ) -> Result<(), Error> {
+        if self.silent {
+            return Ok(());
+        }
         let mut pkt = self.pkt.take().expect("missing len pkt");
         pkt.clear();
         if let Err(err) = builder(&mut pkt) {
@@ -1682,13 +1705,53 @@ impl<A: AsyncWrite + 'static> PacketTx<A> {
     }
 }
 
+fn silent_connection_ignores_msg(id: PacketId) -> bool {
+    [
+        UdpUnicast::ID,
+        Stream::ID,
+        GetSchema::ID,
+        GetTimeSeries::ID,
+        GetComponentMetadata::ID,
+        DumpMetadata::ID,
+        DumpSchema::ID,
+        SubscribeLastUpdated::ID,
+        GetEarliestTimestamp::ID,
+        GetDbSettings::ID,
+        SQLQuery::ID,
+        SparklineQuery::ID,
+        PlotOverviewQuery::ID,
+        MsgStream::ID,
+        FixedRateMsgStream::ID,
+        GetMsgMetadata::ID,
+        GetMsgs::ID,
+        VTableStream::ID,
+        UdpVTableStream::ID,
+        FollowStream::ID,
+        TimestampedMsgStream::ID,
+    ]
+    .contains(&id)
+}
+
 async fn handle_packet<A: AsyncWrite + Send + Sync + 'static>(
     pkt: &Packet<Slice<Vec<u8>>>,
     db: &Arc<DB>,
     tx: &mut PacketTx<A>,
+    silent: bool,
 ) -> Result<PacketAction, Error> {
     let _pkt_span = tracing::info_span!("handle_packet").entered();
     trace!(?pkt, "handling pkt");
+
+    if let Packet::Msg(m) = pkt {
+        if m.id == ConnectionSettings::ID {
+            let settings = m.parse::<ConnectionSettings>()?;
+            trace!(silent = settings.silent, "connection settings updated");
+            return Ok(PacketAction::SetSilent(settings.silent));
+        }
+        if silent && silent_connection_ignores_msg(m.id) {
+            trace!(id = ?m.id, "ignoring reply-producing message on silent connection");
+            return Ok(PacketAction::Continue);
+        }
+    }
 
     match &pkt {
         Packet::Msg(m) if m.id == VTableMsg::ID => {
@@ -2886,8 +2949,9 @@ async fn handle_fixed_stream<A: AsyncWrite>(
         .with_request_id(req_id);
         let t1 = Instant::now();
         {
-            send_with_timeout(&stream, ts_pkt.into_len_packet()).await?;
-            table = send_with_timeout(&stream, table.with_request_id(req_id)).await?;
+            let stream = stream.lock().await;
+            send_locked_with_timeout(&stream, ts_pkt.into_len_packet()).await?;
+            table = send_locked_with_timeout(&stream, table.with_request_id(req_id)).await?;
             let send_elapsed = t1.elapsed();
 
             accum_populate_us += populate_elapsed.as_micros() as u64;

--- a/libs/db/src/lib.rs
+++ b/libs/db/src/lib.rs
@@ -41,7 +41,6 @@ use stellarator::{
     buf::Slice,
     io::{AsyncRead, AsyncWrite, OwnedReader, OwnedWriter, SplitExt},
     net::{TcpListener, TcpStream, UdpSocket},
-    rent,
     struc_con::Joinable,
     sync::{Mutex, WaitQueue},
     util::AtomicCell,
@@ -2672,14 +2671,8 @@ async fn handle_real_time_stream<A: AsyncWrite + 'static>(
 
             // Send ComponentMetadata so the editor knows about this component
             if let Some(metadata) = metadata {
-                let stream = sink.lock().await;
-                if let Err(err) = stream
-                    .send(metadata.into_len_packet().with_request_id(req_id))
-                    .await
-                    .0
-                {
-                    debug!(%err, "error sending component metadata");
-                }
+                send_with_timeout(&sink, metadata.into_len_packet().with_request_id(req_id))
+                    .await?;
             }
 
             // Send schema for this component
@@ -2688,16 +2681,7 @@ async fn handle_real_time_stream<A: AsyncWrite + 'static>(
                 schemas: [(component.component_id, schema)].into_iter().collect(),
                 start_timestamps: [(component.component_id, start_ts)].into_iter().collect(),
             };
-            {
-                let stream = sink.lock().await;
-                if let Err(err) = stream
-                    .send(schema_msg.into_len_packet().with_request_id(req_id))
-                    .await
-                    .0
-                {
-                    debug!(%err, "error sending component schema");
-                }
-            }
+            send_with_timeout(&sink, schema_msg.into_len_packet().with_request_id(req_id)).await?;
 
             // Spawn the data handler for this component
             let sink_clone = sink.clone();
@@ -2728,17 +2712,12 @@ async fn handle_real_time_component<A: AsyncWrite>(
     let waiter = component.time_series.waiter();
     let vtable_id: PacketId = fastrand::u16(..).to_le_bytes();
     {
-        let stream = stream.lock().await;
-        stream
-            .send(
-                VTableMsg {
-                    id: vtable_id,
-                    vtable,
-                }
-                .with_request_id(req_id),
-            )
-            .await
-            .0?;
+        let pkt = VTableMsg {
+            id: vtable_id,
+            vtable,
+        }
+        .into_len_packet();
+        send_with_timeout(&stream, pkt.with_request_id(req_id)).await?;
     }
 
     let mut table = LenPacket::table(vtable_id, 2048 - 16);
@@ -2750,15 +2729,7 @@ async fn handle_real_time_component<A: AsyncWrite>(
         table.push_aligned(timestamp);
         table.pad_for_type(prim_type);
         table.extend_from_slice(buf);
-        {
-            let stream = stream.lock().await;
-            if let Err(err) = rent!(stream.send(table.with_request_id(req_id)).await, table) {
-                debug!(%err, "error sending table");
-                if Error::from(err).is_stream_closed() {
-                    return Ok(());
-                }
-            }
-        }
+        table = send_with_timeout(&stream, table.with_request_id(req_id)).await?;
         table.clear();
     }
 }
@@ -2804,14 +2775,8 @@ async fn handle_real_time_stream_batched<A: AsyncWrite + 'static>(
             // Send metadata and schema for each new component.
             for (component, metadata, schema) in new_components {
                 if let Some(metadata) = metadata {
-                    let stream = sink.lock().await;
-                    if let Err(err) = stream
-                        .send(metadata.into_len_packet().with_request_id(req_id))
-                        .await
-                        .0
-                    {
-                        debug!(%err, "error sending component metadata");
-                    }
+                    send_with_timeout(&sink, metadata.into_len_packet().with_request_id(req_id))
+                        .await?;
                 }
 
                 let start_ts = *component.index_extra();
@@ -2819,16 +2784,8 @@ async fn handle_real_time_stream_batched<A: AsyncWrite + 'static>(
                     schemas: [(component.component_id, schema)].into_iter().collect(),
                     start_timestamps: [(component.component_id, start_ts)].into_iter().collect(),
                 };
-                {
-                    let stream = sink.lock().await;
-                    if let Err(err) = stream
-                        .send(schema_msg.into_len_packet().with_request_id(req_id))
-                        .await
-                        .0
-                    {
-                        debug!(%err, "error sending component schema");
-                    }
-                }
+                send_with_timeout(&sink, schema_msg.into_len_packet().with_request_id(req_id))
+                    .await?;
 
                 components.insert(component.component_id, component);
             }
@@ -2838,17 +2795,12 @@ async fn handle_real_time_stream_batched<A: AsyncWrite + 'static>(
             let id: PacketId = fastrand::u16(..).to_le_bytes();
             table = LenPacket::table(id, 2048 - 16);
             {
-                let stream = sink.lock().await;
-                stream
-                    .send(
-                        VTableMsg {
-                            id,
-                            vtable: vtable_msg,
-                        }
-                        .with_request_id(req_id),
-                    )
-                    .await
-                    .0?;
+                let pkt = VTableMsg {
+                    id,
+                    vtable: vtable_msg,
+                }
+                .into_len_packet();
+                send_with_timeout(&sink, pkt.with_request_id(req_id)).await?;
             }
             current_gen = vtable_gen;
         }
@@ -2859,8 +2811,7 @@ async fn handle_real_time_stream_batched<A: AsyncWrite + 'static>(
 
         // Single lock + send for all components.
         {
-            let stream = sink.lock().await;
-            rent!(stream.send(table.with_request_id(req_id)).await, table)?;
+            table = send_with_timeout(&sink, table.with_request_id(req_id)).await?;
         }
 
         // Wait for the simulation to write new data (1 wake per sim tick).
@@ -2880,12 +2831,11 @@ async fn handle_fixed_stream<A: AsyncWrite>(
     let mut current_timestamp;
 
     // Lightweight profiling: accumulate timings and log every LOG_INTERVAL frames.
-    // Captures both the work time (populate + lock + send) and the wall-clock
+    // Captures both the work time (populate + send) and the wall-clock
     // frame-to-frame time (work + wait) so we can see scheduling overhead.
     const LOG_INTERVAL: u64 = 120;
     let mut frame_count: u64 = 0;
     let mut accum_populate_us: u64 = 0;
-    let mut accum_lock_us: u64 = 0;
     let mut accum_send_us: u64 = 0;
     let mut accum_work_us: u64 = 0;
     let mut accum_wall_us: u64 = 0;
@@ -2908,12 +2858,11 @@ async fn handle_fixed_stream<A: AsyncWrite>(
         let vtable_gen = db.vtable_gen.latest();
         if vtable_gen != current_gen {
             components = db.with_state(|state| state.components.clone());
-            let stream = stream.lock().await;
             let id: PacketId = state.stream_id.to_le_bytes()[..2].try_into().unwrap();
             table = LenPacket::table(id, 2048 - 16);
             let vtable = DBVisitor.vtable(&components)?;
             let msg = VTableMsg { id, vtable };
-            stream.send(msg.with_request_id(req_id)).await.0?;
+            send_with_timeout(&stream, msg.into_len_packet().with_request_id(req_id)).await?;
             current_gen = vtable_gen;
         }
         table.clear();
@@ -2928,8 +2877,8 @@ async fn handle_fixed_stream<A: AsyncWrite>(
         // Yield once more after populating to give the tick driver a chance
         // to run before we acquire the stream lock.
         stellarator::yield_now().await;
-        // Pre-serialize the timestamp message before acquiring the lock so the
-        // critical section is limited to the two TCP writes.
+        // Pre-serialize the timestamp message before sending so the
+        // writer critical section is limited to the two TCP writes.
         let ts_pkt = StreamTimestamp {
             timestamp: current_timestamp,
             stream_id: state.stream_id,
@@ -2937,15 +2886,11 @@ async fn handle_fixed_stream<A: AsyncWrite>(
         .with_request_id(req_id);
         let t1 = Instant::now();
         {
-            let stream = stream.lock().await;
-            let lock_elapsed = t1.elapsed();
-            let t2 = Instant::now();
-            stream.send(ts_pkt).await.0?;
-            rent!(stream.send(table.with_request_id(req_id)).await, table)?;
-            let send_elapsed = t2.elapsed();
+            send_with_timeout(&stream, ts_pkt.into_len_packet()).await?;
+            table = send_with_timeout(&stream, table.with_request_id(req_id)).await?;
+            let send_elapsed = t1.elapsed();
 
             accum_populate_us += populate_elapsed.as_micros() as u64;
-            accum_lock_us += lock_elapsed.as_micros() as u64;
             accum_send_us += send_elapsed.as_micros() as u64;
         }
         let work_elapsed = frame_start.elapsed();
@@ -2958,7 +2903,6 @@ async fn handle_fixed_stream<A: AsyncWrite>(
             let wall_fps = n / (accum_wall_us as f64 / 1_000_000.0);
             debug!(
                 populate_avg_ms = accum_populate_us as f64 / n / 1000.0,
-                lock_avg_ms = accum_lock_us as f64 / n / 1000.0,
                 send_avg_ms = accum_send_us as f64 / n / 1000.0,
                 work_avg_ms = accum_work_us as f64 / n / 1000.0,
                 wall_avg_ms = accum_wall_us as f64 / n / 1000.0,
@@ -2967,7 +2911,6 @@ async fn handle_fixed_stream<A: AsyncWrite>(
                 "fixed_stream consumer stats"
             );
             accum_populate_us = 0;
-            accum_lock_us = 0;
             accum_send_us = 0;
             accum_work_us = 0;
             accum_wall_us = 0;

--- a/libs/db/src/vtable_stream.rs
+++ b/libs/db/src/vtable_stream.rs
@@ -18,12 +18,11 @@ use impeller2_stellar::PacketSink;
 use impeller2_wkt::{ComponentValue, FixedRateBehavior, FixedRateOp, MeanOp, VTableMsg};
 use stellarator::{
     io::AsyncWrite,
-    rent,
     sync::{Mutex, WaitCell, WaitQueue},
 };
 use tracing::{trace, warn};
 
-use crate::{Component, DB, Error, FixedRateStreamState};
+use crate::{Component, DB, Error, FixedRateStreamState, send_with_timeout};
 
 pub async fn handle_vtable_stream<A: AsyncWrite + 'static>(
     id: [u8; 2],
@@ -159,19 +158,17 @@ pub async fn handle_vtable_stream<A: AsyncWrite + 'static>(
     }
     // Send vtable before streaming
     {
-        let mut pkt = VTableMsg {
+        let pkt = VTableMsg {
             vtable: vtable.clone(),
             id,
         }
         .into_len_packet();
-        let tx = tx.lock().await;
-        rent!(tx.send(pkt.with_request_id(req_id)).await, pkt)?;
+        send_with_timeout(&tx, pkt.with_request_id(req_id)).await?;
     }
     loop {
         table.wait_ready().await;
         let mut pkt = table.take().await;
-        let tx = tx.lock().await;
-        rent!(tx.send(pkt.with_request_id(req_id)).await, pkt)?;
+        pkt = send_with_timeout(&tx, pkt.with_request_id(req_id)).await?;
         table.replace_pkt(pkt).await;
         table.notify_writers();
     }

--- a/libs/db/src/vtable_stream.rs
+++ b/libs/db/src/vtable_stream.rs
@@ -43,6 +43,7 @@ pub async fn handle_vtable_stream<A: AsyncWrite + 'static>(
         .max();
     let table_len = table_len.unwrap_or(0);
     let table = FieldTable::new(vtable.fields.len(), table_len, id);
+    let mut field_plans = Vec::with_capacity(vtable.fields.len());
     for (i, field) in vtable.fields.iter().enumerate() {
         let mut realized_op = vtable.realize(field.arg, None)?;
         let mut plan = vec![];
@@ -154,7 +155,7 @@ pub async fn handle_vtable_stream<A: AsyncWrite + 'static>(
             return Err(Error::Impeller(impeller2::error::Error::InvalidOp));
         }
         let prim_type = component.schema.prim_type;
-        stellarator::spawn(handle_plan(plan, shard, timestamp, prim_type));
+        field_plans.push((plan, shard, timestamp, prim_type));
     }
     // Send vtable before streaming
     {
@@ -164,6 +165,11 @@ pub async fn handle_vtable_stream<A: AsyncWrite + 'static>(
         }
         .into_len_packet();
         send_with_timeout(&tx, pkt.with_request_id(req_id)).await?;
+    }
+    let mut plan_guards = Vec::with_capacity(field_plans.len());
+    for (plan, shard, timestamp, prim_type) in field_plans {
+        plan_guards
+            .push(stellarator::spawn(handle_plan(plan, shard, timestamp, prim_type)).drop_guard());
     }
     loop {
         table.wait_ready().await;

--- a/libs/db/tests/src/lib.rs
+++ b/libs/db/tests/src/lib.rs
@@ -46,9 +46,46 @@ mod tests {
         Ok((addr, db))
     }
 
+    async fn receives_packet(client: &mut Client, timeout: Duration) -> bool {
+        futures_lite::future::race(
+            async { client.rx.next_grow(vec![0_u8; 256]).await.is_ok() },
+            async {
+                sleep(timeout).await;
+                false
+            },
+        )
+        .await
+    }
+
     #[test]
     async fn test_connect() {
         let (_client, _db) = setup_test_db().await.unwrap();
+    }
+
+    #[test]
+    async fn test_silent_connection_does_not_emit_replies_or_errors() {
+        let (addr, _db) = setup_test_db().await.unwrap();
+        let mut client = Client::connect(addr).await.unwrap();
+
+        client
+            .send(&ConnectionSettings { silent: true })
+            .await
+            .0
+            .unwrap();
+        client.send(&GetDbSettings).await.0.unwrap();
+        client.send(LenPacket::table([99, 0], 0)).await.0.unwrap();
+
+        assert!(!receives_packet(&mut client, Duration::from_millis(100)).await);
+    }
+
+    #[test]
+    async fn test_non_silent_connection_still_emits_error_responses() {
+        let (addr, _db) = setup_test_db().await.unwrap();
+        let mut client = Client::connect(addr).await.unwrap();
+
+        client.send(LenPacket::table([99, 0], 0)).await.0.unwrap();
+
+        assert!(receives_packet(&mut client, Duration::from_secs(1)).await);
     }
 
     #[test]

--- a/libs/impeller2/stellar/src/lib.rs
+++ b/libs/impeller2/stellar/src/lib.rs
@@ -90,6 +90,14 @@ impl Client {
         })
     }
 
+    /// Send a packet without waiting for a reply.
+    ///
+    /// If a connection is used only for sends, still drain replies with
+    /// [`Self::recv`], [`Self::request`], [`Self::stream`], or a background
+    /// [`PacketStream`].
+    /// The server may send `ErrorResponse` packets for rejected writes; leaving
+    /// those unread can fill TCP buffers and cause the server to close the
+    /// connection.
     pub async fn send(&mut self, packet: impl IntoLenPacket) -> BufResult<(), LenPacket> {
         let len_pkt = packet.into_len_packet();
         self.tx.send(len_pkt).await

--- a/libs/impeller2/wkt/src/msgs.rs
+++ b/libs/impeller2/wkt/src/msgs.rs
@@ -367,6 +367,16 @@ impl Msg for NewConnection {
     const ID: PacketId = [225, 1];
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct ConnectionSettings {
+    /// When true, the server sends no replies on this connection.
+    pub silent: bool,
+}
+
+impl Msg for ConnectionSettings {
+    const ID: PacketId = [224, 39];
+}
+
 macro_rules! impl_user_data_msg {
     ($t: ty) => {
         #[cfg(feature = "mlua")]
@@ -394,6 +404,7 @@ impl_user_data_msg!(Stream);
 impl_user_data_msg!(MsgStream);
 impl_user_data_msg!(SetStreamState);
 impl_user_data_msg!(SetComponentMetadata);
+impl_user_data_msg!(ConnectionSettings);
 impl_user_data_msg!(UdpUnicast);
 impl_user_data_msg!(UdpVTableStream);
 


### PR DESCRIPTION
The CPP examples exposed an issue where a connecting client to the elodin-db could just send and not consume the responses, which eventually overflow the 2MB response buffer, blocking the thread. These changes update the examples, as well as create a timeout for the response to be consumed or face disconnect, for the client to then handle reconnecting.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core DB connection handling and TCP backpressure behavior; misconfigured silent clients won't see errors, and aggressive timeouts may disconnect slow readers.
> 
> **Overview**
> Elodin-DB now treats **write-only clients** that never read TCP replies as a first-class problem: outbound sends use a **2s write timeout** (`WriteTimeout`), treated like a closed stream, and connections can opt into **`ConnectionSettings { silent: true }`** so the server skips replies/errors and ignores query/stream messages.
> 
> **C++ examples** spawn background **reply drain** threads (logging `ErrorResponse`), add **`client-write-only.cpp`** for silent ingest, and extend helpers with **`ConnectionSettings`**, fixed **`PACKET_ID`** encoding, and **`log_elodin_db_replies`**. **Rust** `tegrastats-bridge` splits the socket and races metric sends against reply draining; **impeller2** documents that send-only use still needs draining. Tests cover silent vs non-silent behavior; Betaflight SITL drops a post-warmup **`ctx.truncate()`** call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 683e669270cf2cbe3645ecf5e6b4cdcf29590aeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->