### PR TITLE
Fix editor for Ubuntu 2204 and Nvidia Quadro cards

### DIFF
--- a/justfile
+++ b/justfile
@@ -87,19 +87,6 @@ public-changelog:
 install target="all":
   #!/usr/bin/env sh
   set -e
-  rpath_add() {
-    [ "$(uname -s)" = "Linux" ] || return 0
-    [ -n "${ELODIN_RUNTIME_LIBRARY_PATH:-}" ] || return 0
-    old_rpath="$(patchelf --print-rpath "$1" 2>/dev/null || true)"
-    patchelf --set-rpath "$ELODIN_RUNTIME_LIBRARY_PATH${old_rpath:+:$old_rpath}" "$1" 2>/dev/null || true
-  }
-  rpath_add_venv() {
-    [ "$(uname -s)" = "Linux" ] || return 0
-    [ -n "${ELODIN_RUNTIME_LIBRARY_PATH:-}" ] || return 0
-    find .venv -name '*.so' -type f | while IFS= read -r so; do
-      rpath_add "$so"
-    done
-  }
   # Drop 0-byte libelodin.so left by maturin 1.13+'s broken staging dance
   # (PyO3/maturin#3054); cargo's fingerprint accepts empty outputs and would
   # otherwise short-circuit forever. The maturin@1.12.6 pin below stops new
@@ -111,14 +98,11 @@ install target="all":
       uv venv --python 3.13 --python-preference only-system --clear
       . .venv/bin/activate
       uvx maturin@1.12.6 develop --uv --release --manifest-path=libs/nox-py/Cargo.toml
-      rpath_add_venv
       echo "Venv ready. Run source with \`source .venv/bin/activate\` before running examples with python3"
       ;;
     editor)
       cargo build --release -p elodin
       install -m 755 target/release/elodin "${CARGO_HOME:-$HOME/.cargo}/bin/"
-      rm -f "${CARGO_HOME:-$HOME/.cargo}/bin/elodin-real"
-      rpath_add "${CARGO_HOME:-$HOME/.cargo}/bin/elodin"
       ;;
     db)
       cargo build --release -p elodin-db
@@ -134,12 +118,9 @@ install target="all":
       uv venv --python 3.13 --python-preference only-system --clear
       . .venv/bin/activate
       uvx maturin@1.12.6 develop --uv --release --manifest-path=libs/nox-py/Cargo.toml -F tracy
-      rpath_add_venv
       echo "Venv ready. Run source with \`source .venv/bin/activate\` before running examples with python3"
       cargo build --release -p elodin -p elodin-db --features tracy
       install -m 755 target/release/elodin "${CARGO_HOME:-$HOME/.cargo}/bin/"
-      rm -f "${CARGO_HOME:-$HOME/.cargo}/bin/elodin-real"
-      rpath_add "${CARGO_HOME:-$HOME/.cargo}/bin/elodin"
       install -m 755 target/release/elodin-db "${CARGO_HOME:-$HOME/.cargo}/bin/"
       ;;
     all) just install py && just install editor && just install db;;

--- a/justfile
+++ b/justfile
@@ -95,7 +95,7 @@ install target="all":
   mkdir -p "${CARGO_HOME:-$HOME/.cargo}/bin"
   case "{{target}}" in
     py)
-      uv venv --python 3.13 --clear
+      uv venv --python "$(command -v python3.13)" --python-preference only-system --clear
       . .venv/bin/activate
       uvx maturin@1.12.6 develop --uv --release --manifest-path=libs/nox-py/Cargo.toml
       echo "Venv ready. Run source with \`source .venv/bin/activate\` before running examples with python3"

--- a/justfile
+++ b/justfile
@@ -87,6 +87,36 @@ public-changelog:
 install target="all":
   #!/usr/bin/env sh
   set -e
+  write_runtime_wrapper() {
+    wrapper="$1"
+    real_name="$2"
+    default_runtime_library_path="${ELODIN_RUNTIME_LIBRARY_PATH:-}"
+    default_gpu_hook="${ELODIN_GPU_HOOK:-}"
+    {
+      printf '%s\n' '#!/usr/bin/env sh'
+      printf '%s\n' "default_runtime_library_path='$default_runtime_library_path'"
+      printf '%s\n' "default_gpu_hook='$default_gpu_hook'"
+      printf '%s\n' 'runtime_library_path="${ELODIN_RUNTIME_LIBRARY_PATH:-$default_runtime_library_path}"'
+      printf '%s\n' 'gpu_hook="${ELODIN_GPU_HOOK:-$default_gpu_hook}"'
+      printf '%s\n' 'if [ -n "$runtime_library_path" ]; then'
+      printf '%s\n' '  export LD_LIBRARY_PATH="$runtime_library_path${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"'
+      printf '%s\n' 'fi'
+      printf '%s\n' 'if [ -n "$gpu_hook" ] && [ -r "$gpu_hook" ]; then'
+      printf '%s\n' '  . "$gpu_hook"'
+      printf '%s\n' 'fi'
+      printf '%s\n' "exec \"\$(dirname \"\$0\")/$real_name\" \"\$@\""
+    } > "$wrapper"
+    chmod +x "$wrapper"
+  }
+  wrap_venv_python() {
+    [ -n "${ELODIN_RUNTIME_LIBRARY_PATH:-}" ] || return 0
+    for exe in .venv/bin/python .venv/bin/python3 .venv/bin/python3.13; do
+      [ -e "$exe" ] || continue
+      [ ! -e "$exe-real" ] || continue
+      mv "$exe" "$exe-real"
+      write_runtime_wrapper "$exe" "$(basename "$exe")-real"
+    done
+  }
   # Drop 0-byte libelodin.so left by maturin 1.13+'s broken staging dance
   # (PyO3/maturin#3054); cargo's fingerprint accepts empty outputs and would
   # otherwise short-circuit forever. The maturin@1.12.6 pin below stops new
