### PR TITLE
Enhance the skybox creation command palette with options.

### DIFF
--- a/docs/public/content/reference/command-palette.md
+++ b/docs/public/content/reference/command-palette.md
@@ -51,8 +51,8 @@ order = 8
 
 - `Skybox...`: submenu for skybox actions against `assets/skyboxes/manifest.ron` or
   `$ELODIN_ASSETS_DIR/skyboxes/manifest.ron`.
-  - `Generate Skybox...`: prompt for a description, generate a new skybox via Blockade, add it to
-    the manifest, and activate it.
+  - `Generate Skybox...`: prompt for a description, then choose a Blockade style and local cubemap
+    resolution before generating the skybox, adding it to the manifest, and activating it.
   - `Clear Skybox`: shown when a skybox is active; removes it from viewports and sensor cameras and
     removes the top-level `skybox` node from the current schematic.
   - `Revert to …`: shown after AI generation replaced an active skybox.
@@ -62,9 +62,9 @@ Selecting a cached skybox sets `skybox name="..."` on the current schematic and 
 immediately. Use **Save Schematic** or **Save Schematic To DB** to persist changes.
 
 Skybox generation requires `BLOCKADE_API_KEY` in the editor environment. Generated cubemaps are
-resampled locally to the configured face size (default 2048 px per face); Blockade always returns an
-~8K equirect source, so higher local presets upscale rather than fetching a higher remote tier.
-Generated assets are written next to the manifest used by the editor.
+resampled locally to the selected face size (`4K` is the default, 1024 px per face); Blockade always
+returns an ~8K equirect source, so higher local presets upscale rather than fetching a higher remote
+tier. Generated assets are written next to the manifest used by the editor.
 
 ## Simulation
 

--- a/libs/elodin-editor/src/ui/command_palette/mod.rs
+++ b/libs/elodin-editor/src/ui/command_palette/mod.rs
@@ -116,10 +116,13 @@ impl CommandPaletteState {
                 prev_page_label,
             } => {
                 self.error = None;
-                self.filter = "".to_string();
-                if let Some(prev_page_label) = prev_page_label {
-                    self.page_stack.last_mut().expect("unreachable").label = Some(prev_page_label);
+                if let Some(prev) = self.page_stack.last_mut() {
+                    prev.remembered_filter = Some(std::mem::take(&mut self.filter));
+                    if let Some(prev_page_label) = prev_page_label {
+                        prev.label = Some(prev_page_label);
+                    }
                 }
+                self.filter = String::new();
                 self.page_stack.push(next_page);
                 self.input_focus = true;
                 self.selected_index = 0;
@@ -396,6 +399,11 @@ impl WidgetSystem for PaletteSearch<'_> {
                             popped_page = true;
                             command_palette_state.page_stack.pop();
                             command_palette_state.selected_index = 0;
+                            command_palette_state.filter = command_palette_state
+                                .page_stack
+                                .last_mut()
+                                .and_then(|prev| prev.remembered_filter.take())
+                                .unwrap_or_default();
                         }
                     }
 

--- a/libs/elodin-editor/src/ui/command_palette/palette_items.rs
+++ b/libs/elodin-editor/src/ui/command_palette/palette_items.rs
@@ -23,6 +23,7 @@ use bevy::{
 };
 use bevy_ai_skybox::prelude::{
     GenerateSkybox, SetActiveSkybox, SkyboxCache, SkyboxGenerationSettings, SkyboxGenerationUi,
+    SkyboxResolution, SkyboxStyle,
 };
 use bevy_editor_cam::controller::{component::EditorCam, motion::CurrentMotion};
 use bevy_geo_frames::GeoContext;
