### PR TITLE
Apollo thruster visuals; fix(view-cube): orbit arrows.

### DIFF
--- a/examples/apollo-lander/apollo-lander.kdl
+++ b/examples/apollo-lander/apollo-lander.kdl
@@ -38,6 +38,25 @@ hsplit {
                 color 114 87 179
             }
         }
+        hsplit {
+            // Engine thrust as a fraction of max: this is the quantity bound to
+            // the exhaust plume (the plume is drawn along its opposite, pointing
+            // down). The plume's intensity is proportional to this, so the curve
+            // explains the burn you see (mostly pinned at the fixed throttle
+            // point during braking).
+            graph "lander.main_thrust_viz[2]" name="Engine thrust (fraction of max)" {
+                color 255 128 0
+            }
+            // RCS attitude-control torque command (N·m, roll/pitch/yaw): the
+            // criterion that fires the cold-gas jets. Each nozzle is tied to one
+            // axis and sign, so the signed value on each axis decides which jets
+            // light and how hard.
+            graph "lander.rcs_torque" name="RCS torque command (roll/pitch/yaw, N·m)" {
+                color 106 155 165
+                color 196 160 70
+                color 114 87 179
+            }
+        }
     }
 }
 object_3d surface.world_pos frame=ENU {
@@ -52,22 +71,22 @@ object_3d surface.world_pos frame=ENU {
 object_3d lander.world_pos frame=ENU {
     glb path=apollo-lunar-module.glb translate="(0, -2.5, 0)"
     thruster name="DPS" effect="plume" body_frame=#true position="(0, -0.55, 0)" intensity=lander.main_thrust_viz emission_rate=180.0
-    thruster name="rcs_0" effect="cold_gas" body_frame=#true position="(1.089, 0.870, -1.506)" direction="(0, 0, -1)" intensity="lander.rcs_thruster_viz[0]" emission_rate=360.0 cutoff=0.006
-    thruster name="rcs_1" effect="cold_gas" body_frame=#true position="(1.388, 0.874, -1.361)" direction="(1, 0, 0)" intensity="lander.rcs_thruster_viz[1]" emission_rate=360.0 cutoff=0.006
-    thruster name="rcs_2" effect="cold_gas" body_frame=#true position="(-1.180, 0.527, -1.369)" direction="(0, -1, 0)" intensity="lander.rcs_thruster_viz[2]" emission_rate=360.0 cutoff=0.006
-    thruster name="rcs_3" effect="cold_gas" body_frame=#true position="(-1.360, 0.855, -1.361)" direction="(-1, 0, 0)" intensity="lander.rcs_thruster_viz[3]" emission_rate=360.0 cutoff=0.006
-    thruster name="rcs_4" effect="cold_gas" body_frame=#true position="(-1.062, 0.858, -1.507)" direction="(0, 0, -1)" intensity="lander.rcs_thruster_viz[4]" emission_rate=360.0 cutoff=0.006
-    thruster name="rcs_5" effect="cold_gas" body_frame=#true position="(-1.249, 1.127, 1.230)" direction="(0, 1, 0)" intensity="lander.rcs_thruster_viz[5]" emission_rate=360.0 cutoff=0.006
-    thruster name="rcs_6" effect="cold_gas" body_frame=#true position="(-1.429, 0.916, 1.280)" direction="(-1, 0, 0)" intensity="lander.rcs_thruster_viz[6]" emission_rate=360.0 cutoff=0.006
-    thruster name="rcs_7" effect="cold_gas" body_frame=#true position="(-1.232, 0.912, 1.428)" direction="(0, 0, 1)" intensity="lander.rcs_thruster_viz[7]" emission_rate=360.0 cutoff=0.006
-    thruster name="rcs_8" effect="cold_gas" body_frame=#true position="(1.297, 1.127, 1.243)" direction="(0, 1, 0)" intensity="lander.rcs_thruster_viz[8]" emission_rate=360.0 cutoff=0.006
-    thruster name="rcs_9" effect="cold_gas" body_frame=#true position="(1.296, 0.694, 1.243)" direction="(0, -1, 0)" intensity="lander.rcs_thruster_viz[9]" emission_rate=360.0 cutoff=0.006
-    thruster name="rcs_10" effect="cold_gas" body_frame=#true position="(1.484, 0.905, 1.260)" direction="(1, 0, 0)" intensity="lander.rcs_thruster_viz[10]" emission_rate=360.0 cutoff=0.006
-    thruster name="rcs_11" effect="cold_gas" body_frame=#true position="(1.314, 0.908, 1.442)" direction="(0, 0, 1)" intensity="lander.rcs_thruster_viz[11]" emission_rate=360.0 cutoff=0.006
-    thruster name="rcs_12" effect="cold_gas" body_frame=#true position="(1.207, 1.201, -1.369)" direction="(0, 1, 0)" intensity="lander.rcs_thruster_viz[12]" emission_rate=360.0 cutoff=0.006
-    thruster name="rcs_13" effect="cold_gas" body_frame=#true position="(1.207, 0.527, -1.369)" direction="(0, -1, 0)" intensity="lander.rcs_thruster_viz[13]" emission_rate=360.0 cutoff=0.006
-    thruster name="rcs_14" effect="cold_gas" body_frame=#true position="(-1.249, 0.694, 1.230)" direction="(0, -1, 0)" intensity="lander.rcs_thruster_viz[14]" emission_rate=360.0 cutoff=0.006
-    thruster name="rcs_15" effect="cold_gas" body_frame=#true position="(-1.180, 1.200, -1.369)" direction="(0, 1, 0)" intensity="lander.rcs_thruster_viz[15]" emission_rate=360.0 cutoff=0.006
+    thruster name="rcs_0" effect="cold_gas" body_frame=#true position="(1.089, 0.870, -1.506)" direction="(0, 0, -1)" intensity="lander.rcs_thruster_viz[0]" emission_rate=1100.0 cutoff=0.006
+    thruster name="rcs_1" effect="cold_gas" body_frame=#true position="(1.388, 0.874, -1.361)" direction="(1, 0, 0)" intensity="lander.rcs_thruster_viz[1]" emission_rate=1100.0 cutoff=0.006
+    thruster name="rcs_2" effect="cold_gas" body_frame=#true position="(-1.180, 0.527, -1.369)" direction="(0, -1, 0)" intensity="lander.rcs_thruster_viz[2]" emission_rate=1100.0 cutoff=0.006
+    thruster name="rcs_3" effect="cold_gas" body_frame=#true position="(-1.360, 0.855, -1.361)" direction="(-1, 0, 0)" intensity="lander.rcs_thruster_viz[3]" emission_rate=1100.0 cutoff=0.006
+    thruster name="rcs_4" effect="cold_gas" body_frame=#true position="(-1.062, 0.858, -1.507)" direction="(0, 0, -1)" intensity="lander.rcs_thruster_viz[4]" emission_rate=1100.0 cutoff=0.006
+    thruster name="rcs_5" effect="cold_gas" body_frame=#true position="(-1.249, 1.127, 1.230)" direction="(0, 1, 0)" intensity="lander.rcs_thruster_viz[5]" emission_rate=1100.0 cutoff=0.006
+    thruster name="rcs_6" effect="cold_gas" body_frame=#true position="(-1.429, 0.916, 1.280)" direction="(-1, 0, 0)" intensity="lander.rcs_thruster_viz[6]" emission_rate=1100.0 cutoff=0.006
+    thruster name="rcs_7" effect="cold_gas" body_frame=#true position="(-1.232, 0.912, 1.428)" direction="(0, 0, 1)" intensity="lander.rcs_thruster_viz[7]" emission_rate=1100.0 cutoff=0.006
+    thruster name="rcs_8" effect="cold_gas" body_frame=#true position="(1.297, 1.127, 1.243)" direction="(0, 1, 0)" intensity="lander.rcs_thruster_viz[8]" emission_rate=1100.0 cutoff=0.006
+    thruster name="rcs_9" effect="cold_gas" body_frame=#true position="(1.296, 0.694, 1.243)" direction="(0, -1, 0)" intensity="lander.rcs_thruster_viz[9]" emission_rate=1100.0 cutoff=0.006
+    thruster name="rcs_10" effect="cold_gas" body_frame=#true position="(1.484, 0.905, 1.260)" direction="(1, 0, 0)" intensity="lander.rcs_thruster_viz[10]" emission_rate=1100.0 cutoff=0.006
+    thruster name="rcs_11" effect="cold_gas" body_frame=#true position="(1.314, 0.908, 1.442)" direction="(0, 0, 1)" intensity="lander.rcs_thruster_viz[11]" emission_rate=1100.0 cutoff=0.006
+    thruster name="rcs_12" effect="cold_gas" body_frame=#true position="(1.207, 1.201, -1.369)" direction="(0, 1, 0)" intensity="lander.rcs_thruster_viz[12]" emission_rate=1100.0 cutoff=0.006
+    thruster name="rcs_13" effect="cold_gas" body_frame=#true position="(1.207, 0.527, -1.369)" direction="(0, -1, 0)" intensity="lander.rcs_thruster_viz[13]" emission_rate=1100.0 cutoff=0.006
+    thruster name="rcs_14" effect="cold_gas" body_frame=#true position="(-1.249, 0.694, 1.230)" direction="(0, -1, 0)" intensity="lander.rcs_thruster_viz[14]" emission_rate=1100.0 cutoff=0.006
+    thruster name="rcs_15" effect="cold_gas" body_frame=#true position="(-1.180, 1.200, -1.369)" direction="(0, 1, 0)" intensity="lander.rcs_thruster_viz[15]" emission_rate=1100.0 cutoff=0.006
 }
 // Moon sphere as the curved horizon backdrop. With this rotation/scale the
 // LRO mesh surface directly under the site sits ~1,725,022 m above the sphere

--- a/libs/elodin-editor/src/plugins/thruster_particles/mod.rs
+++ b/libs/elodin-editor/src/plugins/thruster_particles/mod.rs
@@ -5,22 +5,25 @@
 //! DPS plumes are authored this way in the lander schematic; this plugin only
 //! evaluates the nodes and drives the particle effects.
 
+use bevy::asset::RenderAssetUsages;
 use bevy::math::{DVec3, Quat, Vec4};
 use bevy::prelude::*;
+use bevy::render::render_resource::{Extent3d, TextureDimension, TextureFormat};
 use bevy::transform::TransformSystems;
 use bevy_geo_frames::{GeoContext, GeoFrame, GeoRotation};
 use bevy_hanabi::{
-    AlphaMode, Attribute, EffectAsset, EffectSpawner, Gradient, HanabiPlugin, Module,
-    ParticleEffect, SimulationSpace, SpawnerSettings,
+    AlphaMode, Attribute, EffectAsset, EffectMaterial, EffectSpawner, Gradient, HanabiPlugin,
+    Module, ParticleEffect, SimulationSpace, SpawnerSettings,
     modifier::{
         ShapeDimension,
         attr::SetAttributeModifier,
         force::LinearDragModifier,
         output::{
-            ColorBlendMask, ColorBlendMode, ColorOverLifetimeModifier, OrientMode, OrientModifier,
-            SizeOverLifetimeModifier,
+            ColorBlendMask, ColorBlendMode, ColorOverLifetimeModifier, ImageSampleMapping,
+            OrientMode, OrientModifier, ParticleTextureModifier, SizeOverLifetimeModifier,
         },
         position::SetPositionCone3dModifier,
+        velocity::SetVelocitySphereModifier,
     },
 };
 use impeller2_bevy::EntityMap;
@@ -39,6 +42,8 @@ const MIN_THRUST_VECTOR_LENGTH_SQUARED: f32 = 1e-12;
 struct ThrusterEffectAssets {
     plume: Handle<EffectAsset>,
     cold_gas: Handle<EffectAsset>,
+    /// Soft radial mask so billboards render as round puffs, not hard squares.
+    mask: Handle<Image>,
 }
 
 impl ThrusterEffectAssets {
@@ -93,10 +98,48 @@ impl Plugin for ThrusterParticlesPlugin {
     }
 }
 
-fn setup_thruster_effects(mut commands: Commands, mut effects: ResMut<Assets<EffectAsset>>) {
+fn setup_thruster_effects(
+    mut commands: Commands,
+    mut effects: ResMut<Assets<EffectAsset>>,
+    mut images: ResMut<Assets<Image>>,
+) {
     let plume = effects.add(build_dps_exhaust());
     let cold_gas = effects.add(build_rcs_jet());
-    commands.insert_resource(ThrusterEffectAssets { plume, cold_gas });
+    let mask = images.add(build_soft_particle_image());
+    commands.insert_resource(ThrusterEffectAssets {
+        plume,
+        cold_gas,
+        mask,
+    });
+}
+
+/// Single-channel radial falloff (opacity 1 at center, 0 at the rim), sampled
+/// via `ImageSampleMapping::ModulateOpacityFromR` so square billboard quads
+/// render as soft round puffs even when zoomed in.
+fn build_soft_particle_image() -> Image {
+    const SIZE: u32 = 64;
+    let mut data = vec![0u8; (SIZE * SIZE) as usize];
+    let center = (SIZE as f32 - 1.0) * 0.5;
+    for y in 0..SIZE {
+        for x in 0..SIZE {
+            let dx = (x as f32 - center) / center;
+            let dy = (y as f32 - center) / center;
+            let dist = (dx * dx + dy * dy).sqrt().clamp(0.0, 1.0);
+            let falloff = (1.0 - dist) * (1.0 - dist);
+            data[(y * SIZE + x) as usize] = (falloff * 255.0) as u8;
+        }
+    }
+    Image::new(
+        Extent3d {
+            width: SIZE,
+            height: SIZE,
+            depth_or_array_layers: 1,
+        },
+        TextureDimension::D2,
+        data,
+        TextureFormat::R8Unorm,
+        RenderAssetUsages::RENDER_WORLD,
+    )
 }
 
 fn build_dps_exhaust() -> EffectAsset {
@@ -127,6 +170,9 @@ fn build_dps_exhaust() -> EffectAsset {
     size_over_life.add_key(0.75, Vec3::new(1.18, 0.52, 0.52));
     size_over_life.add_key(1.0, Vec3::new(0.42, 0.2, 0.2));
 
+    let mask_slot = module.lit(0u32);
+    module.add_texture_slot("mask");
+
     EffectAsset::new(16384, SpawnerSettings::rate(220.0.into()), module)
         .with_name("dps_exhaust")
         .with_simulation_space(SimulationSpace::Local)
@@ -137,6 +183,11 @@ fn build_dps_exhaust() -> EffectAsset {
         .init(size)
         .update(drag)
         .render(OrientModifier::new(OrientMode::AlongVelocity))
+        // Soft round mask so the quads are not visible flat squares up close.
+        .render(ParticleTextureModifier {
+            texture_slot: mask_slot,
+            sample_mapping: ImageSampleMapping::ModulateOpacityFromR,
+        })
         .render(SizeOverLifetimeModifier {
             gradient: size_over_life,
             screen_space_size: false,
@@ -154,45 +205,63 @@ fn build_rcs_jet() -> EffectAsset {
     // Miniature DPS-style plume: anchored at the nozzle mouth, expanding back
     // into the emitter volume while velocity carries particles outward.
     let init_pos = SetPositionCone3dModifier {
-        height: module.lit(0.12),
-        base_radius: module.lit(0.025),
-        top_radius: module.lit(0.09),
+        height: module.lit(0.08),
+        base_radius: module.lit(0.02),
+        top_radius: module.lit(0.04),
         dimension: ShapeDimension::Volume,
     };
 
-    let init_vel =
-        SetAttributeModifier::new(Attribute::VELOCITY, module.lit(DPS_EXHAUST_BODY * 8.0));
+    // Tighter, faster cone (center farther behind the nozzle = smaller
+    // divergence) so the jet reads as a punchy collimated gas thruster that
+    // shoots out, not a slow diffuse vent puff.
+    let init_vel = SetVelocitySphereModifier {
+        center: module.lit(Vec3::new(0.0, 0.42, 0.0)),
+        speed: module.lit(11.0),
+    };
 
-    let lifetime = SetAttributeModifier::new(Attribute::LIFETIME, module.lit(0.42));
-    let size = SetAttributeModifier::new(Attribute::SIZE3, module.lit(Vec3::new(0.26, 0.08, 0.08)));
-    let drag = LinearDragModifier::new(module.lit(2.0));
+    // Slightly longer reach with low drag so particles keep momentum and the
+    // stream stays continuous instead of popping out in discrete puffs.
+    let lifetime = SetAttributeModifier::new(Attribute::LIFETIME, module.lit(0.5));
+    let size = SetAttributeModifier::new(Attribute::SIZE3, module.lit(Vec3::splat(0.09)));
+    let drag = LinearDragModifier::new(module.lit(1.2));
 
-    // Blue-white cold gas, brighter than the earlier transparent haze but
-    // still slimmer than the DPS exhaust.
+    // Blue-white cold gas. Alpha-blended (not additive) and slightly toned down
+    // so a dense puff stays readable instead of blooming into a dazzling glow.
     let mut gradient = Gradient::<Vec4>::new();
-    gradient.add_key(0.0, Vec4::new(0.85, 0.95, 1.35, 0.9));
-    gradient.add_key(0.1, Vec4::new(0.58, 0.78, 1.25, 0.8));
-    gradient.add_key(0.35, Vec4::new(0.34, 0.56, 1.0, 0.58));
-    gradient.add_key(0.7, Vec4::new(0.18, 0.34, 0.78, 0.28));
+    gradient.add_key(0.0, Vec4::new(0.85, 0.95, 1.2, 0.6));
+    gradient.add_key(0.1, Vec4::new(0.58, 0.78, 1.1, 0.5));
+    gradient.add_key(0.35, Vec4::new(0.34, 0.56, 0.95, 0.34));
+    gradient.add_key(0.7, Vec4::new(0.18, 0.34, 0.72, 0.16));
     gradient.add_key(1.0, Vec4::ZERO);
 
+    // Round puffs that grow modestly downstream: a tight jet near the nozzle
+    // widening slightly, kept dense by the emission rate rather than by size.
     let mut size_over_life = Gradient::<Vec3>::new();
-    size_over_life.add_key(0.0, Vec3::new(0.22, 0.07, 0.07));
-    size_over_life.add_key(0.15, Vec3::new(0.46, 0.16, 0.16));
-    size_over_life.add_key(0.45, Vec3::new(0.64, 0.22, 0.22));
-    size_over_life.add_key(0.75, Vec3::new(0.48, 0.17, 0.17));
-    size_over_life.add_key(1.0, Vec3::new(0.18, 0.06, 0.06));
+    size_over_life.add_key(0.0, Vec3::splat(0.07));
+    size_over_life.add_key(0.15, Vec3::splat(0.16));
+    size_over_life.add_key(0.45, Vec3::splat(0.22));
+    size_over_life.add_key(0.75, Vec3::splat(0.17));
+    size_over_life.add_key(1.0, Vec3::splat(0.07));
 
-    EffectAsset::new(8192, SpawnerSettings::rate(360.0.into()), module)
+    let mask_slot = module.lit(0u32);
+    module.add_texture_slot("mask");
+
+    EffectAsset::new(16384, SpawnerSettings::rate(1100.0.into()), module)
         .with_name("rcs_jet")
         .with_simulation_space(SimulationSpace::Local)
-        .with_alpha_mode(AlphaMode::Add)
+        .with_alpha_mode(AlphaMode::Blend)
         .init(init_pos)
         .init(init_vel)
         .init(lifetime)
         .init(size)
         .update(drag)
-        .render(OrientModifier::new(OrientMode::AlongVelocity))
+        // Camera-facing billboards keep the jet volumetric from any angle.
+        .render(OrientModifier::new(OrientMode::FaceCameraPosition))
+        // Soft round mask so the quads are not visible flat squares up close.
+        .render(ParticleTextureModifier {
+            texture_slot: mask_slot,
+            sample_mapping: ImageSampleMapping::ModulateOpacityFromR,
+        })
         .render(SizeOverLifetimeModifier {
             gradient: size_over_life,
             screen_space_size: false,
@@ -233,6 +302,9 @@ fn ensure_kdl_thrusters(
                 .spawn((
                     KdlThrusterJet::from_config(config, state.data.frame, intensity),
                     ParticleEffect::new(assets.by_name(&config.effect)),
+                    EffectMaterial {
+                        images: vec![assets.mask.clone()],
+                    },
                     Transform::default(),
                     GlobalTransform::default(),
                     Visibility::Hidden,

--- a/libs/elodin-editor/src/plugins/view_cube/camera.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/camera.rs
@@ -6,7 +6,7 @@ use crate::spatial::{FloatingOriginSettings, GridCell, WithFloatingOrigin};
 use bevy::camera::visibility::RenderLayers;
 use bevy::ecs::hierarchy::ChildOf;
 use bevy::ecs::system::SystemParam;
-use bevy::log::{debug, warn};
+use bevy::log::warn;
 use bevy::math::{DVec3, Dir3};
 use bevy::prelude::*;
 use bevy::scene::{SceneInstance, SceneSpawner};
@@ -567,7 +567,7 @@ pub fn handle_view_cube_editor(
         }
 
         if let ViewCubeEvent::ArrowClicked { arrow, .. } = event {
-            if let Some((previous_depth, refreshed_depth)) = refresh_anchor_depth_for_arrow(
+            refresh_anchor_depth_for_arrow(
                 entity,
                 camera_pose.translation,
                 &mut editor_cam,
@@ -575,65 +575,27 @@ pub fn handle_view_cube_editor(
                 lookup.entity_map.as_ref(),
                 &lookup.values,
                 origin_world,
-            ) {
-                debug!(
-                    target: "view_cube::arrow",
-                    camera = ?entity,
-                    arrow = ?arrow,
-                    previous_depth,
-                    refreshed_depth,
-                    "refreshed anchor depth from orbit target before arrow step"
-                );
-            } else {
-                debug!(
-                    target: "view_cube::arrow",
-                    camera = ?entity,
-                    arrow = ?arrow,
-                    current_depth = editor_cam.last_anchor_depth,
-                    "anchor depth refresh unavailable; keeping current depth"
-                );
-            }
+            );
 
             let angle = config.rotation_increment;
-            let (base_rotation, base_source) =
+            // Chain rapid repeats from the last applied arrow target so a held
+            // button steps cleanly; otherwise base off the live pose.
+            let base_rotation =
                 if let Some(cached) = lookup.arrow_cache.get_valid_target(entity, now_secs) {
                     let drift = cached
                         .target_rotation
                         .angle_between(transform.rotation)
                         .abs();
-                    if cached.source != ArrowTargetSource::ArrowStep {
-                        debug!(
-                            target: "view_cube::arrow",
-                            camera = ?entity,
-                            arrow = ?arrow,
-                            cached_source = ?cached.source,
-                            drift_deg = drift.to_degrees(),
-                            "ignoring non-arrow cached target"
-                        );
-                        (transform.rotation, "current_rotation")
-                    } else if drift <= ARROW_CACHE_MAX_DRIFT_RADIANS {
-                        debug!(
-                            target: "view_cube::arrow",
-                            camera = ?entity,
-                            arrow = ?arrow,
-                            drift_deg = drift.to_degrees(),
-                            "using cached arrow target as rotation base"
-                        );
-                        (cached.target_rotation, "cached_arrow_target")
+                    if cached.source == ArrowTargetSource::ArrowStep
+                        && drift <= ARROW_CACHE_MAX_DRIFT_RADIANS
+                    {
+                        cached.target_rotation
                     } else {
-                        debug!(
-                            target: "view_cube::arrow",
-                            camera = ?entity,
-                            arrow = ?arrow,
-                            drift_deg = drift.to_degrees(),
-                            drift_threshold_deg = ARROW_CACHE_MAX_DRIFT_RADIANS.to_degrees(),
-                            "dropping stale cached arrow target"
-                        );
                         lookup.arrow_cache.clear(entity);
-                        (transform.rotation, "current_rotation")
+                        transform.rotation
                     }
                 } else {
-                    (transform.rotation, "current_rotation")
+                    transform.rotation
                 };
             let base_forward_local = base_rotation * Vec3::NEG_Z;
             let base_up_local = base_rotation * Vec3::Y;
@@ -643,9 +605,8 @@ pub fn handle_view_cube_editor(
             let base_right_world = parent_rotation * base_right_local;
 
             // Left/Right is a turntable azimuth: yaw around the orbit's fixed up
-            // (world vertical) like a drag-orbit, so the horizon stays level and
-            // the focus stays put. Falling back to the camera up (the old
-            // behavior) only when the orbit is unconstrained.
+            // (world vertical) like a drag-orbit, so the horizon stays level.
+            // Falls back to the camera up only when the orbit is unconstrained.
             let orbit_up_world = match editor_cam.orbit_constraint {
                 OrbitConstraint::Fixed { up, .. } => up,
                 OrbitConstraint::Free => base_up_world,
@@ -659,47 +620,51 @@ pub fn handle_view_cube_editor(
                 orbit_up_world,
             );
             let step_rotation_world = Quat::from_axis_angle(*step_axis_world, signed_angle);
-            let new_forward_world = step_rotation_world * base_forward_world;
-            let new_up_world = step_rotation_world * base_up_world;
-            let new_forward_local = parent_rotation.inverse() * new_forward_world;
-            let new_up_local = parent_rotation.inverse() * new_up_world;
 
-            if let Ok(facing) = Dir3::new(new_forward_local)
-                && let Ok(up_dir) = Dir3::new(new_up_local)
-            {
-                let trigger = LookToTrigger {
+            // Orbit the live camera around the focus object (the viewport
+            // `look_at`) rather than the screen-center view axis: rotating about
+            // the latter pushed an off-center module out of frame on Left/Right.
+            // With no resolvable focus, pivot around the on-axis anchor so the
+            // behavior degrades to the previous in-place spin.
+            let parent_inv = parent_rotation.inverse();
+            let new_world_rotation = step_rotation_world * (parent_rotation * base_rotation);
+            let new_rotation_local = parent_inv * new_world_rotation;
+
+            let focus_world = view_cube_orbit_target(
+                entity,
+                &lookup.viewports,
+                lookup.entity_map.as_ref(),
+                &lookup.values,
+            )
+            .map(|target| (target - origin_world).as_vec3())
+            .unwrap_or_else(|| {
+                camera_pose.translation
+                    + base_forward_world * (editor_cam.last_anchor_depth.abs() as f32)
+            });
+
+            let camera_world = camera_pose.translation;
+            let new_camera_world = focus_world + step_rotation_world * (camera_world - focus_world);
+
+            transform.translation += parent_inv * (new_camera_world - camera_world);
+            transform.rotation = new_rotation_local;
+
+            // Record the step for chaining, and cancel any in-flight snap
+            // animation by re-targeting the orientation we just applied (a no-op
+            // move for LookTo on the next frame).
+            lookup.arrow_cache.set_target(
+                entity,
+                new_rotation_local,
+                now_secs,
+                ArrowTargetSource::ArrowStep,
+            );
+            let facing_local = new_rotation_local * Vec3::NEG_Z;
+            let up_local = new_rotation_local * Vec3::Y;
+            if let (Ok(facing), Ok(up_dir)) = (Dir3::new(facing_local), Dir3::new(up_local)) {
+                look_to.write(LookToTrigger {
                     target_facing_direction: facing,
                     target_up_direction: up_dir,
                     camera: entity,
-                };
-                let target_rotation = trigger_rotation(&trigger);
-                let target_delta_deg = transform
-                    .rotation
-                    .angle_between(target_rotation)
-                    .to_degrees();
-                debug!(
-                    target: "view_cube::arrow",
-                    camera = ?entity,
-                    arrow = ?arrow,
-                    step_deg = angle.to_degrees(),
-                    base_source,
-                    target_delta_deg,
-                    "arrow click resolved target rotation"
-                );
-                lookup.arrow_cache.set_target(
-                    entity,
-                    target_rotation,
-                    now_secs,
-                    ArrowTargetSource::ArrowStep,
-                );
-                look_to.write(trigger);
-            } else {
-                warn!(
-                    arrow = ?arrow,
-                    new_forward_local = ?new_forward_local,
-                    new_up_local = ?new_up_local,
-                    "view cube: invalid arrow directions"
-                );
+                });
             }
         }
 

--- a/libs/elodin-editor/src/plugins/view_cube/camera.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/camera.rs
@@ -10,7 +10,7 @@ use bevy::log::{debug, warn};
 use bevy::math::{DVec3, Dir3};
 use bevy::prelude::*;
 use bevy::scene::{SceneInstance, SceneSpawner};
-use bevy_editor_cam::controller::component::EditorCam;
+use bevy_editor_cam::controller::component::{EditorCam, OrbitConstraint};
 use bevy_editor_cam::controller::motion::CurrentMotion;
 use bevy_editor_cam::extensions::look_to::LookToTrigger;
 use impeller2_bevy::EntityMap;
@@ -642,12 +642,21 @@ pub fn handle_view_cube_editor(
             let base_up_world = parent_rotation * base_up_local;
             let base_right_world = parent_rotation * base_right_local;
 
+            // Left/Right is a turntable azimuth: yaw around the orbit's fixed up
+            // (world vertical) like a drag-orbit, so the horizon stays level and
+            // the focus stays put. Falling back to the camera up (the old
+            // behavior) only when the orbit is unconstrained.
+            let orbit_up_world = match editor_cam.orbit_constraint {
+                OrbitConstraint::Fixed { up, .. } => up,
+                OrbitConstraint::Free => base_up_world,
+            };
+
             let (step_axis_world, signed_angle, _) = arrow_camera_axis_angle(
                 *arrow,
                 angle,
                 base_right_world,
-                base_up_world,
                 base_forward_world,
+                orbit_up_world,
             );
             let step_rotation_world = Quat::from_axis_angle(*step_axis_world, signed_angle);
             let new_forward_world = step_rotation_world * base_forward_world;
@@ -796,19 +805,19 @@ fn arrow_camera_axis_angle(
     arrow: RotationArrow,
     angle: f32,
     camera_right_world: Vec3,
-    camera_up_world: Vec3,
     camera_forward_world: Vec3,
+    orbit_up_world: Vec3,
 ) -> (Dir3, f32, &'static str) {
     match arrow {
         RotationArrow::Left => (
-            Dir3::new(camera_up_world).unwrap_or(Dir3::new_unchecked(Vec3::Y)),
+            Dir3::new(orbit_up_world).unwrap_or(Dir3::new_unchecked(Vec3::Y)),
             angle,
-            "camera_up",
+            "orbit_up",
         ),
         RotationArrow::Right => (
-            Dir3::new(camera_up_world).unwrap_or(Dir3::new_unchecked(Vec3::Y)),
+            Dir3::new(orbit_up_world).unwrap_or(Dir3::new_unchecked(Vec3::Y)),
             -angle,
-            "camera_up",
+            "orbit_up",
         ),
         RotationArrow::Up => (
             Dir3::new(camera_right_world).unwrap_or(Dir3::new_unchecked(Vec3::X)),
@@ -1229,41 +1238,43 @@ mod tests {
     fn arrow_camera_axis_angle_maps_each_pair_to_camera_axis() {
         let angle = 0.25;
         let right = Vec3::Y;
-        let up = Vec3::Z;
         let forward = Vec3::X;
+        // Distinct from the camera up so we can assert yaw uses the orbit axis.
+        let orbit_up = Vec3::Z;
 
+        // Left/Right yaw around the orbit (world) up, not the camera up.
         let (axis, signed_angle, source) =
-            arrow_camera_axis_angle(RotationArrow::Left, angle, right, up, forward);
-        assert_eq!(*axis, up);
+            arrow_camera_axis_angle(RotationArrow::Left, angle, right, forward, orbit_up);
+        assert_eq!(*axis, orbit_up);
         assert_eq!(signed_angle, angle);
-        assert_eq!(source, "camera_up");
+        assert_eq!(source, "orbit_up");
 
         let (axis, signed_angle, source) =
-            arrow_camera_axis_angle(RotationArrow::Right, angle, right, up, forward);
-        assert_eq!(*axis, up);
+            arrow_camera_axis_angle(RotationArrow::Right, angle, right, forward, orbit_up);
+        assert_eq!(*axis, orbit_up);
         assert_eq!(signed_angle, -angle);
-        assert_eq!(source, "camera_up");
+        assert_eq!(source, "orbit_up");
 
         let (axis, signed_angle, source) =
-            arrow_camera_axis_angle(RotationArrow::Up, angle, right, up, forward);
+            arrow_camera_axis_angle(RotationArrow::Up, angle, right, forward, orbit_up);
         assert_eq!(*axis, right);
         assert_eq!(signed_angle, angle);
         assert_eq!(source, "camera_right");
 
         let (axis, signed_angle, source) =
-            arrow_camera_axis_angle(RotationArrow::Down, angle, right, up, forward);
+            arrow_camera_axis_angle(RotationArrow::Down, angle, right, forward, orbit_up);
         assert_eq!(*axis, right);
         assert_eq!(signed_angle, -angle);
         assert_eq!(source, "camera_right");
 
         let (axis, signed_angle, source) =
-            arrow_camera_axis_angle(RotationArrow::RollLeft, angle, right, up, forward);
+            arrow_camera_axis_angle(RotationArrow::RollLeft, angle, right, forward, orbit_up);
         assert_eq!(*axis, forward);
         assert_eq!(signed_angle, angle);
         assert_eq!(source, "camera_forward");
 
         let (axis, signed_angle, source) =
-            arrow_camera_axis_angle(RotationArrow::RollRight, angle, right, up, forward);
+            arrow_camera_axis_angle(RotationArrow::RollRight, angle, right, forward, orbit_up);
         assert_eq!(*axis, forward);
         assert_eq!(signed_angle, -angle);
         assert_eq!(source, "camera_forward");

--- a/libs/elodin-editor/src/plugins/view_cube/camera.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/camera.rs
@@ -642,8 +642,15 @@ pub fn handle_view_cube_editor(
                     + base_forward_world * (editor_cam.last_anchor_depth.abs() as f32)
             });
 
+            // Yaw/pitch orbit the focus object so it stays framed; roll is about
+            // the view axis and must spin in place (pivot on the camera itself),
+            // otherwise an off-center focus would drift the camera on roll.
             let camera_world = camera_pose.translation;
-            let new_camera_world = focus_world + step_rotation_world * (camera_world - focus_world);
+            let pivot_world = match *arrow {
+                RotationArrow::RollLeft | RotationArrow::RollRight => camera_world,
+                _ => focus_world,
+            };
+            let new_camera_world = pivot_world + step_rotation_world * (camera_world - pivot_world);
 
             transform.translation += parent_inv * (new_camera_world - camera_world);
             transform.rotation = new_rotation_local;


### PR DESCRIPTION
> See https://github.com/elodin-sys/elodin/pull/684

---

### Visual effects

Thruster particles were flat planes; they are now **volumetric** (camera-facing billboards with a soft radial mask, round from every angle, even zoomed in). 
RCS jets are retuned into a punchy collimated jet (normal blending, not the old dazzling additive puffs). DPS is unchanged.

Two graphs let you tie the visuals to the sim:

- **Engine thrust (fraction of max)** — orange. The plume is drawn opposite to  it with proportional intensity, so this curve *is* the main exhaust.
- **RCS torque (roll/pitch/yaw)** — each jet maps to one axis + sign, so the  non-zero axis and its sign tell you which side jets fire and how hard.

---

### View-cube orbit fix

The rotation arrows didn't orbit the focus object.

---

## Video

https://github.com/user-attachments/assets/699853cf-4527-4ddd-9da4-f2770b04a8f1



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes editor camera orbit math and GPU particle rendering paths; behavior is user-facing but limited to visualization and viewport controls, not sim or security logic.
> 
> **Overview**
> Improves **Apollo lander** thruster visuals and ties them to sim telemetry, and fixes **view-cube** rotation arrows so they orbit the viewport focus instead of spinning in place.
> 
> **Thruster particles** now use a procedurally generated soft radial mask on DPS and RCS effects so billboard quads read as round puffs up close. RCS jets are retuned: **alpha blend** (replacing additive), camera-facing orientation, tighter velocity, and higher default spawn rates; spawned jets attach the mask via `EffectMaterial`. The Apollo example adds graphs for **engine thrust fraction** and **RCS torque**, and bumps per-nozzle `emission_rate` to match the denser RCS preset.
> 
> **View-cube arrows** pivot yaw/pitch around the viewport `look_at` target (roll still pivots on the camera), use the orbit constraint’s fixed up for left/right turntable yaw, update translation and rotation directly while issuing `LookTo` to chain held clicks, and drop verbose debug logging around anchor refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b847c58a03366a604f81bdc7a72351d39fb5795. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->