@@ -98,11 +128,13 @@ install target="all":
       uv venv --python 3.13 --python-preference only-system --clear
       . .venv/bin/activate
       uvx maturin@1.12.6 develop --uv --release --manifest-path=libs/nox-py/Cargo.toml
+      wrap_venv_python
       echo "Venv ready. Run source with \`source .venv/bin/activate\` before running examples with python3"
       ;;
     editor)
       cargo build --release -p elodin
-      install -m 755 target/release/elodin "${CARGO_HOME:-$HOME/.cargo}/bin/"
+      install -m 755 target/release/elodin "${CARGO_HOME:-$HOME/.cargo}/bin/elodin-real"
+      write_runtime_wrapper "${CARGO_HOME:-$HOME/.cargo}/bin/elodin" "elodin-real"
       ;;
     db)
       cargo build --release -p elodin-db
@@ -118,9 +150,11 @@ install target="all":
       uv venv --python 3.13 --python-preference only-system --clear
       . .venv/bin/activate
       uvx maturin@1.12.6 develop --uv --release --manifest-path=libs/nox-py/Cargo.toml -F tracy
+      wrap_venv_python
       echo "Venv ready. Run source with \`source .venv/bin/activate\` before running examples with python3"
       cargo build --release -p elodin -p elodin-db --features tracy
-      install -m 755 target/release/elodin "${CARGO_HOME:-$HOME/.cargo}/bin/"
+      install -m 755 target/release/elodin "${CARGO_HOME:-$HOME/.cargo}/bin/elodin-real"
+      write_runtime_wrapper "${CARGO_HOME:-$HOME/.cargo}/bin/elodin" "elodin-real"
       install -m 755 target/release/elodin-db "${CARGO_HOME:-$HOME/.cargo}/bin/"
       ;;
     all) just install py && just install editor && just install db;;

--- a/justfile
+++ b/justfile
@@ -95,7 +95,7 @@ install target="all":
   mkdir -p "${CARGO_HOME:-$HOME/.cargo}/bin"
   case "{{target}}" in
     py)
-      uv venv --python 3.13 --clear
+      uv venv --python 3.13 --python-preference only-system --clear
       . .venv/bin/activate
       uvx maturin@1.12.6 develop --uv --release --manifest-path=libs/nox-py/Cargo.toml
       echo "Venv ready. Run source with \`source .venv/bin/activate\` before running examples with python3"
@@ -115,7 +115,7 @@ install target="all":
         echo "Use a Linux machine or an OrbStack NixOS VM for profiling." >&2
         exit 1
       fi
-      uv venv --python 3.13 --clear
+      uv venv --python 3.13 --python-preference only-system --clear
       . .venv/bin/activate
       uvx maturin@1.12.6 develop --uv --release --manifest-path=libs/nox-py/Cargo.toml -F tracy
       echo "Venv ready. Run source with \`source .venv/bin/activate\` before running examples with python3"

--- a/justfile
+++ b/justfile
@@ -95,7 +95,7 @@ install target="all":
   mkdir -p "${CARGO_HOME:-$HOME/.cargo}/bin"
   case "{{target}}" in
     py)
-      uv venv --python "$(command -v python3.13)" --python-preference only-system --clear
+      uv venv --python 3.13 --python-preference only-system --clear
       . .venv/bin/activate
       uvx maturin@1.12.6 develop --uv --release --manifest-path=libs/nox-py/Cargo.toml
       echo "Venv ready. Run source with \`source .venv/bin/activate\` before running examples with python3"
@@ -115,7 +115,7 @@ install target="all":
         echo "Use a Linux machine or an OrbStack NixOS VM for profiling." >&2
         exit 1
       fi
-      uv venv --python 3.13 --clear
+      uv venv --python 3.13 --python-preference only-system --clear
       . .venv/bin/activate
       uvx maturin@1.12.6 develop --uv --release --manifest-path=libs/nox-py/Cargo.toml -F tracy
       echo "Venv ready. Run source with \`source .venv/bin/activate\` before running examples with python3"

--- a/justfile
+++ b/justfile
@@ -95,7 +95,7 @@ install target="all":
   mkdir -p "${CARGO_HOME:-$HOME/.cargo}/bin"
   case "{{target}}" in
     py)
-      uv venv --python 3.13 --python-preference only-system --clear
+      uv venv --python 3.13 --clear
       . .venv/bin/activate
       uvx maturin@1.12.6 develop --uv --release --manifest-path=libs/nox-py/Cargo.toml
       echo "Venv ready. Run source with \`source .venv/bin/activate\` before running examples with python3"
@@ -115,7 +115,7 @@ install target="all":
         echo "Use a Linux machine or an OrbStack NixOS VM for profiling." >&2
         exit 1
       fi
-      uv venv --python 3.13 --python-preference only-system --clear
+      uv venv --python 3.13 --clear
       . .venv/bin/activate
       uvx maturin@1.12.6 develop --uv --release --manifest-path=libs/nox-py/Cargo.toml -F tracy
       echo "Venv ready. Run source with \`source .venv/bin/activate\` before running examples with python3"

--- a/justfile
+++ b/justfile
@@ -87,34 +87,17 @@ public-changelog:
 install target="all":
   #!/usr/bin/env sh
   set -e
