### PR TITLE
aleph: bump nixpkgs, L4T, jetpack-nixos

### DIFF
--- a/aleph/flake.lock
+++ b/aleph/flake.lock
@@ -12,11 +12,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762806692,
-        "narHash": "sha256-JhgQIwJe0U2vxj+pu+Sgm+VLgNqucpXtZYGKZOgkQdc=",
+        "lastModified": 1768505959,
+        "narHash": "sha256-oFCx/ApQ+S1/apUKWsvT9vq+Eo1m2vINWEDkW7/nckA=",
         "owner": "nixos-cuda",
         "repo": "cuda-legacy",
-        "rev": "9856d70acc3e2ae9081930b33d946326e07f1482",
+        "rev": "86ad7e2c2e314f0234539cbbc66b5cd7746bcd32",
         "type": "github"
       },
       "original": {
@@ -33,32 +33,32 @@
         ]
       },
       "locked": {
-        "lastModified": 1768685536,
-        "narHash": "sha256-94sYZ9jRsrBu24ia4pXEyudpQHCjKyy+4cN98bRrRjo=",
+        "lastModified": 1780334549,
+        "narHash": "sha256-SVmtu81BtkU+3+6CQvarnijlwLunY64CVH+e3GsSl8s=",
         "owner": "anduril",
         "repo": "jetpack-nixos",
-        "rev": "2c98c9d6c326d67ae5f4909db61238d31352e18c",
+        "rev": "4a4e93a7b3fbe1915870ec54002c616f01367195",
         "type": "github"
       },
       "original": {
         "owner": "anduril",
         "repo": "jetpack-nixos",
-        "rev": "2c98c9d6c326d67ae5f4909db61238d31352e18c",
+        "rev": "4a4e93a7b3fbe1915870ec54002c616f01367195",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775002709,
-        "narHash": "sha256-d3Yx83vSrN+2z/loBh4mJpyRqr9aAJqlke4TkpFmRJA=",
+        "lastModified": 1780902259,
+        "narHash": "sha256-q8yYEC5f1mFlQO9RGna4LTc9QrcvWunX6FYp83munkQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bcd464ccd2a1a7cd09aa2f8d4ffba83b761b1d0e",
+        "rev": "bd0ff2d3eac24699c3664d5966b9ef36f388e2ca",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/aleph/flake.nix
+++ b/aleph/flake.nix
@@ -7,9 +7,9 @@
     fallback = true;
   };
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
-    jetpack.url = "github:anduril/jetpack-nixos/2c98c9d6c326d67ae5f4909db61238d31352e18c";
+    jetpack.url = "github:anduril/jetpack-nixos/4a4e93a7b3fbe1915870ec54002c616f01367195";
     rust-overlay.url = "github:oxalica/rust-overlay";
 
     jetpack.inputs.nixpkgs.follows = "nixpkgs";