@@ -1305,10 +1306,7 @@ fn generate_skybox_from_prompt() -> PaletteItem {
     PaletteItem::new(
         LabelSource::placeholder("Describe a new skybox..."),
         SKYBOX_LABEL,
-        |In(prompt): In<String>,
-         settings: Option<Res<SkyboxGenerationSettings>>,
-         skybox_ui: Res<SkyboxGenerationUi>,
-         mut skyboxes: MessageWriter<GenerateSkybox>| {
+        |In(prompt): In<String>| {
             let prompt = prompt.trim();
             if prompt.is_empty() {
                 error!(
@@ -1317,6 +1315,53 @@ fn generate_skybox_from_prompt() -> PaletteItem {
                 );
                 return PaletteEvent::Error("Prompt cannot be empty".into());
             }
+
+            PalettePage::new(skybox_style_items(prompt.to_string()))
+                .label("Skybox Style")
+                .prompt("Select skybox style...")
+                .into_event()
+        },
+    )
+    .default()
+}
+
+fn skybox_style_items(prompt: String) -> Vec<PaletteItem> {
+    [
+        ("M3 Photoreal (default)", SkyboxStyle::M3Photoreal),
+        ("M3 UHD Render", SkyboxStyle::M3UhdRender),
+        ("M3 Advanced", SkyboxStyle::M3Advanced),
+    ]
+    .into_iter()
+    .map(|(label, style)| {
+        let prompt = prompt.clone();
+        PaletteItem::new(label, SKYBOX_LABEL, move |_: In<String>| {
+            PalettePage::new(skybox_resolution_items(prompt.clone(), style))
+                .label("Skybox Resolution")
+                .prompt("Select skybox resolution...")
+                .into_event()
+        })
+    })
+    .collect()
+}
+
+fn skybox_resolution_items(prompt: String, style: SkyboxStyle) -> Vec<PaletteItem> {
+    [
+        ("1K (256 px faces)", SkyboxResolution::OneK),
+        ("2K (512 px faces)", SkyboxResolution::TwoK),
+        ("4K (default, 1024 px faces)", SkyboxResolution::FourK),
+        ("8K (2048 px faces)", SkyboxResolution::EightK),
+        ("16K (4096 px faces)", SkyboxResolution::SixteenK),
+    ]
+    .into_iter()
+    .map(|(label, resolution)| {
+        let prompt = prompt.clone();
+        PaletteItem::new(
+            label,
+            SKYBOX_LABEL,
+            move |_: In<String>,
+                  settings: Option<Res<SkyboxGenerationSettings>>,
+                  skybox_ui: Res<SkyboxGenerationUi>,
+                  mut skyboxes: MessageWriter<GenerateSkybox>| {
             if skybox_ui.is_busy() {
                 error!(
                     target: "bevy_ai_skybox",
@@ -1349,13 +1394,16 @@ fn generate_skybox_from_prompt() -> PaletteItem {
             }
 
             skyboxes.write(GenerateSkybox {
-                prompt: prompt.to_string(),
+                prompt: prompt.clone(),
+                style: Some(style),
+                resolution: Some(resolution),
                 ..Default::default()
             });
             PaletteEvent::Exit
         },
-    )
-    .default()
+        )
+    })
+    .collect()
 }
 
 fn create_object_3d_with_color(eql: String, expr: eql::Expr, mesh: Mesh) -> PaletteEvent {

--- a/libs/elodin-editor/src/ui/command_palette/palette_items.rs
+++ b/libs/elodin-editor/src/ui/command_palette/palette_items.rs
@@ -1345,10 +1345,12 @@ fn skybox_style_items(prompt: String) -> Vec<PaletteItem> {
 }
 
 fn skybox_resolution_items(prompt: String, style: SkyboxStyle) -> Vec<PaletteItem> {
+    // Default (4K) first so confirming with Enter without moving the selection
+    // picks the documented default, matching the style page convention.
     [
+        ("4K (default, 1024 px faces)", SkyboxResolution::FourK),
         ("1K (256 px faces)", SkyboxResolution::OneK),
         ("2K (512 px faces)", SkyboxResolution::TwoK),
-        ("4K (default, 1024 px faces)", SkyboxResolution::FourK),
         ("8K (2048 px faces)", SkyboxResolution::EightK),
         ("16K (4096 px faces)", SkyboxResolution::SixteenK),
     ]

--- a/libs/elodin-editor/src/ui/command_palette/palette_items.rs
+++ b/libs/elodin-editor/src/ui/command_palette/palette_items.rs
@@ -77,6 +77,9 @@ pub struct PalettePage {
     pub label: Option<String>,
     initialized: bool,
     pub prompt: Option<String>,
+    /// Filter text active on this page when it was left for a sub-page, so it
+    /// can be restored when the user navigates back (e.g. a skybox prompt).
+    pub remembered_filter: Option<String>,
 }
 
 impl PalettePage {
@@ -86,6 +89,7 @@ impl PalettePage {
             initialized: false,
             label: None,
             prompt: None,
+            remembered_filter: None,
         }
     }
 


### PR DESCRIPTION

https://github.com/user-attachments/assets/d09b32e4-bd2d-4003-a18a-e6603772272b


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editor-only command palette and documentation changes; generation still uses the existing `GenerateSkybox` path with optional fields that were already defined.
> 
> **Overview**
> **Generate Skybox** in the command palette is now a short wizard instead of firing generation right after the text prompt.
> 
> After you enter a description, you pick a **Blockade style** (M3 Photoreal, UHD Render, or Advanced), then a **local cubemap face size** (1K–16K, with **4K / 1024 px faces** as the default and first option so Enter without moving the selection matches the docs). The chosen `style` and `resolution` are sent on `GenerateSkybox` along with the prompt; existing guards (busy state, API key, plugin) still run on the final step.
> 
> Nested palette navigation **remembers filter text** when drilling into sub-pages and **restores it on Backspace** when you pop back (e.g. returning to the skybox description). Docs for the command palette are updated to describe the new flow and the 4K default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f7d869c4b0b1ea3326391516fe78deabe0140c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->