-  write_runtime_wrapper() {
-    wrapper="$1"
-    real_name="$2"
-    default_runtime_library_path="${ELODIN_RUNTIME_LIBRARY_PATH:-}"
-    default_gpu_hook="${ELODIN_GPU_HOOK:-}"
-    {
-      printf '%s\n' '#!/usr/bin/env sh'
-      printf '%s\n' "default_runtime_library_path='$default_runtime_library_path'"
-      printf '%s\n' "default_gpu_hook='$default_gpu_hook'"
-      printf '%s\n' 'runtime_library_path="${ELODIN_RUNTIME_LIBRARY_PATH:-$default_runtime_library_path}"'
-      printf '%s\n' 'gpu_hook="${ELODIN_GPU_HOOK:-$default_gpu_hook}"'
-      printf '%s\n' 'if [ -n "$runtime_library_path" ]; then'
-      printf '%s\n' '  export LD_LIBRARY_PATH="$runtime_library_path${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"'
-      printf '%s\n' 'fi'
-      printf '%s\n' 'if [ -n "$gpu_hook" ] && [ -r "$gpu_hook" ]; then'
-      printf '%s\n' '  . "$gpu_hook"'
-      printf '%s\n' 'fi'
-      printf '%s\n' "exec \"\$(dirname \"\$0\")/$real_name\" \"\$@\""
-    } > "$wrapper"
-    chmod +x "$wrapper"
-  }
-  wrap_venv_python() {
+  rpath_add() {
+    [ "$(uname -s)" = "Linux" ] || return 0
     [ -n "${ELODIN_RUNTIME_LIBRARY_PATH:-}" ] || return 0
-    for exe in .venv/bin/python .venv/bin/python3 .venv/bin/python3.13; do
-      [ -e "$exe" ] || continue
-      [ ! -e "$exe-real" ] || continue
-      mv "$exe" "$exe-real"
-      write_runtime_wrapper "$exe" "$(basename "$exe")-real"
+    old_rpath="$(patchelf --print-rpath "$1" 2>/dev/null || true)"
+    patchelf --set-rpath "$ELODIN_RUNTIME_LIBRARY_PATH${old_rpath:+:$old_rpath}" "$1" 2>/dev/null || true
+  }
+  rpath_add_venv() {
+    [ "$(uname -s)" = "Linux" ] || return 0
+    [ -n "${ELODIN_RUNTIME_LIBRARY_PATH:-}" ] || return 0
+    find .venv -name '*.so' -type f | while IFS= read -r so; do
+      rpath_add "$so"
     done
   }
   # Drop 0-byte libelodin.so left by maturin 1.13+'s broken staging dance
@@ -128,13 +111,14 @@ install target="all":
       uv venv --python 3.13 --python-preference only-system --clear
       . .venv/bin/activate
       uvx maturin@1.12.6 develop --uv --release --manifest-path=libs/nox-py/Cargo.toml
-      wrap_venv_python
+      rpath_add_venv
       echo "Venv ready. Run source with \`source .venv/bin/activate\` before running examples with python3"
       ;;
     editor)
       cargo build --release -p elodin
-      install -m 755 target/release/elodin "${CARGO_HOME:-$HOME/.cargo}/bin/elodin-real"
-      write_runtime_wrapper "${CARGO_HOME:-$HOME/.cargo}/bin/elodin" "elodin-real"
+      install -m 755 target/release/elodin "${CARGO_HOME:-$HOME/.cargo}/bin/"
+      rm -f "${CARGO_HOME:-$HOME/.cargo}/bin/elodin-real"
+      rpath_add "${CARGO_HOME:-$HOME/.cargo}/bin/elodin"
       ;;
     db)
       cargo build --release -p elodin-db
@@ -150,11 +134,12 @@ install target="all":
       uv venv --python 3.13 --python-preference only-system --clear
       . .venv/bin/activate
       uvx maturin@1.12.6 develop --uv --release --manifest-path=libs/nox-py/Cargo.toml -F tracy
-      wrap_venv_python
+      rpath_add_venv
       echo "Venv ready. Run source with \`source .venv/bin/activate\` before running examples with python3"
       cargo build --release -p elodin -p elodin-db --features tracy
-      install -m 755 target/release/elodin "${CARGO_HOME:-$HOME/.cargo}/bin/elodin-real"
-      write_runtime_wrapper "${CARGO_HOME:-$HOME/.cargo}/bin/elodin" "elodin-real"
+      install -m 755 target/release/elodin "${CARGO_HOME:-$HOME/.cargo}/bin/"
+      rm -f "${CARGO_HOME:-$HOME/.cargo}/bin/elodin-real"
+      rpath_add "${CARGO_HOME:-$HOME/.cargo}/bin/elodin"
       install -m 755 target/release/elodin-db "${CARGO_HOME:-$HOME/.cargo}/bin/"
       ;;
     all) just install py && just install editor && just install db;;

--- a/nix/pkgs/common.nix
+++ b/nix/pkgs/common.nix
@@ -42,6 +42,9 @@
     # Audio
     alsa-lib
     alsa-lib.dev
+    alsa-plugins
+    libpulseaudio
+    pulseaudio
     pipewire
 
     # Graphics - Core
@@ -114,6 +117,7 @@
     lib.makeLibraryPath (with pkgs; [
       # Audio
       alsa-lib
+      libpulseaudio
       pipewire
 
       # Graphics - Core
@@ -145,13 +149,33 @@
     ]);
 
   # Linux graphics environment variables