@@ -32,8 +32,16 @@
     rustToolchain = p: p.rust-bin.fromRustupToolchainFile ../rust-toolchain.toml;
     gitJSONOverlay = builtins.fromJSON (builtins.readFile ./gitrepos.json);
     gitReposOverlay = final: prev: {
-      cudaPackages = prev.cudaPackages_12; # CUDA 12 for JP6
-      nvidia-jetpack = prev.nvidia-jetpack6.overrideScope (jetpackFinal: jetpackPrev: {
+      # Our packing of deepstream7 still needs nvidia sources, so we can't use upstream nixpkgs yet!
+      # Start with upstream nixpkgs _cuda/manifests and overlay jetpack ones (where prevCuda is jetpack-nixos cuda)
+      _cuda = prev._cuda.extend (_: prevCuda: {
+        manifests =
+          final.lib.recursiveUpdate
+          (import "${nixpkgs}/pkgs/development/cuda-modules/_cuda/manifests" {inherit (final) lib;})
+          prevCuda.manifests;
+      });
+      # Override jetpack-nixos gitrepos with other sources specific to the aleph carrier board configuration
+      nvidia-jetpack6 = prev.nvidia-jetpack6.overrideScope (jetpackFinal: jetpackPrev: {
         gitRepos =
           jetpackPrev.gitRepos
           // (final.lib.mapAttrs (_: info:

--- a/aleph/gitrepos.json
+++ b/aleph/gitrepos.json
@@ -1,13 +1,13 @@
 {
   "kernel/kernel-jammy-src": {
-    "url": "https://github.com/elodin-sys/aleph-orin-baseboard-kernel.git",
-    "rev": "0ff14d9f9862250d92d7600c2615edc7b2af4fca",
-    "sha256": "sha256-+Ht02FTI1SijLhd0lsr9gBt6i4FsIALaECFbrhrhmqs="
+  "url": "https://github.com/elodin-sys/linux-jammy-nvidia-tegra.git",
+  "rev": "3ba7e8e092b1682a8b78b0466aaee9196c215640",
+  "sha256": "sha256-UoiuvbqEo9ips5Vn51JrqXviMjl5fpv9NOd6qBBb8Uw="
   },
   "hardware/nvidia/t23x/nv-public": {
     "url": "https://github.com/elodin-sys/aleph-jetson-orin-baseboard-nvidia-t23x-public-dts.git",
-    "rev": "93952823f14ec74d7be93c118d50b3dbd3c914ac",
-    "sha256": "sha256-P55v65QkW08arjePTh0cRArNd3VxmPx9cs84+DbHcks="
+    "rev": "c95b0edb3f4e74e7931e1ff5ae5d183f40b19f09",
+    "sha256": "sha256-DwaWXSA/crCRkHm31RARGH5isSBLuk1H3aMuJcMFD8k="
   },
   "hardware/nvidia/tegra/nv-public": {
     "url": "https://github.com/OE4T/tegra-public-dts.git",
@@ -26,18 +26,17 @@
   },
   "nvdisplay": {
     "url": "https://github.com/OE4T/nv-kernel-display-driver.git",
-    "rev": "2c448bfbebf4314293fd432d2a0b33f66e5a4815",
-    "sha256": "0adq1wvnv36z2dpl39ixban7wjbzy623s9v0crdyaj3s1f4fi642"
+    "rev": "a3da679668071cff718a33922b6d302bd18ebaa1",
+    "sha256": "sha256-MjiircE+B8r15QAEt/ZZiWPV7yZd6/2CuJnbc6Z2YiU="
   },
   "nvgpu": {
     "url": "https://github.com/OE4T/linux-nvgpu.git",
-    "rev": "21d928824dc7ca3dc17603a53b11edc6641ace2d",
-    "sha256": "sha256-5OIjSK1grV/nz3hHkeZKRb7dXIQAokNcChGCtzlfBKs="
+    "rev": "a4145c7b6e05af9b5ee4b8da246e3b3820023dca",
+    "sha256": "sha256-zvnTygjF8BUNxaqcU4Mt6kAwngFpArM5timpjw074uQ="
   },
   "nvidia-oot": {
-    "url": "https://nv-tegra.nvidia.com/linux-nv-oot.git",
-    "rev": "efa698bed82f27e403537b7ecf82743e696d17ef",
-    "sha256": "1x5czgiclfkgi999rld7dg57qffw1qjhawvyj1hjkmqrdr2r4nb3"
+    "url": "https://gitlab.com/nvidia/nv-tegra/linux-nv-oot.git",
+    "rev": "b05da1f94ae5a2dbfe928ef7ab387035a2b77a20",
+    "sha256": "sha256-6sqz+yiG8VfJ5/QHn13a60TKqdwl1LuJfV3jCPoJxp4="
   }
 }
-

--- a/aleph/modules/aleph-cuda.nix
+++ b/aleph/modules/aleph-cuda.nix
@@ -62,6 +62,10 @@ in {
     nixpkgs.config = {
       cudaSupport = true;
       cudaCapabilities = ["8.7"];
+      # see: https://nvidia.custhelp.com/app/answers/detail/a_id/5836
+      permittedInsecurePackages = [
+        "cuda12.6-tensorrt-10.7.0.23"
+      ];
     };
 
     hardware.graphics.enable = true;

--- a/aleph/modules/aleph-dev.nix
+++ b/aleph/modules/aleph-dev.nix
@@ -7,7 +7,6 @@
   cfg = config.aleph.dev;
   pythonPackages = ps:
     (with ps; [
-      pipx
       pip
       virtualenv
       numpy

--- a/aleph/pkgs/video-streamer.nix
+++ b/aleph/pkgs/video-streamer.nix
@@ -2,7 +2,7 @@
   pkgs,
   rustToolchain,
   lib,
-  ffmpeg-full,
+  ffmpeg-headless,
   pkg-config,
   clang,
   ...
@@ -13,6 +13,9 @@
 
   common = import ./common.nix {inherit lib;};
   src = common.src;
+  ffmpeg = ffmpeg-headless.override {
+    withCuda = true;
+  };
 in
   pkgs.rustPlatform.buildRustPackage {
     inherit pname version src;
@@ -30,7 +33,7 @@ in
       clang
     ];
 
-    buildInputs = [ffmpeg-full];
+    buildInputs = [ffmpeg];
 
     HOST_CC = "${pkgs.stdenv.cc.nativePrefix}cc";
     TARGET_CC = "${pkgs.stdenv.cc.targetPrefix}cc";

--- a/aleph/pkgs/yaml_0_7.nix
+++ b/aleph/pkgs/yaml_0_7.nix
@@ -31,6 +31,15 @@ stdenv.mkDerivation rec {
     "-DINSTALL_GTEST=false"
   ];
 
+  # newer GCC versions are stricter about source files including the headers they use
+  # yaml-cpp 0.7.0 uses uint16_t/uint32_t here but did not include <cstdint>
+  # probably fixed upstream, but we have to stick with yaml-cpp 0.7.0 because deepstream 7.1 targets it
+  postPatch = ''
+        substituteInPlace src/emitterutils.cpp \
+          --replace-fail "#include <sstream>" "#include <sstream>
+    #include <cstdint>"
+  '';
+
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   # Fix double slashes in .pc file (CMake issue)


### PR DESCRIPTION
Bump nixpkgs (nixos 26.05), bump jetpack 6.2.2 / L4T 36.5.0 , bump jetpack-nixos (202606), and bump corresponding gitrepos pins. Update kernel source to OE4T 36.5 patches + antmicro patches. 

Update packaging for changes in 26.05 including:
- pin cuda depends to use nvidia instead of upstream nixpkgs (still needed for current deepstream packaging)
- patch source includes in yaml-cpp for GCC 15
- change ffmpeg import to ffmpeg-headless (don't bring in gui dependencies for headless application)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large platform bump (kernel, Jetson firmware sources, CUDA/TensorRT policy) affects device images and GPU/DeepStream builds; regressions are most likely at flash/runtime on hardware.
> 
> **Overview**
> **Bumps the Aleph Nix stack** to `nixos-26.05`, a newer **jetpack-nixos** pin, and refreshed **flake.lock** inputs (`cuda-legacy`, jetpack, nixpkgs).
> 
> **Jetson/L4T sources** in `gitrepos.json` move to L4T 36.5–aligned pins: kernel tree switches to `linux-jammy-nvidia-tegra`, carrier DTS and several OE4T/NVIDIA repos are re-pinned, and `nvidia-oot` now comes from GitLab with a new revision.
> 
> **CUDA packaging** no longer hard-codes `cudaPackages_12`; the overlay **merges upstream nixpkgs `_cuda/manifests` with jetpack’s** so DeepStream 7 can still use NVIDIA-sourced CUDA. **`aleph-cuda`** allows the pinned TensorRT package via `permittedInsecurePackages`.
> 
> **26.05 build fixes:** `video-streamer` builds against **`ffmpeg-headless` with CUDA** instead of `ffmpeg-full`; **`yaml-cpp` 0.7.0** gets a `<cstdint>` include patch for GCC 15; **`pipx` is dropped** from the dev Python set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 133e132c67d7f04c3fdaaa2f53fefdf6b35cbab3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->