### PR TITLE
Feat: Integrate GeoFrame orientation support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9575,6 +9575,7 @@ name = "nox"
 version = "0.17.4-alpha.0"
 dependencies = [
  "approx",
+ "bevy_math",
  "boxcar",
  "faer",
  "fn-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,8 @@ debug = true
 
 [workspace.dependencies.bevy_editor_cam]
 version = "0.8"
-
+[workspace.dependencies.bevy_math]
+version = "0.18"
 [workspace.dependencies.bevy]
 version = "0.18.1"
 default-features = false

--- a/assets/earth.glb
+++ b/assets/earth.glb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9639e3daa1a2b385e9ffcc702cf3ad7321fbf614a377db57a8d5a3bbf66fa5d5
-size 4158348
+oid sha256:510392f69445f38d93a384f649f7a23a036b8eb52e897c9cc7c0be876db3cb98
+size 4160080

--- a/docs/public/content/reference/schematic.md
+++ b/docs/public/content/reference/schematic.md
@@ -14,7 +14,7 @@ order = 6
 
 ## Glossary
 
-- Top-level nodes: `coordinate`, `theme`, `timeline`, `skybox`, `panel` variants, `object_3d`, `line_3d`, `vector_arrow`, `window`.
+- Top-level nodes: `coordinate`, `theme`, `timeline`, `skybox`, `panel` variants, `object_3d`, `line_3d`, `vector_arrow`, `world_mesh`, `window`.
 - EQL: expressions are evaluated in the runtime EQL context. Vector-like fields expect 3 components; `world_pos` is a 7-component array (quat + position).
 - Colors: `color r g b [a]` or named (`black`, `white`, `blue`, `red`, `orange`, `yellow`, `yalk`, `pink`, `cyan`, `gray`, `green`, `mint`, `turquoise`, `slate`, `pumpkin`, `yolk`, `peach`, `reddish`, `hyperblue`); alpha optional. Colors can be inline or in `color`/`colour` child nodes. Defaults to white when omitted unless noted.
 - Booleans: KDL booleans are `#true`/`#false`. A bare `True` is a *string*, not a boolean — most flags silently fall back to their default if given one. Viewport flags (`hdr`, `show_grid`, `active`, ...) leniently accept `True`/`"true"` (case-insensitive), but prefer the `#` forms everywhere.
@@ -23,7 +23,7 @@ order = 6
 ### coordinate
 - Optional top-level node that sets the global coordinate frame for the schematic.
 - `frame`: `"ENU"` (default), `"NED"`, or `"ECEF"`.
-- Elements (`viewport`, `object_3d`, `line_3d`, `vector_arrow`) that don't specify their own `frame` attribute inherit this global frame.
+- Elements (`viewport`, `object_3d`, `line_3d`, `vector_arrow`, `world_mesh`) that don't specify their own `frame` attribute inherit this global frame.
 - Example: `coordinate frame="NED"` sets the entire schematic to use North-East-Down coordinates.
 
 ### theme
@@ -188,6 +188,13 @@ object_3d lander.world_pos {
    label anchor, or absolutely by specifying a number in a string with an 'm'
    suffix, .e.g., "0.3m" for 0.3 meters from origin (default "0.1m").
 
+### world_mesh
+- Positional `region`: required terrain region identifier, e.g. `"death_valley"` or `"globe"`.
+- `lod_count`: optional LOD depth override.
+- `translate`: optional `(x,y,z)` offset in the selected coordinate frame, in meters.
+- `frame`: optional; `ENU`, `NED`, or `ECEF`. Specifies the coordinate frame for interpreting terrain axes and translation. Inherits from global `coordinate` if omitted.
+- `visible`: bool, default `#true`.
+
 ## Schema at a glance
 
 Legend: parentheses group alternatives; `|` means “or”; square brackets `[...]` are optional; curly braces `{...}` repeat; `*` is zero-or-more, `+` is one-or-more; angle brackets `<...>` mark positional args.
@@ -203,6 +210,7 @@ schematic =
   | object_3d
   | line_3d
   | vector_arrow
+  | world_mesh
   )*
 
 coordinate = "coordinate"
@@ -376,6 +384,13 @@ vector_arrow = "vector_arrow"
              [show_name=bool]
              [arrow_thickness=float]
              [label_position=0..1]
+
+world_mesh = "world_mesh"
+           <region>
+           [lod_count=int]
+           [translate=(x,y,z)]
+           [frame=ENU|NED|ECEF]
+           [visible=bool]
 
 color = "color"
       ( r g b [a]

--- a/examples/geo-frames/main.py
+++ b/examples/geo-frames/main.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env uv run
+
+import math
+
+import elodin as el
+import jax.numpy as jnp
+
+SIM_RATE = 60.0
+
+LAT_DEG = 34.72
+LON_DEG = -86.64
+ALT_M = 180.5
+WGS84_A_M = 6_378_137.0
+WGS84_E2 = 6.6943799901413165e-3
+WGS84_B_M = WGS84_A_M * math.sqrt(1.0 - WGS84_E2)
+CUBE_SIZE_M = 500_000.0
+CUBE_SEPARATION_M = 1_500_000.0
+AXIS_ARROW_SCALE_M = 1_000_000.0
+AXIS_ARROW_THICKNESS = 2500.0
+SPIN_RATE_RAD_S = math.radians(10.0)
+PURPLE = "156 39 176"
+ECEF_MARKERS = (
+    ("ecef_equator_x_pos", (WGS84_A_M, 0.0, 0.0)),
+    ("ecef_equator_y_pos", (0.0, WGS84_A_M, 0.0)),
+    ("ecef_equator_x_neg", (-WGS84_A_M, 0.0, 0.0)),
+    ("ecef_equator_y_neg", (0.0, -WGS84_A_M, 0.0)),
+    ("ecef_north_pole", (0.0, 0.0, WGS84_B_M)),
+    ("ecef_south_pole", (0.0, 0.0, -WGS84_B_M)),
+)
+
+
+def _ecef_from_enu(east: float, north: float, up: float) -> jnp.ndarray:
+    lat = math.radians(LAT_DEG)
+    lon = math.radians(LON_DEG)
+
+    sin_lat = math.sin(lat)
+    cos_lat = math.cos(lat)
+    sin_lon = math.sin(lon)
+    cos_lon = math.cos(lon)
+
+    # WGS84_E2 = 0.0
+
+    n = WGS84_A_M / math.sqrt(1.0 - WGS84_E2 * sin_lat * sin_lat)
+    origin = jnp.array(
+        [
+            (n + ALT_M) * cos_lat * cos_lon,
+            (n + ALT_M) * cos_lat * sin_lon,
+            (n * (1.0 - WGS84_E2) + ALT_M) * sin_lat,
+        ]
+    )
+    delta = jnp.array(
+        [
+            -sin_lon * east - sin_lat * cos_lon * north + cos_lat * cos_lon * up,
+            cos_lon * east - sin_lat * sin_lon * north + cos_lat * sin_lon * up,
+            cos_lat * north + sin_lat * up,
+        ]
+    )
+    return origin + delta
+
+
+def _body(pos: jnp.ndarray, angular_vel: jnp.ndarray | None = None) -> el.Body:
+    if angular_vel is None:
+        angular_vel = jnp.zeros(3)
+    return el.Body(
+        world_pos=el.SpatialTransform(linear=pos),
+        world_vel=el.SpatialMotion(angular=angular_vel),
+        inertia=el.SpatialInertia(mass=1.0),
+    )
+
+
+def _ecef_marker_objects() -> str:
+    return "\n".join(
+        f"""
+        object_3d frame="ECEF" {name}.world_pos {{
+            box x={CUBE_SIZE_M} y={CUBE_SIZE_M} z={CUBE_SIZE_M} {{
+                color {PURPLE}
+            }}
+        }}""".rstrip()
+        for name, _ in ECEF_MARKERS
+    )
+
+
+def world() -> el.World:
+    world = el.World()
+    y_axis_spin = jnp.array([0.0, SPIN_RATE_RAD_S, 0.0])
+
+    world.spawn(_body(jnp.array([0.0, 0.0, 0.0]), y_axis_spin), name="ned_origin")
+    world.spawn(
+        _body(jnp.array([CUBE_SEPARATION_M, 0.0, 0.0]), y_axis_spin),
+        name="enu_far_east",
+    )
+    world.spawn(
+        _body(_ecef_from_enu(0.0, 0.0, CUBE_SEPARATION_M), y_axis_spin),
+        name="ecef_far_up",
+    )
+    for name, pos in ECEF_MARKERS:
+        world.spawn(_body(jnp.array(pos)), name=name)
+    world.spawn(_body(jnp.array([0.0, 0.0, 0.0])), name="earth")
+
+    world.schematic(
+        f"""
+        coordinate frame=NED lat={LAT_DEG} lon={LON_DEG} alt={ALT_M}
+        hsplit {{
+            tabs {{
+                viewport name=Frames frame="NED" pos="(0,0,0,1, 4000000,4000000,-3000000)" look_at="(0,0,0,1, 0,0,0)" far=15000000.0 hdr=#true show_grid=#false active=#true
+                inspector
+                hierarchy
+            }}
+        }}
+
+        object_3d frame="ECEF" earth.world_pos {{
+            glb path="earth.glb"
+        }}
+        {_ecef_marker_objects()}
+        object_3d frame="NED" ned_origin.world_pos {{
+            box x={CUBE_SIZE_M} y={CUBE_SIZE_M} z={CUBE_SIZE_M} {{
+                color 244 67 54
+            }}
+        }}
+        object_3d frame="ENU" enu_far_east.world_pos {{
+            box x={CUBE_SIZE_M} y={CUBE_SIZE_M} z={CUBE_SIZE_M} {{
+                color 33 150 243
+            }}
+        }}
+        object_3d frame="ECEF" ecef_far_up.world_pos {{
+            box x={CUBE_SIZE_M} y={CUBE_SIZE_M} z={CUBE_SIZE_M} {{
+                color 76 175 80
+            }}
+        }}
+
+        line_3d frame="NED" ned_origin.world_pos line_width=2.0 {{
+            color 244 67 54
+        }}
+        line_3d frame="ENU" enu_far_east.world_pos line_width=2.0 {{
+            color 33 150 243
+        }}
+        line_3d frame="ECEF" ecef_far_up.world_pos line_width=2.0 {{
+            color 76 175 80
+        }}
+
+        vector_arrow frame="NED" "(0, 1, 0)" origin="ned_origin.world_pos" scale={AXIS_ARROW_SCALE_M} normalize=#true arrow_thickness={AXIS_ARROW_THICKNESS} label_position=0.0 name="NED Y-axis" show_name=#true body_frame=#true {{
+            color 244 67 54
+        }}
+        vector_arrow frame="ENU" "(0, 1, 0)" origin="enu_far_east.world_pos" scale={AXIS_ARROW_SCALE_M} normalize=#true arrow_thickness={AXIS_ARROW_THICKNESS} label_position=0.0 name="ENU Y-axis" show_name=#true body_frame=#true {{
+            color 33 150 243
+        }}
+        vector_arrow frame="ECEF" "(0, 1, 0)" origin="ecef_far_up.world_pos" scale={AXIS_ARROW_SCALE_M} normalize=#true arrow_thickness={AXIS_ARROW_THICKNESS} label_position=0.0 name="ECEF Y-axis" show_name=#true body_frame=#true {{
+            color 76 175 80
+        }}
+        """,
+        "geo-frames.kdl",
+    )
+    return world
+
+
+@el.map
+def no_force(f: el.Force) -> el.Force:
+    return f
+
+
+def system() -> el.System:
+    return el.six_dof(sys=no_force)
+
+
+if __name__ == "__main__":
+    world().run(system(), simulation_rate=SIM_RATE, max_ticks=1200)

--- a/libs/bevy_geo_frames/examples/demo.rs
+++ b/libs/bevy_geo_frames/examples/demo.rs
@@ -7,7 +7,6 @@ use bevy_editor_cam::prelude::*;
 use bevy_geo_frames::*;
 use bevy_infinite_grid::{InfiniteGridBundle, InfiniteGridPlugin, InfiniteGridSettings};
 use map_3d::Ellipsoid;
-use std::f64::consts::PI;
 
 /// Marker for the demo cuboid we switch frames on.
 #[derive(Component)]
@@ -60,7 +59,7 @@ fn main() {
         )
         .add_systems(Update, draw_origin_gizmos)
         .add_systems(Update, draw_frame_zero_gizmo)
-        // .add_systems(Update, draw_frame_axes)
+        .add_systems(Update, draw_frame_axes)
         .add_systems(Update, draw_radius_sphere)
         .init_resource::<CurrentFrame>();
 
@@ -78,7 +77,6 @@ fn setup(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
-    geo_ctx: Res<GeoContext>,
 ) {
     #[cfg(feature = "big_space")]
     let big_space_root = commands
@@ -92,11 +90,11 @@ fn setup(
     let transform = Transform::from_xyz(30.0, 20.0, 30.0).looking_at(Vec3::ZERO, Vec3::Y);
     let _camera_id = commands
         .spawn((
-            GeoPosition::from_transform(GeoFrame::ENU, &transform, &geo_ctx),
-            GeoRotation::from_transform(GeoFrame::ENU, &transform, &geo_ctx),
+            transform,
+            // GeoPosition::from_transform(GeoFrame::ENU, &transform, &geo_ctx),
+            // GeoRotation::from_transform(GeoFrame::ENU, &transform, &geo_ctx),
             Camera3d::default(),
             EditorCam::default(),
-            Transform::default(),
         ))
         .id();
     #[cfg(feature = "big_space")]
@@ -133,7 +131,7 @@ fn setup(
     let cuboid_mat = materials.add(Color::srgb(0.3, 0.8, 0.9));
 
     // Position in ENU frame to start: 20 m east, 0 m north, 1 m up
-    let enu_pos = DVec3::new(0.0, 0.0, 0.0);
+    let enu_pos = DVec3::new(20.0, 0.0, 1.0);
 
     let _cube_id = commands
         .spawn((
@@ -142,8 +140,8 @@ fn setup(
             Transform::default(),
             GeoPosition(GeoFrame::ENU, enu_pos),
             // GeoVelocity(GeoFrame::ENU, DVec3::new(0.1, 0.0, 0.0)),
-            // GeoRotation(GeoFrame::ENU, DQuat::IDENTITY),
-            GeoRotation(GeoFrame::ENU, DQuat::from_rotation_x(0.25 * PI)),
+            GeoRotation::new(GeoFrame::ENU, DQuat::IDENTITY),
+            // GeoRotation::new(GeoFrame::ENU, DQuat::from_rotation_x(0.25 * PI)),
             // GeoAngularVelocity(
             //     GeoFrame::ENU,
             //     // DVec3::new(0.0, 0.0, 10.0_f32.to_radians()),
@@ -182,20 +180,31 @@ fn setup_ui(mut commands: Commands) {
 }
 
 fn update_position_display(
-    q: Query<(&GeoPosition, &Transform), With<FrameDemo>>,
+    q: Query<(&GeoPosition, Option<&GeoRotation>, &Transform), With<FrameDemo>>,
     mut text_query: Query<&mut Text, With<PositionDisplay>>,
     ctx: Res<GeoContext>,
 ) {
-    if let Ok((geo_trans, transform)) = q.single() {
+    if let Ok((geo_trans, geo_rot, transform)) = q.single() {
         let frame = geo_trans.0;
         let pos_in_frame = geo_trans.1;
         let pos_in_bevy = transform.translation;
+        let rot_in_bevy = transform.rotation;
         let lat_deg = ctx.origin.latitude.to_degrees();
         let lon_deg = ctx.origin.longitude.to_degrees();
 
         let frame_name = format!("{:?}", frame);
+        let rot_in_frame = match geo_rot {
+            Some(geo_rot) => {
+                let q = geo_rot.1;
+                format!(
+                    "({:.3}, {:.3}, {:.3}, {:.3}) [{:?}]",
+                    q.x, q.y, q.z, q.w, geo_rot.0
+                )
+            }
+            None => "n/a".to_string(),
+        };
         let text = format!(
-            "Frame: {}\nPosition in frame: ({:.2}, {:.2}, {:.2})\nPosition in Bevy: ({:.2}, {:.2}, {:.2})\nOrigin lat/lon: ({:.2}, {:.2})",
+            "Frame: {}\nPosition in frame: ({:.2}, {:.2}, {:.2})\nPosition in Bevy: ({:.2}, {:.2}, {:.2})\nQuat in frame: {}\nQuat in Bevy: ({:.3}, {:.3}, {:.3}, {:.3})\nOrigin lat/lon: ({:.2}, {:.2})",
             frame_name,
             pos_in_frame.x,
             pos_in_frame.y,
@@ -203,6 +212,11 @@ fn update_position_display(
             pos_in_bevy.x,
             pos_in_bevy.y,
             pos_in_bevy.z,
+            rot_in_frame,
+            rot_in_bevy.x,
+            rot_in_bevy.y,
+            rot_in_bevy.z,
+            rot_in_bevy.w,
             lat_deg,
             lon_deg
         );
@@ -275,6 +289,7 @@ fn toggle_present_mode(
 fn frame_switch_input(
     keys: Res<ButtonInput<KeyCode>>,
     mut q: Query<&mut GeoPosition, With<FrameDemo>>,
+    mut r: Query<&mut GeoRotation, With<FrameDemo>>,
     mut current_frame: ResMut<CurrentFrame>,
 ) {
     let mut target_frame: Option<GeoFrame> = None;
@@ -292,6 +307,11 @@ fn frame_switch_input(
             geo.0 = frame;
             info!(?frame, "Switched demo cuboid to frame");
         }
+
+        for mut geo in &mut r {
+            geo.0 = frame;
+            info!(?frame, "Switched demo cuboid rotation to frame");
+        }
         current_frame.frame = frame;
     }
 }
@@ -304,7 +324,7 @@ fn frame_switch_input(
 fn transform_frame_at_position(
     keys: Res<ButtonInput<KeyCode>>,
     ctx: Res<GeoContext>,
-    mut q: Query<(&Transform, &mut GeoPosition), With<FrameDemo>>,
+    mut q: Query<(&Transform, &mut GeoPosition, &mut GeoRotation), With<FrameDemo>>,
     mut current_frame: ResMut<CurrentFrame>,
 ) {
     let mut target_frame: Option<GeoFrame> = None;
@@ -318,16 +338,20 @@ fn transform_frame_at_position(
     }
 
     if let Some(frame) = target_frame {
-        for (transform, mut geo_trans) in &mut q {
+        for (transform, mut geo_trans, mut geo_rot) in &mut q {
             // Get current Bevy position
             let bevy_pos = transform.translation;
+            let bevy_rot = transform.rotation;
 
             // Convert from Bevy to the target frame
             let pos_in_frame = GeoPosition::from_bevy(frame, bevy_pos, &ctx).1;
+            let rot_in_frame = GeoRotation::from_bevy(frame, bevy_rot.as_dquat(), &ctx).1;
 
             // Update the frame and position
             geo_trans.0 = frame;
             geo_trans.1 = pos_in_frame;
+            geo_rot.0 = frame;
+            geo_rot.1 = rot_in_frame;
             current_frame.frame = frame;
 
             info!(

--- a/libs/bevy_geo_frames/src/geo.rs
+++ b/libs/bevy_geo_frames/src/geo.rs
@@ -80,6 +80,7 @@ impl GeoOrigin {
 /// * origin (for ENU/ECEF)
 /// * Earth rotation model (for ECI/GCRF <-> ECEF).
 #[derive(Resource, Debug, Clone, Reflect)]
+#[reflect(Resource)]
 pub struct GeoContext {
     /// The geographic origin of the coordinate system on Earth.
     pub origin: GeoOrigin,
@@ -136,6 +137,25 @@ impl GeoContext {
 }
 
 impl GeoFrame {
+    fn origin_ecef(origin: &GeoOrigin) -> DVec3 {
+        map_3d::enu2ecef(
+            0.0,
+            0.0,
+            0.0,
+            origin.latitude,
+            origin.longitude,
+            origin.altitude,
+            &origin.ellipsoid,
+        )
+        .into()
+    }
+
+    fn bevy_R_enu_plane() -> DMat3 {
+        // Columns are frame basis vectors expressed in Bevy world space.
+        // ENU: e_hat = +X, n_hat = -Z, u_hat = +Y
+        DMat3::from_cols(DVec3::X, DVec3::NEG_Z, DVec3::Y)
+    }
+
     /// Provides the transformation matrix ${bevy}_M_{from}$ from a coordinate
     /// frame.
     pub fn bevy_M_(from: &Self, context: &GeoContext) -> DMat4 {
@@ -155,12 +175,18 @@ impl GeoFrame {
     /// Provides the origin vector ${bevy}_O_{from}$ of the coordinate frame.
     pub fn bevy_O_(from: &Self, context: &GeoContext) -> DVec3 {
         match context.present {
-            Present::Plane => DVec3::ZERO,
+            Present::Plane => match from {
+                GeoFrame::ENU | GeoFrame::NED => DVec3::ZERO,
+                GeoFrame::ECEF => {
+                    let bevy_R_ecef = Self::bevy_R_(&GeoFrame::ECEF, context);
+                    -bevy_R_ecef * Self::origin_ecef(&context.origin)
+                }
+            },
             Present::Sphere => {
                 match from {
                     GeoFrame::ENU | GeoFrame::NED => {
-                        let bevy_R_enu = Self::bevy_R_(&GeoFrame::ENU, context);
-                        approx_radius(&context.origin.ellipsoid) * bevy_R_enu.z_axis
+                        let bevy_R_ecef = DMat3::from_cols(DVec3::X, DVec3::NEG_Z, DVec3::Y);
+                        bevy_R_ecef * Self::origin_ecef(&context.origin)
                     }
                     // For these, a fully correct basis would require time-dependent
                     // Earth orientation.
@@ -173,18 +199,23 @@ impl GeoFrame {
     /// Provides the origin vector ${self}_O_{from}$ of the coordinate frame.
     pub fn _O_(&self, from: &Self, context: &GeoContext) -> DVec3 {
         match context.present {
-            Present::Plane => DVec3::ZERO,
+            Present::Plane => {
+                let origin_ecef = Self::origin_ecef(&context.origin);
+                match (from, *self) {
+                    (GeoFrame::ECEF, GeoFrame::ENU | GeoFrame::NED) => {
+                        -self._R_(from, context) * origin_ecef
+                    }
+                    (GeoFrame::ENU | GeoFrame::NED, GeoFrame::ECEF) => origin_ecef,
+                    _ => DVec3::ZERO,
+                }
+            }
             Present::Sphere => {
                 match (from, *self) {
-                    (GeoFrame::ECEF, GeoFrame::ENU) => {
-                        -approx_radius(&context.origin.ellipsoid) * DVec3::Z
-                    }
-                    (GeoFrame::ECEF, GeoFrame::NED) => {
-                        approx_radius(&context.origin.ellipsoid) * DVec3::Z
+                    (GeoFrame::ECEF, GeoFrame::ENU | GeoFrame::NED) => {
+                        -self._R_(from, context) * Self::origin_ecef(&context.origin)
                     }
                     (GeoFrame::ENU | GeoFrame::NED, GeoFrame::ECEF) => {
-                        let ecef_R_enu = Self::ecef_R_(&GeoFrame::ENU, &context.origin);
-                        approx_radius(&context.origin.ellipsoid) * ecef_R_enu.z_axis
+                        Self::origin_ecef(&context.origin)
                     }
                     // For these, a fully correct basis would require time-dependent
                     // Earth orientation.
@@ -197,13 +228,13 @@ impl GeoFrame {
     /// Provides the origin vector ${bevy}_O_{from}$ of the coordinate frame.
     pub fn ecef_O_(from: &Self, context: &GeoContext) -> DVec3 {
         match context.present {
-            Present::Plane => DVec3::ZERO,
+            Present::Plane => match from {
+                GeoFrame::ENU | GeoFrame::NED => Self::origin_ecef(&context.origin),
+                GeoFrame::ECEF => DVec3::ZERO,
+            },
             Present::Sphere => {
                 match from {
-                    GeoFrame::ENU | GeoFrame::NED => {
-                        let ecef_R_enu = Self::ecef_R_(&GeoFrame::ENU, &context.origin);
-                        approx_radius(&context.origin.ellipsoid) * ecef_R_enu.z_axis
-                    }
+                    GeoFrame::ENU | GeoFrame::NED => Self::origin_ecef(&context.origin),
                     // For these, a fully correct basis would require time-dependent
                     // Earth orientation.
                     GeoFrame::ECEF => DVec3::ZERO,
@@ -218,10 +249,11 @@ impl GeoFrame {
         use crate::GeoFrame::*;
         match (*from, *self) {
             (x, y) if x == y => DMat3::IDENTITY,
-            (ENU, NED) => DMat3::from_cols(DVec3::Y, DVec3::X, DVec3::NEG_Y),
-            (NED, ENU) => DMat3::from_cols(DVec3::Y, DVec3::X, DVec3::NEG_Y),
-            (ECEF, x) => Self::ecef_R_(&x, &context.origin),
-            (x, ECEF) => Self::ecef_R_(&x, &context.origin).inverse(),
+            (ENU, NED) => Self::ned_R_enu(),
+            (NED, ENU) => Self::enu_R_ned(),
+            // ecef_R_(x) maps x -> ECEF, so self_R_ecef is its inverse.
+            (ECEF, x) => Self::ecef_R_(&x, &context.origin).inverse(),
+            (x, ECEF) => Self::ecef_R_(&x, &context.origin),
             (x, y) => unreachable!("{x:?} -> {y:?}"),
         }
     }
@@ -231,18 +263,15 @@ impl GeoFrame {
         let bevy_R_ecef = DMat3::from_cols(DVec3::X, DVec3::NEG_Z, DVec3::Y);
         match context.present {
             Present::Plane => match from {
-                GeoFrame::ENU => {
-                    // Columns are frame basis vectors expressed in Bevy world space.
-                    // ENU: e_hat = +X, n_hat = -Z, u_hat = +Y
-                    DMat3::from_cols(DVec3::X, DVec3::NEG_Z, DVec3::Y)
-                }
+                GeoFrame::ENU => Self::bevy_R_enu_plane(),
                 GeoFrame::NED => {
                     // NED: n_hat = -Z, e_hat = +X, d_hat = -Y
                     DMat3::from_cols(DVec3::NEG_Z, DVec3::X, DVec3::NEG_Y)
                 }
-                // For these, a fully correct basis would require time-dependent
-                // Earth orientation.
-                GeoFrame::ECEF => bevy_R_ecef,
+                GeoFrame::ECEF => {
+                    Self::bevy_R_enu_plane()
+                        * Self::ecef_R_(&GeoFrame::ENU, &context.origin).inverse()
+                }
             },
             Present::Sphere => bevy_R_ecef * Self::ecef_R_(from, &context.origin),
         }
@@ -330,25 +359,100 @@ impl GeoPosition {
 }
 
 impl GeoRotation {
-    /// Convert orientation to Bevy.
-    pub fn to_bevy(&self, context: &GeoContext) -> DQuat {
-        let frame = self.0;
-        let local_rot = self.1;
-        DQuat::from_mat3(&GeoFrame::bevy_R_(&frame, context)) * local_rot
+    /// A [RotationKind::Relative] rotation expressed in `frame`.
+    pub fn new(frame: GeoFrame, q: impl Into<DQuat>) -> Self {
+        GeoRotation(frame, q.into(), RotationKind::default())
     }
 
-    /// Convert orientation from Bevy.
-    pub fn from_bevy(frame: GeoFrame, v_bevy: impl Into<DQuat>, context: &GeoContext) -> Self {
-        let v = v_bevy.into();
+    /// A [RotationKind::Absolute] rotation expressed in `frame`.
+    pub fn absolute(frame: GeoFrame, q: impl Into<DQuat>) -> Self {
+        GeoRotation(frame, q.into(), RotationKind::Absolute)
+    }
+
+    /// A [RotationKind::Relative] rotation expressed in `frame` that orients a
+    /// camera (Bevy convention: forward `-Z`, up `+Y`) to look along `dir`,
+    /// with the camera's up toward `up`. Both vectors are expressed in `frame`
+    /// coordinates, so the computation is frame agnostic.
+    ///
+    /// If `up` is `None` (or collinear with `dir`), the frame's natural camera
+    /// up — the frame direction that maps to Bevy `+Y` — is used.
+    pub fn look_at(
+        frame: GeoFrame,
+        dir: impl Into<DVec3>,
+        up: Option<DVec3>,
+        context: &GeoContext,
+    ) -> Self {
+        let frame_R_bevy = GeoFrame::bevy_R_(&frame, context).transpose();
+        // The camera's identity axes expressed in `frame` coordinates.
+        let f0 = frame_R_bevy * DVec3::NEG_Z;
+        let u0 = frame_R_bevy * DVec3::Y;
+
+        let f = dir.into().normalize();
+        let mut up = up.unwrap_or(u0);
+        if f.cross(up).length_squared() < 1e-12 {
+            // `up` collinear with `dir`: prefer the frame's camera up, then
+            // its camera forward (orthogonal to `u0`, so always valid).
+            up = if f.cross(u0).length_squared() > 1e-12 {
+                u0
+            } else {
+                f0
+            };
+        }
+        let s = f.cross(up).normalize();
+        let u = s.cross(f);
+
+        // Rotation taking the identity camera axes to the desired ones.
+        let m0 = DMat3::from_cols(f0.cross(u0), f0, u0);
+        let m = DMat3::from_cols(s, f, u);
         GeoRotation(
             frame,
-            DQuat::from_mat3(&GeoFrame::bevy_R_(&frame, context)).inverse() * v,
+            DQuat::from_mat3(&(m * m0.transpose())),
+            RotationKind::Relative,
         )
     }
 
+    /// Convert orientation to Bevy.
+    pub fn to_bevy(&self, context: &GeoContext) -> DQuat {
+        let local_rot = self.1;
+        let q = DQuat::from_mat3(&GeoFrame::bevy_R_(&self.0, context));
+        match self.2 {
+            // Re-express the rotation operator in Bevy coordinates.
+            RotationKind::Relative => q * local_rot * q.conjugate(),
+            // Compose with the frame's basis change into Bevy.
+            RotationKind::Absolute => q * local_rot,
+        }
+    }
+
+    /// Convert a [RotationKind::Relative] orientation from Bevy.
+    pub fn from_bevy(frame: GeoFrame, v_bevy: impl Into<DQuat>, context: &GeoContext) -> Self {
+        Self::from_bevy_kind(frame, v_bevy, context, RotationKind::default())
+    }
+
+    /// Convert orientation from Bevy, inverting [Self::to_bevy] for `kind`.
+    pub fn from_bevy_kind(
+        frame: GeoFrame,
+        v_bevy: impl Into<DQuat>,
+        context: &GeoContext,
+        kind: RotationKind,
+    ) -> Self {
+        let v = v_bevy.into();
+        let q = DQuat::from_mat3(&GeoFrame::bevy_R_(&frame, context));
+        let local_rot = match kind {
+            RotationKind::Relative => q.conjugate() * v * q,
+            RotationKind::Absolute => q.conjugate() * v,
+        };
+        GeoRotation(frame, local_rot, kind)
+    }
+
+    /// Re-express the rotation in another frame, preserving the rotation it
+    /// produces in Bevy and its [RotationKind].
     pub fn as_frame(&self, to_frame: GeoFrame, context: &GeoContext) -> GeoRotation {
-        let R = to_frame._R_(&self.0, context);
-        GeoRotation(to_frame, DQuat::from_mat3(&R) * self.1)
+        let R = DQuat::from_mat3(&to_frame._R_(&self.0, context));
+        let local_rot = match self.2 {
+            RotationKind::Relative => R * self.1 * R.conjugate(),
+            RotationKind::Absolute => R * self.1,
+        };
+        GeoRotation(to_frame, local_rot, self.2)
     }
 
     /// Create from a Bevy Transform's rotation.
@@ -378,12 +482,23 @@ impl GeoVelocity {
     }
 }
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Reflect)]
+pub enum RotationKind {
+    #[default]
+    /// The rotation is relative. An identity rotation in any frame is an
+    /// identity rotation in Bevy's frame.
+    Relative,
+    /// The rotation is absolute. An identity rotation in ENU will produce a
+    /// rotation that rotates [x,y,z] to [x,z,-y] for instance.
+    Absolute,
+}
+
 /// Per-entity geo orientation:
 ///   0: frame the quaternion is expressed in
 ///   1: rotation from local -> that frame
 #[derive(Debug, Component, Reflect, Clone)]
 #[reflect(Component)]
-pub struct GeoRotation(pub GeoFrame, pub DQuat);
+pub struct GeoRotation(pub GeoFrame, pub DQuat, pub RotationKind);
 
 /// Per-entity angular velocity in some frame, in rad/s.
 #[derive(Debug, Component, Reflect, Clone)]
@@ -611,6 +726,50 @@ mod tests {
         }
     }
 
+    fn ecef_plane_to_bevy_expected(v: DVec3, ctx: &GeoContext) -> Vec3 {
+        (GeoFrame::bevy_R_(&GeoFrame::ENU, ctx)
+            * convert_pos_map_3d(GeoFrame::ENU, GeoFrame::ECEF, v, ctx))
+        .as_vec3()
+    }
+
+    fn geo_frames_example_ecef_from_enu(east: f64, north: f64, up: f64) -> DVec3 {
+        const LAT_DEG: f64 = 34.72;
+        const LON_DEG: f64 = -86.64;
+        const ALT_M: f64 = 180.5;
+        const WGS84_A_M: f64 = 6_378_137.0;
+        const WGS84_E2: f64 = 6.6943799901413165e-3;
+
+        let lat = LAT_DEG.to_radians();
+        let lon = LON_DEG.to_radians();
+        let sin_lat = lat.sin();
+        let cos_lat = lat.cos();
+        let sin_lon = lon.sin();
+        let cos_lon = lon.cos();
+
+        let n = WGS84_A_M / (1.0 - WGS84_E2 * sin_lat * sin_lat).sqrt();
+        let origin = DVec3::new(
+            (n + ALT_M) * cos_lat * cos_lon,
+            (n + ALT_M) * cos_lat * sin_lon,
+            (n * (1.0 - WGS84_E2) + ALT_M) * sin_lat,
+        );
+        let delta = DVec3::new(
+            -sin_lon * east - sin_lat * cos_lon * north + cos_lat * cos_lon * up,
+            cos_lon * east - sin_lat * sin_lon * north + cos_lat * sin_lon * up,
+            cos_lat * north + sin_lat * up,
+        );
+        origin + delta
+    }
+
+    fn assert_ned_to_ecef_matches_map_3d(ctx: &GeoContext, ned: DVec3, label: &str) {
+        let expected = convert_pos_map_3d(GeoFrame::ECEF, GeoFrame::NED, ned, ctx);
+        let actual = convert_pos(GeoFrame::ECEF, GeoFrame::NED, ned, ctx);
+        assert!(
+            actual.distance(expected) < 1e-6,
+            "{label}: got {actual:?}, expected {expected:?}, error {}",
+            actual.distance(expected)
+        );
+    }
+
     macro_rules! assert_approx_eq {
         ($x: expr, $y: expr) => {
             assert_approx_eq!($x, $y, 1e-5);
@@ -673,8 +832,157 @@ mod tests {
     fn test_as_frame() {
         let ctx = dummy_ctx();
         let geo_rotation = GeoRotation::from_bevy(GeoFrame::ENU, DQuat::IDENTITY, &ctx);
-        assert_ne!(geo_rotation.1.as_quat(), Quat::IDENTITY);
+        assert_eq!(geo_rotation.1.as_quat(), Quat::IDENTITY);
         assert_eq!(geo_rotation.to_bevy(&ctx).as_quat(), Quat::IDENTITY);
+    }
+
+    /// Quaternion equality up to sign (double cover), robust to fp noise.
+    macro_rules! assert_quat_eq {
+        ($a:expr, $b:expr) => {
+            assert_quat_eq!($a, $b, "quat mismatch")
+        };
+        ($a:expr, $b:expr, $($l:tt)+) => {
+            let a: DQuat = $a;
+            let b: DQuat = $b;
+            assert!(
+                a.dot(b).abs() > 1.0 - 1e-9,
+                "{}: got {:?} expected {:?}",
+                format!($($l)+),
+                a,
+                b
+            );
+        };
+    }
+
+    #[test]
+    fn relative_identity_is_identity_in_bevy() {
+        let ctx = dummy_ctx();
+        for frame in [GeoFrame::ENU, GeoFrame::NED, GeoFrame::ECEF] {
+            let r = GeoRotation::new(frame, DQuat::IDENTITY);
+            assert_eq!(r.2, RotationKind::Relative);
+            assert_quat_eq!(r.to_bevy(&ctx), DQuat::IDENTITY, "{frame:?}");
+        }
+    }
+
+    #[test]
+    fn absolute_identity_is_basis_change() {
+        let ctx = dummy_ctx();
+        // Per the RotationKind doc: identity in ENU rotates [x,y,z] to [x,z,-y].
+        let r = GeoRotation::absolute(GeoFrame::ENU, DQuat::IDENTITY);
+        let q = r.to_bevy(&ctx);
+        assert_approx_eq!(
+            q * DVec3::new(1.0, 2.0, 3.0),
+            DVec3::new(1.0, 3.0, -2.0),
+            1e-9
+        );
+        // It must match the frame's basis-change rotation exactly.
+        let basis = DQuat::from_mat3(&GeoFrame::bevy_R_(&GeoFrame::ENU, &ctx));
+        assert_quat_eq!(q, basis);
+    }
+
+    /// `look_at` is computed entirely in frame coordinates; converting to Bevy
+    /// must point the camera (forward `-Z`, up `+Y`) along the frame-space
+    /// direction in every frame and presentation mode.
+    #[test]
+    fn look_at_orients_camera_in_any_frame() {
+        let contexts = [
+            dummy_ctx(),
+            dummy_ctx().with_present(Present::Sphere),
+            GeoContext::from(GeoOrigin::new_from_degrees(35.0, -110.0, 0.0))
+                .with_present(Present::Sphere),
+        ];
+        let dir = DVec3::new(1.0, -2.0, 0.5);
+        let up = DVec3::new(-0.2, 0.3, 1.0);
+
+        for (c, ctx) in contexts.iter().enumerate() {
+            for frame in [GeoFrame::ENU, GeoFrame::NED, GeoFrame::ECEF] {
+                let bevy_R = GeoFrame::bevy_R_(&frame, ctx);
+
+                let r = GeoRotation::look_at(frame, dir, Some(up), ctx);
+                assert_eq!(r.0, frame);
+                assert_eq!(r.2, RotationKind::Relative);
+                let q = r.to_bevy(ctx);
+
+                let fwd = q * DVec3::NEG_Z;
+                let expected = (bevy_R * dir).normalize();
+                assert_approx_eq!(fwd, expected, 1e-9, format!("ctx {c} {frame:?} forward"));
+
+                // Camera up must tilt toward the requested up.
+                let cam_up = q * DVec3::Y;
+                assert!(
+                    cam_up.dot((bevy_R * up).normalize()) > 0.0,
+                    "ctx {c} {frame:?}: camera up {cam_up:?} points away from requested up"
+                );
+
+                // Default up: same forward, and up matches the frame's
+                // natural camera up projected off the view direction.
+                let q_default = GeoRotation::look_at(frame, dir, None, ctx).to_bevy(ctx);
+                let fwd_default = q_default * DVec3::NEG_Z;
+                assert_approx_eq!(
+                    fwd_default,
+                    expected,
+                    1e-9,
+                    format!("ctx {c} {frame:?} default-up forward")
+                );
+                // Default up maps to Bevy +Y, so the camera stays right side
+                // up for any mostly-horizontal view direction.
+                assert!(
+                    (q_default * DVec3::Y).dot(DVec3::Y) > 0.0,
+                    "ctx {c} {frame:?}: default camera up flipped"
+                );
+            }
+        }
+    }
+
+    /// Looking "north" with frame-up must be the identity attitude in both
+    /// ENU and NED (their camera identity axes differ, the result must not).
+    #[test]
+    fn look_at_identity_per_frame() {
+        let ctx = dummy_ctx();
+        let cases = [
+            (GeoFrame::ENU, DVec3::Y, DVec3::Z),
+            (GeoFrame::NED, DVec3::X, DVec3::NEG_Z),
+        ];
+        for (frame, north, up) in cases {
+            let r = GeoRotation::look_at(frame, north, Some(up), &ctx);
+            assert_quat_eq!(r.1, DQuat::IDENTITY, "{frame:?} local");
+            assert_quat_eq!(r.to_bevy(&ctx), DQuat::IDENTITY, "{frame:?} bevy");
+        }
+    }
+
+    #[test]
+    fn from_bevy_kind_round_trips() {
+        let ctx = dummy_ctx();
+        let v = DQuat::from_euler(bevy::math::EulerRot::XYZ, 0.4, -0.9, 1.3);
+        for frame in [GeoFrame::ENU, GeoFrame::NED, GeoFrame::ECEF] {
+            for kind in [RotationKind::Relative, RotationKind::Absolute] {
+                let r = GeoRotation::from_bevy_kind(frame, v, &ctx, kind);
+                assert_eq!(r.2, kind);
+                assert_quat_eq!(r.to_bevy(&ctx), v, "{frame:?} {kind:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn as_frame_preserves_bevy_rotation_and_kind() {
+        // Sphere mode: all frames map to Bevy consistently. (In Plane mode the
+        // ECEF -> Bevy mapping is a fixed swizzle that intentionally disagrees
+        // with the origin-dependent ENU mapping.)
+        let ctx = dummy_ctx().with_present(Present::Sphere);
+        let q = DQuat::from_euler(bevy::math::EulerRot::XYZ, 0.4, -0.9, 1.3);
+        for kind in [RotationKind::Relative, RotationKind::Absolute] {
+            for to_frame in [GeoFrame::NED, GeoFrame::ECEF] {
+                let r = GeoRotation(GeoFrame::ENU, q, kind);
+                let converted = r.as_frame(to_frame, &ctx);
+                assert_eq!(converted.0, to_frame);
+                assert_eq!(converted.2, kind);
+                assert_quat_eq!(
+                    converted.to_bevy(&ctx),
+                    r.to_bevy(&ctx),
+                    "{to_frame:?} {kind:?}"
+                );
+            }
+        }
     }
 
     #[test]
@@ -685,15 +993,44 @@ mod tests {
     }
 
     #[test]
-    fn bevy_r_ecef_plane_and_sphere_match() {
+    fn bevy_r_ecef_plane_converts_through_enu() {
         let origin = GeoOrigin::new_from_degrees(0.0, 0.0, 0.0)
             .with_ellipsoid(Ellipsoid::Sphere { radius: 1.0 });
         let ctx_plane: GeoContext = origin.into();
         let ctx_sphere = ctx_plane.clone().with_present(Present::Sphere);
 
+        let bevy_R_ecef_p = GeoFrame::bevy_R_(&GeoFrame::ECEF, &ctx_plane);
         let bevy_R_ecef_s = GeoFrame::bevy_R_(&GeoFrame::ECEF, &ctx_sphere);
+        let ecef_R_enu_p = GeoFrame::ecef_R_(&GeoFrame::ENU, &ctx_plane.origin);
         let ecef_R_enu_s = GeoFrame::ecef_R_(&GeoFrame::ENU, &ctx_sphere.origin);
+        let bevy_R_enu_p = GeoFrame::bevy_R_(&GeoFrame::ENU, &ctx_plane);
         let bevy_R_enu_s = GeoFrame::bevy_R_(&GeoFrame::ENU, &ctx_sphere);
+
+        let expected_bevy_R_ecef_p = bevy_R_enu_p * ecef_R_enu_p.inverse();
+        assert_approx_eq!(
+            bevy_R_ecef_p * DVec3::X,
+            expected_bevy_R_ecef_p * DVec3::X,
+            1e-9,
+            "plane ECEF should go through ENU before Bevy"
+        );
+        assert_approx_eq!(
+            bevy_R_ecef_p * DVec3::X,
+            DVec3::Y,
+            1e-9,
+            "plane bevy_R_ecef x-axis"
+        );
+        assert_approx_eq!(
+            bevy_R_ecef_p * DVec3::Y,
+            DVec3::X,
+            1e-9,
+            "plane bevy_R_ecef y-axis"
+        );
+        assert_approx_eq!(
+            bevy_R_ecef_p * DVec3::Z,
+            DVec3::NEG_Z,
+            1e-9,
+            "plane bevy_R_ecef z-axis"
+        );
 
         assert_approx_eq!(
             bevy_R_ecef_s * DVec3::X,
@@ -718,15 +1055,15 @@ mod tests {
 
         assert_approx_eq!(ecef_R_enu_s * DVec3::Y, DVec3::Z, 1e-9, "ecef_R_enu y-axis");
 
-        // The next two assertions show that we do not entirely comport with
-        // what map_3d does.
+        // 1 m north of the origin (1,0,0): north at lat/lon 0 is +Z_ecef.
         assert_approx_eq!(
             convert_pos(GeoFrame::ECEF, GeoFrame::ENU, DVec3::Y, &ctx_sphere),
-            2.0 * DVec3::X,
+            DVec3::new(1.0, 0.0, 1.0),
             1e-9,
             "convert_pos ecef _M_ y-axis"
         );
 
+        // 1 m above the origin (1,0,0): matches map_3d's enu2ecef.
         assert_approx_eq!(
             convert_pos_map_3d(GeoFrame::ECEF, GeoFrame::ENU, DVec3::Z, &ctx_sphere),
             DVec3::new(2.0, 0.0, 0.0),
@@ -735,7 +1072,7 @@ mod tests {
         );
         assert_approx_eq!(
             convert_pos(GeoFrame::ECEF, GeoFrame::ENU, DVec3::Z, &ctx_sphere),
-            DVec3::new(1.0, 1.0, 0.0),
+            DVec3::new(2.0, 0.0, 0.0),
             1e-9,
             "convert_pos ecef _M_ z-axis"
         );
@@ -750,6 +1087,155 @@ mod tests {
         );
         assert_approx_eq!(bevy_R_enu_s * DVec3::Y, DVec3::Y, 1e-9, "bevy_R_enu y-axis");
         assert_approx_eq!(bevy_R_enu_s * DVec3::Z, DVec3::X, 1e-9, "bevy_R_enu z-axis");
+    }
+
+    #[test]
+    fn ecef_plane_positions_are_local_enu_in_bevy() {
+        let ctx: GeoContext = GeoOrigin::new_from_degrees(34.72, -86.64, 180.5).into();
+        let cases = [
+            (
+                convert_pos_map_3d(GeoFrame::ECEF, GeoFrame::ENU, DVec3::ZERO, &ctx),
+                Vec3::ZERO,
+                "origin",
+            ),
+            (
+                convert_pos_map_3d(GeoFrame::ECEF, GeoFrame::ENU, DVec3::X, &ctx),
+                Vec3::X,
+                "1 m east",
+            ),
+            (
+                convert_pos_map_3d(GeoFrame::ECEF, GeoFrame::ENU, DVec3::Y, &ctx),
+                Vec3::NEG_Z,
+                "1 m north",
+            ),
+            (
+                convert_pos_map_3d(GeoFrame::ECEF, GeoFrame::ENU, DVec3::Z, &ctx),
+                Vec3::Y,
+                "1 m up",
+            ),
+        ];
+
+        for (ecef, expected, label) in cases {
+            assert_approx_eq!(
+                GeoPosition(GeoFrame::ECEF, ecef).to_bevy(&ctx).as_vec3(),
+                expected,
+                1e-4,
+                label
+            );
+        }
+    }
+
+    #[test]
+    fn ned_to_ecef_matches_map_3d_for_nontrivial_origins() {
+        let cases = [
+            (
+                GeoOrigin::new_from_degrees(34.72, -86.64, 180.5),
+                DVec3::new(125.0, -42.0, -17.5),
+                "huntsville-ish",
+            ),
+            (
+                GeoOrigin::new_from_degrees(-23.55, 133.88, 700.0),
+                DVec3::new(-310.0, 80.0, 12.0),
+                "southern hemisphere",
+            ),
+            (
+                GeoOrigin::new_from_degrees(67.9, 21.1, 420.0),
+                DVec3::new(4_000.0, -1_250.0, -250.0),
+                "high latitude",
+            ),
+        ];
+
+        for (origin, ned, label) in cases {
+            let ctx_plane: GeoContext = origin.into();
+            assert_ned_to_ecef_matches_map_3d(&ctx_plane, ned, &format!("{label} plane"));
+
+            let ctx_sphere = ctx_plane.with_present(Present::Sphere);
+            assert_ned_to_ecef_matches_map_3d(&ctx_sphere, ned, &format!("{label} sphere"));
+        }
+    }
+
+    #[test]
+    fn geo_frames_example_distances_match_in_plane_and_sphere() {
+        fn assert_example_distances(ctx: &GeoContext, label: &str) {
+            let ned_origin = GeoPosition(GeoFrame::NED, DVec3::ZERO).to_bevy(ctx);
+            let enu_one_meter_east = GeoPosition(GeoFrame::ENU, DVec3::X).to_bevy(ctx);
+            let ecef_one_meter_up = GeoPosition(
+                GeoFrame::ECEF,
+                geo_frames_example_ecef_from_enu(0.0, 0.0, 1.0),
+            )
+            .to_bevy(ctx);
+
+            let east_delta = enu_one_meter_east - ned_origin;
+            let up_delta = ecef_one_meter_up - ned_origin;
+            let bevy_R_enu = GeoFrame::bevy_R_(&GeoFrame::ENU, ctx);
+            let expected_east = bevy_R_enu * DVec3::X;
+            let expected_up = bevy_R_enu * DVec3::Z;
+
+            assert_approx_eq!(
+                east_delta,
+                expected_east,
+                1e-4,
+                format!("{label}: ENU cube should be 1 m east")
+            );
+            assert_approx_eq!(
+                up_delta,
+                expected_up,
+                1e-4,
+                format!("{label}: ECEF cube should be 1 m up")
+            );
+            assert!(
+                (ned_origin.distance(enu_one_meter_east) - 1.0).abs() < 1e-4,
+                "{label}: NED origin to ENU east distance was {}",
+                ned_origin.distance(enu_one_meter_east)
+            );
+            assert!(
+                (ned_origin.distance(ecef_one_meter_up) - 1.0).abs() < 1e-4,
+                "{label}: NED origin to ECEF up distance was {}",
+                ned_origin.distance(ecef_one_meter_up)
+            );
+            assert!(
+                (enu_one_meter_east.distance(ecef_one_meter_up) - 2.0_f64.sqrt()).abs() < 1e-4,
+                "{label}: ENU east to ECEF up distance was {}",
+                enu_one_meter_east.distance(ecef_one_meter_up)
+            );
+        }
+
+        fn example_camera_forward_up(ctx: &GeoContext) -> (DVec3, DVec3) {
+            let camera_pos = DVec3::new(4.0, 4.0, -3.0);
+            let camera_look_at = DVec3::ZERO;
+            let camera_dir = camera_look_at - camera_pos;
+            let camera_rot =
+                GeoRotation::look_at(GeoFrame::NED, camera_dir, None, ctx).to_bevy(ctx);
+            (camera_rot * DVec3::NEG_Z, camera_rot * DVec3::Y)
+        }
+
+        fn projected_ecef_up(ctx: &GeoContext, camera_forward: DVec3) -> DVec3 {
+            let ecef_origin = geo_frames_example_ecef_from_enu(0.0, 0.0, 0.0);
+            let ecef_one_meter_up = geo_frames_example_ecef_from_enu(0.0, 0.0, 1.0);
+            let ecef_down = ecef_origin - ecef_one_meter_up;
+            let bevy_up = GeoFrame::bevy_R_(&GeoFrame::ECEF, ctx) * (-ecef_down.normalize());
+            (bevy_up - camera_forward * bevy_up.dot(camera_forward)).normalize()
+        }
+
+        let ctx_plane: GeoContext = GeoOrigin::new_from_degrees(34.72, -86.64, 180.5).into();
+        assert_example_distances(&ctx_plane, "plane");
+        let (plane_camera_forward, plane_camera_up) = example_camera_forward_up(&ctx_plane);
+        let plane_projected_ecef_up = projected_ecef_up(&ctx_plane, plane_camera_forward);
+        let plane_up_alignment = plane_camera_up.dot(plane_projected_ecef_up);
+        assert!(
+            plane_up_alignment > 1.0 - 1e-9,
+            "plane camera up should match projected ECEF up; camera={plane_camera_up:?}, ecef_up={plane_projected_ecef_up:?}, dot={plane_up_alignment}"
+        );
+
+        let ctx_sphere = ctx_plane.with_present(Present::Sphere);
+        assert_example_distances(&ctx_sphere, "sphere");
+        let (sphere_camera_forward, sphere_camera_up) = example_camera_forward_up(&ctx_sphere);
+        let sphere_projected_ecef_up = projected_ecef_up(&ctx_sphere, sphere_camera_forward);
+        let up_alignment = sphere_camera_up.dot(sphere_projected_ecef_up);
+        assert!(
+            up_alignment < 0.99,
+            "sphere camera up unexpectedly matched projected ECEF up; camera={sphere_camera_up:?}, ecef_up={sphere_projected_ecef_up:?}, dot={up_alignment}"
+        );
     }
 
     #[test]
@@ -849,12 +1335,11 @@ mod tests {
             for (frame, expected_plane, expected_sphere) in expectations {
                 let zero = GeoPosition(frame, DVec3::ZERO);
                 let plane = zero.to_bevy(&ctx_plane).as_vec3();
-                // assert_approx_eq(
-                //     &format!("{frame:?} plane zero ({label})"),
-                //     plane,
-                //     expected_plane,
-                //     eps,
-                // );
+                let expected_plane = if frame == GeoFrame::ECEF {
+                    ecef_plane_to_bevy_expected(DVec3::ZERO, &ctx_plane)
+                } else {
+                    expected_plane
+                };
                 assert_approx_eq!(
                     plane,
                     expected_plane,
@@ -896,7 +1381,7 @@ mod tests {
             ),
             (
                 GeoFrame::ECEF,
-                Vec3::new(1.0, 3.0, -2.0),
+                ecef_plane_to_bevy_expected(v, &ctx_plane),
                 Vec3::new(1.0, 3.0, -2.0),
             ),
         ];
@@ -933,7 +1418,7 @@ mod tests {
         let cases = [
             (GeoFrame::ENU, Vec3::new(1.0, 3.0, -2.0)),
             (GeoFrame::NED, Vec3::new(2.0, -3.0, -1.0)),
-            (GeoFrame::ECEF, Vec3::new(1.0, 3.0, -2.0)),
+            (GeoFrame::ECEF, ecef_plane_to_bevy_expected(v, &ctx_plane)),
         ];
 
         for (frame, expected_plane) in cases {
@@ -949,7 +1434,7 @@ mod tests {
             assert_approx_eq!(
                 sphere,
                 if frame == GeoFrame::ECEF {
-                    expected_plane
+                    Vec3::new(1.0, 3.0, -2.0)
                 } else {
                     expected_plane + Vec3::Y
                 },
@@ -972,7 +1457,7 @@ mod tests {
         let cases = [
             (GeoFrame::ENU, Vec3::new(1.0, 3.0, -2.0)),
             (GeoFrame::NED, Vec3::new(2.0, -3.0, -1.0)),
-            (GeoFrame::ECEF, Vec3::new(1.0, 3.0, -2.0)),
+            (GeoFrame::ECEF, ecef_plane_to_bevy_expected(v, &ctx_plane)),
         ];
 
         for (frame, expected_plane) in cases {
@@ -988,7 +1473,7 @@ mod tests {
             assert_approx_eq!(
                 sphere,
                 if frame == GeoFrame::ECEF {
-                    expected_plane
+                    Vec3::new(1.0, 3.0, -2.0)
                 } else {
                     Vec3::new(
                         -expected_plane.z,
@@ -1019,7 +1504,7 @@ mod tests {
         let cases = [
             (GeoFrame::ENU, Vec3::new(1.0, 3.0, -2.0)),
             (GeoFrame::NED, Vec3::new(2.0, -3.0, -1.0)),
-            (GeoFrame::ECEF, Vec3::new(1.0, 3.0, -2.0)),
+            (GeoFrame::ECEF, ecef_plane_to_bevy_expected(v, &ctx_plane)),
         ];
 
         for (frame, expected_plane) in cases {
@@ -1035,7 +1520,7 @@ mod tests {
             assert_approx_eq!(
                 sphere,
                 if frame == GeoFrame::ECEF {
-                    expected_plane
+                    Vec3::new(1.0, 3.0, -2.0)
                 } else {
                     Vec3::new(
                         -expected_plane.z,

--- a/libs/bevy_geo_frames/src/prelude.rs
+++ b/libs/bevy_geo_frames/src/prelude.rs
@@ -8,3 +8,5 @@ pub use super::GeoContext;
 pub use super::GeoPosition;
 #[cfg(feature = "bevy")]
 pub use super::GeoRotation;
+#[cfg(feature = "bevy")]
+pub use super::RotationKind;

--- a/libs/elodin-editor/Cargo.toml
+++ b/libs/elodin-editor/Cargo.toml
@@ -19,6 +19,7 @@ tracy = ["bevy/trace_tracy", "bevy/debug"]
 hamann-chen-line = { path = "../hamann-chen-line" }
 nox.path = "../nox"
 nox.default-features = false
+nox.features = ["bevy_math"]
 egui_material_icons = "0.5"
 ab_glyph = "0.2"
 
@@ -29,6 +30,7 @@ bevy = { workspace = true, features = [
   "bevy_audio",
   "vorbis",
 ] }
+# bevy_math.version = "0.18"
 bevy_render.version = "0.18"
 bevy_color.version = "0.18"
 bevy_egui.version = "0.39.1"

--- a/libs/elodin-editor/src/headless.rs
+++ b/libs/elodin-editor/src/headless.rs
@@ -61,6 +61,8 @@ pub struct HeadlessEditorPlugin;
 
 impl Plugin for HeadlessEditorPlugin {
     fn build(&self, app: &mut App) {
+        // Must run before anything can spawn a `WorldPos` entity.
+        crate::register_world_pos_components(app);
         app.add_plugins(crate::plugins::WebAssetPlugin)
             .add_plugins(crate::plugins::env_asset_source::plugin)
             .add_plugins(
@@ -122,6 +124,8 @@ impl Plugin for HeadlessEditorPlugin {
                     // with the sensor camera's pose (which reads the TelemetryCache
                     // directly), preventing one-frame jitter in `sensor_view`.
                     sync_pos,
+                    #[cfg(not(feature = "big_space"))]
+                    bevy_geo_frames::apply_transforms,
                     bevy_geo_frames::apply_geo_rotation,
                     #[cfg(feature = "big_space")]
                     crate::spatial::apply_big_translation,
@@ -147,9 +151,9 @@ impl Plugin for HeadlessEditorPlugin {
             .add_systems(Update, load_headless_scene)
             .set_runner(render_server_runner);
 
+        app.add_systems(PreUpdate, crate::warn_missing_geo.before(PositionSync));
         #[cfg(feature = "big_space")]
-        app.add_plugins(crate::spatial::FloatingOriginPlugin::new(16_000., 100.))
-            .add_systems(PreUpdate, crate::setup_cell.after(impeller2_bevy::sink));
+        app.add_plugins(crate::spatial::FloatingOriginPlugin::new(16_000., 100.));
         if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app
                 .init_resource::<HeadlessMode>()
@@ -185,8 +189,8 @@ fn load_headless_scene(
     mut mat3_materials: ResMut<Assets<Mat3Material>>,
     mut world_mesh_materials: ResMut<Assets<bevy_world_mesh::prelude::WorldMeshMaterial>>,
     asset_server: Res<AssetServer>,
-    geo_context: Res<GeoContext>,
     connection_addr: Option<Res<ConnectionAddr>>,
+    mut geo_context: ResMut<GeoContext>,
 ) {
     if *loaded {
         return;
@@ -207,6 +211,11 @@ fn load_headless_scene(
     };
     let connection_addr = connection_addr.as_ref().map(|addr| addr.0);
     let fallback_frame = schematic.frame;
+
+    if let Some(o) = schematic.origin {
+        geo_context.origin =
+            bevy_geo_frames::GeoOrigin::new_from_degrees(o.latitude, o.longitude, o.altitude);
+    }
 
     for elem in &schematic.elems {
         match elem {

--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -56,7 +56,8 @@ use ui::{
 /// Global coordinate frame resource set by the schematic's top-level `coordinate` node.
 /// Individual elements (viewport, object_3d, line_3d, vector_arrow) use this as a fallback
 /// when they don't specify their own frame.
-#[derive(Resource, Default, Clone, Copy, Debug)]
+#[derive(Resource, Default, Clone, Copy, Debug, Reflect)]
+#[reflect(Resource)]
 pub struct Coordinate(pub Option<GeoFrame>);
 
 mod embedded_lfs;
@@ -183,6 +184,8 @@ impl EditorPlugin {
 
 impl Plugin for EditorPlugin {
     fn build(&self, app: &mut App) {
+        // Must run before anything can spawn a `WorldPos` entity.
+        register_world_pos_components(app);
         let composite_alpha_mode = if cfg!(target_os = "macos") {
             bevy::window::CompositeAlphaMode::PostMultiplied
         } else {
@@ -325,6 +328,8 @@ impl Plugin for EditorPlugin {
                     sync_object_3d,
                     set_viewport_pos,
                     sync_pos,
+                    #[cfg(not(feature = "big_space"))]
+                    bevy_geo_frames::apply_transforms,
                     bevy_geo_frames::apply_geo_rotation,
                     #[cfg(feature = "big_space")]
                     spatial::apply_big_translation,
@@ -395,9 +400,9 @@ impl Plugin for EditorPlugin {
             .add_systems(Update, sensor_camera::patch_sensor_view_dims)
             .add_systems(Update, throttle_for_sensor_cameras);
 
+        app.add_systems(PreUpdate, warn_missing_geo.before(PositionSync));
         #[cfg(feature = "big_space")]
-        app.add_plugins(spatial::FloatingOriginPlugin::new(16_000., 100.))
-            .add_systems(PreUpdate, setup_cell.before(PositionSync));
+        app.add_plugins(spatial::FloatingOriginPlugin::new(16_000., 100.));
         if cfg!(target_os = "windows") || cfg!(target_os = "linux") {
             app.add_systems(Update, handle_drag_resize);
         }
@@ -933,22 +938,61 @@ fn set_icon_mac() {
     }
 }
 
-#[cfg(feature = "big_space")]
-pub fn setup_cell(
-    query: Query<Entity, (With<WorldPos>, Without<crate::spatial::GridCell>)>,
-    mut cmds: Commands,
+/// `WorldPos` entities are positioned exclusively by the geo pipeline
+/// (`sync_pos` -> `GeoPosition`/`GeoRotation` -> `Transform`/`GridCell`), so
+/// inserting `WorldPos` must always bring the pipeline components along.
+/// Spawners that need a non-default frame insert their own `Geo*` components,
+/// which take precedence over these defaults.
+pub fn register_world_pos_components(app: &mut App) {
+    app.register_required_components_with::<WorldPos, GeoPosition>(|| {
+        GeoPosition(GeoFrame::default(), DVec3::ZERO)
+    });
+    app.register_required_components_with::<WorldPos, GeoRotation>(|| {
+        GeoRotation::new(GeoFrame::default(), DQuat::IDENTITY)
+    });
+    app.register_required_components::<WorldPos, Transform>();
+    #[cfg(feature = "big_space")]
+    app.register_required_components::<WorldPos, crate::spatial::GridCell>();
+}
+
+/// `WorldPos` requires the `Geo*` components ([`register_world_pos_components`]),
+/// so this should never fire; an entity that escapes the geo pipeline is never
+/// positioned.
+#[allow(clippy::type_complexity)]
+pub fn warn_missing_geo(
+    query: Query<
+        (Entity, Option<&Name>),
+        (
+            With<WorldPos>,
+            Or<(Without<GeoPosition>, Without<GeoRotation>)>,
+        ),
+    >,
 ) {
-    for e in query.iter() {
-        cmds.entity(e)
-            .insert((Transform::default(), crate::spatial::GridCell::default()));
+    for (entity, name) in query.iter() {
+        bevy::log::warn_once!(
+            "{entity} ({name:?}) has WorldPos without GeoPosition/GeoRotation; it will not be positioned"
+        );
     }
 }
 
+/// Accessors for `WorldPos` simulation coordinates.
+///
+/// Positioning goes exclusively through the geo pipeline: read `pos()`/`att()`
+/// and convert with `GeoPosition`/`GeoRotation` + `GeoContext`. The `bevy_*`
+/// methods hard-code the ENU-Plane mapping and exist only as legacy oracles
+/// for tests; they silently disagree with `Present::Sphere` and non-ENU
+/// frames.
 pub trait WorldPosExt {
+    /// Legacy ENU-Plane position swizzle `(x, z, -y)`. Test oracle only;
+    /// use `GeoPosition::to_bevy` instead.
     fn bevy_pos(&self) -> DVec3;
+    /// Legacy ENU-Plane attitude swizzle. Test oracle only; use
+    /// `GeoRotation::to_bevy` instead.
     fn bevy_att(&self) -> DQuat;
 
+    /// Position in simulation coordinates.
     fn pos(&self) -> DVec3;
+    /// Attitude in simulation coordinates.
     fn att(&self) -> DQuat;
 }
 
@@ -1012,87 +1056,27 @@ pub fn follow_latest(
     current_ts.0 = latest.0;
 }
 
-#[cfg(feature = "big_space")]
-#[allow(clippy::type_complexity)]
+/// Sync `WorldPos` (sim coordinates) into the entity's `GeoPosition` and
+/// `GeoRotation`. The geo pipeline (`apply_transforms`/`apply_big_translation`
+/// plus `apply_geo_rotation`) then produces the Bevy `Transform`/`GridCell`.
+///
+/// Every `WorldPos` entity gets its `Geo*` components at insertion
+/// ([`register_world_pos_components`]) or from its spawner, so there is no
+/// direct `WorldPos` -> `Transform` path.
 pub fn sync_pos(
-    mut query: Query<
-        (
-            &mut Transform,
-            Option<&mut GeoPosition>,
-            Option<&mut GeoRotation>,
-            &mut crate::spatial::GridCell,
-            &WorldPos,
-        ),
-        Changed<WorldPos>,
-    >,
-    geo_context: Res<GeoContext>,
-    floating_origin: Res<FloatingOriginSettings>,
-) {
-    query.iter_mut().for_each(
-        |(mut transform, mut geo_pos, mut geo_rot, mut grid_cell, world_pos)| {
-            if let Some(ref mut geo_pos) = geo_pos {
-                geo_pos.1 = world_pos.pos();
-            }
-            if let Some(ref mut geo_rot) = geo_rot {
-                // att() is in ENU. We have to do a conversion if geo_rot.0 isn't ENU.
-                **geo_rot = GeoRotation::from_bevy(geo_rot.0, world_pos.bevy_att(), &geo_context);
-                //geo_rot.1 = world_pos.att();
-            }
-
-            if geo_pos.is_none() {
-                // We only update the transform here if geo_pos is not present.
-                let pos = world_pos.bevy_pos();
-                let (new_grid_cell, translation) = floating_origin.translation_to_grid(pos);
-                *grid_cell = new_grid_cell;
-                transform.translation = translation;
-            }
-            if geo_rot.is_none() {
-                // We only update the transform here if geo_rot is not present.
-                let att = world_pos.bevy_att();
-                // Preserve the existing scale when updating position and rotation
-                transform.rotation = att.as_quat();
-            }
-        },
-    );
-}
-
-#[cfg(not(feature = "big_space"))]
-#[allow(clippy::type_complexity)]
-pub fn sync_pos(
-    mut query: Query<
-        (
-            &mut Transform,
-            Option<&mut GeoPosition>,
-            Option<&mut GeoRotation>,
-            &WorldPos,
-        ),
-        Changed<WorldPos>,
-    >,
-    geo_context: Res<GeoContext>,
+    mut query: Query<(&mut GeoPosition, &mut GeoRotation, &WorldPos), Changed<WorldPos>>,
 ) {
     query
         .iter_mut()
-        .for_each(|(mut transform, mut geo_pos, mut geo_rot, world_pos)| {
-            if let Some(ref mut geo_pos) = geo_pos {
-                geo_pos.1 = world_pos.pos();
-            }
-            if let Some(ref mut geo_rot) = geo_rot {
-                // att() is in ENU. We have to do a conversion if geo_rot.0 isn't ENU.
-                **geo_rot = GeoRotation::from_bevy(geo_rot.0, world_pos.bevy_att(), &geo_context);
-                //geo_rot.1 = world_pos.att();
-            }
-
-            if geo_pos.is_none() {
-                // We only update the transform here if geo_pos is not present.
-                let pos = world_pos.bevy_pos();
-                transform.translation = pos.as_vec3();
-            }
-            if geo_rot.is_none() {
-                // We only update the transform here if geo_rot is not present.
-                let att = world_pos.bevy_att();
-                // Preserve the existing scale when updating position and rotation
-                transform.rotation = att.as_quat();
-            }
+        .for_each(|(mut geo_pos, mut geo_rot, world_pos)| {
+            geo_pos.1 = world_pos.pos();
+            // att() is in ENU. We have to do a conversion if geo_rot.0 isn't ENU.
+            // (`GeoRotation::new(ENU, att).to_bevy` matches the legacy
+            // `bevy_att()` swizzle in Plane mode; see
+            // `test_bevy_att_vs_geo_frames_plane`.)
+            geo_rot.1 = world_pos.att();
+            // let bevy_att = GeoRotation::new(GeoFrame::ENU, world_pos.att()).to_bevy(&geo_context);
+            // *geo_rot = GeoRotation::from_bevy_kind(geo_rot.0, bevy_att, &geo_context, geo_rot.2);
         });
 }
 
@@ -1424,6 +1408,7 @@ pub enum TimeRangeError {
 }
 
 #[derive(Resource, PartialEq, Eq, Clone, Copy, Debug)]
+
 enum Offset {
     Earliest(Duration),
     Latest(Duration),
@@ -1691,4 +1676,50 @@ pub fn set_eql_context_range(time_range: Res<SelectedTimeRange>, mut eql: ResMut
 
 pub fn dirs() -> directories::ProjectDirs {
     directories::ProjectDirs::from("systems", "elodin", "editor").unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::app::App;
+    use bevy::math::{DQuat, EulerRot};
+
+    /// Inserting a bare `WorldPos` must pull in the `Geo*` components
+    /// (required components) and end up at the same Bevy pose the old
+    /// `sync_pos` fallback (`bevy_pos()`/`bevy_att()`) produced.
+    #[test]
+    fn world_pos_geo_pipeline_matches_legacy_swizzle() {
+        let ctx = GeoContext::default();
+        let mut app = App::new();
+        app.insert_resource(ctx.clone());
+        register_world_pos_components(&mut app);
+        app.add_systems(bevy::app::Update, sync_pos);
+
+        let att = DQuat::from_euler(EulerRot::XYZ, 0.3, -0.8, 1.1);
+        let world_pos = WorldPos {
+            att: nox::Quaternion::new(att.w, att.x, att.y, att.z),
+            pos: nox::Vector3::new(1.0, 2.0, 3.0),
+        };
+        let entity = app.world_mut().spawn(world_pos).id();
+        app.update();
+
+        let world = app.world();
+        let wp = world.get::<WorldPos>(entity).unwrap();
+        let geo_pos = world.get::<GeoPosition>(entity).unwrap();
+        let geo_rot = world.get::<GeoRotation>(entity).unwrap();
+        assert!(world.get::<Transform>(entity).is_some());
+
+        let pos = geo_pos.to_bevy(&ctx);
+        assert!(
+            (pos - wp.bevy_pos()).length() < 1e-9,
+            "got {pos:?}, expected {:?}",
+            wp.bevy_pos()
+        );
+        let q = geo_rot.to_bevy(&ctx);
+        assert!(
+            q.dot(wp.bevy_att()).abs() > 1.0 - 1e-9,
+            "got {q:?}, expected {:?}",
+            wp.bevy_att()
+        );
+    }
 }

--- a/libs/elodin-editor/src/plugins/gizmos/README.md
+++ b/libs/elodin-editor/src/plugins/gizmos/README.md
@@ -4,13 +4,17 @@ Rendering systems for vector arrows, body axes, and related UI labels.
 
 ## What it does
 - Registers `GizmoPlugin` systems for arrow/body-axis rendering.
+- Evaluates arrow expressions into start/end `WorldPos` endpoint entities
+  (`evaluate_vector_arrows`), which the canonical position pipeline
+  (`sync_pos` -> `GeoPosition`/`GeoRotation` -> `Transform`) places in Bevy
+  space; rendering then only reads the resulting endpoint poses.
 - Manages arrow-label UI cameras and label placement.
 - Defines shared render-layer constant `GIZMO_RENDER_LAYER`.
 
 ## Main API
 - `GizmoPlugin`
 - `GIZMO_RENDER_LAYER`
-- `evaluate_vector_arrow`
+- `evaluate_vector_arrows`
 
 ## Status
 Partially legacy: navigation cube UX is now handled by Cube-Viewer (`view_cube`).

--- a/libs/elodin-editor/src/plugins/gizmos/mod.rs
+++ b/libs/elodin-editor/src/plugins/gizmos/mod.rs
@@ -13,7 +13,7 @@ use bevy::{
         gizmos::Gizmos,
     },
     log::warn,
-    math::{DQuat, DVec3},
+    math::DVec3,
     prelude::*,
     text::{TextColor, TextFont},
     transform::components::Transform,
@@ -24,6 +24,7 @@ use impeller2::types::ComponentId;
 use impeller2_bevy::EntityMap;
 use impeller2_wkt::{
     BodyAxes, Color as WktColor, ComponentValue as WktComponentValue, LabelPosition, VectorArrow3d,
+    WorldPos,
 };
 use std::collections::{HashMap, HashSet};
 
@@ -34,7 +35,8 @@ use crate::{
     ui::tiles::ViewportConfig,
     ui::window::window_entity_from_target,
     vector_arrow::{
-        ArrowLabelScope, ArrowVisual, VectorArrowState, ViewportArrow, component_value_tail_to_vec3,
+        ArrowEndpoint, ArrowEndpoints, ArrowLabelScope, ArrowVisual, VectorArrowState,
+        ViewportArrow, component_value_tail_to_vec3,
     },
 };
 
@@ -43,7 +45,6 @@ type ArrowLabelCameraItem<'w> = (
     &'w Camera,
     &'w RenderTarget,
     &'w GlobalTransform,
-    Option<&'w ChildOf>,
     Option<&'w ViewportConfig>,
 );
 
@@ -78,20 +79,19 @@ const MIN_RADIUS_WORLD: f32 = 0.005;
 const MAX_RADIUS_WORLD: f32 = 0.05;
 const MAX_FINAL_RADIUS_WORLD: f32 = 0.1;
 
-#[derive(Clone)]
-pub struct EvaluatedVectorArrow {
-    pub start: DVec3,
-    pub end: DVec3,
-    pub color: Color,
-    pub name: Option<String>,
-    pub label_position: LabelPosition,
-}
-
 pub struct GizmoPlugin;
 
 impl Plugin for GizmoPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(Startup, (gizmo_setup, arrow_mesh_setup));
+        // Evaluate arrow expressions into endpoint `WorldPos` before the
+        // canonical position pipeline converts them to Transforms.
+        app.add_systems(
+            bevy::app::PreUpdate,
+            evaluate_vector_arrows
+                .after(impeller2_bevy::apply_cached_data)
+                .before(crate::sync_pos),
+        );
         // This is how the `big_space` crate did it.
         // app.add_systems(PostUpdate, render_vector_arrow.after(TransformSystem::TransformPropagate));
         app.add_systems(
@@ -163,21 +163,16 @@ fn arrow_mesh_setup(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>) {
     commands.insert_resource(ArrowMeshes { shaft, head });
 }
 
-/// Evaluate a vector arrow's expressions and return its world-space positions+metadata.
-pub fn evaluate_vector_arrow(
+/// Evaluate a vector arrow's expressions entirely in simulation coordinates,
+/// returning the start and end poses as `WorldPos` (same frame as the arrow).
+fn evaluate_arrow_endpoints(
     arrow: &VectorArrow3d,
     state: &VectorArrowState,
     entity_map: &EntityMap,
     component_values: &Query<'_, '_, &'static WktComponentValue>,
-    geo_context: &GeoContext,
-) -> Option<EvaluatedVectorArrow> {
-    let Some(vector_expr) = &state.vector_expr else {
-        return None;
-    };
-
-    let Ok(vector_value) = vector_expr.execute(entity_map, component_values) else {
-        return None;
-    };
+) -> Option<(WorldPos, WorldPos)> {
+    let vector_expr = state.vector_expr.as_ref()?;
+    let vector_value = vector_expr.execute(entity_map, component_values).ok()?;
 
     let mut direction = component_value_tail_to_vec3(&vector_value)?;
 
@@ -194,66 +189,128 @@ pub fn evaluate_vector_arrow(
         return None;
     }
 
-    let mut start_world = DVec3::ZERO;
-    let mut rotation = DQuat::IDENTITY;
+    let mut start = WorldPos::default();
     if let Some(origin_expr) = &state.origin_expr {
-        let Ok(origin_value) = origin_expr.execute(entity_map, component_values) else {
-            return None;
-        };
+        let origin_value = origin_expr.execute(entity_map, component_values).ok()?;
         if let Some(world_pos) = origin_value.as_world_pos() {
-            // Use ENU if no frame is specified.
-            if let Some(frame) = arrow.frame.or_default() {
-                start_world = GeoPosition(frame, world_pos.pos()).to_bevy(geo_context);
-                rotation = GeoRotation(frame, world_pos.att()).to_bevy(geo_context);
-            } else {
-                start_world = world_pos.bevy_pos();
-                rotation = world_pos.bevy_att();
-            }
+            start = world_pos;
         } else if let Some(origin) = component_value_tail_to_vec3(&origin_value) {
-            // Use ENU if no frame is specified.
-            if let Some(frame) = arrow.frame.or_default() {
-                start_world = GeoPosition(frame, origin).to_bevy(geo_context);
-            } else {
-                start_world = origin;
-            }
+            start.pos = nox::Vector3::new(origin.x, origin.y, origin.z);
         }
     }
 
-    if arrow.body_frame {
-        // Body-frame vectors are rotated by the body's orientation directly to Bevy world
-        direction = rotation * direction;
-    } else {
-        // World-frame vectors need geo-frame to Bevy transformation
-        direction =
-            GeoFrame::bevy_R_(&arrow.frame.unwrap_or(GeoFrame::ENU), geo_context) * direction;
+    Some((start, arrow_end_pos(&start, direction, arrow.body_frame)))
+}
+
+/// Compute the arrow's end pose in simulation coordinates: body-frame vectors
+/// are rotated by the body's attitude, world-frame vectors are added as-is.
+fn arrow_end_pos(start: &WorldPos, mut direction: DVec3, body_frame: bool) -> WorldPos {
+    if body_frame {
+        direction = start.att() * direction;
     }
+    let end_pos = start.pos() + direction;
+    WorldPos {
+        att: start.att,
+        pos: nox::Vector3::new(end_pos.x, end_pos.y, end_pos.z),
+    }
+}
 
-    let end_world = start_world + direction;
-    let label_position = arrow.label_position.clone();
+fn spawn_arrow_endpoint(
+    commands: &mut Commands,
+    owner: Entity,
+    world_pos: WorldPos,
+    frame: Option<GeoFrame>,
+    name: &'static str,
+) -> Entity {
+    let mut endpoint = commands.spawn((
+        world_pos,
+        Transform::default(),
+        #[cfg(feature = "big_space")]
+        GridCell::default(),
+        ArrowEndpoint { owner },
+        Name::new(name),
+    ));
+    if let Some(frame) = frame {
+        endpoint.insert((
+            GeoPosition(frame, DVec3::ZERO),
+            GeoRotation::new(frame, bevy::math::DQuat::IDENTITY),
+        ));
+    }
+    endpoint.id()
+}
 
-    Some(EvaluatedVectorArrow {
-        start: start_world,
-        end: end_world,
-        color: axis_color_from_name(arrow.name.as_deref(), wkt_color_to_bevy(&arrow.color)),
-        name: arrow.name.clone(),
-        label_position,
-    })
+/// Evaluate arrow expressions and write the results into the arrow's two
+/// endpoint entities as `WorldPos`. The canonical position pipeline
+/// (`sync_pos` -> Geo* -> Transform/GridCell) then places the endpoints in
+/// Bevy space; `render_vector_arrow` only reads the resulting poses.
+pub fn evaluate_vector_arrows(
+    mut commands: Commands,
+    entity_map: Res<EntityMap>,
+    component_values: Query<&'static WktComponentValue>,
+    mut arrows: Query<(
+        Entity,
+        &VectorArrow3d,
+        &mut VectorArrowState,
+        Option<&ArrowEndpoints>,
+    )>,
+    mut world_pos: Query<&mut WorldPos>,
+    mut logged_missing: Local<HashSet<Entity>>,
+) {
+    for (entity, arrow, mut state, endpoints) in arrows.iter_mut() {
+        let Some((start, end)) =
+            evaluate_arrow_endpoints(arrow, &state, &entity_map, &component_values)
+        else {
+            if logged_missing.insert(entity) {
+                info!(
+                    ?entity,
+                    name = ?arrow.name,
+                    "vector_arrow: evaluation failed (missing data or zero-length)"
+                );
+            }
+            state.valid = false;
+            continue;
+        };
+        state.valid = true;
+
+        if let Some(endpoints) = endpoints {
+            if let Ok(mut pos) = world_pos.get_mut(endpoints.start) {
+                pos.set_if_neq(start);
+            }
+            if let Ok(mut pos) = world_pos.get_mut(endpoints.end) {
+                pos.set_if_neq(end);
+            }
+        } else {
+            // Use ENU if no frame is specified.
+            let frame = arrow.frame.or_default();
+            let start = spawn_arrow_endpoint(&mut commands, entity, start, frame, "arrow_start");
+            let end = spawn_arrow_endpoint(&mut commands, entity, end, frame, "arrow_end");
+            commands
+                .entity(entity)
+                .insert(ArrowEndpoints { start, end });
+        }
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
 fn render_vector_arrow(
     mut commands: Commands,
-    entity_map: Res<EntityMap>,
-    mut vector_arrows: Query<(Entity, &VectorArrow3d, &mut VectorArrowState)>,
-    component_values: Query<&'static WktComponentValue>,
+    mut vector_arrows: Query<(
+        Entity,
+        &VectorArrow3d,
+        &mut VectorArrowState,
+        Option<&ArrowEndpoints>,
+    )>,
+    #[cfg(feature = "big_space")] endpoint_poses: Query<
+        (&Transform, &GridCell),
+        With<ArrowEndpoint>,
+    >,
+    #[cfg(not(feature = "big_space"))] endpoint_poses: Query<&Transform, With<ArrowEndpoint>>,
     #[cfg(feature = "big_space")] floating_origin: Res<FloatingOriginSettings>,
     arrow_meshes: Res<ArrowMeshes>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     main_cameras: Query<MainCameraQueryItem<'_>, With<crate::MainCamera>>,
     viewport_arrows: Query<&ViewportArrow>,
-    mut logged_missing: Local<HashSet<Entity>>,
     mut logged_small: Local<HashSet<Entity>>,
-    geo_context: Res<GeoContext>,
 ) {
     let main_camera_data: Vec<_> = main_cameras.iter().collect();
     let mut camera_index: HashMap<Entity, usize> = HashMap::new();
@@ -264,7 +321,7 @@ fn render_vector_arrow(
         .iter()
         .any(|(_, _, _, _, config, _)| config.as_ref().map(|c| c.show_arrows).unwrap_or(true));
 
-    for (entity, arrow, mut state) in vector_arrows.iter_mut() {
+    for (entity, arrow, mut state, endpoints) in vector_arrows.iter_mut() {
         if !has_show_arrows {
             for visual in state.visuals.values() {
                 hide_arrow_visual(&mut commands, visual);
@@ -273,16 +330,14 @@ fn render_vector_arrow(
             continue;
         }
 
-        let Some(result) =
-            evaluate_vector_arrow(arrow, &state, &entity_map, &component_values, &geo_context)
-        else {
-            if logged_missing.insert(entity) {
-                info!(
-                    ?entity,
-                    name = ?arrow.name,
-                    "vector_arrow: evaluation failed (missing data or zero-length)"
-                );
-            }
+        // Endpoints are spawned and evaluated by `evaluate_vector_arrows` and
+        // placed in Bevy space by the canonical position pipeline.
+        let endpoint_pair = endpoints.filter(|_| state.valid).and_then(|endpoints| {
+            endpoint_poses
+                .get_many([endpoints.start, endpoints.end])
+                .ok()
+        });
+        let Some([start_pose, end_pose]) = endpoint_pair else {
             for visual in state.visuals.values() {
                 hide_arrow_visual(&mut commands, visual);
             }
@@ -292,10 +347,21 @@ fn render_vector_arrow(
 
         cfg_select! {
             feature = "big_space" => {
-                let (start_cell, start) = floating_origin.translation_to_grid(result.start);
+                let (start_transform, start_cell) = start_pose;
+                let (end_transform, end_cell) = end_pose;
+                let start = start_transform.translation;
+                let start_cell = *start_cell;
+                let edge = floating_origin.grid_edge_length();
+                let cell_delta = Vec3::new(
+                    (end_cell.x as f64 - start_cell.x as f64) as f32 * edge,
+                    (end_cell.y as f64 - start_cell.y as f64) as f32 * edge,
+                    (end_cell.z as f64 - start_cell.z as f64) as f32 * edge,
+                );
+                let direction_world = cell_delta + (end_transform.translation - start_transform.translation);
             }
             _ => {
-                let start = result.start.as_vec3();
+                let start = start_pose.translation;
+                let direction_world = end_pose.translation - start_pose.translation;
             }
         }
 
@@ -307,7 +373,6 @@ fn render_vector_arrow(
             continue;
         }
 
-        let direction_world = (result.end - result.start).as_vec3();
         let length = direction_world.length();
         let dir_norm = if length > 0.0 {
             direction_world / length
@@ -315,14 +380,15 @@ fn render_vector_arrow(
             Vec3::Y
         };
         let rotation = Quat::from_rotation_arc(Vec3::Y, dir_norm);
-        let base_color = axis_color_from_name(result.name.as_deref(), result.color);
+        let base_color =
+            axis_color_from_name(arrow.name.as_deref(), wkt_color_to_bevy(&arrow.color));
 
         // Keep a minimum draw length so a near-zero vector still shows a tiny arrow.
         let draw_length = length.max(0.05);
         if draw_length <= (MIN_ARROW_LENGTH_SQUARED as f32).sqrt() && logged_small.insert(entity) {
             info!(
                 ?entity,
-                name = ?result.name,
+                name = ?arrow.name,
                 length,
                 "vector_arrow: very small magnitude, drawing minimum-sized arrow"
             );
@@ -346,7 +412,7 @@ fn render_vector_arrow(
                 if let Some(visual) = state.visuals.remove(&cam_entity) {
                     hide_arrow_visual(&mut commands, &visual);
                 }
-                state.label_grid_pos = None;
+                state.label_offset = None;
                 state.label_name = None;
                 state.label_color = None;
                 if let Some(label_entity) = state.label.take() {
@@ -448,11 +514,11 @@ fn render_vector_arrow(
 
         // Calculate and cache label offset from arrow root for the UI system.
         // Store as offset from arrow start so UI can use arrow's GlobalTransform.
-        if arrow.show_name && result.name.is_some() {
+        if arrow.show_name && arrow.name.is_some() {
             // Use proportional separation (10% of arrow length) with min/max bounds
             // to handle both very small and very large arrows gracefully
             let separation = (length * 0.1).clamp(0.005, 0.08);
-            let total_offset = match result.label_position {
+            let total_offset = match arrow.label_position {
                 LabelPosition::Proportionate(label_position) => {
                     // Place the label near the arrow tip by biasing toward the end of the vector
                     let label_t = label_position.max(0.8);
@@ -469,12 +535,12 @@ fn render_vector_arrow(
                 }
             };
             // Store just the offset from the arrow root
-            state.label_grid_pos = Some((0, 0, 0, total_offset));
-            state.label_name = result.name.clone();
+            state.label_offset = Some(total_offset);
+            state.label_name = arrow.name.clone();
             state.label_color = None;
             state.label_scope = arrow_scope;
         } else {
-            state.label_grid_pos = None;
+            state.label_offset = None;
             state.label_name = None;
             state.label_color = None;
             state.label_scope = ArrowLabelScope::Global;
@@ -578,16 +644,27 @@ fn hide_label(commands: &mut Commands, label: Option<Entity>) {
     }
 }
 
-// Despawn visuals when a VectorArrow3d is removed, to avoid stray meshes.
+// Despawn visuals and endpoints when a VectorArrow3d is removed, to avoid stray entities.
 fn cleanup_removed_arrows(
     mut removed_arrows: RemovedComponents<VectorArrow3d>,
     mut removed_states: RemovedComponents<VectorArrowState>,
     mut commands: Commands,
     mut states: Query<&mut VectorArrowState>,
     visuals: Query<(Entity, &ArrowVisualOwner)>,
+    endpoints: Query<(Entity, &ArrowEndpoint)>,
 ) {
     let mut owners: HashSet<Entity> = removed_arrows.read().collect();
     owners.extend(removed_states.read());
+
+    // Endpoint entities belong to the arrow regardless of whether its state survives.
+    for (endpoint_entity, endpoint) in endpoints.iter() {
+        if owners.contains(&endpoint.owner) {
+            commands.entity(endpoint_entity).despawn();
+            if let Ok(mut owner) = commands.get_entity(endpoint.owner) {
+                owner.remove::<ArrowEndpoints>();
+            }
+        }
+    }
 
     // If the state still exists, use it to clean up the associated visuals.
     for owner in owners.clone() {
@@ -633,44 +710,30 @@ fn lighten_color(color: Color, factor: f32) -> Color {
 fn update_arrow_label_ui(
     mut commands: Commands,
     arrows: Query<(Entity, &VectorArrowState)>,
-    #[cfg(feature = "big_space")] arrow_transforms: Query<(&Transform, &GridCell)>,
-    #[cfg(not(feature = "big_space"))] arrow_transforms: Query<&Transform>,
+    arrow_transforms: Query<&GlobalTransform>,
     cameras: Query<ArrowLabelCameraItem<'_>, With<MainCamera>>,
-    #[cfg(feature = "big_space")] parent_cells: Query<&GridCell, Without<MainCamera>>,
-    #[cfg(feature = "big_space")] floating_origin: Res<FloatingOriginSettings>,
     mut labels: Query<(Entity, &ArrowLabelUI, &mut Node, &mut Text, &mut TextColor)>,
     primary_window: Query<Entity, With<bevy::window::PrimaryWindow>>,
     ui_cameras: Query<(Entity, &RenderTarget), With<ArrowLabelUiCamera>>,
     // Key: (arrow_entity, camera_entity) -> label_entity
     mut label_map: Local<HashMap<(Entity, Entity), Entity>>,
 ) {
-    #[cfg(feature = "big_space")]
-    let edge = floating_origin.grid_edge_length();
     let Some(primary_entity) = primary_window.iter().next() else {
         return;
     };
 
     let mut window_cameras: HashMap<Entity, Vec<_>> = HashMap::new();
-    for (entity, cam, render_target, gt, _parent, config) in cameras.iter() {
+    for (entity, cam, render_target, gt, config) in cameras.iter() {
         if !cam.is_active {
             continue;
         }
         let Some(window) = window_entity_from_target(render_target, primary_entity) else {
             continue;
         };
-        let cell = cfg_select! {
-            feature = "big_space" => {
-                _parent
-                .and_then(|parent| parent_cells.get(parent.parent()).ok())
-                .copied()
-                .unwrap_or_default()
-            }
-            _ => { () }
-        };
         window_cameras
             .entry(window)
             .or_default()
-            .push((entity, cam, gt, cell, config));
+            .push((entity, cam, gt, config));
     }
 
     if window_cameras.is_empty() {
@@ -721,18 +784,11 @@ fn update_arrow_label_ui(
         let Some(visual) = arrow_state.visuals.values().next() else {
             continue;
         };
-        cfg_select! {
-            feature = "big_space" => {
-                let Ok((arrow_transform, arrow_cell)) = arrow_transforms.get(visual.root) else {
-                    continue;
-                };
-            }
-            _ => {
-                let Ok(arrow_transform) = arrow_transforms.get(visual.root) else {
-                    continue;
-                };
-            }
-        }
+        // GlobalTransform is propagated grid-aware by big_space, so it is
+        // already relative to the floating origin like the camera's.
+        let Ok(arrow_transform) = arrow_transforms.get(visual.root) else {
+            continue;
+        };
         let Some(ref name) = arrow_state.label_name else {
             continue;
         };
@@ -741,19 +797,16 @@ fn update_arrow_label_ui(
             use crate::ui::colors::ColorExt;
             crate::ui::colors::get_scheme().text_primary.into_bevy()
         };
-        let label_offset = arrow_state
-            .label_grid_pos
-            .map(|(_, _, _, offset)| offset)
-            .unwrap_or(Vec3::ZERO);
+        let label_offset = arrow_state.label_offset.unwrap_or(Vec3::ZERO);
 
         let label_text = name.clone();
-        let label_local = arrow_transform.translation + label_offset;
+        let label_pos = arrow_transform.translation() + label_offset;
 
         for (window, cameras) in &window_cameras {
             let Some(&ui_cam_entity) = window_ui_camera.get(window) else {
                 continue;
             };
-            for (cam_entity, cam, cam_transform, _cam_cell, config) in cameras {
+            for (cam_entity, cam, cam_transform, config) in cameras {
                 let show_arrows = config.map(|config| config.show_arrows).unwrap_or(true);
                 let key = (arrow_entity, *cam_entity);
 
@@ -774,22 +827,7 @@ fn update_arrow_label_ui(
                     continue;
                 }
 
-                let dv = cfg_select! {
-                    feature = "big_space" => {
-                        {
-                            let dx = (arrow_cell.x as f64 - _cam_cell.x as f64) as f32 * edge;
-                            let dy = (arrow_cell.y as f64 - _cam_cell.y as f64) as f32 * edge;
-                            let dz = (arrow_cell.z as f64 - _cam_cell.z as f64) as f32 * edge;
-                            Vec3::new(dx, dy, dz)
-                        }
-                    }
-                    _ => { Vec3::ZERO }
-                };
-
-                let camera_relative_pos = label_local + dv;
-
-                let Ok(screen_pos) = cam.world_to_viewport(cam_transform, camera_relative_pos)
-                else {
+                let Ok(screen_pos) = cam.world_to_viewport(cam_transform, label_pos) else {
                     if let Some(&label_entity) = label_map.get(&key)
                         && let Ok((_, _, mut node, _, _)) = labels.get_mut(label_entity)
                     {
@@ -877,6 +915,67 @@ fn update_arrow_label_ui(
     for key in labels_to_remove {
         if let Some(label_entity) = label_map.remove(&key) {
             commands.entity(label_entity).despawn();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::math::DQuat;
+    use bevy_geo_frames::{GeoContext, GeoRotation};
+
+    fn world_pos(pos: DVec3, att: DQuat) -> WorldPos {
+        WorldPos {
+            att: nox::Quaternion::new(att.w, att.x, att.y, att.z),
+            pos: nox::Vector3::new(pos.x, pos.y, pos.z),
+        }
+    }
+
+    fn bevy_delta(start: &WorldPos, end: &WorldPos, frame: GeoFrame, ctx: &GeoContext) -> DVec3 {
+        GeoPosition(frame, end.pos()).to_bevy(ctx) - GeoPosition(frame, start.pos()).to_bevy(ctx)
+    }
+
+    /// World-frame arrows: routing the endpoints through `GeoPosition::to_bevy`
+    /// must match converting the direction directly with `bevy_R_(frame)`.
+    #[test]
+    fn endpoints_match_direct_world_frame_conversion() {
+        let ctx = GeoContext::default();
+        let start = world_pos(
+            DVec3::new(10.0, -4.0, 2.5),
+            DQuat::from_euler(bevy::math::EulerRot::XYZ, 0.3, -0.8, 1.1),
+        );
+        let direction = DVec3::new(1.0, 2.0, 3.0);
+
+        for frame in [GeoFrame::ENU, GeoFrame::NED, GeoFrame::ECEF] {
+            let end = arrow_end_pos(&start, direction, false);
+            let delta = bevy_delta(&start, &end, frame, &ctx);
+            let expected = GeoFrame::bevy_R_(&frame, &ctx) * direction;
+            assert!(
+                (delta - expected).length() < 1e-9,
+                "{frame:?}: got {delta:?}, expected {expected:?}"
+            );
+        }
+    }
+
+    /// Body-frame arrows: rotating the direction by the body attitude in sim
+    /// coordinates must match the Bevy-space rotation by
+    /// `GeoRotation::absolute(frame, att).to_bevy`.
+    #[test]
+    fn endpoints_match_direct_body_frame_conversion() {
+        let ctx = GeoContext::default();
+        let att = DQuat::from_euler(bevy::math::EulerRot::XYZ, 0.5, 0.2, -0.7);
+        let start = world_pos(DVec3::new(-3.0, 8.0, 1.0), att);
+        let direction = DVec3::new(0.5, -1.5, 2.0);
+
+        for frame in [GeoFrame::ENU, GeoFrame::NED] {
+            let end = arrow_end_pos(&start, direction, true);
+            let delta = bevy_delta(&start, &end, frame, &ctx);
+            let expected = GeoRotation::absolute(frame, att).to_bevy(&ctx) * direction;
+            assert!(
+                (delta - expected).length() < 1e-9,
+                "{frame:?}: got {delta:?}, expected {expected:?}"
+            );
         }
     }
 }

--- a/libs/elodin-editor/src/plugins/thruster_particles/mod.rs
+++ b/libs/elodin-editor/src/plugins/thruster_particles/mod.rs
@@ -358,7 +358,7 @@ impl KdlThrusterJet {
 
 fn body_rotation(world_pos: &WorldPos, frame: Option<GeoFrame>, geo_context: &GeoContext) -> Quat {
     if let Some(frame) = frame {
-        GeoRotation(frame, world_pos.att())
+        GeoRotation::new(frame, world_pos.att())
             .to_bevy(geo_context)
             .as_quat()
     } else {

--- a/libs/elodin-editor/src/plugins/view_cube/camera.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/camera.rs
@@ -23,9 +23,11 @@ use super::components::{
 };
 use super::config::ViewCubeConfig;
 use super::events::ViewCubeEvent;
+use crate::Coordinate;
 use crate::WorldPosExt;
 use crate::object_3d::ComponentArrayExt;
 use crate::plugins::render_layer_alloc::RenderLayerLease;
+use bevy_geo_frames::{GeoContext, GeoPosition};
 
 const FACE_IN_SCREEN_PLANE_DOT_THRESHOLD: f32 = 0.999;
 const CORNER_IN_SCREEN_AXIS_DOT_THRESHOLD: f32 = 0.998;
@@ -294,6 +296,7 @@ pub(super) struct ViewCubeEditorLookup<'w, 's> {
     >,
     entity_map: Res<'w, EntityMap>,
     values: Query<'w, 's, &'static ComponentValue>,
+    geo_context: Res<'w, GeoContext>,
     time: Res<'w, Time>,
     arrow_cache: ResMut<'w, ViewCubeArrowTargetCache>,
     camera_parents: CameraParentQuery<'w, 's>,
@@ -384,6 +387,7 @@ impl<'w, 's> ViewCubeEditorLookup<'w, 's> {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn handle_view_cube_editor(
     mut events: MessageReader<ViewCubeEvent>,
     view_cube_query: Query<&ViewCubeLink, With<ViewCubeRoot>>,
@@ -392,6 +396,7 @@ pub fn handle_view_cube_editor(
     mut lookup: ViewCubeEditorLookup,
     config: Res<ViewCubeConfig>,
     mut look_to: MessageWriter<LookToTrigger>,
+    coordinate: Res<Coordinate>,
 ) {
     for event in events.read() {
         let now_secs = lookup.time.elapsed_secs_f64();
@@ -416,6 +421,8 @@ pub fn handle_view_cube_editor(
                 &lookup.viewports,
                 lookup.entity_map.as_ref(),
                 &lookup.values,
+                &lookup.geo_context,
+                &coordinate,
                 origin_world,
             );
         }
@@ -574,6 +581,8 @@ pub fn handle_view_cube_editor(
                 &lookup.viewports,
                 lookup.entity_map.as_ref(),
                 &lookup.values,
+                &lookup.geo_context,
+                &coordinate,
                 origin_world,
             );
 
@@ -1006,10 +1015,18 @@ fn update_anchor_depth_for_view_cube(
     viewports: &Query<&crate::ui::inspector::viewport::Viewport, With<ViewCubeTargetCamera>>,
     entity_map: &EntityMap,
     values: &Query<&'static ComponentValue>,
+    geo_context: &GeoContext,
+    coordinate: &Coordinate,
     origin_world: DVec3,
 ) {
-    let Some(orbit_target_world) = view_cube_orbit_target(camera, viewports, entity_map, values)
-    else {
+    let Some(orbit_target_world) = view_cube_orbit_target(
+        camera,
+        viewports,
+        entity_map,
+        values,
+        geo_context,
+        coordinate,
+    ) else {
         return;
     };
     let orbit_target = (orbit_target_world - origin_world).as_vec3();
@@ -1027,9 +1044,18 @@ fn refresh_anchor_depth_for_arrow(
     viewports: &Query<&crate::ui::inspector::viewport::Viewport, With<ViewCubeTargetCamera>>,
     entity_map: &EntityMap,
     values: &Query<&'static ComponentValue>,
+    geo_context: &GeoContext,
+    coordinate: &Coordinate,
     origin_world: DVec3,
 ) -> Option<(f32, f32)> {
-    let orbit_target_world = view_cube_orbit_target(camera, viewports, entity_map, values)?;
+    let orbit_target_world = view_cube_orbit_target(
+        camera,
+        viewports,
+        entity_map,
+        values,
+        geo_context,
+        coordinate,
+    )?;
     let orbit_target = (orbit_target_world - origin_world).as_vec3();
     let measured_distance = (orbit_target - camera_translation).length();
     if !measured_distance.is_finite() || measured_distance <= 1.0e-3 {
@@ -1048,12 +1074,14 @@ fn view_cube_orbit_target(
     viewports: &Query<&crate::ui::inspector::viewport::Viewport, With<ViewCubeTargetCamera>>,
     entity_map: &EntityMap,
     values: &Query<&'static ComponentValue>,
+    geo_context: &GeoContext,
+    coordinate: &Coordinate,
 ) -> Option<DVec3> {
     let viewport = viewports.get(camera).ok()?;
     let compiled_expr = viewport.look_at.compiled_expr.as_ref()?;
     let val = compiled_expr.execute(entity_map, values).ok()?;
     let world_pos = val.as_world_pos()?;
-    Some(world_pos.bevy_pos())
+    Some(GeoPosition(coordinate.0.unwrap_or_default(), world_pos.pos()).to_bevy(geo_context))
 }
 
 #[cfg(test)]

--- a/libs/elodin-editor/src/plugins/view_cube/camera.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/camera.rs
@@ -396,6 +396,7 @@ pub fn handle_view_cube_editor(
     mut lookup: ViewCubeEditorLookup,
     config: Res<ViewCubeConfig>,
     mut look_to: MessageWriter<LookToTrigger>,
+    geo_context: Res<GeoContext>,
     coordinate: Res<Coordinate>,
 ) {
     for event in events.read() {
@@ -644,6 +645,8 @@ pub fn handle_view_cube_editor(
                 &lookup.viewports,
                 lookup.entity_map.as_ref(),
                 &lookup.values,
+                &geo_context,
+                &coordinate,
             )
             .map(|target| (target - origin_world).as_vec3())
             .unwrap_or_else(|| {
@@ -701,6 +704,8 @@ pub fn handle_view_cube_editor(
                         &lookup.viewports,
                         lookup.entity_map.as_ref(),
                         &lookup.values,
+                        &geo_context,
+                        &coordinate,
                         origin_world,
                     );
                     if let Ok(facing) = Dir3::new(Vec3::NEG_Z) {

--- a/libs/elodin-editor/src/plugins/world_mesh/mod.rs
+++ b/libs/elodin-editor/src/plugins/world_mesh/mod.rs
@@ -1,8 +1,10 @@
 use bevy::{
     ecs::query::Or,
+    math::{DQuat, DVec3},
     pbr::wireframe::{Wireframe, WireframeColor},
     prelude::*,
 };
+use bevy_geo_frames::{GeoPosition, GeoRotation, OrDefault};
 use bevy_world_mesh::prelude::WorldMeshPlugin as BevyWorldMeshRendererPlugin;
 use bevy_world_mesh::terrain::{
     math::TerrainModel,
@@ -96,6 +98,7 @@ pub(crate) fn spawn_world_mesh_terrain(
                 ))
                 .id();
 
+            insert_geo_components(commands, entity, world_mesh);
             insert_big_space_cell(commands, entity);
             entity
         }
@@ -119,18 +122,34 @@ fn apply_world_mesh_transform_and_visibility(
     terrain_bundle: &mut TerrainBundle,
     world_mesh: &impeller2_wkt::WorldMesh,
 ) {
-    if let Some((tx, ty, tz)) = world_mesh.translate {
-        terrain_bundle.transform.translation += Vec3::new(tx as f32, ty as f32, tz as f32);
-    }
+    terrain_bundle.transform = world_mesh_transform(world_mesh);
     terrain_bundle.visibility = world_mesh_visibility(world_mesh);
 }
 
 fn world_mesh_transform(world_mesh: &impeller2_wkt::WorldMesh) -> Transform {
     let mut transform = Transform::default();
+    if world_mesh.frame.or_default().is_some() {
+        return transform;
+    }
     if let Some((tx, ty, tz)) = world_mesh.translate {
         transform.translation += Vec3::new(tx as f32, ty as f32, tz as f32);
     }
     transform
+}
+
+fn insert_geo_components(
+    commands: &mut Commands,
+    entity: Entity,
+    world_mesh: &impeller2_wkt::WorldMesh,
+) {
+    let Some(frame) = world_mesh.frame.or_default() else {
+        return;
+    };
+    let (x, y, z) = world_mesh.translate.unwrap_or_default();
+    commands.entity(entity).insert((
+        GeoPosition(frame, DVec3::new(x, y, z)),
+        GeoRotation::absolute(frame, DQuat::IDENTITY),
+    ));
 }
 
 fn world_mesh_visibility(world_mesh: &impeller2_wkt::WorldMesh) -> Visibility {
@@ -343,6 +362,7 @@ fn spawn_world_mesh_fallback(
         }
     };
 
+    insert_geo_components(commands, entity, world_mesh);
     insert_big_space_cell(commands, entity);
     entity
 }
@@ -487,6 +507,8 @@ fn sync_terrain_view_positions(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bevy_geo_frames::GeoFrame;
+    use impeller2_wkt::{NodeId, WorldMesh};
 
     #[test]
     fn planar_lod_count_defaults_to_preprocessed_depth() {
@@ -501,5 +523,30 @@ mod tests {
     #[test]
     fn planar_lod_count_keeps_lower_values() {
         assert_eq!(planar_lod_count(Some(3)), 3);
+    }
+
+    #[test]
+    fn framed_world_mesh_transform_stays_at_origin_for_geo_pipeline() {
+        let world_mesh = world_mesh(Some(GeoFrame::NED), Some((1.0, 2.0, 3.0)));
+
+        assert_eq!(world_mesh_transform(&world_mesh).translation, Vec3::ZERO);
+    }
+
+    #[test]
+    fn unframed_world_mesh_transform_uses_default_geo_frame() {
+        let world_mesh = world_mesh(None, Some((1.0, 2.0, 3.0)));
+
+        assert_eq!(world_mesh_transform(&world_mesh).translation, Vec3::ZERO);
+    }
+
+    fn world_mesh(frame: Option<GeoFrame>, translate: Option<(f64, f64, f64)>) -> WorldMesh {
+        WorldMesh {
+            region: "no_such_region".to_string(),
+            lod_count: None,
+            translate,
+            frame,
+            visible: true,
+            node_id: NodeId::default(),
+        }
     }
 }

--- a/libs/elodin-editor/src/spatial.rs
+++ b/libs/elodin-editor/src/spatial.rs
@@ -104,6 +104,10 @@ impl Plugin for FloatingOriginPlugin {
             .add_plugins(big_space::prelude::BigSpaceDefaultPlugins)
             .add_systems(Startup, setup_floating_origin)
             .add_systems(PreUpdate, attach_parentless_grid_cells)
+            // Also adopt right before transform propagation (and big_space's
+            // PostUpdate hierarchy validation) so entities that gained a
+            // `GridCell` during this frame never cross a validation pass
+            // parentless.
             .add_systems(
                 PostUpdate,
                 attach_parentless_grid_cells.before(TransformSystems::Propagate),

--- a/libs/elodin-editor/src/ui/inspector/viewport.rs
+++ b/libs/elodin-editor/src/ui/inspector/viewport.rs
@@ -2,9 +2,9 @@
 use std::collections::HashSet;
 
 use bevy::ecs::system::{SystemParam, SystemState};
-use bevy::picking::prelude::Pickable;
 use bevy::ecs::system::{SystemParam, SystemState};
 use bevy::math::DVec3;
+use bevy::picking::prelude::Pickable;
 use bevy::prelude::*;
 use bevy::{
     camera::Projection,
@@ -498,7 +498,6 @@ pub fn set_viewport_pos(
                 }
                 refresh_default_anchor_depth(&mut editor_cam, target_distance);
                 let up = viewport
->>>>>>> 3968efdb0 (chore: Soft reset to one commit to ease rebase.)
                     .up
                     .compiled_expr
                     .as_ref()

--- a/libs/elodin-editor/src/ui/inspector/viewport.rs
+++ b/libs/elodin-editor/src/ui/inspector/viewport.rs
@@ -2,7 +2,6 @@
 use std::collections::HashSet;
 
 use bevy::ecs::system::{SystemParam, SystemState};
-use bevy::ecs::system::{SystemParam, SystemState};
 use bevy::math::DVec3;
 use bevy::picking::prelude::Pickable;
 use bevy::prelude::*;

--- a/libs/elodin-editor/src/ui/inspector/viewport.rs
+++ b/libs/elodin-editor/src/ui/inspector/viewport.rs
@@ -1,7 +1,10 @@
+#![allow(non_snake_case)]
 use std::collections::HashSet;
 
 use bevy::ecs::system::{SystemParam, SystemState};
 use bevy::picking::prelude::Pickable;
+use bevy::ecs::system::{SystemParam, SystemState};
+use bevy::math::DVec3;
 use bevy::prelude::*;
 use bevy::{
     camera::Projection,
@@ -10,13 +13,14 @@ use bevy::{
 };
 use bevy_editor_cam::prelude::EditorCam;
 use bevy_egui::egui::{self, Align};
-use bevy_geo_frames::GeoFrame;
+use bevy_geo_frames::{GeoContext, GeoFrame, GeoRotation, OrDefault};
 use bevy_infinite_grid::InfiniteGrid;
 use impeller2_bevy::EntityMap;
 use impeller2_wkt::{ComponentValue, QueryType, WorldPos};
-use nox::{ArrayBuf, ArrayRepr, Vector3};
+use nox::ArrayBuf;
 
 use crate::EqlContext;
+use crate::WorldPosExt;
 use crate::object_3d::{ComponentArrayExt, EditableEQL, Object3DState, compile_eql_expr};
 use crate::ui::button::EButton;
 use crate::ui::colors::{EColor, get_scheme};
@@ -38,7 +42,7 @@ const ANCHOR_DEPTH_EPSILON: f64 = 1.0e-9;
 pub struct ViewportFocusPickTarget;
 
 /// Extract a 3-vector from a ComponentValue (e.g. F64 array of length >= 3). Returns None if not a numeric array or length < 3.
-fn extract_vec3(val: &ComponentValue) -> Option<Vector3<f64, ArrayRepr>> {
+fn extract_vec3(val: &ComponentValue) -> Option<DVec3> {
     let ComponentValue::F64(array) = val else {
         return None;
     };
@@ -46,7 +50,7 @@ fn extract_vec3(val: &ComponentValue) -> Option<Vector3<f64, ArrayRepr>> {
     if data.len() < 3 {
         return None;
     }
-    Some(Vector3::new(data[0], data[1], data[2]))
+    Some(DVec3::new(data[0], data[1], data[2]))
 }
 
 #[derive(Component)]
@@ -458,6 +462,7 @@ pub fn set_viewport_pos(
     mut pos: Query<&mut WorldPos>,
     entity_map: Res<EntityMap>,
     values: Query<&'static ComponentValue>,
+    geo_context: Res<GeoContext>,
 ) {
     for (viewport, mut editor_cam) in viewports.iter_mut() {
         let Ok(mut pos) = pos.get_mut(viewport.parent_entity) else {
@@ -480,33 +485,27 @@ pub fn set_viewport_pos(
                 && let Ok(val) = compiled_expr.execute(&entity_map, &values)
                 && let Some(look_at) = val.as_world_pos()
             {
-                let to_target = look_at.pos - pos.pos;
-                let target_distance = to_target.norm().into_buf();
+                let frame = viewport.frame.or_default().unwrap_or(GeoFrame::ENU);
+                // Everything stays in the viewport's frame: direction and up
+                // are frame coordinates, and `GeoRotation::look_at` yields the
+                // attitude expressed in that frame. `sync_pos` carries it into
+                // the entity's `GeoRotation` unchanged.
+                let dir = look_at.pos() - pos.pos();
+                let target_distance = dir.length();
+
                 if !is_valid_viewport_target_distance(target_distance) {
                     continue;
                 }
                 refresh_default_anchor_depth(&mut editor_cam, target_distance);
-                let dir = to_target.normalize();
-                let dir = match viewport.frame {
-                    Some(GeoFrame::NED) => nox::Vec3::new(dir.y(), dir.x(), -dir.z()),
-                    _ => dir,
-                };
-                let up_vec = viewport
+                let up = viewport
+>>>>>>> 3968efdb0 (chore: Soft reset to one commit to ease rebase.)
                     .up
                     .compiled_expr
                     .as_ref()
                     .and_then(|up_expr| up_expr.execute(&entity_map, &values).ok())
                     .and_then(|v| extract_vec3(&v))
-                    .and_then(|v| {
-                        let n_sq = v.norm_squared();
-                        if n_sq.into_buf() > 1e-20 {
-                            Some(v.normalize())
-                        } else {
-                            None
-                        }
-                    })
-                    .unwrap_or(nox::Vec3::z_axis());
-                pos.att = nox::Quaternion::look_at_rh(dir, up_vec);
+                    .filter(|v| v.length_squared() > 1e-20);
+                pos.att = GeoRotation::look_at(frame, dir, up, &geo_context).1.into();
             }
         }
     }
@@ -594,6 +593,8 @@ fn collect_mesh_descendants(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::WorldPosExt;
+    use bevy::math::{Mat3, Quat, Vec3};
 
     #[test]
     fn refresh_default_anchor_depth_uses_viewport_look_at_distance() {
@@ -630,6 +631,255 @@ mod tests {
         }
     }
 
+    /// Full pipeline test with real EQL: `set_viewport_pos` -> `sync_pos` ->
+    /// `apply_geo_rotation`. A NED viewport with an explicit `up="(0,0,-1)"`
+    /// (up, away from the ground in NED) must produce a right-side-up rig
+    /// looking at the target; `up="(0,0,1)"` (down) must produce an inverted
+    /// one.
+    #[test]
+    fn ned_viewport_explicit_up_through_pipeline() {
+        use crate::object_3d::{EditableEQL, compile_eql_expr};
+        use bevy::math::{DQuat, DVec3};
+        use bevy::prelude::{IntoScheduleConfigs, Transform};
+        use bevy_geo_frames::{GeoContext, GeoFrame, GeoPosition, GeoRotation};
+
+        let eql_ctx = eql::Context::default();
+        let editable = |s: &str| EditableEQL {
+            eql: s.to_string(),
+            compiled_expr: Some(
+                compile_eql_expr(
+                    eql_ctx
+                        .parse_str(s)
+                        .unwrap_or_else(|e| panic!("parse {s:?}: {e}")),
+                )
+                .unwrap_or_else(|e| panic!("compile {s:?}: {e}")),
+            ),
+        };
+
+        for (up_eql, expect_up_y) in [("(0,0,-1)", 1.0f32), ("(0,0,1)", -1.0f32)] {
+            let mut app = bevy::app::App::new();
+            app.insert_resource(GeoContext::default());
+            app.init_resource::<super::EntityMap>();
+            crate::register_world_pos_components(&mut app);
+            app.add_systems(
+                bevy::app::Update,
+                (
+                    super::set_viewport_pos,
+                    crate::sync_pos,
+                    bevy_geo_frames::apply_geo_rotation,
+                )
+                    .chain(),
+            );
+
+            let frame = GeoFrame::NED;
+            let parent = app
+                .world_mut()
+                .spawn((
+                    super::WorldPos::default(),
+                    GeoPosition(frame, DVec3::ZERO),
+                    GeoRotation::new(frame, DQuat::IDENTITY),
+                ))
+                .id();
+            // Values from the failing ball.kdl viewport.
+            app.world_mut().spawn(super::Viewport::new(
+                parent,
+                editable("(0,0,0,0, 0,0,0)"),
+                editable("(0,0,0,0, 0,-3,0)"),
+                editable(up_eql),
+                Some(frame),
+            ));
+            app.update();
+
+            let transform = *app.world().get::<Transform>(parent).unwrap();
+            let up = transform.rotation * Vec3::Y;
+            assert!(
+                up.y * expect_up_y > 0.5,
+                "up={up_eql}: rig up {up:?}, expected y sign {expect_up_y}"
+            );
+            // NED (0,-3,0) is 3 m west of the origin => bevy -X.
+            let fwd = transform.rotation * Vec3::NEG_Z;
+            assert!(
+                (fwd.x - -1.0).abs() < 1e-5 && fwd.y.abs() < 1e-5,
+                "up={up_eql}: camera fwd = {fwd:?}, expected -X"
+            );
+        }
+    }
+
+    macro_rules! assert_eq_mat {
+        ($a:expr, $b:expr $(,)?) => {{
+            assert_eq_mat!($a, $b, "");
+        }};
+        ($a:expr, $b:expr, $($arg:tt)+) => {{
+            let a = $a;
+            let b = $b;
+
+            for i in 0..3 {
+                let aa = a.col(i);
+                let bb = b.col(i);
+                for j in 0..3 {
+                    let delta = aa[j] - bb[j];
+                    if delta.abs() > 1e-5 {
+                        panic!("First mismatch on column {}:\nleft:  {}\nright: {}: {}",
+                                i + 1, a, b, format_args!($($arg)+));
+                    }
+                }
+            }
+        }};
+    }
+    macro_rules! assert_eq_vec {
+        ($a:expr, $b:expr $(,)?) => {{
+            assert_eq_vec!($a, $b, "");
+        }};
+        ($a:expr, $b:expr, $($arg:tt)+) => {{
+            let a = $a;
+            let b = $b;
+
+            for i in 0..3 {
+                let delta = a[i] - b[i];
+                if delta.abs() > 1e-5 {
+                    panic!("First mismatch on index {}:\nleft:  {}\nright: {}: {}",
+                           i, a, b, format_args!($($arg)+));
+                }
+            }
+        }};
+    }
+    macro_rules! assert_eq_quat {
+        ($a:expr, $b:expr $(,)?) => {{
+            assert_eq_quat!($a, $b, "");
+        }};
+
+        ($a:expr, $b:expr, $($arg:tt)+) => {{
+
+            let a = $a;
+            let b = $b;
+
+
+            let dot = a.dot(b).abs();
+
+            assert!(
+                (1.0 - dot) <= 1e-5,
+                "Quat mismatch:\nleft:  {:?}\nright: {:?}: {}",
+                a,
+                b,
+                format_args!($($arg)+)
+            );
+        }};
+    }
+
+    #[inline]
+    fn are_collinear(a: Vec3, b: Vec3) -> bool {
+        a.cross(b).length_squared() < 1e-6
+    }
+
+    /// Constructs a look_at rotation matrix that matches
+    /// [nox::Matrix3::look_at_rh].
+    fn glam_look_at_rh(dir: Vec3, up: Vec3) -> (Mat3, Vec3) {
+        let up_candidates = [up, Vec3::Y, Vec3::X, Vec3::Z];
+        let up = up_candidates
+            .into_iter()
+            .find(|up| !are_collinear(*up, dir))
+            .expect("it can't be collinear with everyone");
+        // Constructs a look_at rotation matrix using the same algorithm as
+        // nox::Matrix3::look_at_rh.
+        //
+        // let f = dir.normalize();
+        // let s = f.cross(up).normalize();
+        // let u = s.cross(f);
+        // // nox uses from_rows then transpose, which equals from_cols
+        // Mat3::from_cols(s, f, u)
+        (Mat3::look_to_rh(dir, up), up)
+    }
+
+    /// This function converts an Elodin rotation matrix to an EUS/Bevy rotation
+    /// matrix and vice versa. It behaves as though one right-multiplied M by
+    /// bevy_R_enu and transposed, i.e., (M * bevy_R_elodin)^T but no actual matrix
+    /// multiplication happens because column re-ordering is faster.
+    ///
+    ///
+    /// ```ignore
+    ///   elodin_R_bevy =  [ 1  0  0 ]
+    ///                    [ 0  0 -1 ]
+    ///                    [ 0  1  0 ]
+    /// ```
+    ///
+    /// Note: It's orthonormal, so its transpose is its inverse.
+    #[inline]
+    fn elodin_R_bevy(M: Mat3) -> Mat3 {
+        // Bevy +X -> ENU East
+        // Bevy +Y -> ENU Up
+        // Bevy +Z -> -ENU North
+        Mat3::from_cols(M.x_axis, M.z_axis, -M.y_axis).transpose()
+    }
+
+    // #[inline]
+    fn bevy_R_elodin(M: Mat3) -> Mat3 {
+        // ENU East  -> Bevy +X
+        // ENU North -> Bevy -Z
+        // ENU Up    -> Bevy +Y
+        let M = M.transpose();
+        Mat3::from_cols(M.x_axis, -M.z_axis, M.y_axis)
+    }
+
+    #[test]
+    fn test_inverses() {
+        let A = Mat3::from_cols(
+            Vec3::new(1.0, 2.0, 3.0),
+            Vec3::new(4.0, 5.0, 6.0),
+            Vec3::new(7.0, 8.0, 9.0),
+        );
+        let B = elodin_R_bevy(A);
+        let C = bevy_R_elodin(B);
+        assert_eq_mat!(A, C, "b to e to b");
+        let B = bevy_R_elodin(A);
+        let C = elodin_R_bevy(B);
+        assert_eq_mat!(A, C, "e to b to e");
+    }
+
+    /// Compare against elodin's ENU.
+    #[test]
+    fn test_look_at_rh_nox_vs_glam_elodin() {
+        test_look_at_rh_nox_vs_glam(
+            |glam_mat, nox_mat| (elodin_R_bevy(glam_mat), nox_mat),
+            |M| M,
+        );
+    }
+
+    /// Compare against Bevy's EUS.
+    #[test]
+    fn test_look_at_rh_nox_vs_glam_bevy() {
+        test_look_at_rh_nox_vs_glam(
+            |glam_mat, nox_mat| (glam_mat, bevy_R_elodin(nox_mat)),
+            elodin_R_bevy,
+        );
+    }
+
+    /// `WorldPosExt::bevy_att` must match `GeoRotation::to_bevy` in plane mode.
+    #[test]
+    fn test_bevy_att_vs_geo_frames_plane() {
+        use bevy_geo_frames::{GeoContext, GeoFrame, GeoRotation, Present};
+
+        let ctx = GeoContext::default().with_present(Present::Plane);
+
+        for (i, (dir, up)) in look_at_test_cases().into_iter().enumerate() {
+            let nox_dir = nox::Vec3::from(dir.as_dvec3());
+            let nox_up = nox::Vec3::from(up.as_dvec3());
+            let (nox_mat, _) = nox::Matrix3::look_at_rh_up(nox_dir, nox_up);
+            let nox_quat = nox::Quaternion::from_rot_mat(nox_mat);
+            let world_pos = super::WorldPos {
+                att: nox_quat,
+                pos: nox::Vec3::new(0.0, 0.0, 0.0),
+            };
+
+            let elodin_bevy = world_pos.bevy_att();
+            let geo_frames_bevy = GeoRotation::new(GeoFrame::ENU, world_pos.att()).to_bevy(&ctx);
+            assert_eq_quat!(
+                elodin_bevy.as_quat(),
+                geo_frames_bevy.as_quat(),
+                "case {i} dir {dir} up {up}"
+            );
+        }
+    }
+
     #[test]
     fn focus_object_eql_matches_trimmed_viewport_look_at() {
         let focus_eqls = HashSet::from(["lander.world_pos".to_string()]);
@@ -637,5 +887,81 @@ mod tests {
         assert!(is_focus_object_eql(&focus_eqls, " lander.world_pos "));
         assert!(!is_focus_object_eql(&focus_eqls, "lander_truth.world_pos"));
         assert!(!is_focus_object_eql(&focus_eqls, ""));
+    }
+    #[test]
+    fn test_from_mat3() {
+        let q = Quat::from_mat3(&Mat3::IDENTITY);
+        assert_eq_quat!(q, Quat::IDENTITY);
+
+        let dir = Vec3::Y;
+        let up = Vec3::Z;
+        let (M, _) = glam_look_at_rh(dir, up);
+        assert_eq_mat!(M, Mat3::from_cols(Vec3::X, Vec3::NEG_Z, Vec3::Y));
+        let q = Quat::from_mat3(&Mat3::IDENTITY);
+        assert_eq_quat!(q, Quat::IDENTITY);
+        let S = elodin_R_bevy(M).transpose();
+        assert_eq_mat!(S, Mat3::IDENTITY);
+
+        assert_eq_mat!(
+            Mat3::from_cols(Vec3::NEG_X, Vec3::NEG_Y, Vec3::Z),
+            glam_look_at_rh(Vec3::NEG_Z, Vec3::NEG_Y).0,
+            "trial 0"
+        );
+        // assert_eq_mat!(Mat3::from_cols(Vec3::NEG_X, Vec3::NEG_Y, Vec3::Z), glam_look_at_rh(Vec3::Z, Vec3::Y).0, "current");
+    }
+
+    fn look_at_test_cases() -> [(Vec3, Vec3); 10] {
+        [
+            (Vec3::new(0.0, 1.0, 0.0), Vec3::Z), // 0: identity for Elodin ENU
+            (Vec3::NEG_Z, Vec3::Y),              // 1: identity for Bevy
+            (Vec3::new(0.0, 1.0, 0.0), Vec3::Z),
+            (Vec3::new(0.0, 0.0, 1.0), Vec3::Y),
+            (Vec3::new(1.0, 2.0, 3.0).normalize(), Vec3::Y),
+            (Vec3::new(-1.0, 0.5, 0.3).normalize(), Vec3::Y),
+            (Vec3::new(0.0, 0.0, -1.0), Vec3::Y),
+            (Vec3::new(1.0, 0.0, 0.0), Vec3::Y),
+            (Vec3::new(0.0, 1.0, 0.0), Vec3::Y),
+            (Vec3::new(0.0, 0.0, 1.0), Vec3::Z),
+        ]
+    }
+
+    fn test_look_at_rh_nox_vs_glam(f: fn(Mat3, Mat3) -> (Mat3, Mat3), g: fn(Mat3) -> Mat3) {
+        for (i, (dir, up)) in look_at_test_cases().into_iter().enumerate() {
+            let nox_dir = nox::Vec3::from(dir.as_dvec3());
+            let nox_up = nox::Vec3::from(up.as_dvec3());
+
+            let (nox_mat, nox_up_actual) = nox::Matrix3::look_at_rh_up(nox_dir, nox_up);
+            let (glam_mat, up_actual) = glam_look_at_rh(dir, up);
+            assert_eq_vec!(
+                up_actual,
+                bevy::math::DVec3::from(nox_up_actual).as_vec3(),
+                "case {i} nox and bevy up vector don't match"
+            );
+            // let glam_mat = elodin_R_bevy(glam_mat);
+            let nox_mat_bevy: bevy::math::Mat3 = bevy::math::DMat3::from(nox_mat).as_mat3();
+            // let nox_mat_bevy = bevy_R_elodin(nox_mat_bevy);
+            let (glam_mat, _nox_mat_bevy) = f(glam_mat, nox_mat_bevy);
+
+            // Weird thing. The matrices are not always the same but the
+            // quaternions are.
+            // assert_eq_mat!(nox_mat_bevy, glam_mat, "\ncase {i} dir {dir} up {up}");
+
+            // Also compare resulting quaternions
+            let nox_quat_look_at = nox::Quaternion::look_at_rh(nox_dir, nox_up);
+            let nox_quat = nox::Quaternion::from_rot_mat(nox_mat);
+            assert_eq_quat!(
+                bevy::math::DQuat::from(nox_quat),
+                bevy::math::DQuat::from(nox_quat_look_at),
+                "case {i} look_at_rh vs mat"
+            );
+            let world_pos = super::WorldPos {
+                att: nox_quat,
+                pos: nox::Vec3::new(0.0, 0.0, 0.0),
+            };
+            let nox_quat_bevy = world_pos.bevy_att();
+            // let glam_quat = Quat::from_mat3(&elodin_R_bevy(glam_mat).transpose());
+            let glam_quat = Quat::from_mat3(&g(glam_mat));
+            assert_eq_quat!(nox_quat_bevy.as_quat(), glam_quat, "case {i} second");
+        }
     }
 }

--- a/libs/elodin-editor/src/ui/inspector/viewport.rs
+++ b/libs/elodin-editor/src/ui/inspector/viewport.rs
@@ -679,15 +679,26 @@ mod tests {
                 ))
                 .id();
             // Values from the failing ball.kdl viewport.
-            app.world_mut().spawn(super::Viewport::new(
-                parent,
-                editable("(0,0,0,0, 0,0,0)"),
-                editable("(0,0,0,0, 0,-3,0)"),
-                editable(up_eql),
-                Some(frame),
-            ));
+            let viewport_entity = app
+                .world_mut()
+                .spawn((
+                    super::Viewport::new(
+                        parent,
+                        editable("(0,0,0,0, 0,0,0)"),
+                        editable("(0,0,0,0, 0,-3,0)"),
+                        editable(up_eql),
+                        Some(frame),
+                    ),
+                    EditorCam::default(),
+                ))
+                .id();
             app.update();
 
+            let editor_cam = app.world().get::<EditorCam>(viewport_entity).unwrap();
+            assert!(
+                (editor_cam.last_anchor_depth + 3.0).abs() < 1e-9,
+                "up={up_eql}: viewport positioning system did not run"
+            );
             let transform = *app.world().get::<Transform>(parent).unwrap();
             let up = transform.rotation * Vec3::Y;
             assert!(

--- a/libs/elodin-editor/src/ui/plot_3d/mod.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/mod.rs
@@ -101,7 +101,9 @@ pub fn sync_line_plot_3d(
                 crate::spatial::GridCell::default(),
             ));
             if let Some(frame) = line_plot.frame {
-                entity.try_insert(GeoRotation(frame, DQuat::IDENTITY));
+                // Absolute: the line's vertex data is raw frame coordinates, so
+                // its transform must carry the frame -> Bevy basis change.
+                entity.try_insert(GeoRotation::absolute(frame, DQuat::IDENTITY));
             }
         }
     }

--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -128,8 +128,8 @@ pub struct LoadSchematicParams<'w, 's> {
     pub timeline_settings: ResMut<'w, TimelineSettings>,
     pub schema_reg: Res<'w, ComponentSchemaRegistry>,
     pub eql: Res<'w, EqlContext>,
-    pub geo_context: Res<'w, GeoContext>,
     connection_addr: Option<Res<'w, ConnectionAddr>>,
+    pub geo_context: ResMut<'w, GeoContext>,
     pub sensor_camera_configs: Res<'w, crate::sensor_camera::SensorCameraConfigs>,
     pub coordinate: ResMut<'w, crate::Coordinate>,
     cameras: Query<'w, 's, &'static mut Camera>,
@@ -233,6 +233,23 @@ impl LoadSchematicParams<'_, '_> {
     ) {
         // Set global coordinate frame from schematic
         self.coordinate.0 = schematic.frame;
+
+        // Set the GeoContext origin from the schematic (degrees -> radians),
+        // resetting to the default when absent so reloads are deterministic.
+        // Only write on change: mutating GeoContext re-touches every
+        // GeoPosition/GeoRotation in the world.
+        let origin = schematic
+            .origin
+            .map(|o| {
+                bevy_geo_frames::GeoOrigin::new_from_degrees(o.latitude, o.longitude, o.altitude)
+            })
+            .unwrap_or_default();
+        let current = &self.geo_context.origin;
+        if (current.latitude, current.longitude, current.altitude)
+            != (origin.latitude, origin.longitude, origin.altitude)
+        {
+            self.geo_context.origin = origin;
+        }
 
         for (id, window_id, mut window_state) in &mut self.window_states {
             if window_id.is_primary() {
@@ -648,10 +665,12 @@ impl LoadSchematicParams<'_, '_> {
         spawn.insert(Name::new("line_3d"));
 
         // Add GeoPosition and GeoRotation; use ENU if no frame is specified.
+        // The rotation is Absolute: the line's vertex data is raw frame
+        // coordinates, so its transform must carry the frame -> Bevy basis change.
         if let Some(frame) = frame.or_default() {
             spawn.insert((
                 bevy_geo_frames::GeoPosition(frame, bevy::math::DVec3::ZERO),
-                bevy_geo_frames::GeoRotation(frame, bevy::math::DQuat::IDENTITY),
+                bevy_geo_frames::GeoRotation::absolute(frame, bevy::math::DQuat::IDENTITY),
             ));
         }
         spawn.insert(SchematicSpawned);
@@ -681,7 +700,8 @@ impl LoadSchematicParams<'_, '_> {
                 .ok()
         });
 
-        let frame = vector_arrow.frame;
+        // The arrow's frame is carried by VectorArrow3d and applied to its
+        // endpoint entities in `evaluate_vector_arrows`.
         let mut spawn = self.commands.spawn((
             vector_arrow,
             VectorArrowState {
@@ -693,14 +713,6 @@ impl LoadSchematicParams<'_, '_> {
             },
             SchematicSpawned,
         ));
-
-        // Add GeoPosition and GeoRotation; use ENU if no frame is specified.
-        if let Some(frame) = frame.or_default() {
-            spawn.insert((
-                bevy_geo_frames::GeoPosition(frame, bevy::math::DVec3::ZERO),
-                bevy_geo_frames::GeoRotation(frame, bevy::math::DQuat::IDENTITY),
-            ));
-        }
 
         if let Some(camera) = viewport_camera {
             spawn.insert(ViewportArrow { camera });
@@ -1323,10 +1335,11 @@ mod tests {
     use bevy::{
         asset::{AssetApp, AssetPlugin, UnapprovedPathMode},
         ecs::system::SystemState,
+        math::DVec3,
         prelude::*,
         window::{PrimaryWindow, Window},
     };
-    use bevy_geo_frames::{GeoFrame, GeoFramePlugin};
+    use bevy_geo_frames::{GeoFrame, GeoFramePlugin, GeoPosition, GeoRotation};
     use bevy_mat3_material::Mat3Material;
     use impeller2_bevy::ComponentSchemaRegistry;
     use impeller2_kdl::FromKdl;
@@ -1516,6 +1529,50 @@ mod tests {
 
         load_schematic(&mut app, &Schematic::default());
         assert_eq!(app.world().resource::<crate::Coordinate>().0, None);
+    }
+
+    #[test]
+    fn geo_origin_is_applied_and_reset_on_clear() {
+        let mut app = test_app();
+        let schematic = Schematic::from_kdl("coordinate frame=NED lat=34.72 lon=-86.64 alt=180.0")
+            .expect("parse test schematic");
+
+        load_schematic(&mut app, &schematic);
+        let origin = app.world().resource::<bevy_geo_frames::GeoContext>().origin;
+        assert_eq!(origin.latitude, 34.72f64.to_radians());
+        assert_eq!(origin.longitude, (-86.64f64).to_radians());
+        assert_eq!(origin.altitude, 180.0);
+
+        load_schematic(&mut app, &Schematic::default());
+        let origin = app.world().resource::<bevy_geo_frames::GeoContext>().origin;
+        let default_origin = bevy_geo_frames::GeoOrigin::default();
+        assert_eq!(origin.latitude, default_origin.latitude);
+        assert_eq!(origin.longitude, default_origin.longitude);
+        assert_eq!(origin.altitude, default_origin.altitude);
+    }
+
+    #[test]
+    fn world_mesh_inherits_coordinate_frame_and_translate() {
+        let mut app = test_app();
+        let schematic = Schematic::from_kdl(
+            r#"
+            coordinate frame="NED"
+            world_mesh "no_such_region" translate="(1, 2, 3)"
+            "#,
+        )
+        .expect("parse test schematic");
+
+        load_schematic(&mut app, &schematic);
+
+        let mut query = app.world_mut().query_filtered::<
+            (&GeoPosition, &GeoRotation),
+            With<crate::plugins::world_mesh::WorldMeshTerrain>,
+        >();
+        let (geo_pos, geo_rot) = query.iter(app.world()).next().expect("world_mesh terrain");
+
+        assert_eq!(geo_pos.0, GeoFrame::NED);
+        assert_eq!(geo_pos.1, DVec3::new(1.0, 2.0, 3.0));
+        assert_eq!(geo_rot.0, GeoFrame::NED);
     }
 
     #[test]

--- a/libs/elodin-editor/src/ui/schematic/mod.rs
+++ b/libs/elodin-editor/src/ui/schematic/mod.rs
@@ -83,6 +83,7 @@ pub struct SchematicParam<'w, 's> {
     pub metadata: Res<'w, ComponentMetadataRegistry>,
     pub geo_positions: Query<'w, 's, &'static GeoPosition>,
     pub coordinate: Res<'w, crate::Coordinate>,
+    pub geo_context: Res<'w, bevy_geo_frames::GeoContext>,
 }
 
 impl SchematicParam<'_, '_> {
@@ -411,6 +412,22 @@ pub fn tiles_to_schematic(
 ) {
     schematic.elems.clear();
     schematic.frame = param.coordinate.0;
+
+    // Persist the GeoContext origin (radians -> degrees), omitting the
+    // default origin so plain schematics stay unchanged.
+    let origin = &param.geo_context.origin;
+    let default_origin = bevy_geo_frames::GeoOrigin::default();
+    schematic.origin = ((origin.latitude, origin.longitude, origin.altitude)
+        != (
+            default_origin.latitude,
+            default_origin.longitude,
+            default_origin.altitude,
+        ))
+        .then(|| impeller2_wkt::GeoOriginConfig {
+            latitude: origin.latitude.to_degrees(),
+            longitude: origin.longitude.to_degrees(),
+            altitude: origin.altitude,
+        });
     bindings.clear_ephemeral();
 
     if let Some(root_panels) =

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -1458,7 +1458,7 @@ impl ViewportPane {
         if let Some(frame) = viewport.frame.or_default() {
             parent_cmd.insert((
                 bevy_geo_frames::GeoPosition(frame, transform.translation.as_dvec3()),
-                bevy_geo_frames::GeoRotation(frame, transform.rotation.as_dquat()),
+                bevy_geo_frames::GeoRotation::new(frame, transform.rotation.as_dquat()),
             ));
         }
 

--- a/libs/elodin-editor/src/vector_arrow.rs
+++ b/libs/elodin-editor/src/vector_arrow.rs
@@ -10,15 +10,30 @@ pub struct ViewportArrow {
     pub camera: Entity,
 }
 
+/// The two pose entities carrying an arrow's start and end as `WorldPos`,
+/// placed by the canonical position pipeline (`sync_pos` -> Geo* -> Transform).
+#[derive(Component)]
+pub struct ArrowEndpoints {
+    pub start: Entity,
+    pub end: Entity,
+}
+
+/// Marker on endpoint entities pointing back at the owning arrow entity.
+#[derive(Component)]
+pub struct ArrowEndpoint {
+    pub owner: Entity,
+}
+
 #[derive(Component, Default)]
 pub struct VectorArrowState {
     pub vector_expr: Option<CompiledExpr>,
     pub origin_expr: Option<CompiledExpr>,
+    /// Whether the last expression evaluation produced a drawable arrow.
+    pub valid: bool,
     pub visuals: HashMap<Entity, ArrowVisual>,
     pub label: Option<Entity>,
-    /// Cached label data calculated in render_vector_arrow for UI sync.
-    /// Stores (grid_cell_x, grid_cell_y, grid_cell_z, local_position) to handle big_space correctly.
-    pub label_grid_pos: Option<(i128, i128, i128, Vec3)>,
+    /// Label offset from the arrow root, cached in render_vector_arrow for UI sync.
+    pub label_offset: Option<Vec3>,
     pub label_name: Option<String>,
     pub label_color: Option<Color>,
     pub label_scope: ArrowLabelScope,

--- a/libs/impeller2/kdl/README.md
+++ b/libs/impeller2/kdl/README.md
@@ -11,7 +11,7 @@ Serializer/deserializer for `impeller2_wkt::Schematic` to and from KDL.
 
 The parser accepts these root nodes:
 
-- `coordinate`: sets the global coordinate frame (`frame=ENU|NED|ECEF`)
+- `coordinate`: sets the global coordinate frame (`frame=ENU|NED|ECEF`) and optional geographic origin (`lat`/`lon`/`alt`)
 - `theme`
 - `timeline`
 - `window`
@@ -32,6 +32,15 @@ Supported frames:
 - `ECEF`: Earth-Centered Earth-Fixed
 
 Individual elements (`viewport`, `object_3d`, `line_3d`, `vector_arrow`) can override the global frame with their own `frame` attribute.
+
+The `coordinate` node also accepts an optional geographic origin that sets the viewer's `GeoContext` origin:
+
+```kdl
+coordinate frame="NED" lat=34.72 lon=-86.64 alt=180.0
+```
+
+- `lat`/`lon` are geodetic latitude/longitude in degrees; `alt` is altitude in meters.
+- `lat` and `lon` must be given together; `alt` is optional and defaults to `0.0`.
 
 ## Panel Nodes
 

--- a/libs/impeller2/kdl/src/de.rs
+++ b/libs/impeller2/kdl/src/de.rs
@@ -33,7 +33,10 @@ pub fn parse_schematic(input: &str) -> Result<Schematic, KdlSchematicError> {
         match elem {
             SchematicElem::Theme(theme) => schematic.theme = Some(theme),
             SchematicElem::Timeline(timeline) => schematic.timeline = Some(timeline),
-            SchematicElem::Coordinate(frame) => schematic.frame = Some(frame),
+            SchematicElem::Coordinate(coordinate) => {
+                schematic.frame = Some(coordinate.frame);
+                schematic.origin = coordinate.origin;
+            }
             other => schematic.elems.push(other),
         }
     }
@@ -240,7 +243,7 @@ fn parse_timeline(node: &KdlNode, src: &str) -> Result<TimelineConfig, KdlSchema
     })
 }
 
-fn parse_coordinate(node: &KdlNode, src: &str) -> Result<GeoFrame, KdlSchematicError> {
+fn parse_coordinate(node: &KdlNode, src: &str) -> Result<CoordinateConfig, KdlSchematicError> {
     let frame_str = node
         .get("frame")
         .and_then(|v| v.as_string())
@@ -251,13 +254,52 @@ fn parse_coordinate(node: &KdlNode, src: &str) -> Result<GeoFrame, KdlSchematicE
             span: node.span(),
         })?;
 
-    GeoFrame::from_str(frame_str).map_err(|_| KdlSchematicError::InvalidValue {
+    let frame = GeoFrame::from_str(frame_str).map_err(|_| KdlSchematicError::InvalidValue {
         property: "frame".to_string(),
         node: "coordinate".to_string(),
         expected: "ENU, NED, or ECEF".to_string(),
         src: src.to_string(),
         span: node.span(),
-    })
+    })?;
+
+    let get_number = |property: &str| -> Result<Option<f64>, KdlSchematicError> {
+        node.get(property)
+            .map(|v| {
+                v.as_float()
+                    .or_else(|| v.as_integer().map(|i| i as f64))
+                    .ok_or_else(|| KdlSchematicError::InvalidValue {
+                        property: property.to_string(),
+                        node: "coordinate".to_string(),
+                        expected: "a number".to_string(),
+                        src: src.to_string(),
+                        span: node.span(),
+                    })
+            })
+            .transpose()
+    };
+
+    let lat = get_number("lat")?;
+    let lon = get_number("lon")?;
+    let alt = get_number("alt")?;
+    let origin = match (lat, lon) {
+        (Some(latitude), Some(longitude)) => Some(GeoOriginConfig {
+            latitude,
+            longitude,
+            altitude: alt.unwrap_or(0.0),
+        }),
+        (None, None) if alt.is_none() => None,
+        _ => {
+            return Err(KdlSchematicError::InvalidValue {
+                property: "lat/lon".to_string(),
+                node: "coordinate".to_string(),
+                expected: "both lat and lon (alt optional)".to_string(),
+                src: src.to_string(),
+                span: node.span(),
+            });
+        }
+    };
+
+    Ok(CoordinateConfig { frame, origin })
 }
 
 fn parse_world_mesh(node: &KdlNode, src: &str) -> Result<WorldMesh, KdlSchematicError> {
@@ -2239,6 +2281,49 @@ object_3d "a.world_pos" {
         } else {
             panic!("Expected object_3d");
         }
+    }
+
+    #[test]
+    fn test_parse_coordinate_with_origin() {
+        let kdl = r#"coordinate frame="NED" lat=34.72 lon=-86.64 alt=180"#;
+        let schematic = parse_schematic(kdl).unwrap();
+        assert_eq!(schematic.frame, Some(GeoFrame::NED));
+        assert_eq!(
+            schematic.origin,
+            Some(GeoOriginConfig {
+                latitude: 34.72,
+                longitude: -86.64,
+                altitude: 180.0,
+            })
+        );
+    }
+
+    #[test]
+    fn test_parse_coordinate_origin_alt_defaults_to_zero() {
+        let kdl = r#"coordinate frame="ENU" lat=10.5 lon=20.25"#;
+        let schematic = parse_schematic(kdl).unwrap();
+        assert_eq!(
+            schematic.origin,
+            Some(GeoOriginConfig {
+                latitude: 10.5,
+                longitude: 20.25,
+                altitude: 0.0,
+            })
+        );
+    }
+
+    #[test]
+    fn test_parse_coordinate_without_origin() {
+        let schematic = parse_schematic(r#"coordinate frame="NED""#).unwrap();
+        assert_eq!(schematic.frame, Some(GeoFrame::NED));
+        assert_eq!(schematic.origin, None);
+    }
+
+    #[test]
+    fn test_parse_coordinate_lat_without_lon_is_an_error() {
+        assert!(parse_schematic(r#"coordinate frame="NED" lat=34.72"#).is_err());
+        assert!(parse_schematic(r#"coordinate frame="NED" lon=-86.64"#).is_err());
+        assert!(parse_schematic(r#"coordinate frame="NED" alt=100.0"#).is_err());
     }
 
     #[test]

--- a/libs/impeller2/kdl/src/ser.rs
+++ b/libs/impeller2/kdl/src/ser.rs
@@ -9,7 +9,11 @@ pub fn serialize_schematic(schematic: &Schematic) -> String {
     let mut doc = KdlDocument::new();
 
     if let Some(frame) = schematic.frame {
-        doc.nodes_mut().push(serialize_coordinate(frame));
+        doc.nodes_mut()
+            .push(serialize_coordinate(&CoordinateConfig {
+                frame,
+                origin: schematic.origin,
+            }));
     }
     if let Some(theme) = schematic.theme.as_ref() {
         doc.nodes_mut().push(serialize_theme(theme));
@@ -42,14 +46,24 @@ fn serialize_schematic_elem(elem: &SchematicElem) -> KdlNode {
         SchematicElem::Window(window) => serialize_window(window),
         SchematicElem::Theme(theme) => serialize_theme(theme),
         SchematicElem::Timeline(timeline) => serialize_timeline(timeline),
-        SchematicElem::Coordinate(frame) => serialize_coordinate(*frame),
+        SchematicElem::Coordinate(coordinate) => serialize_coordinate(coordinate),
     }
 }
 
-fn serialize_coordinate(frame: bevy_geo_frames::GeoFrame) -> KdlNode {
+fn serialize_coordinate(coordinate: &CoordinateConfig) -> KdlNode {
     let mut node = KdlNode::new("coordinate");
     node.entries_mut()
-        .push(KdlEntry::new_prop("frame", <&str>::from(frame)));
+        .push(KdlEntry::new_prop("frame", <&str>::from(coordinate.frame)));
+    if let Some(origin) = coordinate.origin {
+        node.entries_mut()
+            .push(KdlEntry::new_prop("lat", origin.latitude));
+        node.entries_mut()
+            .push(KdlEntry::new_prop("lon", origin.longitude));
+        if origin.altitude != 0.0 {
+            node.entries_mut()
+                .push(KdlEntry::new_prop("alt", origin.altitude));
+        }
+    }
     node
 }
 
@@ -1918,6 +1932,39 @@ viewport name=main"#;
             Some(bevy_geo_frames::GeoFrame::NED),
             "Re-parsed schematic should preserve NED frame"
         );
+    }
+
+    #[test]
+    fn test_roundtrip_coordinate_origin() {
+        let original = r#"coordinate frame="NED" lat=34.72 lon=-86.64 alt=180.5
+
+viewport name="main"
+"#;
+        let parsed = parse_schematic(original).unwrap();
+        let origin = GeoOriginConfig {
+            latitude: 34.72,
+            longitude: -86.64,
+            altitude: 180.5,
+        };
+        assert_eq!(parsed.origin, Some(origin));
+
+        let serialized = serialize_schematic(&parsed);
+        let expected = r#"coordinate frame=NED lat=34.72 lon=-86.64 alt=180.5
+viewport name=main"#;
+        assert_eq!(serialized, expected, "Full serialized output");
+
+        let reparsed = parse_schematic(&serialized).unwrap();
+        assert_eq!(reparsed.frame, Some(bevy_geo_frames::GeoFrame::NED));
+        assert_eq!(reparsed.origin, Some(origin));
+    }
+
+    #[test]
+    fn test_roundtrip_coordinate_origin_zero_alt_omitted() {
+        let parsed = parse_schematic(r#"coordinate frame="ENU" lat=1.5 lon=-2.5"#).unwrap();
+        let serialized = serialize_schematic(&parsed);
+        assert_eq!(serialized, "coordinate frame=ENU lat=1.5 lon=-2.5");
+        let reparsed = parse_schematic(&serialized).unwrap();
+        assert_eq!(reparsed.origin, parsed.origin);
     }
 
     #[test]

--- a/libs/impeller2/wkt/src/gui.rs
+++ b/libs/impeller2/wkt/src/gui.rs
@@ -54,8 +54,32 @@ pub struct Schematic {
     pub timeline: Option<TimelineConfig>,
     #[serde(default)]
     pub frame: Option<bevy_geo_frames::GeoFrame>,
+    /// Geographic origin of the schematic's coordinate system, used to set
+    /// the viewer's `GeoContext` origin.
+    #[serde(default)]
+    pub origin: Option<GeoOriginConfig>,
     #[serde(default)]
     pub skybox: Option<SkyboxConfig>,
+}
+
+/// Geographic origin in degrees/meters, as written in the schematic's
+/// `coordinate` node (`lat`/`lon`/`alt`).
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+pub struct GeoOriginConfig {
+    /// Geodetic latitude [deg]
+    pub latitude: f64,
+    /// Geodetic longitude [deg]
+    pub longitude: f64,
+    /// Altitude above mean radius [m]
+    pub altitude: f64,
+}
+
+/// Contents of the global `coordinate` schematic node.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+pub struct CoordinateConfig {
+    pub frame: bevy_geo_frames::GeoFrame,
+    #[serde(default)]
+    pub origin: Option<GeoOriginConfig>,
 }
 
 #[cfg(feature = "bevy")]
@@ -76,7 +100,7 @@ pub enum SchematicElem {
     Window(WindowSchematic),
     Theme(ThemeConfig),
     Timeline(TimelineConfig),
-    Coordinate(bevy_geo_frames::GeoFrame),
+    Coordinate(CoordinateConfig),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, Default, PartialEq, Eq)]

--- a/libs/nox-py/src/world_builder.rs
+++ b/libs/nox-py/src/world_builder.rs
@@ -1527,30 +1527,35 @@ impl WorldBuilder {
     #[pyo3(signature = (default_content = None, path = None,))]
     pub fn schematic(&mut self, default_content: Option<String>, path: Option<String>) {
         let requested_path = path.map(PathBuf::from);
-        let resolved_path = requested_path
+        let file_contents = requested_path
             .as_ref()
-            .map(|p| impeller2_kdl::env::schematic_file(Path::new(p)));
-        let file_contents = resolved_path.as_ref().and_then(|path| {
-            if path.exists() {
-                std::fs::read_to_string(path)
-                    .inspect(|_| info!("read schematic at {:?}", path.display()))
-                    .inspect_err(|err| {
-                        error!(
-                            ?err,
-                            "could not read schematic file at {:?}",
-                            path.display()
-                        )
-                    })
-                    .ok()
-            } else {
-                None
-            }
-        });
-        self.world.metadata.schematic_path = if file_contents.is_some() {
-            resolved_path
-        } else {
-            requested_path
-        };
+            .map(|p| impeller2_kdl::env::schematic_file(p))
+            .and_then(|path| {
+                if path.exists() {
+                    std::fs::read_to_string(&path)
+                        .inspect(|_| {
+                            if default_content.is_some() {
+                                tracing::warn!(
+                                    "using schematic file {:?} instead of the default KDL; \
+                                     delete the file to use the default",
+                                    path.display()
+                                );
+                            } else {
+                                info!("read schematic at {:?}", path.display());
+                            }
+                        })
+                        .inspect_err(|err| {
+                            error!(
+                                ?err,
+                                "could not read schematic file at {:?}",
+                                path.display()
+                            )
+                        })
+                        .ok()
+                } else {
+                    None
+                }
+            });
         self.world.metadata.schematic = file_contents.or(default_content);
     }
 

--- a/libs/nox/Cargo.toml
+++ b/libs/nox/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/elodin-sys/elodin"
 [features]
 default = []
 std = ["thiserror/std", "faer/std", "num-traits/std", "nox-array/std"]
+bevy_math = ["dep:bevy_math"]
 jax = ["pyo3", "numpy", "noxpr"]
 noxpr = ["boxcar", "paste", "itertools", "indent_write", "std"]
 shared = []
@@ -55,6 +56,9 @@ serde.optional = true
 traversal = "0.1.2"
 
 tracing = "0.1"
+
+bevy_math.workspace = true
+bevy_math.optional = true
 
 [build-dependencies]
 which = "6.0.3"

--- a/libs/nox/src/array/dynamic.rs
+++ b/libs/nox/src/array/dynamic.rs
@@ -50,7 +50,7 @@ impl<T: Elem> ArrayBuf<T> for DynArray<T, Vec<T>> {
         self.storage.as_mut_slice()
     }
 
-    fn default(dims: &[usize]) -> Self {
+    fn default_for_shape(dims: &[usize]) -> Self {
         let len: usize = if dims.is_empty() {
             1
         } else {

--- a/libs/nox/src/array/mod.rs
+++ b/libs/nox/src/array/mod.rs
@@ -272,7 +272,7 @@ impl ArrayShape for SmallVec<[usize; 4]> {
 pub trait ArrayBuf<T>: Clone {
     fn as_buf(&self) -> &[T];
     fn as_mut_buf(&mut self) -> &mut [T];
-    fn default(dims: &[usize]) -> Self;
+    fn default_for_shape(dims: &[usize]) -> Self;
 }
 
 impl<T: Elem + Clone> ArrayBuf<T> for T {
@@ -284,7 +284,7 @@ impl<T: Elem + Clone> ArrayBuf<T> for T {
         core::slice::from_mut(self)
     }
 
-    fn default(_dims: &[usize]) -> Self {
+    fn default_for_shape(_dims: &[usize]) -> Self {
         T::default()
     }
 }
@@ -298,7 +298,7 @@ impl<const D: usize, T: Elem + Clone> ArrayBuf<T> for [T; D] {
         self
     }
 
-    fn default(_dims: &[usize]) -> Self {
+    fn default_for_shape(_dims: &[usize]) -> Self {
         [T::default(); D]
     }
 }
@@ -312,7 +312,7 @@ impl<T: Clone + Elem, const D1: usize, const D2: usize> ArrayBuf<T> for [[T; D1]
         self.as_flattened_mut()
     }
 
-    fn default(_dims: &[usize]) -> Self {
+    fn default_for_shape(_dims: &[usize]) -> Self {
         [[T::default(); D1]; D2]
     }
 }
@@ -328,7 +328,7 @@ impl<T: Clone + Elem, const D1: usize, const D2: usize, const D3: usize> ArrayBu
         self.as_flattened_mut().as_flattened_mut()
     }
 
-    fn default(_dims: &[usize]) -> Self {
+    fn default_for_shape(_dims: &[usize]) -> Self {
         [[[T::default(); D1]; D2]; D3]
     }
 }
@@ -336,7 +336,7 @@ impl<T: Clone + Elem, const D1: usize, const D2: usize, const D3: usize> ArrayBu
 impl<T1: Elem, D1: ArrayDim + TensorDim> Array<T1, D1> {
     pub fn zeroed(dims: &[usize]) -> Self {
         Array {
-            buf: D1::Buf::<T1>::default(dims),
+            buf: D1::Buf::<T1>::default_for_shape(dims),
         }
     }
 }

--- a/libs/nox/src/bevy.rs
+++ b/libs/nox/src/bevy.rs
@@ -1,0 +1,176 @@
+//! Conversions between nox tensors and Bevy math types.
+use crate::{ArrayRepr, Matrix3, Quaternion, Tensor, Vec3};
+
+/// Row-major `[[T; 3]; 3]` (nox layout) to Bevy column-major `Mat3`.
+#[inline]
+pub fn mat3_from_buf(buf: [[f32; 3]; 3]) -> bevy_math::Mat3 {
+    bevy_math::Mat3::from_cols_array(&[
+        buf[0][0], buf[1][0], buf[2][0], buf[0][1], buf[1][1], buf[2][1], buf[0][2], buf[1][2],
+        buf[2][2],
+    ])
+}
+
+/// Row-major `[[T; 3]; 3]` (nox layout) to Bevy column-major `DMat3`.
+#[inline]
+pub fn dmat3_from_buf(buf: [[f64; 3]; 3]) -> bevy_math::DMat3 {
+    bevy_math::DMat3::from_cols_array(&[
+        buf[0][0], buf[1][0], buf[2][0], buf[0][1], buf[1][1], buf[2][1], buf[0][2], buf[1][2],
+        buf[2][2],
+    ])
+}
+
+impl From<Matrix3<f32, ArrayRepr>> for bevy_math::Mat3 {
+    fn from(mat: Matrix3<f32, ArrayRepr>) -> Self {
+        mat3_from_buf(mat.into_buf())
+    }
+}
+
+impl From<Matrix3<f64, ArrayRepr>> for bevy_math::DMat3 {
+    fn from(mat: Matrix3<f64, ArrayRepr>) -> Self {
+        dmat3_from_buf(mat.into_buf())
+    }
+}
+
+impl From<bevy_math::Vec3> for Vec3<f32> {
+    fn from(v: bevy_math::Vec3) -> Self {
+        Vec3::new(v.x, v.y, v.z)
+    }
+}
+
+impl From<bevy_math::DVec3> for Vec3<f64> {
+    fn from(v: bevy_math::DVec3) -> Self {
+        Vec3::new(v.x, v.y, v.z)
+    }
+}
+
+impl From<Vec3<f32>> for bevy_math::Vec3 {
+    fn from(v: Vec3<f32>) -> Self {
+        let [x, y, z] = v.parts().map(Tensor::into_buf);
+        bevy_math::Vec3::new(x, y, z)
+    }
+}
+
+impl From<Vec3<f64>> for bevy_math::DVec3 {
+    fn from(v: Vec3<f64>) -> Self {
+        let [x, y, z] = v.parts().map(Tensor::into_buf);
+        bevy_math::DVec3::new(x, y, z)
+    }
+}
+
+impl From<Quaternion<f32, ArrayRepr>> for bevy_math::Quat {
+    fn from(q: Quaternion<f32, ArrayRepr>) -> Self {
+        let [x, y, z, w] = q.0.into_buf();
+        bevy_math::Quat::from_xyzw(x, y, z, w)
+    }
+}
+
+impl From<Quaternion<f64, ArrayRepr>> for bevy_math::DQuat {
+    fn from(q: Quaternion<f64, ArrayRepr>) -> Self {
+        let [x, y, z, w] = q.0.into_buf();
+        bevy_math::DQuat::from_xyzw(x, y, z, w)
+    }
+}
+
+impl From<bevy_math::Quat> for Quaternion<f32, ArrayRepr> {
+    fn from(q: bevy_math::Quat) -> Self {
+        Quaternion::new(q.w, q.x, q.y, q.z)
+    }
+}
+
+impl From<bevy_math::DQuat> for Quaternion<f64, ArrayRepr> {
+    fn from(q: bevy_math::DQuat) -> Self {
+        Quaternion::new(q.w, q.x, q.y, q.z)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Matrix3, Quaternion, Vector3, tensor};
+
+    #[test]
+    fn identity_to_bevy_mat3() {
+        let m: Matrix3<f64, ArrayRepr> = Matrix3::eye();
+        let bevy: bevy_math::DMat3 = m.into();
+        assert!(bevy.abs_diff_eq(bevy_math::DMat3::IDENTITY, 1e-6));
+    }
+
+    #[test]
+    fn look_at_to_bevy_mat3() {
+        let m = Matrix3::look_at_rh(
+            Vector3::new(1.0f32, 2.0, 3.0).normalize(),
+            Vector3::y_axis(),
+        );
+        let buf = m.into_buf();
+        let bevy: bevy_math::Mat3 = Matrix3::from_buf(buf).into();
+        for col in 0..3 {
+            let axis = [bevy.x_axis, bevy.y_axis, bevy.z_axis][col];
+            for row in 0..3 {
+                assert!((axis[row] - buf[row][col]).abs() < 1e-5);
+            }
+        }
+    }
+
+    #[test]
+    fn tensor_literal_matches_from_cols() {
+        let m: Matrix3<f32, ArrayRepr> = tensor![[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]];
+        let bevy: bevy_math::Mat3 = m.into();
+        let expected = bevy_math::Mat3::from_cols(
+            bevy_math::Vec3::new(1.0, 4.0, 7.0),
+            bevy_math::Vec3::new(2.0, 5.0, 8.0),
+            bevy_math::Vec3::new(3.0, 6.0, 9.0),
+        );
+        assert!(bevy.abs_diff_eq(expected, 1e-6));
+    }
+
+    #[test]
+    fn vec3_from_bevy() {
+        let bevy = bevy_math::Vec3::new(1.0, 2.0, 3.0);
+        let nox: Vec3<f32> = bevy.into();
+        assert_eq!(nox.into_buf(), [1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn vec3_from_bevy_dvec3() {
+        let bevy = bevy_math::DVec3::new(4.0, 5.0, 6.0);
+        let nox: Vec3<f64> = bevy.into();
+        assert_eq!(nox.into_buf(), [4.0, 5.0, 6.0]);
+    }
+
+    #[test]
+    fn quat_from_nox() {
+        let q = Quaternion::new(0.5, 0.5, 0.5, 0.5);
+        let bevy: bevy_math::Quat = q.into();
+        assert!((bevy.x - 0.5).abs() < 1e-6);
+        assert!((bevy.y - 0.5).abs() < 1e-6);
+        assert!((bevy.z - 0.5).abs() < 1e-6);
+        assert!((bevy.w - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn dquat_from_nox() {
+        let q = Quaternion::from_axis_angle(Vector3::x_axis(), core::f64::consts::FRAC_PI_2);
+        let bevy: bevy_math::DQuat = q.into();
+        let expected =
+            bevy_math::DQuat::from_axis_angle(bevy_math::DVec3::X, core::f64::consts::FRAC_PI_2);
+        assert!(bevy.abs_diff_eq(expected, 1e-6));
+    }
+
+    #[test]
+    fn quat_round_trips_through_bevy() {
+        let bevy = bevy_math::Quat::from_xyzw(0.1, 0.2, 0.3, 0.4);
+        let nox: Quaternion<f32, ArrayRepr> = bevy.into();
+        assert_eq!(nox.0.into_buf(), [0.1, 0.2, 0.3, 0.4]);
+        assert_eq!(bevy_math::Quat::from(nox), bevy);
+    }
+
+    #[test]
+    fn dquat_round_trips_through_bevy() {
+        let bevy = bevy_math::DQuat::from_axis_angle(
+            bevy_math::DVec3::new(1.0, 2.0, -0.5).normalize(),
+            0.7,
+        );
+        let nox: Quaternion<f64, ArrayRepr> = bevy.into();
+        assert!(bevy_math::DQuat::from(nox).abs_diff_eq(bevy, 1e-12));
+    }
+}

--- a/libs/nox/src/lib.rs
+++ b/libs/nox/src/lib.rs
@@ -34,6 +34,9 @@ pub use spatial::*;
 pub use tensor::*;
 pub use vector::*;
 
+#[cfg(feature = "bevy_math")]
+pub mod bevy;
+
 #[cfg(feature = "jax")]
 pub mod jax;
 

--- a/libs/nox/src/matrix.rs
+++ b/libs/nox/src/matrix.rs
@@ -96,18 +96,34 @@ impl<T: RealField> Matrix3<T, ArrayRepr> {
         dir: impl Into<Vector<T, 3, ArrayRepr>>,
         up: impl Into<Vector<T, 3, ArrayRepr>>,
     ) -> Self {
+        Self::look_at_rh_up(dir, up).0
+    }
+
+    pub fn look_at_rh_up(
+        dir: impl Into<Vector<T, 3, ArrayRepr>>,
+        up: impl Into<Vector<T, 3, ArrayRepr>>,
+    ) -> (Self, Vector<T, 3, ArrayRepr>) {
         let dir = dir.into();
-        let up = up.into();
-        // apply gram-schmidt orthogonalization to create a rot matrix
+        let mut up = up.into();
+        // Apply gram-schmidt orthogonalization to create a rotation matrix.
         let f = dir.normalize();
-        let up = if up.dot(&dir).abs() == T::one() {
-            Vector::y_axis()
-        } else {
-            up
-        };
+
+        // Try up, Y, X, Z as up directions. Ensure up isn't collinear with dir.
+        for i in 0..=2 {
+            if up.dot(&dir).abs() == T::one() {
+                up = match i {
+                    0 => Vector::y_axis(),
+                    1 => Vector::x_axis(),
+                    2 => Vector::z_axis(),
+                    _ => unreachable!(),
+                };
+            } else {
+                break;
+            }
+        }
         let s = f.cross(&up).normalize();
         let u = s.cross(&f);
-        Self::from_rows([s, f, u]).transpose()
+        (Self::from_rows([s, f, u]).transpose(), up)
     }
 }
 

--- a/libs/nox/src/quaternion.rs
+++ b/libs/nox/src/quaternion.rs
@@ -204,6 +204,7 @@ impl<T: RealField> Quaternion<T, ArrayRepr> {
         let m20 = mat.get([2, 0]).into_buf();
         let m21 = mat.get([2, 1]).into_buf();
         let m22 = mat.get([2, 2]).into_buf();
+        // w = sqrt(1 + trace(M))/2
         let w = (T::one_prim() + m00 + m11 + m22).max(T::zero_prim()).sqrt() / T::two_prim();
         let x = (T::one_prim() + m00 - m11 - m22).max(T::zero_prim()).sqrt() / T::two_prim();
         let y = (T::one_prim() - m00 + m11 - m22).max(T::zero_prim()).sqrt() / T::two_prim();


### PR DESCRIPTION
# Problem

Elodin orientations uses ENU quaternions despite supporting NED and ECEF for positions.

# Solution

Support NED, ENU, and ECEF for orientations.

This adds a geo-frames example shown below to demonstrate the orientations working properly. The red cube is specified in NED and rotating on its East- or Y-axis. The blue cube is specified in ENU and rotates on its North or Y-axis. The green cube is specified in ECEF and rotates on its Y-axis.

https://github.com/user-attachments/assets/6a65af95-36b2-4adf-96ce-7e15f33d3a46

## Ancillary Changes

* Doubled the position vector of earth.glb so that it was appropriately sized.
* Added documentation for world_mesh.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core transform/geo math, camera look-at, and schematic coordinate origin—incorrect frame or rotation semantics would misplace entities across NED/ENU/ECEF and plane vs sphere modes.
> 
> **Overview**
> Adds **full geo-frame support for orientations** (not just positions): `GeoRotation` gains **Relative vs Absolute** semantics, frame-aware `look_at`, and corrected ECEF/plane/sphere position and basis math in `bevy_geo_frames`, backed by a large new test suite.
> 
> The editor **routes all `WorldPos` posing through geo components**—required `GeoPosition`/`GeoRotation` on spawn, `sync_pos` only updates geo fields, then `apply_transforms` / `apply_geo_rotation` (and big-space when enabled). Viewports, view-cube orbit targets, **vector arrows** (endpoint entities + pipeline), **lines/plots** (absolute frame basis), and **`world_mesh`** (frame + translate via geo) are updated to use this path instead of legacy ENU swizzles.
> 
> Schematics now support **`coordinate lat/lon/alt`** → `GeoContext` origin (load/save/headless), documented **`world_mesh`**, and a new **`examples/geo-frames`** demo; **`earth.glb`** is rescaled. Ancillary: optional **`nox` ↔ `bevy_math`** conversions and `Matrix3::look_at_rh_up`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88ae6fddfa167931115ddfd924a6b4231c5b0c55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->