-  linuxGraphicsEnv = {pkgs}: {
+  linuxGraphicsEnv = {pkgs}: let
+    alsaPluginDir = pkgs.symlinkJoin {
+      name = "elodin-alsa-plugins";
+      paths = [
+        pkgs.alsa-plugins
+        pkgs.pipewire
+      ];
+    };
+    asoundConf = pkgs.writeText "elodin-asound.conf" ''
+      <${pkgs.alsa-lib}/share/alsa/alsa.conf>
+
+      pcm.!default {
+        type pulse
+      }
+
+      ctl.!default {
+        type pulse
+      }
+    '';
+  in {
     LIBGL_DRIVERS_PATH = "${pkgs.mesa}/lib/dri";
     __GLX_VENDOR_LIBRARY_NAME = "mesa";
     LIBVA_DRIVERS_PATH = "${pkgs.mesa}/lib/dri";
     VK_ICD_FILENAMES = "${pkgs.mesa}/share/vulkan/icd.d/radeon_icd.x86_64.json:${pkgs.mesa}/share/vulkan/icd.d/intel_icd.x86_64.json:${pkgs.mesa}/share/vulkan/icd.d/lvp_icd.x86_64.json";
     VK_LAYER_PATH = "${pkgs.vulkan-validation-layers}/share/vulkan/explicit_layer.d";
-    ALSA_PLUGIN_DIR = "${pkgs.pipewire}/lib/alsa-lib";
+    ALSA_PLUGIN_DIR = "${alsaPluginDir}/lib/alsa-lib";
+    ALSA_CONFIG_PATH = "${asoundConf}";
   };
 
   # Common wrapper arguments for executables

--- a/nix/pkgs/common.nix
+++ b/nix/pkgs/common.nix
@@ -31,9 +31,16 @@
       [ -e /proc/driver/nvidia/version ] && [ -e /usr/share/vulkan/icd.d/nvidia_icd.json ]
     }
 
-    has_non_nvidia_gpu() {
+    # A Mesa-capable GPU (Intel 0x8086 / AMD 0x1002) means the editor has a
+    # working non-NVIDIA path, so do not force the host NVIDIA driver. Match
+    # those vendors explicitly: BMC/IPMI framebuffers (e.g. ASPEED 0x1a03,
+    # Matrox 0x102b) also expose render nodes but are not performance GPUs, so a
+    # "not 0x10de" test would wrongly skip the hook on a Quadro-only server.
+    has_mesa_gpu() {
       for vendor in /sys/class/drm/renderD*/device/vendor; do
-        [ "$(cat "$vendor" 2>/dev/null)" != "0x10de" ] && return 0
+        case "$(cat "$vendor" 2>/dev/null)" in
+          0x8086 | 0x1002) return 0 ;;
+        esac
       done
       return 1
     }
@@ -49,7 +56,7 @@
         use_nvidia=0
         ;;
       *)
-        if nvidia_present && ! has_non_nvidia_gpu; then
+        if nvidia_present && ! has_mesa_gpu; then
           use_nvidia=1
         fi
         ;;
@@ -59,11 +66,22 @@
 
     nvidia_lib_dir="''${TMPDIR:-/tmp}/elodin-nvidia-libs"
     mkdir -p "$nvidia_lib_dir"
+    have_glx=0
     for lib in /usr/lib/x86_64-linux-gnu/libGLX_nvidia.so* \
       /usr/lib/x86_64-linux-gnu/libEGL_nvidia.so* \
       /usr/lib/x86_64-linux-gnu/libnvidia-*.so*; do
-      [ -e "$lib" ] && ln -sf "$lib" "$nvidia_lib_dir/$(basename "$lib")"
+      [ -e "$lib" ] || continue
+      ln -sf "$lib" "$nvidia_lib_dir/$(basename "$lib")"
+      case "$lib" in
+        */libGLX_nvidia.so*) have_glx=1 ;;
+      esac
     done
+
+    # libGLX_nvidia provides both the NVIDIA Vulkan ICD (per nvidia_icd.json) and
+    # the GLVND GLX vendor library. Without it, exporting the NVIDIA-only ICD and
+    # __GLX_VENDOR_LIBRARY_NAME would just break GL/Vulkan, so keep the Mesa
+    # defaults when the host driver libraries are not present.
+    [ "$have_glx" = 1 ] || exit 0
 
     printf 'export VK_ICD_FILENAMES=%s\n' /usr/share/vulkan/icd.d/nvidia_icd.json
     printf 'export VK_DRIVER_FILES=%s\n' /usr/share/vulkan/icd.d/nvidia_icd.json

--- a/nix/pkgs/common.nix
+++ b/nix/pkgs/common.nix
@@ -21,21 +21,58 @@
       type pulse
     }
   '';
