### PR TITLE
fix: vector-arrow rendering at planetary scale.

### DIFF
--- a/examples/apollo-lander/apollo-lander.kdl
+++ b/examples/apollo-lander/apollo-lander.kdl
@@ -70,7 +70,7 @@ object_3d surface.world_pos frame=ENU {
 // The Apollo LM GLB has four RCS quads; each quad has four perpendicular yellow nozzles.
 object_3d lander.world_pos frame=ENU {
     glb path=apollo-lunar-module.glb translate="(0, -2.5, 0)"
-    thruster name="DPS" effect="plume" body_frame=#true position="(0, -0.55, 0)" intensity=lander.main_thrust_viz emission_rate=180.0
+    thruster name="DPS" effect="plume" body_frame=#true position="(0, -0.55, 0)" direction="(0, -1, 0)" intensity="lander.main_thrust_viz[2]" emission_rate=180.0
     thruster name="rcs_0" effect="cold_gas" body_frame=#true position="(1.089, 0.870, -1.506)" direction="(0, 0, -1)" intensity="lander.rcs_thruster_viz[0]" emission_rate=1100.0 cutoff=0.006
     thruster name="rcs_1" effect="cold_gas" body_frame=#true position="(1.388, 0.874, -1.361)" direction="(1, 0, 0)" intensity="lander.rcs_thruster_viz[1]" emission_rate=1100.0 cutoff=0.006
     thruster name="rcs_2" effect="cold_gas" body_frame=#true position="(-1.180, 0.527, -1.369)" direction="(0, -1, 0)" intensity="lander.rcs_thruster_viz[2]" emission_rate=1100.0 cutoff=0.006
@@ -106,7 +106,4 @@ vector_arrow lander.main_thrust_viz origin=lander.world_pos scale=2.0 name="DPS 
 }
 vector_arrow lander.rcs_torque_viz origin=lander.world_pos scale=1.5 name="RCS torque" body_frame=#true frame=ENU {
     color white
-}
-window screen=0 {
-    rect 3 3 97 97
 }

