### PR TITLE
fix: Error once for formula execution error.

### DIFF
--- a/libs/elodin-editor/src/ui/inspector/viewport.rs
+++ b/libs/elodin-editor/src/ui/inspector/viewport.rs
@@ -464,7 +464,7 @@ pub fn set_viewport_pos(
                     }
                 }
                 Err(e) => {
-                    bevy::log::error!("viewport pos formula execution error: {}", e);
+                    bevy::log::error_once!("viewport pos formula execution error: {}", e);
                 }
             }
             if let Some(compiled_expr) = &viewport.look_at.compiled_expr


### PR DESCRIPTION
# Problem

This often happens during startup when no data has been written yet. 

<img width="1456" height="956" alt="image (5)" src="https://github.com/user-attachments/assets/b9a4e958-e335-4640-9082-5124a78b5693" />

# Solution 

Let's just error once for now. As a future TODO we could keep track of which formulas have errored and then only report those we haven't already reported.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single logging macro change in viewport inspector; no behavior change to camera positioning or formula execution.
> 
> **Overview**
> **Reduces log spam** when viewport position EQL formulas fail during early startup (before entity data is available).
> 
> In `set_viewport_pos`, the error path for failed `viewport.pos` formula execution now uses Bevy's `error_once!` instead of `error!`, so the same failure is reported at most once per process instead of every frame the system runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e372f64683263639969033b5fa71aa095edf6f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->