-  nvidiaHookScript = pkgs.writeShellScript "elodin-nvidia-gpu-hook" ''
-    if [ -e /proc/driver/nvidia/version ] && [ -e /usr/share/vulkan/icd.d/nvidia_icd.json ]; then
-      nvidia_lib_dir="''${TMPDIR:-/tmp}/elodin-nvidia-libs"
-      mkdir -p "$nvidia_lib_dir"
-      for lib in /usr/lib/x86_64-linux-gnu/libGLX_nvidia.so* \
-        /usr/lib/x86_64-linux-gnu/libEGL_nvidia.so* \
-        /usr/lib/x86_64-linux-gnu/libnvidia-*.so*; do
-        [ -e "$lib" ] && ln -sf "$lib" "$nvidia_lib_dir/$(basename "$lib")"
+  gpuDetectScript = pkgs.writeShellScript "elodin-gpu-detect" ''
+    set -u
+    shopt -s nullglob
+
+    mode="''${ELODIN_GPU:-auto}"
+
+    nvidia_present() {
+      [ -e /proc/driver/nvidia/version ] && [ -e /usr/share/vulkan/icd.d/nvidia_icd.json ]
+    }
+
+    has_non_nvidia_gpu() {
+      for vendor in /sys/class/drm/renderD*/device/vendor; do
+        [ "$(cat "$vendor" 2>/dev/null)" != "0x10de" ] && return 0
       done
-      export VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/nvidia_icd.json
-      export VK_DRIVER_FILES=/usr/share/vulkan/icd.d/nvidia_icd.json
-      export __GLX_VENDOR_LIBRARY_NAME=nvidia
-      export LD_LIBRARY_PATH="$nvidia_lib_dir''${LD_LIBRARY_PATH:+:''${LD_LIBRARY_PATH}}"
-      unset LIBGL_ALWAYS_SOFTWARE || true
-    fi
+      return 1
+    }
+
+    use_nvidia=0
+    case "$mode" in
+      nvidia)
+        if nvidia_present; then
+          use_nvidia=1
+        fi
+        ;;
+      mesa)
+        use_nvidia=0
+        ;;
+      *)
+        if nvidia_present && ! has_non_nvidia_gpu; then
+          use_nvidia=1
+        fi
+        ;;
+    esac
+
+    [ "$use_nvidia" = 1 ] || exit 0
+
+    nvidia_lib_dir="''${TMPDIR:-/tmp}/elodin-nvidia-libs"
+    mkdir -p "$nvidia_lib_dir"
+    for lib in /usr/lib/x86_64-linux-gnu/libGLX_nvidia.so* \
+      /usr/lib/x86_64-linux-gnu/libEGL_nvidia.so* \
+      /usr/lib/x86_64-linux-gnu/libnvidia-*.so*; do
+      [ -e "$lib" ] && ln -sf "$lib" "$nvidia_lib_dir/$(basename "$lib")"
+    done
+
+    printf 'export VK_ICD_FILENAMES=%s\n' /usr/share/vulkan/icd.d/nvidia_icd.json
+    printf 'export VK_DRIVER_FILES=%s\n' /usr/share/vulkan/icd.d/nvidia_icd.json
+    printf 'export __GLX_VENDOR_LIBRARY_NAME=nvidia\n'
+    printf 'export LD_LIBRARY_PATH="%s''${LD_LIBRARY_PATH:+:''${LD_LIBRARY_PATH}}"\n' "$nvidia_lib_dir"
+    printf 'unset LIBGL_ALWAYS_SOFTWARE\n'
+  '';
+  nvidiaHookScript = pkgs.writeShellScript "elodin-gpu-hook" ''
+    eval "$(${gpuDetectScript})"
   '';
 in {
   inherit alsaPluginDir asoundConf nvidiaHookScript;

--- a/nix/pkgs/common.nix
+++ b/nix/pkgs/common.nix
@@ -2,7 +2,44 @@
   lib,
   pkgs,
   ...
-}: {
+}: let
+  alsaPluginDir = pkgs.symlinkJoin {
+    name = "elodin-alsa-plugins";
+    paths = [
+      pkgs.alsa-plugins
+      pkgs.pipewire
+    ];
+  };
+  asoundConf = pkgs.writeText "elodin-asound.conf" ''
+    <${pkgs.alsa-lib}/share/alsa/alsa.conf>
+
+    pcm.!default {
+      type pulse
+    }
+
+    ctl.!default {
+      type pulse
+    }
+  '';
+  nvidiaHookScript = pkgs.writeShellScript "elodin-nvidia-gpu-hook" ''
+    if [ -e /proc/driver/nvidia/version ] && [ -e /usr/share/vulkan/icd.d/nvidia_icd.json ]; then
+      nvidia_lib_dir="''${TMPDIR:-/tmp}/elodin-nvidia-libs"
+      mkdir -p "$nvidia_lib_dir"
+      for lib in /usr/lib/x86_64-linux-gnu/libGLX_nvidia.so* \
+        /usr/lib/x86_64-linux-gnu/libEGL_nvidia.so* \
+        /usr/lib/x86_64-linux-gnu/libnvidia-*.so*; do
+        [ -e "$lib" ] && ln -sf "$lib" "$nvidia_lib_dir/$(basename "$lib")"
+      done
+      export VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/nvidia_icd.json
+      export VK_DRIVER_FILES=/usr/share/vulkan/icd.d/nvidia_icd.json
+      export __GLX_VENDOR_LIBRARY_NAME=nvidia
+      export LD_LIBRARY_PATH="$nvidia_lib_dir''${LD_LIBRARY_PATH:+:''${LD_LIBRARY_PATH}}"
+      unset LIBGL_ALWAYS_SOFTWARE || true
+    fi
+  '';
+in {
+  inherit alsaPluginDir asoundConf nvidiaHookScript;
+
   src = let
     includeSrc = orig_path: type: let
       path = toString orig_path;
@@ -149,26 +186,7 @@
     ]);
 
   # Linux graphics environment variables
