### PR TITLE
`line_3d`: per-segment trail colors from KDL.

### DIFF
--- a/docs/public/content/reference/schematic.md
+++ b/docs/public/content/reference/schematic.md
@@ -170,7 +170,9 @@ object_3d lander.world_pos {
 - Positional `eql`: required; expects 3 values (or 7 where the last 3 are XYZ).
 - `frame`: optional; `ENU`, `NED`, or `ECEF`. Specifies the coordinate frame for interpreting the line points. Inherits from global `coordinate` if omitted.
 - `line_width`: default 1.0.
-- `color`: default white.
+- The trail is split into a *played* segment (up to the current playback time) and a *future* segment (ahead of it). The future segment is always faded by the timeline's `future_trail_alpha`.
+- `color`: color of the played segment. When omitted, falls back to the timeline `played_color` (default `yalk`). If set without `future_color`, it also colors the future segment — a single `color` paints the whole line.
+- `future_color`: color of the future segment. When omitted, falls back to `color` (if set), otherwise the timeline `future_color` (default `white`).
 - `perspective`: default true (set false for screen-space lines).
 
 ### vector_arrow
@@ -370,6 +372,7 @@ line_3d = "line_3d"
         [frame=ENU|NED|ECEF]
         [line_width=float]
         [color]
+        [future_color]
         [perspective=bool]
 
 vector_arrow = "vector_arrow"

--- a/libs/elodin-editor/src/ui/inspector/timeline.rs
+++ b/libs/elodin-editor/src/ui/inspector/timeline.rs
@@ -40,13 +40,13 @@ impl WidgetSystem for InspectorTimeline<'_> {
                 .margin(egui::Margin::same(0).bottom(16.0)),
         );
 
