### PR TITLE
Fix: Create Graph on saved DB & graph labels.

### DIFF
--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -1560,6 +1560,45 @@ mod time_range_tests {
         let result = behavior.calculate_selected_range(earliest, latest);
         assert!(matches!(result, Err(TimeRangeError::NoData)));
     }
+
+    #[test]
+    fn last_30s_window_at_mid_replay_position() {
+        let behavior = TimeRangeBehavior::last(Duration::from_secs(30));
+        let earliest = timestamp_secs(0);
+        let effective_latest = timestamp_secs(40);
+
+        let range = behavior
+            .calculate_selected_range(earliest, effective_latest)
+            .expect("valid replay window");
+        assert_eq!(range.start, timestamp_secs(10));
+        assert_eq!(range.end, timestamp_secs(40));
+    }
+
+    #[test]
+    fn last_30s_window_at_early_replay_clamps_to_earliest() {
+        let behavior = TimeRangeBehavior::last(Duration::from_secs(30));
+        let earliest = timestamp_secs(0);
+        let effective_latest = timestamp_secs(15);
+
+        let range = behavior
+            .calculate_selected_range(earliest, effective_latest)
+            .expect("valid replay window");
+        assert_eq!(range.start, timestamp_secs(0));
+        assert_eq!(range.end, timestamp_secs(15));
+    }
+
+    #[test]
+    fn full_range_at_replay_position_uses_effective_latest() {
+        let behavior = TimeRangeBehavior::FULL;
+        let earliest = timestamp_secs(0);
+        let effective_latest = timestamp_secs(20);
+
+        let range = behavior
+            .calculate_selected_range(earliest, effective_latest)
+            .expect("valid replay window");
+        assert_eq!(range.start, earliest);
+        assert_eq!(range.end, effective_latest);
+    }
 }
 
 fn clamp_range(total_range: Range<Timestamp>, b: Range<Timestamp>) -> Range<Timestamp> {

--- a/libs/elodin-editor/src/ui/command_palette/palette_items.rs
+++ b/libs/elodin-editor/src/ui/command_palette/palette_items.rs
@@ -465,19 +465,19 @@ fn graph_parts(
                                 component.name
                             ));
                         };
-                        let Some(metadata) = metadata_reg.get_metadata(&component_id) else {
+                        if metadata_reg.get_metadata(&component_id).is_none() {
                             return PaletteEvent::Error(format!(
                                 "No metadata registered for component {}",
                                 component.name
                             ));
-                        };
+                        }
 
                         let component_path = path_reg
                             .get(&component_id)
                             .cloned()
                             .unwrap_or_else(|| ComponentPath::from_name(&component.name));
 
-                        let values = graph_lines_from_component(&component_path, schema, metadata);
+                        let values = graph_lines_from_component(&component_path, schema);
                         let graph_label = component.name.clone();
                         let components =
                             BTreeMap::from_iter(std::iter::once((component_path, values)));

--- a/libs/elodin-editor/src/ui/command_palette/palette_items.rs
+++ b/libs/elodin-editor/src/ui/command_palette/palette_items.rs
@@ -30,7 +30,7 @@ use bevy_infinite_grid::InfiniteGrid;
 use egui_tiles::{Tile, TileId};
 use fuzzy_matcher::{FuzzyMatcher, skim::SkimMatcherV2};
 use impeller2::types::Timestamp;