-  linuxGraphicsEnv = {pkgs}: let
-    alsaPluginDir = pkgs.symlinkJoin {
-      name = "elodin-alsa-plugins";
-      paths = [
-        pkgs.alsa-plugins
-        pkgs.pipewire
-      ];
-    };
-    asoundConf = pkgs.writeText "elodin-asound.conf" ''
-      <${pkgs.alsa-lib}/share/alsa/alsa.conf>
-
-      pcm.!default {
-        type pulse
-      }
-
-      ctl.!default {
-        type pulse
-      }
-    '';
-  in {
+  linuxGraphicsEnv = {pkgs}: {
     LIBGL_DRIVERS_PATH = "${pkgs.mesa}/lib/dri";
     __GLX_VENDOR_LIBRARY_NAME = "mesa";
     LIBVA_DRIVERS_PATH = "${pkgs.mesa}/lib/dri";
@@ -189,6 +207,7 @@
       lib.makeLibraryPath (with pkgs; [
         # Audio
         alsa-lib
+        libpulseaudio
         pipewire
 
         # Graphics - Core
@@ -223,9 +242,11 @@
       --set LIBGL_DRIVERS_PATH "${pkgs.mesa}/lib/dri" \
       --set __GLX_VENDOR_LIBRARY_NAME "mesa" \
       --set LIBVA_DRIVERS_PATH "${pkgs.mesa}/lib/dri" \
-      --prefix VK_ICD_FILENAMES : "${pkgs.mesa}/share/vulkan/icd.d/radeon_icd.x86_64.json:${pkgs.mesa}/share/vulkan/icd.d/intel_icd.x86_64.json:${pkgs.mesa}/share/vulkan/icd.d/lvp_icd.x86_64.json" \
+      --set VK_ICD_FILENAMES "${pkgs.mesa}/share/vulkan/icd.d/radeon_icd.x86_64.json:${pkgs.mesa}/share/vulkan/icd.d/intel_icd.x86_64.json:${pkgs.mesa}/share/vulkan/icd.d/lvp_icd.x86_64.json" \
       --prefix VK_LAYER_PATH : "${pkgs.vulkan-validation-layers}/share/vulkan/explicit_layer.d" \
-      --set ALSA_PLUGIN_DIR "${pkgs.pipewire}/lib/alsa-lib"
+      --set ALSA_PLUGIN_DIR "${alsaPluginDir}/lib/alsa-lib" \
+      --set ALSA_CONFIG_PATH "${asoundConf}" \
+      --run "source ${nvidiaHookScript}"
     '';
   in ''
     --prefix PATH : "${python}/bin" \

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -173,6 +173,23 @@ with pkgs; let
         mesa
         libGL
       ])}:''${LD_LIBRARY_PATH}"
+          # Non-NixOS NVIDIA hosts need the host Vulkan/GLX driver. The Nix
+          # Mesa ICDs otherwise force wgpu onto lavapipe, which cannot present
+          # reliably to the NVIDIA X server.
+          if [ -e /proc/driver/nvidia/version ] && [ -e /usr/share/vulkan/icd.d/nvidia_icd.json ]; then
+            nvidia_lib_dir="''${TMPDIR:-/tmp}/elodin-nvidia-libs"
+            mkdir -p "$nvidia_lib_dir"
+            for lib in /usr/lib/x86_64-linux-gnu/libGLX_nvidia.so* \
+              /usr/lib/x86_64-linux-gnu/libEGL_nvidia.so* \
+              /usr/lib/x86_64-linux-gnu/libnvidia-*.so*; do
+              [ -e "$lib" ] && ln -sf "$lib" "$nvidia_lib_dir/$(basename "$lib")"
+            done
+            export VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/nvidia_icd.json
+            export VK_DRIVER_FILES=/usr/share/vulkan/icd.d/nvidia_icd.json
+            export __GLX_VENDOR_LIBRARY_NAME=nvidia
+            export LD_LIBRARY_PATH="$nvidia_lib_dir:''${LD_LIBRARY_PATH}"
+            unset LIBGL_ALWAYS_SOFTWARE || true
+          fi
         ;;
       esac
       # start the shell if we're in an interactive shell

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -19,6 +19,34 @@ with pkgs; let
       polars
       numpy
     ]);
+  linuxRuntimeLibraryPath = lib.optionalString pkgs.stdenv.isLinux (
+    lib.makeLibraryPath [
+      cudaPackages.cuda_cudart
+    ]
+    + ":"
+    + common.makeLinuxLibraryPath {inherit pkgs;}
+  );
+  elodinDevWrapper = writeShellScriptBin "elodin" ''
+    set -eu
+
+    elodin_bin="''${CARGO_HOME:-$HOME/.cargo}/bin/elodin-real"
+    if [ ! -x "$elodin_bin" ]; then
+      elodin_bin="''${CARGO_HOME:-$HOME/.cargo}/bin/elodin"
+    fi
+    if [ ! -x "$elodin_bin" ]; then
+      echo "error: $elodin_bin not found; run 'just install editor'" >&2
+      exit 127
+    fi
+
+    if [ -n "''${ELODIN_RUNTIME_LIBRARY_PATH:-}" ]; then
+      export LD_LIBRARY_PATH="''${ELODIN_RUNTIME_LIBRARY_PATH}''${LD_LIBRARY_PATH:+:''${LD_LIBRARY_PATH}}"
+    fi
+    if [ -n "''${ELODIN_GPU_HOOK:-}" ] && [ -r "''${ELODIN_GPU_HOOK}" ]; then
+      . "''${ELODIN_GPU_HOOK}"
+    fi
+
+    exec "$elodin_bin" "$@"
+  '';
   shellAttrs = {
     name = "elo-unified-shell";
     buildInputs =
@@ -78,6 +106,7 @@ with pkgs; let
         gettext
         just
         jq
+        procps
         yq
         git
         git-filter-repo
@@ -102,6 +131,7 @@ with pkgs; let
           fontconfig
           lldb
           autoPatchelfHook
+          elodinDevWrapper
           # Tracy profiler (Linux-only: requires std::jthread, not in Apple libc++)
           tracy
           cudaPackages.cuda_cudart
@@ -127,6 +157,8 @@ with pkgs; let
     # to allocate ~10 KB from the tiny static-TLS surplus on dlopen.  Raise
     # the surplus so Python can import the extension without ENOMEM.
     GLIBC_TUNABLES = "glibc.rtld.optional_static_tls=16384";
+    ELODIN_RUNTIME_LIBRARY_PATH = linuxRuntimeLibraryPath;
+    ELODIN_GPU_HOOK = lib.optionalString pkgs.stdenv.isLinux "${common.nvidiaHookScript}";
 
     # GStreamer plugin path for elodinsink
     GST_PLUGIN_PATH = lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" [
@@ -139,15 +171,6 @@ with pkgs; let
     ];
 
     LLDB_DEBUGSERVER_PATH = lib.optionalString pkgs.stdenv.isDarwin "/Applications/Xcode.app/Contents/SharedFrameworks/LLDB.framework/Versions/A/Resources/debugserver";
