### PR TITLE
fix(editor): default Windows connect address to [::1]:2240

### DIFF
--- a/libs/elodin-editor/src/ui/startup_window.rs
+++ b/libs/elodin-editor/src/ui/startup_window.rs
@@ -312,7 +312,7 @@ impl RootWidgetSystem for StartupLayout<'_, '_> {
                         {
                             *state.modal_state = ModalState::ConnectToIp {
                                 addr: if cfg!(target_os = "windows") {
-                                    "127.0.0.1:2240"
+                                    "[::1]:2240"
                                 } else {
                                     "[::]:2240"
                                 }


### PR DESCRIPTION
## Summary

The editor's Connect-to-IP dialog pre-fills `127.0.0.1:2240` on Windows, which doesn't reach a sim running under WSL. `[::1]:2240` does (confirmed in the issue thread). This changes the Windows default to `[::1]:2240`, matching the IPv6 form already used on other platforms (`[::]:2240`). One line in `libs/elodin-editor/src/ui/startup_window.rs`; #667 fixed the quickstart docs but the editor default was kept open for this.

Fixes #666

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single default string in the startup connect modal; no auth, networking stack, or connection logic changes.
> 
> **Overview**
> On **Windows**, opening **Connect to IP Address** now pre-fills **`[::1]:2240`** instead of **`127.0.0.1:2240`**, so the default can reach a sim on **WSL** (IPv4 loopback often does not). Non-Windows still defaults to **`[::]:2240`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da3cbba3f2a330d6ef18a95a66eaa38a359703a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->