-use impeller2_bevy::{ComponentPathRegistry, EntityMap, PacketTx};
+use impeller2_bevy::{ComponentMetadataRegistry, ComponentPathRegistry, EntityMap, PacketTx};
 use impeller2_kdl::{ToKdl, env::schematic_dir_or_cwd};
 use impeller2_wkt::SkyboxConfig;
 use impeller2_wkt::{
@@ -45,7 +45,7 @@ use crate::{
     ui::{
         FocusedWindow, HdrEnabled, Paused, colors,
         command_palette::CommandPaletteState,
-        plot::{GraphBundle, default_component_values},
+        plot::{GraphBundle, graph_lines_from_component},
         schematic::{
             CurrentSchematic, CurrentWindowSchematics, LoadSchematicParams, OpenDocumentRequest,
             SaveCurrentDocumentRequest, WindowDocumentSave,
@@ -447,11 +447,11 @@ fn graph_parts(
                 name.clone(),
                 "Component",
                 move |_: In<String>,
-                      query: Query<&ComponentValue>,
-                      entity_map: Res<EntityMap>,
                       mut render_layer_alloc: ResMut<RenderLayerAllocator>,
                       mut tile_param: TileParam,
                       path_reg: Res<ComponentPathRegistry>,
+                      schema_reg: Res<impeller2_bevy::ComponentSchemaRegistry>,
+                      metadata_reg: Res<ComponentMetadataRegistry>,
                       palette_state: Res<CommandPaletteState>| {
                     let Some(mut tile_state) = tile_param.target(palette_state.target_window)
                     else {
@@ -459,27 +459,35 @@ fn graph_parts(
                     };
                     if let Some(component) = &part.component {
                         let component_id = component.id;
-                        let Some(entity) = entity_map.get(&component_id) else {
-                            return PaletteEvent::Exit;
+                        let Some(schema) = schema_reg.0.get(&component_id) else {
+                            return PaletteEvent::Error(format!(
+                                "No schema registered for component {}",
+                                component.name
+                            ));
                         };
-                        let Ok(value) = query.get(*entity) else {
-                            return PaletteEvent::Exit;
+                        let Some(metadata) = metadata_reg.get_metadata(&component_id) else {
+                            return PaletteEvent::Error(format!(
+                                "No metadata registered for component {}",
+                                component.name
+                            ));
                         };
-
-                        let values = default_component_values(&component_id, value);
 
                         let component_path = path_reg
                             .get(&component_id)
                             .cloned()
                             .unwrap_or_else(|| ComponentPath::from_name(&component.name));
 
+                        let values = graph_lines_from_component(&component_path, schema, metadata);
+                        let graph_label = component.name.clone();
                         let components =
-                            BTreeMap::from_iter(std::iter::once((component_path, values.clone())));
-                        let bundle = GraphBundle::new(
-                            &mut render_layer_alloc,
-                            components,
-                            "Graph".to_string(),
-                        );
+                            BTreeMap::from_iter(std::iter::once((component_path, values)));
+                        let Some(bundle) =
+                            GraphBundle::try_new(&mut render_layer_alloc, components, graph_label)
+                        else {
+                            return PaletteEvent::Error(
+                                "Unable to create graph: render layer budget exhausted".to_string(),
+                            );
+                        };
                         tile_state.create_graph_tile(tile_id, bundle);
                         PaletteEvent::Exit
                     } else {

--- a/libs/elodin-editor/src/ui/inspector/entity.rs
+++ b/libs/elodin-editor/src/ui/inspector/entity.rs
@@ -9,8 +9,8 @@ use bevy_egui::egui::{self, Align, Color32, Layout, RichText, emath};
 use fuzzy_matcher::{FuzzyMatcher, skim::SkimMatcherV2};
 use impeller2::types::ComponentId;
 use impeller2_bevy::{
-    ComponentMetadataRegistry, ComponentPath, ComponentPathRegistry, ComponentValue,
-    ComponentValueExt, ElementValueMut,
+    ComponentMetadataRegistry, ComponentPath, ComponentPathRegistry, ComponentSchemaRegistry,
+    ComponentValue, ComponentValueExt, ElementValueMut,
 };
 use impeller2_wkt::{ComponentMetadata, MetadataExt};
 use smallvec::SmallVec;
@@ -22,7 +22,7 @@ use crate::{
         colors::get_scheme,
         inspector::search,
         label,
-        plot::{GraphBundle, default_component_values},
+        plot::{GraphBundle, graph_lines_from_component},
         tiles::TreeAction,
         utils::{MarginSides, format_num},
         widgets::WidgetSystem,
@@ -38,6 +38,7 @@ pub struct InspectorEntity<'w, 's> {
     values: Query<'w, 's, &'static mut ComponentValue>,
     metadata_query: Query<'w, 's, &'static mut ComponentMetadata>,
     metadata_store: Res<'w, ComponentMetadataRegistry>,
+    schema_reg: Res<'w, ComponentSchemaRegistry>,
     path_reg: Res<'w, ComponentPathRegistry>,
     render_layer_alloc: ResMut<'w, RenderLayerAllocator>,
     filter: ResMut<'w, ComponentFilter>,
@@ -61,6 +62,7 @@ impl WidgetSystem for InspectorEntity<'_, '_> {
             metadata_query,
             mut values,
             metadata_store,
+            schema_reg,
             path_reg,
             mut render_layer_alloc,
             mut filter,
@@ -144,15 +146,22 @@ impl WidgetSystem for InspectorEntity<'_, '_> {
             );
 
             if create_graph {
-                let values = default_component_values(component_id, &component_value);
+                let Some(schema) = schema_reg.0.get(component_id) else {
+                    continue;
+                };
                 let component_path = path_reg
                     .get(component_id)
                     .cloned()
                     .unwrap_or_else(|| ComponentPath::from_name(&metadata.name));
-                let components =
-                    BTreeMap::from_iter(std::iter::once((component_path, values.clone())));
-                let bundle =
-                    GraphBundle::new(&mut render_layer_alloc, components, metadata.name.clone());
+                let values = graph_lines_from_component(&component_path, schema, metadata);
+                let components = BTreeMap::from_iter(std::iter::once((component_path, values)));
+                let Some(bundle) = GraphBundle::try_new(
+                    &mut render_layer_alloc,
+                    components,
+                    metadata.name.clone(),
+                ) else {
+                    continue;
+                };
                 tree_actions.push(TreeAction::AddGraph(None, Box::new(Some(bundle))));
             }
         }

--- a/libs/elodin-editor/src/ui/inspector/entity.rs
+++ b/libs/elodin-editor/src/ui/inspector/entity.rs
@@ -147,19 +147,27 @@ impl WidgetSystem for InspectorEntity<'_, '_> {
 
             if create_graph {
                 let Some(schema) = schema_reg.0.get(component_id) else {
+                    bevy::log::warn!(
+                        component = %metadata.name,
+                        "Create Graph: no schema registered for component"
+                    );
                     continue;
                 };
                 let component_path = path_reg
                     .get(component_id)
                     .cloned()
                     .unwrap_or_else(|| ComponentPath::from_name(&metadata.name));
-                let values = graph_lines_from_component(&component_path, schema, metadata);
+                let values = graph_lines_from_component(&component_path, schema);
                 let components = BTreeMap::from_iter(std::iter::once((component_path, values)));
                 let Some(bundle) = GraphBundle::try_new(
                     &mut render_layer_alloc,
                     components,
                     metadata.name.clone(),
                 ) else {
+                    bevy::log::warn!(
+                        component = %metadata.name,
+                        "Create Graph: render layer budget exhausted"
+                    );
                     continue;
                 };
                 tree_actions.push(TreeAction::AddGraph(None, Box::new(Some(bundle))));

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -440,7 +440,12 @@ fn process_time_series<T>(
     };
     for i in 0..len {
         let line = plot_data.lines.entry(i).or_insert_with(|| {
-            let label = format!("[{i}]");
+            let label = plot_data
+                .element_names
+                .get(i)
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| format!("[{i}]"));
             lines.add(Line {
                 label,
                 ..Default::default()

--- a/libs/elodin-editor/src/ui/plot/state.rs
+++ b/libs/elodin-editor/src/ui/plot/state.rs
@@ -147,12 +147,12 @@ pub fn element_names_for_graph(
     if !from_metadata.is_empty() {
         return from_metadata;
     }
-    let names = eql::Component::new(metadata.name.clone(), metadata.component_id, schema.clone())
-        .element_names;
     let len = schema.shape().iter().copied().product::<usize>().max(1);
-    if len == 1 && names.iter().all(|n| n.is_empty()) {
+    if len == 1 {
         return vec![metadata.name.clone()];
     }
+    let names = eql::Component::new(metadata.name.clone(), metadata.component_id, schema.clone())
+        .element_names;
     names
 }
 
@@ -231,7 +231,17 @@ mod tests {
     }
 
     #[test]
-    fn element_names_scalar_uses_component_name() {
+    fn element_names_scalar_shape_one_uses_component_name() {
+        let schema = test_schema(&[1]);
+        let metadata = test_metadata("STATEMACHINEOUTPUT.MISSILE_MODE", "");
+        assert_eq!(
+            element_names_for_graph(&schema, &metadata),
+            vec!["STATEMACHINEOUTPUT.MISSILE_MODE"]
+        );
+    }
+
+    #[test]
+    fn element_names_scalar_empty_shape_uses_component_name() {
         let schema = test_schema(&[]);
         let metadata = test_metadata("STATEMACHINEOUTPUT.MISSILE_MODE", "");
         assert_eq!(

--- a/libs/elodin-editor/src/ui/plot/state.rs
+++ b/libs/elodin-editor/src/ui/plot/state.rs
@@ -157,7 +157,6 @@ pub fn element_names_for_graph(
 pub fn graph_lines_from_component(
     component_path: &ComponentPath,
     schema: &Schema<Vec<u64>>,
-    _metadata: &ComponentMetadata,
 ) -> GraphStateComponent {
     let len = schema.shape().iter().copied().product::<usize>().max(1);
     let color_base = component_path.id.0 as usize;
@@ -192,8 +191,7 @@ mod tests {
     fn graph_lines_scalar_enables_one_line() {
         let path = ComponentPath::from_name("rocket.mach");
         let schema = test_schema(&[1]);
-        let metadata = test_metadata("rocket.mach", "");
-        let lines = graph_lines_from_component(&path, &schema, &metadata);
+        let lines = graph_lines_from_component(&path, &schema);
         assert_eq!(lines.len(), 1);
         assert!(lines[0].0);
     }
@@ -202,8 +200,7 @@ mod tests {
     fn graph_lines_vector_enables_all_elements() {
         let path = ComponentPath::from_name("CONTROLMESSAGE.FIN_DEFLECTION_DEG");
         let schema = test_schema(&[4]);
-        let metadata = test_metadata("CONTROLMESSAGE.FIN_DEFLECTION_DEG", "");
-        let lines = graph_lines_from_component(&path, &schema, &metadata);
+        let lines = graph_lines_from_component(&path, &schema);
         assert_eq!(lines.len(), 4);
         assert!(lines.iter().all(|(enabled, _)| *enabled));
     }

--- a/libs/elodin-editor/src/ui/plot/state.rs
+++ b/libs/elodin-editor/src/ui/plot/state.rs
@@ -151,9 +151,7 @@ pub fn element_names_for_graph(
     if len == 1 {
         return vec![metadata.name.clone()];
     }
-    let names = eql::Component::new(metadata.name.clone(), metadata.component_id, schema.clone())
-        .element_names;
-    names
+    eql::Component::new(metadata.name.clone(), metadata.component_id, schema.clone()).element_names
 }
 
 pub fn graph_lines_from_component(

--- a/libs/elodin-editor/src/ui/plot/state.rs
+++ b/libs/elodin-editor/src/ui/plot/state.rs
@@ -7,9 +7,10 @@ use bevy::core_pipeline::tonemapping::Tonemapping;
 use bevy::prelude::*;
 use bevy_egui::egui::{self, Color32};
 
+use impeller2::schema::Schema;
 use impeller2::types::{ComponentId, Timestamp};
-use impeller2_bevy::{ComponentPath, ComponentValue};
-use impeller2_wkt::GraphType;
+use impeller2_bevy::ComponentPath;
+use impeller2_wkt::{ComponentMetadata, GraphType};
 
 use super::gpu::LineVisibleRange;
 use crate::MainCamera;
@@ -56,14 +57,12 @@ pub struct GraphState {
 }
 
 impl GraphBundle {
-    pub fn new(
+    pub fn try_new(
         render_layer_alloc: &mut RenderLayerAllocator,
         components: BTreeMap<ComponentPath, GraphStateComponent>,
         label: String,
-    ) -> Self {
-        let Some(allocated_layer) = render_layer_alloc.alloc() else {
-            todo!("ran out of layers")
-        };
+    ) -> Option<Self> {
+        let allocated_layer = render_layer_alloc.alloc()?;
         let render_layers = allocated_layer.render_layers();
         let graph_state = GraphState {
             components,
@@ -84,7 +83,7 @@ impl GraphBundle {
             x_rev: 0,
             x_dirty: false,
         };
-        GraphBundle {
+        Some(GraphBundle {
             camera: Camera {
                 order: 2,
                 ..Default::default()
@@ -107,7 +106,15 @@ impl GraphBundle {
             main_camera: MainCamera,
             render_layers,
             allocated_layer,
-        }
+        })
+    }
+
+    pub fn new(
+        render_layer_alloc: &mut RenderLayerAllocator,
+        components: BTreeMap<ComponentPath, GraphStateComponent>,
+        label: String,
+    ) -> Self {
+        Self::try_new(render_layer_alloc, components, label).expect("ran out of render layers")
     }
 }
 
@@ -127,14 +134,109 @@ impl GraphState {
     }
 }
 
-pub fn default_component_values(
-    component_id: &ComponentId,
-    component_value: &ComponentValue,
+pub fn element_names_for_graph(
+    schema: &Schema<Vec<u64>>,
+    metadata: &ComponentMetadata,
+) -> Vec<String> {
+    let from_metadata: Vec<String> = metadata
+        .element_names()
+        .split(',')
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect();
+    if !from_metadata.is_empty() {
+        return from_metadata;
+    }
+    let names = eql::Component::new(metadata.name.clone(), metadata.component_id, schema.clone())
+        .element_names;
+    let len = schema.shape().iter().copied().product::<usize>().max(1);
+    if len == 1 && names.iter().all(|n| n.is_empty()) {
+        return vec![metadata.name.clone()];
+    }
+    names
+}
+
+pub fn graph_lines_from_component(
+    component_path: &ComponentPath,
+    schema: &Schema<Vec<u64>>,
+    _metadata: &ComponentMetadata,
 ) -> GraphStateComponent {
-    component_value
-        .iter()
-        .enumerate()
-        .map(|(i, _)| component_id.0 as usize + i)
-        .map(|i| (true, colors::get_color_by_index_all(i)))
-        .collect::<Vec<(bool, egui::Color32)>>()
+    let len = schema.shape().iter().copied().product::<usize>().max(1);
+    let color_base = component_path.id.0 as usize;
+    (0..len)
+        .map(|i| (true, colors::get_color_by_index_all(color_base + i)))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use impeller2::types::PrimType;
+    use std::collections::HashMap;
+
+    fn test_schema(shape: &[u64]) -> Schema<Vec<u64>> {
+        Schema::new(PrimType::F64, shape).unwrap()
+    }
+
+    fn test_metadata(name: &str, element_names: &str) -> ComponentMetadata {
+        let mut metadata = HashMap::new();
+        if !element_names.is_empty() {
+            metadata.insert("element_names".to_string(), element_names.to_string());
+        }
+        ComponentMetadata {
+            component_id: ComponentId::new(name),
+            name: name.to_string(),
+            metadata,
+        }
+    }
+
+    #[test]
+    fn graph_lines_scalar_enables_one_line() {
+        let path = ComponentPath::from_name("rocket.mach");
+        let schema = test_schema(&[1]);
+        let metadata = test_metadata("rocket.mach", "");
+        let lines = graph_lines_from_component(&path, &schema, &metadata);
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].0);
+    }
+
+    #[test]
+    fn graph_lines_vector_enables_all_elements() {
+        let path = ComponentPath::from_name("CONTROLMESSAGE.FIN_DEFLECTION_DEG");
+        let schema = test_schema(&[4]);
+        let metadata = test_metadata("CONTROLMESSAGE.FIN_DEFLECTION_DEG", "");
+        let lines = graph_lines_from_component(&path, &schema, &metadata);
+        assert_eq!(lines.len(), 4);
+        assert!(lines.iter().all(|(enabled, _)| *enabled));
+    }
+
+    #[test]
+    fn element_names_prefers_metadata() {
+        let schema = test_schema(&[3]);
+        let metadata = test_metadata("foo.bar", "a,b,c");
+        assert_eq!(
+            element_names_for_graph(&schema, &metadata),
+            vec!["a", "b", "c"]
+        );
+    }
+
+    #[test]
+    fn element_names_falls_back_to_schema_defaults() {
+        let schema = test_schema(&[4]);
+        let metadata = test_metadata("foo.bar", "");
+        assert_eq!(
+            element_names_for_graph(&schema, &metadata),
+            vec!["x", "y", "z", "w"]
+        );
+    }
+
+    #[test]
+    fn element_names_scalar_uses_component_name() {
+        let schema = test_schema(&[]);
+        let metadata = test_metadata("STATEMACHINEOUTPUT.MISSILE_MODE", "");
+        assert_eq!(
+            element_names_for_graph(&schema, &metadata),
+            vec!["STATEMACHINEOUTPUT.MISSILE_MODE"]
+        );
+    }
 }

--- a/libs/elodin-editor/src/ui/plot/widget.rs
+++ b/libs/elodin-editor/src/ui/plot/widget.rs
@@ -1377,23 +1377,25 @@ pub fn sync_graphs(
             let Some(component_metadata) = metadata_store.get_metadata(component_id) else {
                 continue;
             };
-            let component_label = component_metadata.name.clone();
-            let element_name_list = schema_store
-                .0
-                .get(component_id)
-                .map(|schema| element_names_for_graph(schema, component_metadata))
-                .unwrap_or_else(|| {
-                    component_metadata
-                        .element_names()
-                        .split(',')
-                        .filter(|s| !s.is_empty())
-                        .map(str::to_string)
-                        .collect()
-                });
             let component = collected_graph_data
                 .components
                 .entry(*component_id)
-                .or_insert_with(|| PlotDataComponent::new(component_label, element_name_list));
+                .or_insert_with(|| {
+                    let label = component_metadata.name.clone();
+                    let element_names = schema_store
+                        .0
+                        .get(component_id)
+                        .map(|schema| element_names_for_graph(schema, component_metadata))
+                        .unwrap_or_else(|| {
+                            component_metadata
+                                .element_names()
+                                .split(',')
+                                .filter(|s| !s.is_empty())
+                                .map(str::to_string)
+                                .collect()
+                        });
+                    PlotDataComponent::new(label, element_names)
+                });
 
             for (value_index, (enabled, color)) in component_values.iter().enumerate() {
                 let entity = graph_state

--- a/libs/elodin-editor/src/ui/plot/widget.rs
+++ b/libs/elodin-editor/src/ui/plot/widget.rs
@@ -26,7 +26,7 @@ use bevy::{
 };
 use bevy_egui::egui::{self, Align, CornerRadius, Frame, Layout, Margin, RichText, Stroke};
 use impeller2::types::Timestamp;
-use impeller2_bevy::{ComponentMetadataRegistry, ComponentPath};
+use impeller2_bevy::{ComponentMetadataRegistry, ComponentPath, ComponentSchemaRegistry};
 use impeller2_wkt::{CurrentTimestamp, EarliestTimestamp};
 use std::time::{Duration, Instant};
 use std::{
@@ -42,7 +42,7 @@ use crate::{
         colors::{ColorExt, get_scheme, with_opacity},
         input_owner::UiInputOwners,
         plot::{
-            CollectedGraphData, GraphState, Line, OVERVIEW_MAX_POINTS,
+            CollectedGraphData, GraphState, Line, OVERVIEW_MAX_POINTS, element_names_for_graph,
             gpu::{LineBundle, LineConfig, LineUniform},
         },
         tiles::WindowState,
@@ -1365,6 +1365,7 @@ pub fn auto_y_bounds(
 pub fn sync_graphs(
     mut graph_states: Query<&mut GraphState>,
     metadata_store: Res<ComponentMetadataRegistry>,
+    schema_store: Res<ComponentSchemaRegistry>,
     mut collected_graph_data: ResMut<CollectedGraphData>,
     mut commands: Commands,
 ) {
@@ -1377,20 +1378,22 @@ pub fn sync_graphs(
                 continue;
             };
             let component_label = component_metadata.name.clone();
-            let element_names = component_metadata.element_names();
+            let element_name_list = schema_store
+                .0
+                .get(component_id)
+                .map(|schema| element_names_for_graph(schema, component_metadata))
+                .unwrap_or_else(|| {
+                    component_metadata
+                        .element_names()
+                        .split(',')
+                        .filter(|s| !s.is_empty())
+                        .map(str::to_string)
+                        .collect()
+                });
             let component = collected_graph_data
                 .components
                 .entry(*component_id)
-                .or_insert_with(|| {
-                    PlotDataComponent::new(
-                        component_label,
-                        element_names
-                            .split(',')
-                            .filter(|s| !s.is_empty())
-                            .map(str::to_string)
-                            .collect(),
-                    )
-                });
+                .or_insert_with(|| PlotDataComponent::new(component_label, element_name_list));
 
             for (value_index, (enabled, color)) in component_values.iter().enumerate() {
                 let entity = graph_state

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -2972,19 +2972,19 @@ impl WidgetSystem for TileLayout<'_, '_> {
                         if read_only {
                             continue;
                         }
-                        let graph_label = graph_label(&Graph::default());
-
                         let graph_bundle = if let Some(graph_bundle) = *graph_bundle {
                             graph_bundle
                         } else {
+                            let graph_label = graph_label(&Graph::default());
                             GraphBundle::new(
                                 &mut state_mut.render_layer_alloc,
                                 BTreeMap::default(),
                                 graph_label.clone(),
                             )
                         };
+                        let tab_label = graph_bundle.graph_state.label.clone();
                         let graph_id = state_mut.commands.spawn(graph_bundle).id();
-                        let graph = GraphPane::new(graph_id, graph_label.clone());
+                        let graph = GraphPane::new(graph_id, tab_label);
                         let pane = Pane::Graph(graph);
 
                         if let Some(tile_id) =


### PR DESCRIPTION
## Content
- Fix graph line labels when loading recorded data via time series: use `element_names` when set, schema defaults for vectors (`x`, `y`, `z`, `w`), and the component name for scalars; name graph tabs after the selected component.
- Fix Create Graph on recorded databases (including replay after cache-first playback): build graph lines from schema/metadata instead of requiring ECS `ComponentValue`; show explicit palette errors when schema or metadata is missing.
- Add unit tests for graph helpers and time-range selection at a replay playback head.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editor UI and graph/timeline behavior only; no auth, persistence, or security-sensitive paths.
> 
> **Overview**
> Fixes **Create Graph** and graph labeling for **recorded / replay** databases where live ECS `ComponentValue` may be missing.
> 
> Graph creation (command palette and entity inspector) now builds enabled lines from **component schema + metadata** via `graph_lines_from_component`, with **`GraphBundle::try_new`** and clear errors when schema, metadata, or render layers are unavailable. Plot sync and time-series rendering use **`element_names_for_graph`** so series labels prefer metadata names, schema defaults for vectors, and the component name for scalars; graph **tabs** use the bundle’s component label instead of a generic default.
> 
> Adds unit tests for graph naming/line counts and for **time range** windows at a replay playback head (`effective_latest`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f041e3b19fa67250f7e0d0836a34d913a0225578. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->