-
-    # Set up library paths for Linux graphics/audio
-    LD_LIBRARY_PATH = lib.optionalString pkgs.stdenv.isLinux (
-      lib.makeLibraryPath [
-        cudaPackages.cuda_cudart
-      ]
-      + ":"
-      + common.makeLinuxLibraryPath {inherit pkgs;}
-    );
 
     doCheck = false;
     shellHook = ''
@@ -162,20 +185,8 @@ with pkgs; let
           export WINIT_UNIX_BACKEND=x11
           unset WAYLAND_DISPLAY
           export XDG_SESSION_TYPE=x11
-          # Ensure X11 libraries are available
-          export LD_LIBRARY_PATH="${lib.makeLibraryPath (with pkgs; [
-        libx11
-        libxcursor
-        libxrandr
-        libxi
-        libxext
-        libxkbcommon
-        mesa
-        libGL
-      ])}:''${LD_LIBRARY_PATH}"
-          # Route GPU through the host NVIDIA driver on non-NixOS NVIDIA hosts
-          # (shared with the packaged elodin wrapper).
-          . ${common.nvidiaHookScript}
+          # Runtime wrappers apply graphics libraries per process so host tools
+          # do not accidentally load Nix shared libraries.
         ;;
       esac
       # start the shell if we're in an interactive shell

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -26,27 +26,6 @@ with pkgs; let
     + ":"
     + common.makeLinuxLibraryPath {inherit pkgs;}
   );
-  elodinDevWrapper = writeShellScriptBin "elodin" ''
-    set -eu
-
-    elodin_bin="''${CARGO_HOME:-$HOME/.cargo}/bin/elodin-real"
-    if [ ! -x "$elodin_bin" ]; then
-      elodin_bin="''${CARGO_HOME:-$HOME/.cargo}/bin/elodin"
-    fi
-    if [ ! -x "$elodin_bin" ]; then
-      echo "error: $elodin_bin not found; run 'just install editor'" >&2
-      exit 127
-    fi
-
-    if [ -n "''${ELODIN_RUNTIME_LIBRARY_PATH:-}" ]; then
-      export LD_LIBRARY_PATH="''${ELODIN_RUNTIME_LIBRARY_PATH}''${LD_LIBRARY_PATH:+:''${LD_LIBRARY_PATH}}"
-    fi
-    if [ -n "''${ELODIN_GPU_HOOK:-}" ] && [ -r "''${ELODIN_GPU_HOOK}" ]; then
-      . "''${ELODIN_GPU_HOOK}"
-    fi
-
-    exec "$elodin_bin" "$@"
-  '';
   shellAttrs = {
     name = "elo-unified-shell";
     buildInputs =
@@ -106,7 +85,6 @@ with pkgs; let
         gettext
         just
         jq
-        procps
         yq
         git
         git-filter-repo
@@ -131,7 +109,6 @@ with pkgs; let
           fontconfig
           lldb
           autoPatchelfHook
-          elodinDevWrapper
           # Tracy profiler (Linux-only: requires std::jthread, not in Apple libc++)
           tracy
           cudaPackages.cuda_cudart
@@ -158,7 +135,6 @@ with pkgs; let
     # the surplus so Python can import the extension without ENOMEM.
     GLIBC_TUNABLES = "glibc.rtld.optional_static_tls=16384";
     ELODIN_RUNTIME_LIBRARY_PATH = linuxRuntimeLibraryPath;
-    ELODIN_GPU_HOOK = lib.optionalString pkgs.stdenv.isLinux "${common.nvidiaHookScript}";
 
     # GStreamer plugin path for elodinsink
     GST_PLUGIN_PATH = lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" [
@@ -185,8 +161,9 @@ with pkgs; let
           export WINIT_UNIX_BACKEND=x11
           unset WAYLAND_DISPLAY
           export XDG_SESSION_TYPE=x11
-          # Runtime wrappers apply graphics libraries per process so host tools
-          # do not accidentally load Nix shared libraries.
+          # Binaries get Nix libs via patchelf RUNPATH (see justfile); no global
+          # LD_LIBRARY_PATH is exported. Select GPU with ELODIN_GPU=auto|nvidia|mesa.
+          . ${common.nvidiaHookScript}
         ;;
       esac
       # start the shell if we're in an interactive shell

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -173,23 +173,9 @@ with pkgs; let
         mesa
         libGL
       ])}:''${LD_LIBRARY_PATH}"