-        node_color_picker(ui, "PLAYED TRAIL", &mut timeline_settings.played_color);
-        node_color_picker(ui, "FUTURE TRAIL", &mut timeline_settings.future_color);
+        node_color_picker(ui, "PLAYED COLOR", &mut timeline_settings.played_color);
+        node_color_picker(ui, "FUTURE COLOR", &mut timeline_settings.future_color);
 
         egui::Frame::NONE
             .inner_margin(egui::Margin::symmetric(0, 8))
             .show(ui, |ui| {
-                ui.label(egui::RichText::new("FUTURE TRAIL ALPHA").color(scheme.text_secondary));
+                ui.label(egui::RichText::new("FUTURE TRAIL OPACITY").color(scheme.text_secondary));
 
                 ui.label(
                     egui::RichText::new(format!("{:.2}", timeline_settings.future_trail_alpha))

--- a/libs/elodin-editor/src/ui/plot_3d/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/gpu.rs
@@ -169,6 +169,24 @@ fn update_uniform_model(mut query: Query<(&mut LineUniform, &GlobalTransform)>) 
 #[require(SyncToRenderWorld)]
 pub struct LineHandles(pub [Handle<Line>; 3]);
 
+/// Where a `line_3d` gets its color from.
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LineColorSource {
+    /// Use the line's own `LineUniform.color` (set from the KDL `color`).
+    Explicit,
+    /// Fall back to the timeline played/future trail colors.
+    Timeline,
+}
+
+/// Linearize a schematic (sRGB) color for the line shader, preserving alpha.
+fn wkt_color_linear(color: impeller2_wkt::Color) -> Vec4 {
+    Vec4::from_array(
+        Color::srgba(color.r, color.g, color.b, color.a)
+            .to_linear()
+            .to_f32_array(),
+    )
+}
+
 #[derive(Component, ShaderType, Clone, Copy, Reflect)]
 pub struct LineUniform {
     pub line_width: f32,
@@ -432,6 +450,7 @@ type LineQueryMut = (
     &'static LineHandles,
     &'static LineConfig,
     &'static mut LineUniform,
+    Option<&'static LineColorSource>,
     Option<&'static mut GpuLine>,
 );
 
@@ -462,20 +481,11 @@ fn extract_lines(
         } else {
             selected_range.clone()
         };
-        let played_color = timeline_settings.played_color;
-        let played_trail_color = Vec4::new(
-            played_color.r,
-            played_color.g,
-            played_color.b,
-            played_color.a,
-        );
-        let mut future_color = Vec4::new(
-            timeline_settings.future_color.r,
-            timeline_settings.future_color.g,
-            timeline_settings.future_color.b,
-            timeline_settings.future_color.a,
-        );
-        future_color.w *= timeline_settings.future_trail_alpha;
+        let future_trail_alpha = timeline_settings.future_trail_alpha;
+        // Fallback colors for lines without an explicit KDL `color`.
+        let played_timeline_color = wkt_color_linear(timeline_settings.played_color);
+        let mut future_timeline_color = wkt_color_linear(timeline_settings.future_color);
+        future_timeline_color.w *= future_trail_alpha;
 
         // Live-follow mode: the whole trail is "already played", so render
         // everything in the played color (yolk) and skip the future pass
@@ -497,7 +507,10 @@ fn extract_lines(
         // the split back onto the previous sample boundary instead.
         let split = selected_range.start.max(current_timestamp.0);
 
-        'outer: for (entity, line_handles, config, uniform, gpu_line) in lines.iter_mut() {
+        'outer: for (entity, line_handles, config, uniform, color_source, gpu_line) in
+            lines.iter_mut()
+        {
+            let use_timeline_colors = color_source.copied() == Some(LineColorSource::Timeline);
             for line in &line_handles.0 {
                 let Some(line) = line_assets.get_mut(line) else {
                     continue 'outer;
@@ -617,7 +630,9 @@ fn extract_lines(
 
             if let Some(gpu_line) = build_gpu_line(played_range.clone()) {
                 let mut played_uniform = *uniform;
-                played_uniform.color = played_trail_color;
+                if use_timeline_colors {
+                    played_uniform.color = played_timeline_color;
+                }
                 commands.spawn((
                     MainEntity::from(entity),
                     line_handles.clone(),
@@ -649,7 +664,11 @@ fn extract_lines(
 
             if let Some(gpu_line) = build_gpu_line(future_range.clone()) {
                 let mut future_uniform = *uniform;
-                future_uniform.color = future_color;
+                if use_timeline_colors {
+                    future_uniform.color = future_timeline_color;
+                } else {
+                    future_uniform.color.w *= future_trail_alpha;
+                }
                 commands.spawn((
                     MainEntity::from(entity),
                     line_handles.clone(),

--- a/libs/elodin-editor/src/ui/plot_3d/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/gpu.rs
@@ -1,10 +1,8 @@
-use std::mem;
-
 use crate::{
     SelectedTimeRange,
     ui::plot::{
         Line,
-        gpu::{INDEX_BUFFER_LEN, INDEX_BUFFER_SIZE, LineHandle, VALUE_BUFFER_SIZE},
+        gpu::{INDEX_BUFFER_LEN, INDEX_BUFFER_SIZE, VALUE_BUFFER_SIZE},
     },
     ui::timeline::TimelineSettings,
 };
@@ -19,9 +17,8 @@ use bevy::{
         prepass::{DeferredPrepass, DepthPrepass, MotionVectorPrepass, NormalPrepass},
     },
     ecs::{
-        bundle::Bundle,
         component::Component,
-        entity::{ContainsEntity, Entity},
+        entity::Entity,
         query::Has,
         schedule::{IntoScheduleConfigs, SystemSet},
         system::{
@@ -34,7 +31,7 @@ use bevy::{
     math::{Mat4, Vec4},
     mesh::VertexBufferLayout,
     pbr::{MeshPipeline, MeshPipelineKey, SetMeshViewBindGroup},
-    prelude::{Color, Deref, Reflect, Resource},
+    prelude::{Color, Reflect, Resource},
     render::{
         ExtractSchedule, MainWorld, Render, RenderApp, RenderSystems,
         extract_component::{ComponentUniforms, DynamicUniformIndex, UniformComponentPlugin},
@@ -52,7 +49,6 @@ use bevy::{
 use bevy_render::{
     extract_component::ExtractComponent,
     sync_world::{MainEntity, SyncToRenderWorld, TemporaryRenderEntity},
-    view::RetainedViewEntity,
 };
 use binding_types::storage_buffer_read_only_sized;
 use impeller2_wkt::{CurrentTimestamp, EarliestTimestamp, LastUpdated};
@@ -382,7 +378,6 @@ pub struct LineConfig {
 pub struct GpuLine {
     values_bind_group: BindGroup,
     index_bind_group: BindGroup,
-    index_buffers: [Buffer; 3],
     count: u32,
 }
 
@@ -446,19 +441,21 @@ type DrawLineData = (
     DrawLine,
 );
 
+type ExtractLinesParams = (
+    Query<'static, 'static, LineQueryMut>,
+    ResMut<'static, Assets<Line>>,
+    Commands<'static, 'static>,
+    Res<'static, SelectedTimeRange>,
+    Res<'static, EarliestTimestamp>,
+    Res<'static, LastUpdated>,
+    Res<'static, CurrentTimestamp>,
+    Res<'static, TimelineSettings>,
+    Res<'static, crate::ui::timeline::LatestFollow>,
+);
+
 #[derive(Resource)]
 struct CachedSystemState {
-    state: SystemState<(
-        Query<'static, 'static, LineQueryMut>,
-        ResMut<'static, Assets<Line>>,
-        Commands<'static, 'static>,
-        Res<'static, SelectedTimeRange>,
-        Res<'static, EarliestTimestamp>,
-        Res<'static, LastUpdated>,
-        Res<'static, CurrentTimestamp>,
-        Res<'static, TimelineSettings>,
-        Res<'static, crate::ui::timeline::LatestFollow>,
-    )>,
+    state: SystemState<ExtractLinesParams>,
 }
 
 impl FromWorld for CachedSystemState {
@@ -595,7 +592,7 @@ fn extract_lines(
                 render_device.create_bind_group("line values", &values_layout.layout, &entries)
             };
 
-            let mut build_gpu_line = |range: std::ops::Range<impeller2::types::Timestamp>| {
+            let build_gpu_line = |range: std::ops::Range<impeller2::types::Timestamp>| {
                 if range.start >= range.end {
                     return None;
                 }
@@ -651,7 +648,6 @@ fn extract_lines(
                 Some(GpuLine {
                     values_bind_group: values_bind_group.clone(),
                     index_bind_group,
-                    index_buffers,
                     count,
                 })
             };

--- a/libs/elodin-editor/src/ui/plot_3d/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/gpu.rs
@@ -378,6 +378,14 @@ pub struct LineConfig {
 pub struct GpuLine {
     values_bind_group: BindGroup,
     index_bind_group: BindGroup,
+    /// Strip indices (decimated by a uniform sampling step to fit
+    /// `INDEX_BUFFER_LEN`) backing `index_bind_group`. This is the GPU-side
+    /// point reduction, distinct from the upstream Hamann-Chen (1994) in-memory
+    /// simplification done on the `LineTree`. Never read directly, but owned
+    /// here so the buffers outlive the bind group / draw rather than relying on
+    /// wgpu's internal reference counting.
+    #[allow(dead_code)]
+    index_buffers: [Buffer; 3],
     count: u32,
 }
 
@@ -648,6 +656,7 @@ fn extract_lines(
                 Some(GpuLine {
                     values_bind_group: values_bind_group.clone(),
                     index_bind_group,
+                    index_buffers,
                     count,
                 })
             };

--- a/libs/elodin-editor/src/ui/plot_3d/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/gpu.rs
@@ -169,13 +169,37 @@ fn update_uniform_model(mut query: Query<(&mut LineUniform, &GlobalTransform)>) 
 #[require(SyncToRenderWorld)]
 pub struct LineHandles(pub [Handle<Line>; 3]);
 
-/// Where a `line_3d` gets its color from.
-#[derive(Component, Debug, Clone, Copy, PartialEq, Eq)]
-pub enum LineColorSource {
-    /// Use the line's own `LineUniform.color` (set from the KDL `color`).
-    Explicit,
-    /// Fall back to the timeline played/future trail colors.
-    Timeline,
+/// Per-line trail colors resolved from the KDL `color`/`future_color`.
+///
+/// Each is linear RGBA; `None` falls back to the timeline trail colors. A line
+/// with only `color` set leaves `future = None`, so the future segment reuses
+/// `played` (the whole line takes that color, just faded).
+#[derive(Component, Debug, Clone, Copy, Default)]
+pub struct LineTrailColors {
+    pub played: Option<Vec4>,
+    pub future: Option<Vec4>,
+}
+
+impl LineTrailColors {
+    /// Resolve the played/future segment colors against the timeline fallbacks.
+    ///
+    /// - played: explicit `played`, else the timeline played color.
+    /// - future: explicit `future`, else explicit `played` (a lone KDL `color`
+    ///   paints the whole line), else the timeline future color.
+    ///
+    /// The future segment's alpha fade (`future_alpha`) is applied uniformly,
+    /// regardless of where the color came from.
+    fn resolve(
+        &self,
+        played_timeline: Vec4,
+        future_timeline: Vec4,
+        future_alpha: f32,
+    ) -> (Vec4, Vec4) {
+        let played = self.played.unwrap_or(played_timeline);
+        let mut future = self.future.or(self.played).unwrap_or(future_timeline);
+        future.w *= future_alpha;
+        (played, future)
+    }
 }
 
 /// Linearize a schematic (sRGB) color for the line shader, preserving alpha.
@@ -450,7 +474,7 @@ type LineQueryMut = (
     &'static LineHandles,
     &'static LineConfig,
     &'static mut LineUniform,
-    Option<&'static LineColorSource>,
+    Option<&'static LineTrailColors>,
     Option<&'static mut GpuLine>,
 );
 
@@ -482,10 +506,10 @@ fn extract_lines(
             selected_range.clone()
         };
         let future_trail_alpha = timeline_settings.future_trail_alpha;
-        // Fallback colors for lines without an explicit KDL `color`.
+        // Fallback colors for lines without explicit KDL colors. Kept unfaded
+        // here; the future segment's alpha fade is applied uniformly below.
         let played_timeline_color = wkt_color_linear(timeline_settings.played_color);
-        let mut future_timeline_color = wkt_color_linear(timeline_settings.future_color);
-        future_timeline_color.w *= future_trail_alpha;
+        let future_timeline_color = wkt_color_linear(timeline_settings.future_color);
 
         // Live-follow mode: the whole trail is "already played", so render
         // everything in the played color (yolk) and skip the future pass
@@ -507,10 +531,14 @@ fn extract_lines(
         // the split back onto the previous sample boundary instead.
         let split = selected_range.start.max(current_timestamp.0);
 
-        'outer: for (entity, line_handles, config, uniform, color_source, gpu_line) in
+        'outer: for (entity, line_handles, config, uniform, trail_colors, gpu_line) in
             lines.iter_mut()
         {
-            let use_timeline_colors = color_source.copied() == Some(LineColorSource::Timeline);
+            let (played_color, future_color) = trail_colors.copied().unwrap_or_default().resolve(
+                played_timeline_color,
+                future_timeline_color,
+                future_trail_alpha,
+            );
             for line in &line_handles.0 {
                 let Some(line) = line_assets.get_mut(line) else {
                     continue 'outer;
@@ -630,9 +658,7 @@ fn extract_lines(
 
             if let Some(gpu_line) = build_gpu_line(played_range.clone()) {
                 let mut played_uniform = *uniform;
-                if use_timeline_colors {
-                    played_uniform.color = played_timeline_color;
-                }
+                played_uniform.color = played_color;
                 commands.spawn((
                     MainEntity::from(entity),
                     line_handles.clone(),
@@ -664,11 +690,7 @@ fn extract_lines(
 
             if let Some(gpu_line) = build_gpu_line(future_range.clone()) {
                 let mut future_uniform = *uniform;
-                if use_timeline_colors {
-                    future_uniform.color = future_timeline_color;
-                } else {
-                    future_uniform.color.w *= future_trail_alpha;
-                }
+                future_uniform.color = future_color;
                 commands.spawn((
                     MainEntity::from(entity),
                     line_handles.clone(),
@@ -761,5 +783,62 @@ fn queue_line(
                 indexed: true,
             });
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PLAYED_TL: Vec4 = Vec4::new(1.0, 1.0, 0.0, 1.0); // timeline played (yalk-ish)
+    const FUTURE_TL: Vec4 = Vec4::new(1.0, 1.0, 1.0, 1.0); // timeline future (white)
+    const G: Vec4 = Vec4::new(0.0, 1.0, 0.0, 1.0); // KDL `color green`
+    const W: Vec4 = Vec4::new(1.0, 1.0, 1.0, 1.0); // KDL `future_color white`
+    const ALPHA: f32 = 0.5;
+
+    fn resolve(trail: LineTrailColors) -> (Vec4, Vec4) {
+        trail.resolve(PLAYED_TL, FUTURE_TL, ALPHA)
+    }
+
+    fn faded(mut c: Vec4) -> Vec4 {
+        c.w *= ALPHA;
+        c
+    }
+
+    #[test]
+    fn no_kdl_colors_use_timeline() {
+        let (played, future) = resolve(LineTrailColors::default());
+        assert_eq!(played, PLAYED_TL);
+        assert_eq!(future, faded(FUTURE_TL));
+    }
+
+    #[test]
+    fn color_only_paints_whole_line() {
+        let (played, future) = resolve(LineTrailColors {
+            played: Some(G),
+            future: None,
+        });
+        assert_eq!(played, G);
+        assert_eq!(future, faded(G));
+    }
+
+    #[test]
+    fn color_and_future_color_are_independent() {
+        let (played, future) = resolve(LineTrailColors {
+            played: Some(G),
+            future: Some(W),
+        });
+        assert_eq!(played, G);
+        assert_eq!(future, faded(W));
+    }
+
+    #[test]
+    fn future_color_only_keeps_timeline_played() {
+        let (played, future) = resolve(LineTrailColors {
+            played: None,
+            future: Some(W),
+        });
+        assert_eq!(played, PLAYED_TL);
+        assert_eq!(future, faded(W));
     }
 }

--- a/libs/elodin-editor/src/ui/plot_3d/mod.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/mod.rs
@@ -21,11 +21,13 @@ use crate::{EqlContext, ui::schematic::EqlExt};
 
 pub mod gpu;
 
-/// Convert a schematic (sRGB) color into the linear RGB the line pipeline renders,
-/// keeping it consistent with meshes/gizmos. Alpha is forced opaque.
+/// Convert a schematic (sRGB) color into the linear RGBA the line pipeline
+/// renders, keeping it consistent with meshes/gizmos. Alpha is preserved so a
+/// KDL `color`/`future_color` can set per-line opacity (the future segment is
+/// additionally faded by the timeline `future_trail_alpha`).
 fn line_color_linear(color: &impeller2_wkt::Color) -> Vec4 {
     let linear = Color::srgba(color.r, color.g, color.b, color.a).to_linear();
-    Vec4::new(linear.red, linear.green, linear.blue, 1.0)
+    Vec4::new(linear.red, linear.green, linear.blue, linear.alpha)
 }
 
 /// Resolve a `line_3d`'s played/future trail colors from its KDL `color`/
@@ -41,7 +43,12 @@ fn line_trail_colors(line_plot: &Line3d) -> gpu::LineTrailColors {
 pub fn sync_line_plot_3d(
     line_plot_3d_query: Query<(Entity, &Line3d), Without<gpu::LineHandles>>,
     mut uniforms: Query<
-        (&Line3d, &mut LineUniform, &mut gpu::LineTrailColors),
+        (
+            Entity,
+            &Line3d,
+            &mut LineUniform,
+            Option<&mut gpu::LineTrailColors>,
+        ),
         With<gpu::LineHandles>,
     >,
     mut commands: Commands,
@@ -113,12 +120,22 @@ pub fn sync_line_plot_3d(
             }
         }
     }
-    for (line_plot, mut uniform, mut trail) in uniforms.iter_mut() {
+    for (entity, line_plot, mut uniform, trail) in uniforms.iter_mut() {
         let next = line_trail_colors(line_plot);
         uniform.color = next.played.unwrap_or(Vec4::ZERO);
         uniform.line_width = line_plot.line_width;
         uniform.perspective = if line_plot.perspective { 1 } else { 0 };
-        *trail = next;
+        // Entities that have handles but lost their trail colors (e.g. an older
+        // build) still get width/perspective/color re-applied; re-attach the
+        // trail colors so rendering doesn't silently fall back to defaults.
+        match trail {
+            Some(mut trail) => *trail = next,
+            None => {
+                if let Ok(mut entity) = commands.get_entity(entity) {
+                    entity.try_insert(next);
+                }
+            }
+        }
     }
 }
 
@@ -129,5 +146,19 @@ impl bevy::app::Plugin for LinePlot3dPlugin {
         app.init_resource::<CollectedGraphData>()
             .add_plugins(gpu::Plot3dGpuPlugin)
             .add_systems(Update, sync_line_plot_3d);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn line_color_linear_preserves_alpha() {
+        // A KDL color/future_color alpha must survive into the line uniform
+        // (sRGB->linear leaves alpha untouched); only the timeline
+        // future_trail_alpha should fade it further, applied in `resolve`.
+        let color = impeller2_wkt::Color::rgba(1.0, 1.0, 1.0, 0.25);
+        assert_eq!(line_color_linear(&color).w, 0.25);
     }
 }

--- a/libs/elodin-editor/src/ui/plot_3d/mod.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/mod.rs
@@ -39,9 +39,21 @@ fn line_color_linear(color: &impeller2_wkt::Color) -> Vec4 {
     Vec4::new(linear.red, linear.green, linear.blue, 1.0)
 }
 
+/// Resolve a `line_3d` color: an explicit KDL color uses the line's own color,
+/// otherwise the timeline played/future trail colors are used at render time.
+fn line_color_and_source(color: &Option<impeller2_wkt::Color>) -> (Vec4, gpu::LineColorSource) {
+    match color {
+        Some(color) => (line_color_linear(color), gpu::LineColorSource::Explicit),
+        None => (Vec4::ZERO, gpu::LineColorSource::Timeline),
+    }
+}
+
 pub fn sync_line_plot_3d(
     line_plot_3d_query: Query<(Entity, &Line3d), Without<gpu::LineHandles>>,
-    mut uniforms: Query<(&Line3d, &mut LineUniform), With<gpu::LineHandles>>,
+    mut uniforms: Query<
+        (&Line3d, &mut LineUniform, &mut gpu::LineColorSource),
+        With<gpu::LineHandles>,
+    >,
     mut lines: ResMut<Assets<Line>>,
     mut commands: Commands,
     eql_ctx: Res<EqlContext>,
@@ -88,18 +100,20 @@ pub fn sync_line_plot_3d(
             continue;
         };
 
+        let (color, color_source) = line_color_and_source(&line_plot.color);
         if let Ok(mut entity) = commands.get_entity(entity) {
             entity.try_insert((
                 gpu::LineHandles([x, y, z]),
                 LineUniform {
                     line_width: line_plot.line_width,
-                    color: line_color_linear(&line_plot.color),
+                    color,
                     depth_bias: 0.0,
                     model: Mat4::IDENTITY,
                     perspective: if line_plot.perspective { 1 } else { 0 },
                     #[cfg(target_arch = "wasm32")]
                     _padding: Default::default(),
                 },
+                color_source,
                 LineConfig {
                     render_layers: RenderLayers::layer(crate::plugins::gizmos::GIZMO_RENDER_LAYER),
                 },
@@ -111,10 +125,12 @@ pub fn sync_line_plot_3d(
             }
         }
     }
-    for (line_plot, mut uniform) in uniforms.iter_mut() {
-        uniform.color = line_color_linear(&line_plot.color);
+    for (line_plot, mut uniform, mut color_source) in uniforms.iter_mut() {
+        let (color, source) = line_color_and_source(&line_plot.color);
+        uniform.color = color;
         uniform.line_width = line_plot.line_width;
         uniform.perspective = if line_plot.perspective { 1 } else { 0 };
+        *color_source = source;
     }
 }
 

--- a/libs/elodin-editor/src/ui/plot_3d/mod.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/mod.rs
@@ -1,11 +1,6 @@
-#![allow(warnings)]
-
-use std::collections::BTreeMap;
-
 use bevy::{
-    animation::graph,
-    app::{Startup, Update},
-    asset::{Assets, Handle},
+    app::Update,
+    asset::Handle,
     camera::visibility::RenderLayers,
     ecs::{
         entity::Entity,
@@ -15,20 +10,14 @@ use bevy::{
     math::{DQuat, Mat4, Vec4},
     prelude::Color,
 };
-use bevy_geo_frames::{GeoContext, GeoFrame, GeoRotation};
-use eql;
-use impeller2_bevy::{CommandsExt, ComponentMetadataRegistry, EntityMap};
-use impeller2_wkt::LastUpdated;
-use impeller2_wkt::{ComponentValue, EntityMetadata, GetTimeSeries, Line3d};
+use bevy_geo_frames::GeoRotation;
+use impeller2_bevy::ComponentMetadataRegistry;
+use impeller2_wkt::Line3d;
 
 use gpu::{LineConfig, LineUniform};
 
 use super::plot::{CollectedGraphData, Line, PlotDataComponent};
-use crate::{
-    EqlContext,
-    object_3d::{CompiledExpr, EditableEQL, compile_eql_expr},
-    ui::schematic::EqlExt,
-};
+use crate::{EqlContext, ui::schematic::EqlExt};
 
 pub mod gpu;
 
@@ -55,12 +44,10 @@ pub fn sync_line_plot_3d(
         (&Line3d, &mut LineUniform, &mut gpu::LineTrailColors),
         With<gpu::LineHandles>,
     >,
-    mut lines: ResMut<Assets<Line>>,
     mut commands: Commands,
     eql_ctx: Res<EqlContext>,
     mut collected_graph_data: ResMut<CollectedGraphData>,
     metadata_store: Res<ComponentMetadataRegistry>,
-    geo_ctx: Option<Res<GeoContext>>,
 ) {
     for (entity, line_plot) in line_plot_3d_query.iter() {
         // Parse and compile the EQL expression

--- a/libs/elodin-editor/src/ui/plot_3d/mod.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/mod.rs
@@ -13,6 +13,7 @@ use bevy::{
         system::{Commands, Query, Res, ResMut},
     },
     math::{DQuat, Mat4, Vec4},
+    prelude::Color,
 };
 use bevy_geo_frames::{GeoContext, GeoFrame, GeoRotation};
 use eql;
@@ -30,6 +31,13 @@ use crate::{
 };
 
 pub mod gpu;
+
+/// Convert a schematic (sRGB) color into the linear RGB the line pipeline renders,
+/// keeping it consistent with meshes/gizmos. Alpha is forced opaque.
+fn line_color_linear(color: &impeller2_wkt::Color) -> Vec4 {
+    let linear = Color::srgba(color.r, color.g, color.b, color.a).to_linear();
+    Vec4::new(linear.red, linear.green, linear.blue, 1.0)
+}
 
 pub fn sync_line_plot_3d(
     line_plot_3d_query: Query<(Entity, &Line3d), Without<gpu::LineHandles>>,
@@ -85,7 +93,7 @@ pub fn sync_line_plot_3d(
                 gpu::LineHandles([x, y, z]),
                 LineUniform {
                     line_width: line_plot.line_width,
-                    color: Vec4::new(line_plot.color.r, line_plot.color.g, line_plot.color.b, 1.0),
+                    color: line_color_linear(&line_plot.color),
                     depth_bias: 0.0,
                     model: Mat4::IDENTITY,
                     perspective: if line_plot.perspective { 1 } else { 0 },
@@ -104,7 +112,7 @@ pub fn sync_line_plot_3d(
         }
     }
     for (line_plot, mut uniform) in uniforms.iter_mut() {
-        uniform.color = Vec4::new(line_plot.color.r, line_plot.color.g, line_plot.color.b, 1.0);
+        uniform.color = line_color_linear(&line_plot.color);
         uniform.line_width = line_plot.line_width;
         uniform.perspective = if line_plot.perspective { 1 } else { 0 };
     }

--- a/libs/elodin-editor/src/ui/plot_3d/mod.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/mod.rs
@@ -39,19 +39,20 @@ fn line_color_linear(color: &impeller2_wkt::Color) -> Vec4 {
     Vec4::new(linear.red, linear.green, linear.blue, 1.0)
 }
 
-/// Resolve a `line_3d` color: an explicit KDL color uses the line's own color,
-/// otherwise the timeline played/future trail colors are used at render time.
-fn line_color_and_source(color: &Option<impeller2_wkt::Color>) -> (Vec4, gpu::LineColorSource) {
-    match color {
-        Some(color) => (line_color_linear(color), gpu::LineColorSource::Explicit),
-        None => (Vec4::ZERO, gpu::LineColorSource::Timeline),
+/// Resolve a `line_3d`'s played/future trail colors from its KDL `color`/
+/// `future_color`. `None` entries fall back to the timeline colors at render
+/// time (see `extract_lines`).
+fn line_trail_colors(line_plot: &Line3d) -> gpu::LineTrailColors {
+    gpu::LineTrailColors {
+        played: line_plot.color.as_ref().map(line_color_linear),
+        future: line_plot.future_color.as_ref().map(line_color_linear),
     }
 }
 
 pub fn sync_line_plot_3d(
     line_plot_3d_query: Query<(Entity, &Line3d), Without<gpu::LineHandles>>,
     mut uniforms: Query<
-        (&Line3d, &mut LineUniform, &mut gpu::LineColorSource),
+        (&Line3d, &mut LineUniform, &mut gpu::LineTrailColors),
         With<gpu::LineHandles>,
     >,
     mut lines: ResMut<Assets<Line>>,
@@ -100,20 +101,20 @@ pub fn sync_line_plot_3d(
             continue;
         };
 
-        let (color, color_source) = line_color_and_source(&line_plot.color);
+        let trail = line_trail_colors(line_plot);
         if let Ok(mut entity) = commands.get_entity(entity) {
             entity.try_insert((
                 gpu::LineHandles([x, y, z]),
                 LineUniform {
                     line_width: line_plot.line_width,
-                    color,
+                    color: trail.played.unwrap_or(Vec4::ZERO),
                     depth_bias: 0.0,
                     model: Mat4::IDENTITY,
                     perspective: if line_plot.perspective { 1 } else { 0 },
                     #[cfg(target_arch = "wasm32")]
                     _padding: Default::default(),
                 },
-                color_source,
+                trail,
                 LineConfig {
                     render_layers: RenderLayers::layer(crate::plugins::gizmos::GIZMO_RENDER_LAYER),
                 },
@@ -125,12 +126,12 @@ pub fn sync_line_plot_3d(
             }
         }
     }
-    for (line_plot, mut uniform, mut color_source) in uniforms.iter_mut() {
-        let (color, source) = line_color_and_source(&line_plot.color);
-        uniform.color = color;
+    for (line_plot, mut uniform, mut trail) in uniforms.iter_mut() {
+        let next = line_trail_colors(line_plot);
+        uniform.color = next.played.unwrap_or(Vec4::ZERO);
         uniform.line_width = line_plot.line_width;
         uniform.perspective = if line_plot.perspective { 1 } else { 0 };
-        *color_source = source;
+        *trail = next;
     }
 }
 

--- a/libs/elodin-editor/src/ui/plot_3d/mod.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/mod.rs
@@ -22,7 +22,7 @@ use impeller2_wkt::{ComponentValue, EntityMetadata, GetTimeSeries, Line3d};
 
 use gpu::{LineConfig, LineUniform};
 
-use super::plot::{CollectedGraphData, Line, PlotDataComponent, gpu::LineHandle};
+use super::plot::{CollectedGraphData, Line, PlotDataComponent};
 use crate::{
     EqlContext,
     object_3d::{CompiledExpr, EditableEQL, compile_eql_expr},
@@ -33,7 +33,7 @@ pub mod gpu;
 
 pub fn sync_line_plot_3d(
     line_plot_3d_query: Query<(Entity, &Line3d), Without<gpu::LineHandles>>,
-    mut uniforms: Query<(&Line3d, &mut LineUniform), With<LineHandle>>,
+    mut uniforms: Query<(&Line3d, &mut LineUniform), With<gpu::LineHandles>>,
     mut lines: ResMut<Assets<Line>>,
     mut commands: Commands,
     eql_ctx: Res<EqlContext>,

--- a/libs/impeller2/kdl/README.md
+++ b/libs/impeller2/kdl/README.md
@@ -88,7 +88,7 @@ All scene nodes support an optional `frame` attribute (`ENU`, `NED`, or `ECEF`) 
   - `plane [size=10.0] [width=size] [depth=size]`
   - `ellipsoid [scale="(1, 1, 1)"]`
   - mesh nodes support optional `color` and optional `emissivity` (clamped to `[0.0, 1.0]` on serialization).
-- `line_3d <eql> [frame=ENU|NED|ECEF] [line_width=1.0] [color] [perspective=#true]`
+- `line_3d <eql> [frame=ENU|NED|ECEF] [line_width=1.0] [color] [future_color] [perspective=#true]` — `color` is the played segment (falls back to timeline `played_color`); `future_color` is the future segment (falls back to `color`, then timeline `future_color`).
 - `vector_arrow <vector-eql> [frame=ENU|NED|ECEF] [origin] [scale=1.0] [name] [body_frame|in_body_frame=#false] [normalize=#false] [show_name|display_name=#true] [arrow_thickness=0.1] [label_position] [color]`
 
 ## Defaults And Aliases

--- a/libs/impeller2/kdl/src/de.rs
+++ b/libs/impeller2/kdl/src/de.rs
@@ -1462,6 +1462,7 @@ fn parse_line_3d(node: &KdlNode, src: &str) -> Result<Line3d, KdlSchematicError>
         .unwrap_or(1.0) as f32;
 
     let color = parse_color_from_node_or_children(node, None);
+    let future_color = parse_named_color_field(node, "future_color");
 
     let perspective = node
         .get("perspective")
@@ -1477,10 +1478,34 @@ fn parse_line_3d(node: &KdlNode, src: &str) -> Result<Line3d, KdlSchematicError>
         eql,
         line_width,
         color,
+        future_color,
         perspective,
         frame,
         node_id: NodeId::default(),
     })
+}
+
+/// Parses a named color field (e.g. `future_color`) from a property string or a
+/// matching child node. Unlike [`parse_color_from_node_or_children`], this never
+/// reads the node's own positional color args.
+fn parse_named_color_field(node: &KdlNode, field: &str) -> Option<Color> {
+    if let Some(text) = node.get(field).and_then(|v| v.as_string())
+        && let Some(color) = parse_color_from_text(text)
+    {
+        return Some(color);
+    }
+
+    if let Some(children) = node.children() {
+        for child in children.nodes() {
+            if child.name().value() == field
+                && let Some(color) = parse_color_from_node(child)
+            {
+                return Some(color);
+            }
+        }
+    }
+
+    None
 }
 
 fn parse_arrow_thickness(node: &KdlNode, src: &str) -> Result<ArrowThickness, KdlSchematicError> {
@@ -2864,6 +2889,29 @@ tabs {
             panic!("Expected line_3d");
         };
         assert_eq!(line.color, None);
+        assert_eq!(line.future_color, None);
+    }
+
+    #[test]
+    fn test_parse_line_3d_future_color() {
+        // Played and future colors can be set independently from KDL.
+        let schematic =
+            parse_schematic(r#"line_3d "traj" { color 0 255 0; future_color 255 255 255 }"#)
+                .unwrap();
+        let SchematicElem::Line3d(line) = &schematic.elems[0] else {
+            panic!("Expected line_3d");
+        };
+        assert_eq!(line.color, Some(Color::GREEN));
+        assert_eq!(line.future_color, Some(Color::WHITE));
+
+        // `future_color` also accepts a named color as a child node.
+        let schematic =
+            parse_schematic(r#"line_3d "traj" { color green; future_color green }"#).unwrap();
+        let SchematicElem::Line3d(line) = &schematic.elems[0] else {
+            panic!("Expected line_3d");
+        };
+        assert_eq!(line.color, Some(Color::GREEN));
+        assert_eq!(line.future_color, Some(Color::GREEN));
     }
 
     #[test]

--- a/libs/impeller2/kdl/src/de.rs
+++ b/libs/impeller2/kdl/src/de.rs
@@ -1461,7 +1461,7 @@ fn parse_line_3d(node: &KdlNode, src: &str) -> Result<Line3d, KdlSchematicError>
         .and_then(|v| v.as_float())
         .unwrap_or(1.0) as f32;
 
-    let color = parse_color_from_node_or_children(node, None).unwrap_or(Color::WHITE);
+    let color = parse_color_from_node_or_children(node, None);
 
     let perspective = node
         .get("perspective")
@@ -2839,13 +2839,31 @@ tabs {
         if let SchematicElem::Line3d(line) = &schematic.elems[0] {
             assert_eq!(line.eql, "trajectory");
             assert_eq!(line.line_width, 2.0);
-            assert_eq!(line.color.r, Color::MINT.r);
-            assert_eq!(line.color.g, Color::MINT.g);
-            assert_eq!(line.color.b, Color::MINT.b);
+            let color = line.color.expect("color");
+            assert_eq!(color.r, Color::MINT.r);
+            assert_eq!(color.g, Color::MINT.g);
+            assert_eq!(color.b, Color::MINT.b);
             assert!(!line.perspective);
         } else {
             panic!("Expected line_3d");
         }
+    }
+
+    #[test]
+    fn test_parse_line_3d_color_optional() {
+        // Explicit KDL color must be honored.
+        let schematic = parse_schematic(r#"line_3d "traj" { color 0 255 0 }"#).unwrap();
+        let SchematicElem::Line3d(line) = &schematic.elems[0] else {
+            panic!("Expected line_3d");
+        };
+        assert_eq!(line.color, Some(Color::GREEN));
+
+        // No color falls back to the timeline trail colors (None at parse time).
+        let schematic = parse_schematic(r#"line_3d "traj""#).unwrap();
+        let SchematicElem::Line3d(line) = &schematic.elems[0] else {
+            panic!("Expected line_3d");
+        };
+        assert_eq!(line.color, None);
     }
 
     #[test]

--- a/libs/impeller2/kdl/src/ser.rs
+++ b/libs/impeller2/kdl/src/ser.rs
@@ -924,6 +924,10 @@ fn serialize_line_3d(line: &Line3d) -> KdlNode {
         serialize_color_to_node(&mut node, &color);
     }
 
+    if let Some(future_color) = line.future_color {
+        serialize_color_to_node_named(&mut node, &future_color, Some("future_color"));
+    }
+
     if !line.perspective {
         node.entries_mut()
             .push(KdlEntry::new_prop("perspective", false));
@@ -1616,6 +1620,7 @@ object_3d lander.world_pos {
             eql: "ball.world_pos".to_string(),
             line_width: 2.0,
             color: Some(Color::WHITE),
+            future_color: None,
             perspective: true,
             frame: Some(GeoFrame::ENU),
             node_id: NodeId::next(),
@@ -1726,6 +1731,7 @@ object_3d lander.world_pos {
             eql: "trajectory".to_string(),
             line_width: 2.0,
             color: Some(Color::MINT),
+            future_color: Some(Color::WHITE),
             perspective: false,
             frame: None,
             node_id: NodeId::default(),
@@ -1739,6 +1745,7 @@ object_3d lander.world_pos {
             assert_eq!(line.eql, "trajectory");
             assert_eq!(line.line_width, 2.0);
             assert_color_close(line.color.expect("color"), Color::MINT);
+            assert_color_close(line.future_color.expect("future_color"), Color::WHITE);
             assert!(!line.perspective);
         } else {
             panic!("Expected line_3d");

--- a/libs/impeller2/kdl/src/ser.rs
+++ b/libs/impeller2/kdl/src/ser.rs
@@ -920,7 +920,9 @@ fn serialize_line_3d(line: &Line3d) -> KdlNode {
             .push(KdlEntry::new_prop("frame", <&str>::from(frame)));
     }
 
-    serialize_color_to_node(&mut node, &line.color);
+    if let Some(color) = line.color {
+        serialize_color_to_node(&mut node, &color);
+    }
 
     if !line.perspective {
         node.entries_mut()
@@ -1613,7 +1615,7 @@ object_3d lander.world_pos {
         schematic.elems.push(SchematicElem::Line3d(Line3d {
             eql: "ball.world_pos".to_string(),
             line_width: 2.0,
-            color: Color::WHITE,
+            color: Some(Color::WHITE),
             perspective: true,
             frame: Some(GeoFrame::ENU),
             node_id: NodeId::next(),
@@ -1723,7 +1725,7 @@ object_3d lander.world_pos {
         schematic.elems.push(SchematicElem::Line3d(Line3d {
             eql: "trajectory".to_string(),
             line_width: 2.0,
-            color: Color::MINT,
+            color: Some(Color::MINT),
             perspective: false,
             frame: None,
             node_id: NodeId::default(),
@@ -1736,7 +1738,7 @@ object_3d lander.world_pos {
         if let SchematicElem::Line3d(line) = &parsed.elems[0] {
             assert_eq!(line.eql, "trajectory");
             assert_eq!(line.line_width, 2.0);
-            assert_color_close(line.color, Color::MINT);
+            assert_color_close(line.color.expect("color"), Color::MINT);
             assert!(!line.perspective);
         } else {
             panic!("Expected line_3d");

--- a/libs/impeller2/wkt/src/gui.rs
+++ b/libs/impeller2/wkt/src/gui.rs
@@ -365,9 +365,13 @@ pub enum GraphType {
 pub struct Line3d {
     pub eql: String,
     pub line_width: f32,
-    /// `None` falls back to the timeline played/future trail colors.
+    /// Played-segment color. `None` falls back to the timeline played color.
     #[serde(default)]
     pub color: Option<Color>,
+    /// Future-segment color. `None` falls back to `color`, then the timeline
+    /// future color.
+    #[serde(default)]
+    pub future_color: Option<Color>,
     pub perspective: bool,
     #[serde(default)]
     pub frame: Option<bevy_geo_frames::GeoFrame>,

--- a/libs/impeller2/wkt/src/gui.rs
+++ b/libs/impeller2/wkt/src/gui.rs
@@ -24,7 +24,7 @@ fn default_true() -> bool {
 }
 
 pub fn default_timeline_played_color() -> Color {
-    Color::YELLOW
+    Color::YALK
 }
 
 pub fn default_timeline_future_color() -> Color {
@@ -365,7 +365,9 @@ pub enum GraphType {
 pub struct Line3d {
     pub eql: String,
     pub line_width: f32,
-    pub color: Color,
+    /// `None` falls back to the timeline played/future trail colors.
+    #[serde(default)]
+    pub color: Option<Color>,
     pub perspective: bool,
     #[serde(default)]
     pub frame: Option<bevy_geo_frames::GeoFrame>,


### PR DESCRIPTION
## What this adds

A `line_3d` trail is drawn in two parts: the **played** segment (up to the current playback time) and the **future** segment (ahead of it). You can now control the color of each part directly from KDL.
- `color` sets the **played** segment color.
- `future_color` (new) sets the **future** segment color.
- A single `color` paints the **whole** trail — you no longer need to repeat it for the future part.
- When a color is not set, it falls back to the global **timeline** colors (`played_color` defaults to `yalk`, `future_color` defaults to `white`).

The future segment is always faded by the timeline `future_trail_alpha`, whatever its color comes from.

## KDL configurations

### 1. Nothing — use timeline defaults

```kdl
line_3d rocket.world_pos
```

Played = timeline `played_color` (yalk), future = timeline `future_color` (white).

### 2. One color — paint the whole trail

```kdl
line_3d rocket.world_pos {
    color green
}
```

The entire trail is green (the future part is the same green, just faded).

### 3. Two colors — played vs future

```kdl
line_3d rocket.world_pos {
    color green
    future_color white
}
```

Played = green, future = white.

### 4. Future color only — keep the timeline played color

```kdl
line_3d rocket.world_pos {
    future_color white
}
```

Played = timeline `played_color` (yalk), future = white.

### Color syntax

Colors accept named values (`green`, `white`, `red`, ...) or RGB(A) tuples:

```kdl
line_3d rocket.world_pos {
    color 0 255 0
    future_color 255 255 255 128
}
```

---

## Timeline inspector wording

The timeline color pickers were renamed for clarity. They set the timeline's playback colors — used by the LIVE badge and the timeline cursors — so the "TRAIL" wording (which made them sound specific to the 3D `line_3d` trail) was dropped:

- `PLAYED TRAIL` → `PLAYED COLOR`
- `FUTURE TRAIL` → `FUTURE COLOR`
- `FUTURE TRAIL ALPHA` → `FUTURE TRAIL OPACITY` (this one *does* only affect the
  3D trail, so it keeps "trail")

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Visualization and KDL/schema changes only; optional fields and unit tests cover color fallback behavior.
> 
> **Overview**
> Adds **`future_color`** on `line_3d` and makes **`color` optional**, so played vs future trail segments can be styled in KDL. **`color`** is the played segment; omitting it uses timeline **`played_color`** (default **`yalk`**). **`future_color`** is the ahead-of-playhead segment; it falls back to **`color`**, then timeline **`future_color`**. A lone **`color`** tints the whole line; the future part still uses **`future_trail_alpha`**.
> 
> The 3D line path resolves those values at draw time via **`LineTrailColors`**, linearizes sRGB, and applies timeline fallbacks in **`extract_lines`**. Timeline inspector labels are renamed (**PLAYED COLOR**, **FUTURE COLOR**, **FUTURE TRAIL OPACITY**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0bcac42e64a7f2e3d611f02fa15d2e0b7fe1c1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->