### PR TITLE
docs: add Ubuntu/Linux build prerequisites to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,24 @@ cargo elodin editor examples/three-body/main.py
 > [!NOTE]
 > Local setup instructions were validated on M1 architecture, macOS 15.6.1 on 2025-11-03.
 
+## Alternative Local Setup (Ubuntu/Linux)
+
+> [!WARNING]
+> This setup is more complex and may lead to inconsistent environments across developers. We strongly recommend using Nix instead.
+
+If you cannot use Nix, you can manually install dependencies on Ubuntu/Linux:
+
+### Prerequisites
+```sh
+# Install required tools via apt
+sudo apt install just git-lfs pkg-config libasound2-dev libudev-dev cmake gfortran patchelf python3-dev
+
+# Initialize git-lfs
+git lfs install
+```
+
+After installing these packages, follow the same `just install` and `uvx maturin` local build steps above.
+
 ## Additional Resources
 
 - [Elodin App Documentation](apps/elodin/README.md)


### PR DESCRIPTION
## Summary

The README's local setup covers macOS only; non-Nix Ubuntu builds fail on missing system packages. This adds an "Alternative Local Setup (Ubuntu/Linux)" section with the apt prerequisites, kept behind a warning that recommends Nix first.

## Why this matters

#188 (filed by @anderspitman) lists the exact packages a fresh Ubuntu 24.04 needed before `cargo build --release -p elodin` and `maturin build` would run: `pkg-config libasound2-dev libudev-dev cmake gfortran patchelf python3-dev`. This section uses that list verbatim, plus `just` and `git-lfs` which the referenced `just install` steps require (both available via apt on 24.04). Purely additive; the Nix path stays the recommended default.

## Testing

- README-only change; verified the referenced `just install` and `uvx maturin` steps exist in the doc (lines 61/117/124)
- apt package names checked against the issue's list

Fixes #188

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only documentation with no runtime, build script, or dependency manifest changes.
> 
> **Overview**
> Adds an **Alternative Local Setup (Ubuntu/Linux)** section to the README, mirroring the existing macOS-only manual path but with a warning to prefer Nix.
> 
> The new section documents a single `apt install` line for system deps (`just`, `git-lfs`, `pkg-config`, `libasound2-dev`, `libudev-dev`, `cmake`, `gfortran`, `patchelf`, `python3-dev`), `git lfs install`, and points readers to the same **`just install`** and **`uvx maturin`** steps already described in the macOS alternative setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2fda63a785b7eceaf21d8bbad94e5c6b7d75ee6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->