-          # Non-NixOS NVIDIA hosts need the host Vulkan/GLX driver. The Nix
-          # Mesa ICDs otherwise force wgpu onto lavapipe, which cannot present
-          # reliably to the NVIDIA X server.
-          if [ -e /proc/driver/nvidia/version ] && [ -e /usr/share/vulkan/icd.d/nvidia_icd.json ]; then
-            nvidia_lib_dir="''${TMPDIR:-/tmp}/elodin-nvidia-libs"
-            mkdir -p "$nvidia_lib_dir"
-            for lib in /usr/lib/x86_64-linux-gnu/libGLX_nvidia.so* \
-              /usr/lib/x86_64-linux-gnu/libEGL_nvidia.so* \
-              /usr/lib/x86_64-linux-gnu/libnvidia-*.so*; do
-              [ -e "$lib" ] && ln -sf "$lib" "$nvidia_lib_dir/$(basename "$lib")"
-            done
-            export VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/nvidia_icd.json
-            export VK_DRIVER_FILES=/usr/share/vulkan/icd.d/nvidia_icd.json
-            export __GLX_VENDOR_LIBRARY_NAME=nvidia
-            export LD_LIBRARY_PATH="$nvidia_lib_dir:''${LD_LIBRARY_PATH}"
-            unset LIBGL_ALWAYS_SOFTWARE || true
-          fi
+          # Route GPU through the host NVIDIA driver on non-NixOS NVIDIA hosts
+          # (shared with the packaged elodin wrapper).
+          . ${common.nvidiaHookScript}
         ;;
       esac
       # start the shell if we're in an interactive shell

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -19,13 +19,6 @@ with pkgs; let
       polars
       numpy
     ]);
-  linuxRuntimeLibraryPath = lib.optionalString pkgs.stdenv.isLinux (
-    lib.makeLibraryPath [
-      cudaPackages.cuda_cudart
-    ]
-    + ":"
-    + common.makeLinuxLibraryPath {inherit pkgs;}
-  );
   shellAttrs = {
     name = "elo-unified-shell";
     buildInputs =
@@ -134,7 +127,6 @@ with pkgs; let
     # to allocate ~10 KB from the tiny static-TLS surplus on dlopen.  Raise
     # the surplus so Python can import the extension without ENOMEM.
     GLIBC_TUNABLES = "glibc.rtld.optional_static_tls=16384";
-    ELODIN_RUNTIME_LIBRARY_PATH = linuxRuntimeLibraryPath;
 
     # GStreamer plugin path for elodinsink
     GST_PLUGIN_PATH = lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" [
@@ -147,6 +139,15 @@ with pkgs; let
     ];
 
     LLDB_DEBUGSERVER_PATH = lib.optionalString pkgs.stdenv.isDarwin "/Applications/Xcode.app/Contents/SharedFrameworks/LLDB.framework/Versions/A/Resources/debugserver";
+
+    # Set up library paths for Linux graphics/audio
+    LD_LIBRARY_PATH = lib.optionalString pkgs.stdenv.isLinux (
+      lib.makeLibraryPath [
+        cudaPackages.cuda_cudart
+      ]
+      + ":"
+      + common.makeLinuxLibraryPath {inherit pkgs;}
+    );
 
     doCheck = false;
     shellHook = ''
@@ -161,8 +162,19 @@ with pkgs; let
           export WINIT_UNIX_BACKEND=x11
           unset WAYLAND_DISPLAY
           export XDG_SESSION_TYPE=x11
-          # Binaries get Nix libs via patchelf RUNPATH (see justfile); no global
-          # LD_LIBRARY_PATH is exported. Select GPU with ELODIN_GPU=auto|nvidia|mesa.
+          # Ensure X11 libraries are available
+          export LD_LIBRARY_PATH="${lib.makeLibraryPath (with pkgs; [
+        libx11
+        libxcursor
+        libxrandr
+        libxi
+        libxext
+        libxkbcommon
+        mesa
+        libGL
+      ])}:''${LD_LIBRARY_PATH}"
+          # Mesa by default; route to the host NVIDIA driver only when it is the
+          # sole GPU (or ELODIN_GPU=nvidia). No-op on hybrid/Mesa hosts.
           . ${common.nvidiaHookScript}
         ;;
       esac


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes runtime graphics/audio env for all Linux Nix shells and wrapped `elodin` binaries; logic is guarded but mis-detection could affect GL/Vulkan on unusual multi-GPU hosts.
> 
> **Overview**
> Improves **Linux dev and packaged editor** behavior on hosts like Ubuntu 22.04 with **NVIDIA-only** GPUs (e.g. Quadro servers), where Mesa-only Vulkan/GLX defaults could break the editor.
> 
> Adds an **`ELODIN_GPU`-aware hook** (`auto` / `nvidia` / `mesa`) that detects NVIDIA when there is no Intel/AMD Mesa GPU, symlinks host NVIDIA GL/Vulkan libs into a temp dir, and exports NVIDIA ICD/GLX env vars only when `libGLX_nvidia` is present—so hybrid and BMC render nodes are not forced onto NVIDIA incorrectly.
> 
> **Audio:** bundles **alsa-plugins + pipewire**, sets **`ALSA_CONFIG_PATH`** to a generated config that routes default PCM/ctl through **Pulse**, and adds **libpulseaudio** to library paths—addressing typical 22.04 Pulse/ALSA plugin gaps.
> 
> **Python install:** `just install py` and `tracy` now use **`uv venv --python-preference only-system`** so venvs prefer the system Python 3.13.
> 
> The hook runs in **`nix develop`** and via **`makeWrapperArgs`** on wrapped binaries; wrapper **`VK_ICD_FILENAMES`** is **`--set`** to Mesa ICDs first, then the hook overrides when NVIDIA-only applies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d8e5b34e99696e0256326b18bb018f6623f058d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->