--- a/libs/cranelift-mlir/ARCHITECTURE.md
+++ b/libs/cranelift-mlir/ARCHITECTURE.md
@@ -443,6 +443,7 @@ jit_builder.symbol("tensor_broadcast_nd_f64", tensor_broadcast_nd_f64 as *const 
 | Elementwise | add, sub, mul, div, negate, sqrt, abs, ... | f64, i64, i32 variants |
 | Broadcast | broadcast_f64, broadcast_nd_f64, broadcast_i32 | N-D shape-aware |
 | Shape | transpose_f64, transpose_nd_f64, concat_nd_f64 | Element-size-aware concat |
+| Matrix | matmul_f64 | Row-major C = A·B; used by pointer-ABI `dot_general` batched fast path |
 | Reduce | reduce_sum_f64, reduce_max_f64, reduce_min_f64 | Outer x inner dimensions |
 | Indexing | gather_f64, gather_nd_f64, scatter_f64 | N-D with element-size param |
 | Dynamic | dynamic_slice_f64, dynamic_update_slice_f64 | Runtime index values |
@@ -455,6 +456,42 @@ to handle mixed-type tensors. For example, `tensor_concat_nd_f64` operates on ra
 with an explicit element size. This was added after discovering that concatenating
 `tensor<65x1xi32>` data (4 bytes per element) as if it were f64 (8 bytes) corrupted
 index tensors used by the EGM08 gravity model's N-D gather.
+
+### Pointer-ABI `dot_general` and `concatenate`
+
+Two shape ops have non-obvious pointer-ABI lowering that is easy to get wrong
+when extending the compiler.
+
+**`stablehlo.concatenate`**
+
+| Case | Lowering |
+|------|----------|
+| `dim == 0`, rank ≤ 1, or a single operand | Contiguous `memcpy` of each operand back-to-back |
+| `dim > 0` (any operand count) | Pairwise fold through `tensor_concat_nd_f64` |
+
+A naive back-to-back `memcpy` along a non-zero dimension lays out
+`[x…x y…y z…z]` instead of interleaved `[xyzw]…`. That breaks quaternion
+assembly (`[B×1]×4` along dim 1 → `[B×4]`) once a function crosses the
+pointer-ABI threshold.
+
+**`stablehlo.dot_general`**
+
+The scalar path has a dedicated batched rank-2 handler (`batching_dims=[0]`,
+contracting on dim 1). The pointer-ABI path adds a `matmul_f64` fast path only
+when the batch slices are contiguous row-major `m×k` and `k×n` blocks:
+
+- Leading batch dims: `[0, 1, …, nb−1]` on both operands
+- Single contracting dim on lhs: `lhs_contracting[0] == rank(lhs) − 1`
+- Single contracting dim on rhs: `rhs_contracting[0] == nb` (contracting axis
+  immediately after the batch axes — e.g. `[batch…, k, n]` not `[batch…, n, k]`)
+
+Each batch index `b` calls `matmul_f64` on slice offsets `b·m·k` and `b·k·n`.
+This covers the common Elodin pattern `tensor<B×K> · tensor<B×K> → tensor<B>`
+(per-entity inner products in `six_dof`). Layouts outside the guard fall back
+to the generic pointer-ABI `dot_general` lowering.
+
+Golden tests: `test_concatenate_dim1_four_operands_mem`, `test_dot_general_batched_mem`
+in [`tests/ops.rs`](tests/ops.rs).
 
 ---
 
@@ -819,7 +856,7 @@ ELODIN_BACKEND=cranelift bash scripts/ci/regress.sh --all   # full regression su
 | stablehlo.reshape | yes | yes | yes | arbitrary shape changes |
 | stablehlo.broadcast_in_dim | yes | yes | yes (all types) | byte-generic for non-f64 |
 | stablehlo.slice | yes | yes | yes (all types) | byte-generic for non-f64 |
-| stablehlo.concatenate | yes | yes | yes (all types) | byte-aware via `elem_sz` |
+| stablehlo.concatenate | yes | yes | yes (all types) | dim 0: contiguous memcpy; dim > 0: pairwise `concat_nd_f64` (never memcpy for 3+ operands on non-zero dim) |
 | stablehlo.transpose | yes | yes | yes (all types) | byte-generic for non-f64 |
 | stablehlo.pad | yes | yes | yes | |
 | stablehlo.reverse | yes | yes | yes | |
@@ -851,7 +888,7 @@ ELODIN_BACKEND=cranelift bash scripts/ci/regress.sh --all   # full regression su
 ### Linear Algebra
 | Op | Tested | Notes |
 |----|--------|-------|
-| stablehlo.dot_general | yes | scalar, 1D inner product, rank1-rank2, matvec, matmul, batched |
+| stablehlo.dot_general | yes | scalar + pointer ABI: 1D inner product, rank1-rank2, matvec, matmul, batched rank-2; pointer batched fast path when slices are row-major `[…,m,k]·[…,k,n]` ([details](#pointer-abi-dot_general-and-concatenate)) |
 | stablehlo.reduce | yes | add/min/max (f64 + i64), and/or, all dimensions |
 | stablehlo.reduce (multi-operand) | yes | argmin/argmax pattern: 2-operand reduce with value+index |
 
@@ -921,6 +958,13 @@ improvement ideas live in [Opportunities](#opportunities).
   [`tests/checkpoint_test.rs`](tests/checkpoint_test.rs)'s `verify_checkpoint`
   uses the same 256 MB for parity. Bisection helpers run on 64 MB, adequate for
   their scope.
+
+- **Pointer-ABI threshold sensitivity.** Any single tensor > 64 elements
+  classifies the whole function to pointer ABI. Simulations with many entities
+  (e.g. `WorldPos` as `[N×7]` once `N ≥ 10`) therefore exercise the pointer
+  paths for ops like `dot_general` and `concatenate` even when most per-entity
+  math is small. Regress with `run_mlir_mem` / `_mem` golden tests when touching
+  those lowerings.
 
 - **CPU-only by design.** There is no GPU execution path. Elodin simulations are
   single-threaded, small-tensor physics ticks where kernel launch and

--- a/libs/cranelift-mlir/src/lower.rs
+++ b/libs/cranelift-mlir/src/lower.rs
@@ -4284,7 +4284,7 @@ fn lower_instruction_mem(
             let dim = *dimension as usize;
             let dst = alloc_slot_for_vid(builder, pool, result_vid, n * elem_sz);
 
-            if dim == 0 || rt.rank() <= 1 {
+            if dim == 0 || rt.rank() <= 1 || operands.len() == 1 {
                 let memcpy_ref = jit_module.declare_func_in_func(trt_ids.memcpy, builder.func);
                 let mut byte_off = 0i64;
                 for vid in operands {
@@ -4295,44 +4295,52 @@ fn lower_instruction_mem(
                     builder.ins().call(memcpy_ref, &[d, get(vid)?, nb]);
                     byte_off += src_bytes as i64;
                 }
-            } else if operands.len() == 2 {
-                let a_ty = type_map.get(&operands[0]).cloned().unwrap_or(rt.clone());
-                let b_ty = type_map.get(&operands[1]).cloned().unwrap_or(rt.clone());
+            } else {
                 let func_ref = jit_module.declare_func_in_func(trt_ids.concat_nd_f64, builder.func);
-                let n_dst_v = builder.ins().iconst(types::I64, n as i64);
-                let n_a_v = builder.ins().iconst(types::I64, a_ty.num_elements() as i64);
-                let n_b_v = builder.ins().iconst(types::I64, b_ty.num_elements() as i64);
-                let dst_shape_ptr = store_i64_array(builder, &rt.shape);
-                let a_shape_ptr = store_i64_array(builder, &a_ty.shape);
                 let rank_v = builder.ins().iconst(types::I64, rt.rank() as i64);
                 let dim_v = builder.ins().iconst(types::I64, dim as i64);
                 let esz_v = builder.ins().iconst(types::I64, elem_sz as i64);
-                builder.ins().call(
-                    func_ref,
-                    &[
-                        dst,
-                        n_dst_v,
-                        get(&operands[0])?,
-                        n_a_v,
-                        get(&operands[1])?,
-                        n_b_v,
-                        dst_shape_ptr,
-                        a_shape_ptr,
-                        rank_v,
-                        dim_v,
-                        esz_v,
-                    ],
-                );
-            } else {
-                let memcpy_ref = jit_module.declare_func_in_func(trt_ids.memcpy, builder.func);
-                let mut byte_off = 0i64;
-                for vid in operands {
-                    let src_ty = type_map.get(vid).cloned().unwrap_or(rt.clone());
-                    let src_bytes = src_ty.byte_size();
-                    let d = builder.ins().iadd_imm(dst, byte_off);
-                    let nb = builder.ins().iconst(types::I64, src_bytes as i64);
-                    builder.ins().call(memcpy_ref, &[d, get(vid)?, nb]);
-                    byte_off += src_bytes as i64;
+
+                let a0_ty = type_map.get(&operands[0]).cloned().unwrap_or(rt.clone());
+                let mut acc_ptr = get(&operands[0])?;
+                let mut acc_shape = a0_ty.shape.clone();
+                let mut acc_n = a0_ty.num_elements();
+                for (i, vid) in operands.iter().enumerate().skip(1) {
+                    let b_ty = type_map.get(vid).cloned().unwrap_or(rt.clone());
+                    let b_n = b_ty.num_elements();
+                    let mut new_shape = acc_shape.clone();
+                    new_shape[dim] += b_ty.shape[dim];
+                    let new_n: usize = new_shape.iter().map(|&d| d as usize).product();
+                    let is_last = i == operands.len() - 1;
+                    let out_ptr = if is_last {
+                        dst
+                    } else {
+                        alloc_slot(builder, new_n * elem_sz)
+                    };
+                    let n_dst_v = builder.ins().iconst(types::I64, new_n as i64);
+                    let n_a_v = builder.ins().iconst(types::I64, acc_n as i64);
+                    let n_b_v = builder.ins().iconst(types::I64, b_n as i64);
+                    let dst_shape_ptr = store_i64_array(builder, &new_shape);
+                    let a_shape_ptr = store_i64_array(builder, &acc_shape);
+                    builder.ins().call(
+                        func_ref,
+                        &[
+                            out_ptr,
+                            n_dst_v,
+                            acc_ptr,
+                            n_a_v,
+                            get(vid)?,
+                            n_b_v,
+                            dst_shape_ptr,
+                            a_shape_ptr,
+                            rank_v,
+                            dim_v,
+                            esz_v,
+                        ],
+                    );
+                    acc_ptr = out_ptr;
+                    acc_shape = new_shape;
+                    acc_n = new_n;
                 }
             }
             Ok(vec![LaneRepr::scalar(vec![dst])])
@@ -4638,6 +4646,61 @@ fn lower_instruction_mem(
         Instruction::DotGeneral { lhs, rhs, dims } => {
             let l_ty = type_map.get(lhs).cloned().unwrap_or(rt.clone());
             let r_ty = type_map.get(rhs).cloned().unwrap_or(rt.clone());
+
+            let nb = dims.lhs_batch.len();
+            let leading_batch: Vec<i64> = (0..nb as i64).collect();
+            let lhs_contract_last = dims.lhs_contracting.len() == 1
+                && dims.lhs_contracting[0] == l_ty.rank() as i64 - 1;
+            let rhs_contract_after_batch =
+                dims.rhs_contracting.len() == 1 && dims.rhs_contracting[0] == nb as i64;
+            if nb > 0
+                && dims.lhs_batch == leading_batch
+                && dims.rhs_batch == leading_batch
+                && !dims.lhs_contracting.is_empty()
+                && lhs_contract_last
+                && rhs_contract_after_batch
+            {
+                let batch: usize = dims
+                    .lhs_batch
+                    .iter()
+                    .map(|&d| l_ty.shape[d as usize] as usize)
+                    .product();
+                let k = l_ty.shape[dims.lhs_contracting[0] as usize] as usize;
+                let m: usize = (0..l_ty.rank())
+                    .filter(|&d| {
+                        !dims.lhs_batch.contains(&(d as i64))
+                            && !dims.lhs_contracting.contains(&(d as i64))
+                    })
+                    .map(|d| l_ty.shape[d] as usize)
+                    .product();
+                let nn: usize = (0..r_ty.rank())
+                    .filter(|&d| {
+                        !dims.rhs_batch.contains(&(d as i64))
+                            && !dims.rhs_contracting.contains(&(d as i64))
+                    })
+                    .map(|d| r_ty.shape[d] as usize)
+                    .product();
+                let out_size = batch * m * nn * elem_sz;
+                let dst = alloc_slot_for_vid(builder, pool, result_vid, out_size);
+                let func_ref = jit_module.declare_func_in_func(trt_ids.matmul_f64, builder.func);
+                let m_v = builder.ins().iconst(types::I64, m as i64);
+                let k_v = builder.ins().iconst(types::I64, k as i64);
+                let n_v = builder.ins().iconst(types::I64, nn as i64);
+                let lhs_ptr = get(lhs)?;
+                let rhs_ptr = get(rhs)?;
+                for b in 0..batch {
+                    let lp = builder
+                        .ins()
+                        .iadd_imm(lhs_ptr, (b * m * k * elem_sz) as i64);
+                    let rp = builder
+                        .ins()
+                        .iadd_imm(rhs_ptr, (b * k * nn * elem_sz) as i64);
+                    let dp = builder.ins().iadd_imm(dst, (b * m * nn * elem_sz) as i64);
+                    builder.ins().call(func_ref, &[dp, lp, rp, m_v, k_v, n_v]);
+                }
+                return Ok(vec![LaneRepr::scalar(vec![dst])]);
+            }
+
             let (m, k, nn) = if l_ty.rank() == 1 && r_ty.rank() == 1 {
                 let k = l_ty.shape[0] as usize;
                 (1usize, k, 1usize)

--- a/libs/cranelift-mlir/tests/ops.rs
+++ b/libs/cranelift-mlir/tests/ops.rs
@@ -2337,6 +2337,48 @@ module @module {
 }
 
 #[test]
+fn test_concatenate_dim1_four_operands_mem() {
+    let mlir = r#"
+module @module {
+  func.func public @main(%a: tensor<3x1xf64>, %b: tensor<3x1xf64>, %c: tensor<3x1xf64>, %d: tensor<3x1xf64>) -> tensor<3x4xf64> {
+    %0 = stablehlo.concatenate %a, %b, %c, %d, dim = 1 : (tensor<3x1xf64>, tensor<3x1xf64>, tensor<3x1xf64>, tensor<3x1xf64>) -> tensor<3x4xf64>
+    return %0 : tensor<3x4xf64>
+  }
+}
+"#;
+    let a = f64_buf(&[1.0, 2.0, 3.0]);
+    let b = f64_buf(&[10.0, 20.0, 30.0]);
+    let c = f64_buf(&[100.0, 200.0, 300.0]);
+    let d = f64_buf(&[1000.0, 2000.0, 3000.0]);
+    let out = run_mlir_mem(mlir, &[&a, &b, &c, &d], &[96]);
+    assert_f64s_close(
+        &read_f64s(&out[0]),
+        &[
+            1.0, 10.0, 100.0, 1000.0, 2.0, 20.0, 200.0, 2000.0, 3.0, 30.0, 300.0, 3000.0,
+        ],
+    );
+}
+
+#[test]
+fn test_dot_general_batched_mem() {
+    let mlir = r#"
+module @module {
+  func.func public @main(%arg0: tensor<3x4xf64>, %arg1: tensor<3x4xf64>) -> tensor<3xf64> {
+    %0 = stablehlo.dot_general %arg0, %arg1, batching_dims = [0] x [0], contracting_dims = [1] x [1], precision = [DEFAULT, DEFAULT] : (tensor<3x4xf64>, tensor<3x4xf64>) -> tensor<3xf64>
+    return %0 : tensor<3xf64>
+  }
+}
+"#;
+    let a = f64_buf(&[
+        1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+    ]);
+    let b = f64_buf(&[1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0]);
+    let out = run_mlir_mem(mlir, &[&a, &b], &[24]);
+    // row dots: [1,2,3,4]·[1,0,0,0]=1, [5,6,7,8]·[0,1,0,0]=6, [9,10,11,12]·[0,0,1,0]=11
+    assert_f64s_close(&read_f64s(&out[0]), &[1.0, 6.0, 11.0]);
+}
+
+#[test]
 fn test_gather_nd_2d_index_mem() {
     // Gather individual elements from a 3x3 matrix using 2D index vectors
     // Matrix: [[10,20,30],[40,50,60],[70,80,90]]

--- a/libs/elodin-editor/src/plugins/gizmos/mod.rs
+++ b/libs/elodin-editor/src/plugins/gizmos/mod.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "big_space")]
-use crate::spatial::{FloatingOriginSettings, GridCell};
 use bevy::camera::RenderTarget;
 use bevy::camera::visibility::RenderLayers;
 use bevy::picking::prelude::Pickable;
@@ -29,14 +27,16 @@ use impeller2_wkt::{
 use std::collections::{HashMap, HashSet};
 
 use crate::plugins::render_layer_alloc::RenderLayerLease;
+#[cfg(feature = "big_space")]
+use crate::spatial::GridCell;
 use crate::{
     MainCamera, WorldPosExt,
     object_3d::ComponentArrayExt,
     ui::tiles::ViewportConfig,
     ui::window::window_entity_from_target,
     vector_arrow::{
-        ArrowEndpoint, ArrowEndpoints, ArrowLabelScope, ArrowVisual, VectorArrowState,
-        ViewportArrow, component_value_tail_to_vec3,
+        ArrowEndpoint, ArrowEndpoints, ArrowLabelScope, ArrowVisual, CachedArrowPose,
+        VectorArrowState, ViewportArrow, component_value_tail_to_vec3,
     },
 };
 
@@ -70,14 +70,15 @@ pub(crate) const MIN_ARROW_LENGTH_SQUARED: f64 = 1.0e-6;
 /// Camera order for arrow label UI cameras. Must be higher than all viewport cameras
 /// (SECONDARY_GRAPH_ORDER_BASE=1000, stride=50 per window) to avoid order collisions.
 const ARROW_LABEL_UI_CAMERA_ORDER: isize = 100_000;
-const BASE_HEAD_LENGTH: f32 = 0.06;
-const HEAD_RADIUS_FACTOR: f32 = 1.6;
-const MAX_HEAD_PORTION: f32 = 0.5;
+const HEAD_LENGTH_FRAC: f32 = 0.32;
+const HEAD_RADIUS_FACTOR: f32 = 2.2;
+const MAX_HEAD_PORTION: f32 = 0.50;
+const MIN_HEAD_LENGTH_PX: f32 = 14.0;
+const MIN_SHAFT_LENGTH_PX: f32 = 4.0;
 const DRAW_RAW_ARROW_MESHES: bool = true;
 const TARGET_DIAMETER_PX: f32 = 7.0;
-const MIN_RADIUS_WORLD: f32 = 0.005;
-const MAX_RADIUS_WORLD: f32 = 0.05;
-const MAX_FINAL_RADIUS_WORLD: f32 = 0.1;
+const MIN_VISIBLE_DIAMETER_PX: f32 = 2.0;
+const MAX_RADIUS_FRAC: f32 = 0.05;
 
 pub struct GizmoPlugin;
 
@@ -92,11 +93,9 @@ impl Plugin for GizmoPlugin {
                 .after(impeller2_bevy::apply_cached_data)
                 .before(crate::sync_pos),
         );
-        // This is how the `big_space` crate did it.
-        // app.add_systems(PostUpdate, render_vector_arrow.after(TransformSystem::TransformPropagate));
         app.add_systems(
-            bevy::app::PreUpdate,
-            render_vector_arrow.after(crate::PositionSync),
+            PostUpdate,
+            render_vector_arrow.after(bevy::transform::TransformSystems::Propagate),
         );
         app.add_systems(bevy::app::PostUpdate, cleanup_removed_arrows);
         app.add_systems(Update, render_body_axis);
@@ -105,6 +104,34 @@ impl Plugin for GizmoPlugin {
             PostUpdate,
             update_arrow_label_ui.after(bevy::transform::TransformSystems::Propagate),
         );
+    }
+}
+
+fn arrow_head_and_shaft_lengths(draw_length: f32, world_per_px: f32) -> (f32, f32) {
+    let mut head_length = (draw_length * HEAD_LENGTH_FRAC)
+        .max(world_per_px * MIN_HEAD_LENGTH_PX)
+        .min(draw_length * MAX_HEAD_PORTION)
+        .min(draw_length);
+    let min_shaft_length = world_per_px * MIN_SHAFT_LENGTH_PX;
+    if draw_length - head_length < min_shaft_length {
+        head_length = (draw_length - min_shaft_length).max(0.0);
+    }
+    let shaft_length = (draw_length - head_length).max(0.0);
+    (head_length, shaft_length)
+}
+
+/// Pixel-based shaft radius with a length-fraction cap when zoomed in. When zoomed
+/// out, the length-fraction cap can fall below the screen-minimum diameter — in that
+/// case screen visibility wins so arrows stay visible at planetary scale.
+fn compute_shaft_radius(draw_length: f32, world_per_px: f32, thickness: f32) -> f32 {
+    let desired_radius = TARGET_DIAMETER_PX * 0.5 * world_per_px * thickness;
+    let screen_min_radius = MIN_VISIBLE_DIAMETER_PX * 0.5 * world_per_px;
+    let max_radius = draw_length * MAX_RADIUS_FRAC;
+
+    if max_radius < screen_min_radius {
+        screen_min_radius
+    } else {
+        desired_radius.clamp(screen_min_radius, max_radius)
     }
 }
 
@@ -291,6 +318,36 @@ pub fn evaluate_vector_arrows(
     }
 }
 
+fn resolve_arrow_pose(
+    endpoints: &ArrowEndpoints,
+    endpoint_gt: &Query<&GlobalTransform, With<ArrowEndpoint>>,
+) -> Option<CachedArrowPose> {
+    let Ok([start_gt, end_gt]) = endpoint_gt.get_many([endpoints.start, endpoints.end]) else {
+        return None;
+    };
+    let direction_world = end_gt.translation() - start_gt.translation();
+    if direction_world.length_squared() <= MIN_ARROW_LENGTH_SQUARED as f32 {
+        return None;
+    }
+    let dir_local = start_gt
+        .affine()
+        .inverse()
+        .transform_vector3(direction_world);
+    let local_rotation = rotation_y_to(dir_local);
+    Some(CachedArrowPose {
+        direction_world,
+        local_rotation,
+    })
+}
+
+fn rotation_y_to(direction: Vec3) -> Quat {
+    let len_sq = direction.length_squared();
+    if len_sq <= MIN_ARROW_LENGTH_SQUARED as f32 {
+        return Quat::IDENTITY;
+    }
+    Quat::from_rotation_arc(Vec3::Y, direction / len_sq.sqrt())
+}
+
 #[allow(clippy::too_many_arguments)]
 fn render_vector_arrow(
     mut commands: Commands,
@@ -300,12 +357,7 @@ fn render_vector_arrow(
         &mut VectorArrowState,
         Option<&ArrowEndpoints>,
     )>,
-    #[cfg(feature = "big_space")] endpoint_poses: Query<
-        (&Transform, &GridCell),
-        With<ArrowEndpoint>,
-    >,
-    #[cfg(not(feature = "big_space"))] endpoint_poses: Query<&Transform, With<ArrowEndpoint>>,
-    #[cfg(feature = "big_space")] floating_origin: Res<FloatingOriginSettings>,
+    endpoint_gt: Query<&GlobalTransform, With<ArrowEndpoint>>,
     arrow_meshes: Res<ArrowMeshes>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     main_cameras: Query<MainCameraQueryItem<'_>, With<crate::MainCamera>>,
@@ -324,62 +376,49 @@ fn render_vector_arrow(
     for (entity, arrow, mut state, endpoints) in vector_arrows.iter_mut() {
         if !has_show_arrows {
             for visual in state.visuals.values() {
-                hide_arrow_visual(&mut commands, visual);
+                despawn_arrow_visual(&mut commands, visual);
             }
             state.visuals.clear();
+            state.cached_pose = None;
             continue;
         }
 
-        // Endpoints are spawned and evaluated by `evaluate_vector_arrows` and
-        // placed in Bevy space by the canonical position pipeline.
-        let endpoint_pair = endpoints.filter(|_| state.valid).and_then(|endpoints| {
-            endpoint_poses
-                .get_many([endpoints.start, endpoints.end])
-                .ok()
-        });
-        let Some([start_pose, end_pose]) = endpoint_pair else {
-            for visual in state.visuals.values() {
-                hide_arrow_visual(&mut commands, visual);
-            }
-            state.visuals.clear();
+        let Some(endpoints) = endpoints else {
             continue;
         };
 
-        cfg_select! {
-            feature = "big_space" => {
-                let (start_transform, start_cell) = start_pose;
-                let (end_transform, end_cell) = end_pose;
-                let start = start_transform.translation;
-                let start_cell = *start_cell;
-                let edge = floating_origin.grid_edge_length();
-                let cell_delta = Vec3::new(
-                    (end_cell.x as f64 - start_cell.x as f64) as f32 * edge,
-                    (end_cell.y as f64 - start_cell.y as f64) as f32 * edge,
-                    (end_cell.z as f64 - start_cell.z as f64) as f32 * edge,
-                );
-                let direction_world = cell_delta + (end_transform.translation - start_transform.translation);
+        if !state.valid {
+            for visual in state.visuals.values() {
+                despawn_arrow_visual(&mut commands, visual);
             }
-            _ => {
-                let start = start_pose.translation;
-                let direction_world = end_pose.translation - start_pose.translation;
-            }
+            state.visuals.clear();
+            state.cached_pose = None;
+            continue;
         }
+
+        let live_pose = resolve_arrow_pose(endpoints, &endpoint_gt);
+        let pose = live_pose.clone().or_else(|| state.cached_pose.clone());
+        if live_pose.is_some() {
+            state.cached_pose = live_pose;
+        }
+        let Some(pose) = pose else {
+            continue;
+        };
+
+        let direction_world = pose.direction_world;
+        let local_rotation = pose.local_rotation;
 
         if !DRAW_RAW_ARROW_MESHES {
             for visual in state.visuals.values() {
-                hide_arrow_visual(&mut commands, visual);
+                despawn_arrow_visual(&mut commands, visual);
             }
             state.visuals.clear();
+            state.cached_pose = None;
             continue;
         }
 
         let length = direction_world.length();
-        let dir_norm = if length > 0.0 {
-            direction_world / length
-        } else {
-            Vec3::Y
-        };
-        let rotation = Quat::from_rotation_arc(Vec3::Y, dir_norm);
+        let dir_norm = direction_world / length;
         let base_color =
             axis_color_from_name(arrow.name.as_deref(), wkt_color_to_bevy(&arrow.color));
 
@@ -394,10 +433,13 @@ fn render_vector_arrow(
             );
         }
 
-        let mut head_length = BASE_HEAD_LENGTH.min(draw_length * MAX_HEAD_PORTION);
-        // Ensure the head never exceeds the total length.
-        head_length = head_length.min(draw_length);
-        let shaft_length = (draw_length - head_length).max(0.0);
+        // Skip this frame if the start endpoint transform is unavailable. The
+        // visual is parented to the start endpoint, so a transient read failure
+        // must not fall back to the world origin for screen-space sizing.
+        let Ok(start_world) = endpoint_gt.get(endpoints.start).map(|gt| gt.translation()) else {
+            continue;
+        };
+
         let mut seen_cameras: HashSet<Entity> = HashSet::new();
 
         let mut render_for_camera = |idx: usize| {
@@ -410,7 +452,7 @@ fn render_vector_arrow(
                 .unwrap_or(true);
             if !show_arrows {
                 if let Some(visual) = state.visuals.remove(&cam_entity) {
-                    hide_arrow_visual(&mut commands, &visual);
+                    despawn_arrow_visual(&mut commands, &visual);
                 }
                 state.label_offset = None;
                 state.label_name = None;
@@ -427,33 +469,35 @@ fn render_vector_arrow(
             // otherwise independent viewports.
             let Some(arrow_layers) = render_layer_lease.map(RenderLayerLease::render_layers) else {
                 if let Some(visual) = state.visuals.remove(&cam_entity) {
-                    hide_arrow_visual(&mut commands, &visual);
+                    despawn_arrow_visual(&mut commands, &visual);
                 }
                 return;
             };
 
-            let world_per_px = world_units_per_pixel(cam, proj, cam_tf, start);
-            let shaft_radius = (TARGET_DIAMETER_PX * 0.5 * world_per_px)
-                .clamp(MIN_RADIUS_WORLD, MAX_RADIUS_WORLD)
-                * arrow.thickness.value();
-            let shaft_radius = shaft_radius.clamp(MIN_RADIUS_WORLD, MAX_FINAL_RADIUS_WORLD);
+            let world_per_px = world_units_per_pixel(cam, proj, cam_tf, start_world);
+            let (head_length, shaft_length) =
+                arrow_head_and_shaft_lengths(draw_length, world_per_px);
+            let thickness = arrow.thickness.value();
+            let shaft_radius = compute_shaft_radius(draw_length, world_per_px, thickness);
             let head_radius = (shaft_radius * HEAD_RADIUS_FACTOR).min(draw_length * 0.75);
 
             let visual = state.visuals.entry(cam_entity).or_insert_with(|| {
-                spawn_arrow_visual(
+                let visual = spawn_arrow_visual(
                     &mut commands,
                     &arrow_meshes,
                     &mut materials,
                     base_color,
                     entity,
                     arrow_layers.clone(),
-                )
+                );
+                commands
+                    .entity(visual.root)
+                    .insert(ChildOf(endpoints.start));
+                visual
             });
 
             commands.entity(visual.root).insert((
-                Transform::from_translation(start).with_rotation(rotation),
-                #[cfg(feature = "big_space")]
-                start_cell,
+                Transform::from_rotation(local_rotation),
                 Visibility::Visible,
                 arrow_layers.clone(),
             ));
@@ -477,7 +521,7 @@ fn render_vector_arrow(
                 true
             } else {
                 for visual in state.visuals.values() {
-                    hide_arrow_visual(&mut commands, visual);
+                    despawn_arrow_visual(&mut commands, visual);
                 }
                 state.visuals.clear();
                 false
@@ -508,7 +552,7 @@ fn render_vector_arrow(
         }
         for cam_entity in to_remove {
             if let Some(visual) = state.visuals.remove(&cam_entity) {
-                hide_arrow_visual(&mut commands, &visual);
+                despawn_arrow_visual(&mut commands, &visual);
             }
         }
 
@@ -634,8 +678,8 @@ fn spawn_arrow_visual(
     ArrowVisual { root, shaft, head }
 }
 
-fn hide_arrow_visual(commands: &mut Commands, visual: &ArrowVisual) {
-    commands.entity(visual.root).insert(Visibility::Hidden);
+fn despawn_arrow_visual(commands: &mut Commands, visual: &ArrowVisual) {
+    commands.entity(visual.root).despawn();
 }
 
 fn hide_label(commands: &mut Commands, label: Option<Entity>) {
@@ -934,6 +978,44 @@ mod tests {
 
     fn bevy_delta(start: &WorldPos, end: &WorldPos, frame: GeoFrame, ctx: &GeoContext) -> DVec3 {
         GeoPosition(frame, end.pos()).to_bevy(ctx) - GeoPosition(frame, start.pos()).to_bevy(ctx)
+    }
+
+    #[test]
+    fn compute_shaft_radius_visible_when_zoomed_out() {
+        let draw_length = 1_000_000.0;
+        let world_per_px = 50_000.0;
+        let thickness = 2500.0;
+        let radius = compute_shaft_radius(draw_length, world_per_px, thickness);
+        let diameter_px = radius * 2.0 / world_per_px;
+        assert!(diameter_px >= MIN_VISIBLE_DIAMETER_PX);
+        assert_eq!(radius, MIN_VISIBLE_DIAMETER_PX * 0.5 * world_per_px);
+    }
+
+    #[test]
+    fn compute_shaft_radius_caps_when_zoomed_in() {
+        let draw_length = 1_000_000.0;
+        let world_per_px = 1.0;
+        let thickness = 1.0;
+        let radius = compute_shaft_radius(draw_length, world_per_px, thickness);
+        assert!(radius <= draw_length * MAX_RADIUS_FRAC);
+        assert!(radius >= MIN_VISIBLE_DIAMETER_PX * 0.5 * world_per_px);
+    }
+
+    #[test]
+    fn arrow_head_and_shaft_lengths_keep_visible_shaft() {
+        let draw_length = 100.0;
+        let world_per_px = 10.0;
+        let (head, shaft) = arrow_head_and_shaft_lengths(draw_length, world_per_px);
+        assert!(shaft > 0.0);
+        assert!(head + shaft <= draw_length);
+        assert!(shaft >= world_per_px * MIN_SHAFT_LENGTH_PX);
+    }
+
+    #[test]
+    fn arrow_head_and_shaft_lengths_degenerate_when_very_short() {
+        let (head, shaft) = arrow_head_and_shaft_lengths(0.05, 10.0);
+        assert_eq!(head, 0.0);
+        assert_eq!(shaft, 0.05);
     }
 
     /// World-frame arrows: routing the endpoints through `GeoPosition::to_bevy`

--- a/libs/elodin-editor/src/spatial.rs
+++ b/libs/elodin-editor/src/spatial.rs
@@ -66,10 +66,6 @@ impl FloatingOriginSettings {
         self.grid.translation_to_grid(translation)
     }
 
-    pub fn grid_edge_length(&self) -> f32 {
-        self.grid.cell_edge_length()
-    }
-
     pub fn grid_position_double(&self, grid_cell: &GridCell, transform: &Transform) -> DVec3 {
         self.grid.grid_position_double(grid_cell, transform)
     }

--- a/libs/elodin-editor/src/ui/inspector/viewport.rs
+++ b/libs/elodin-editor/src/ui/inspector/viewport.rs
@@ -221,8 +221,16 @@ impl WidgetSystem for InspectorViewport<'_, '_> {
                         persp.far = far;
                         configured_clip_planes = Some((near, far));
 
-                        if near_changed && let Ok(mut editor_cam) = editor_cams.get_mut(camera) {
-                            editor_cam.perspective.near_clip_limits = near..near;
+                        if let Ok(mut editor_cam) = editor_cams.get_mut(camera) {
+                            if near_changed {
+                                editor_cam.perspective.near_clip_limits = near..near;
+                            }
+                            if far_changed {
+                                let (min_size_per_pixel, max_size_per_pixel) =
+                                    crate::ui::tiles::zoom_limits_for_far(far);
+                                editor_cam.zoom_limits.min_size_per_pixel = min_size_per_pixel;
+                                editor_cam.zoom_limits.max_size_per_pixel = max_size_per_pixel;
+                            }
                         }
                     }
 

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -94,6 +94,14 @@ fn set_perspective_near(perspective: &mut PerspectiveProjection, near: f32) {
     perspective.near_clip_plane = crate::plugins::frustum_common::near_clip_plane(near);
 }
 
+/// Derive zoom bounds from the viewport far plane.
+pub(crate) fn zoom_limits_for_far(far: f32) -> (f64, f64) {
+    let far = (far as f64).max(DEFAULT_VIEWPORT_FAR as f64);
+    let min_size_per_pixel = (far * 1.0e-6).max(1.0e-3);
+    let max_size_per_pixel = (far * 2.0).max(10.0);
+    (min_size_per_pixel, max_size_per_pixel)
+}
+
 fn bloom_from_config(config: Option<&BloomConfig>) -> Bloom {
     let Some(config) = config else {
         return Bloom::default();
@@ -117,7 +125,22 @@ fn bloom_from_config(config: Option<&BloomConfig>) -> Bloom {
 pub(crate) fn plugin(app: &mut App) {
     app.register_type::<WindowId>()
         .add_message::<WindowRelayout>()
-        .add_systems(Startup, setup_primary_window_state);
+        .add_systems(Startup, setup_primary_window_state)
+        .add_systems(Update, sync_editor_cam_zoom_limits);
+}
+
+type EditorCamZoomLimitsQuery<'w> = (&'w Projection, Mut<'w, EditorCam>);
+
+fn sync_editor_cam_zoom_limits(
+    mut cameras: Query<EditorCamZoomLimitsQuery<'_>, (With<MainCamera>, Changed<Projection>)>,
+) {
+    for (projection, mut editor_cam) in &mut cameras {
+        if let Projection::Perspective(persp) = projection {
+            let (min_size_per_pixel, max_size_per_pixel) = zoom_limits_for_far(persp.far);
+            editor_cam.zoom_limits.min_size_per_pixel = min_size_per_pixel;
+            editor_cam.zoom_limits.max_size_per_pixel = max_size_per_pixel;
+        }
+    }
 }
 
 fn setup_primary_window_state(
@@ -1549,6 +1572,8 @@ impl ViewportPane {
             perspective.far = DEFAULT_VIEWPORT_FAR;
         }
 
+        let (min_size_per_pixel, max_size_per_pixel) = zoom_limits_for_far(perspective.far);
+
         let mut camera = commands.spawn((
             Transform::default(),
             Camera3d::default(),
@@ -1574,8 +1599,8 @@ impl ViewportPane {
                     can_pass_tdc: false,
                 },
                 zoom_limits: ZoomLimits {
-                    min_size_per_pixel: 1e-3,
-                    max_size_per_pixel: 10.0,
+                    min_size_per_pixel,
+                    max_size_per_pixel,
                     zoom_through_objects: false,
                 },
                 sensitivity: Sensitivity {

--- a/libs/elodin-editor/src/vector_arrow.rs
+++ b/libs/elodin-editor/src/vector_arrow.rs
@@ -24,12 +24,21 @@ pub struct ArrowEndpoint {
     pub owner: Entity,
 }
 
+/// Last successfully rendered arrow pose, reused when endpoint reads fail transiently.
+#[derive(Clone)]
+pub struct CachedArrowPose {
+    pub direction_world: Vec3,
+    /// Shaft direction in the start endpoint's local space (mesh +Y).
+    pub local_rotation: Quat,
+}
+
 #[derive(Component, Default)]
 pub struct VectorArrowState {
     pub vector_expr: Option<CompiledExpr>,
     pub origin_expr: Option<CompiledExpr>,
     /// Whether the last expression evaluation produced a drawable arrow.
     pub valid: bool,
+    pub cached_pose: Option<CachedArrowPose>,
     pub visuals: HashMap<Entity, ArrowVisual>,
     pub label: Option<Entity>,
     /// Label offset from the arrow root, cached in render_vector_arrow for UI sync.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Editor gizmo/transform parenting changes affect all vector arrows; cranelift lowering changes can alter simulation numerics for large batched MLIR once pointer ABI is active—mitigated by new golden tests and docs.
> 
> **Overview**
> **Vector arrows** now render readably at very large scene scales (e.g. Apollo lander with `far=200000`). Arrow meshes run in **PostUpdate** after transform propagation, are **parented to the start endpoint** with rotation-only local transforms, and use **screen-pixel–based** head length, shaft length, and radius (with a minimum visible diameter when zoomed out). **`CachedArrowPose`** keeps the last good pose when endpoint reads fail briefly; visuals are **despawned** instead of hidden. The old `big_space` grid-cell delta path for arrow direction is dropped in favor of **`GlobalTransform`** on endpoints.
> 
> **Viewport zoom** is tied to the far clip plane via **`zoom_limits_for_far`**, updated when projection changes (inspector far edits and new cameras).
> 
> **cranelift-mlir (pointer ABI):** **`concatenate`** on `dim > 0` with multiple operands now **pairwise-folds** through `tensor_concat_nd_f64` (fixes wrong layout vs back-to-back `memcpy`); **`dot_general`** adds a **batched `matmul_f64`** fast path for leading batch dims and standard contracting layout. Docs and **`_mem`** golden tests cover both.
> 
> **apollo-lander.kdl:** DPS plume uses fixed body **direction** and scalar **`main_thrust_viz[2]`** intensity; removes an unused **window** layout block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae61ae866ee2b660bea2ada8627634e777a6700c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



https://github.com/user-attachments/assets/ad9f9706-d9a1-45c5-af1c-675c966ab426
