### PR TITLE
chore(plot_3d): Remove blanket `#![allow(warnings)]` and fix surfaced lints.

### DIFF
--- a/libs/elodin-editor/src/ui/plot_3d/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/gpu.rs
@@ -1,10 +1,8 @@
-use std::mem;
-
 use crate::{
     SelectedTimeRange,
     ui::plot::{
         Line,
-        gpu::{INDEX_BUFFER_LEN, INDEX_BUFFER_SIZE, LineHandle, VALUE_BUFFER_SIZE},
+        gpu::{INDEX_BUFFER_LEN, INDEX_BUFFER_SIZE, VALUE_BUFFER_SIZE},
     },
     ui::timeline::TimelineSettings,
 };
@@ -19,9 +17,8 @@ use bevy::{
         prepass::{DeferredPrepass, DepthPrepass, MotionVectorPrepass, NormalPrepass},
     },
     ecs::{
-        bundle::Bundle,
         component::Component,
-        entity::{ContainsEntity, Entity},
+        entity::Entity,
         query::Has,
         schedule::{IntoScheduleConfigs, SystemSet},
         system::{
@@ -34,7 +31,7 @@ use bevy::{
     math::{Mat4, Vec4},
     mesh::VertexBufferLayout,
     pbr::{MeshPipeline, MeshPipelineKey, SetMeshViewBindGroup},
-    prelude::{Color, Deref, Reflect, Resource},
+    prelude::{Color, Reflect, Resource},
     render::{
         ExtractSchedule, MainWorld, Render, RenderApp, RenderSystems,
         extract_component::{ComponentUniforms, DynamicUniformIndex, UniformComponentPlugin},
@@ -52,7 +49,6 @@ use bevy::{
 use bevy_render::{
     extract_component::ExtractComponent,
     sync_world::{MainEntity, SyncToRenderWorld, TemporaryRenderEntity},
-    view::RetainedViewEntity,
 };
 use binding_types::storage_buffer_read_only_sized;
 use impeller2_wkt::{CurrentTimestamp, EarliestTimestamp, LastUpdated};
@@ -382,7 +378,6 @@ pub struct LineConfig {
 pub struct GpuLine {
     values_bind_group: BindGroup,
     index_bind_group: BindGroup,
-    index_buffers: [Buffer; 3],
     count: u32,
 }
 
@@ -446,19 +441,21 @@ type DrawLineData = (
     DrawLine,
 );
 
+type ExtractLinesParams = (
+    Query<'static, 'static, LineQueryMut>,
+    ResMut<'static, Assets<Line>>,
+    Commands<'static, 'static>,
+    Res<'static, SelectedTimeRange>,
+    Res<'static, EarliestTimestamp>,
+    Res<'static, LastUpdated>,
+    Res<'static, CurrentTimestamp>,
+    Res<'static, TimelineSettings>,
+    Res<'static, crate::ui::timeline::LatestFollow>,
+);
+
 #[derive(Resource)]
 struct CachedSystemState {
-    state: SystemState<(
-        Query<'static, 'static, LineQueryMut>,
-        ResMut<'static, Assets<Line>>,
-        Commands<'static, 'static>,
-        Res<'static, SelectedTimeRange>,
-        Res<'static, EarliestTimestamp>,
-        Res<'static, LastUpdated>,
-        Res<'static, CurrentTimestamp>,
-        Res<'static, TimelineSettings>,
-        Res<'static, crate::ui::timeline::LatestFollow>,
-    )>,
+    state: SystemState<ExtractLinesParams>,
 }
 
 impl FromWorld for CachedSystemState {
@@ -595,7 +592,7 @@ fn extract_lines(
                 render_device.create_bind_group("line values", &values_layout.layout, &entries)
             };
 
-            let mut build_gpu_line = |range: std::ops::Range<impeller2::types::Timestamp>| {
+            let build_gpu_line = |range: std::ops::Range<impeller2::types::Timestamp>| {
                 if range.start >= range.end {
                     return None;
                 }
@@ -651,7 +648,6 @@ fn extract_lines(
                 Some(GpuLine {
                     values_bind_group: values_bind_group.clone(),
                     index_bind_group,
-                    index_buffers,
                     count,
                 })
             };

--- a/libs/elodin-editor/src/ui/plot_3d/mod.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/mod.rs
@@ -1,11 +1,6 @@
-#![allow(warnings)]
-
-use std::collections::BTreeMap;
-
 use bevy::{
-    animation::graph,
-    app::{Startup, Update},
-    asset::{Assets, Handle},
+    app::Update,
+    asset::Handle,
     camera::visibility::RenderLayers,
     ecs::{
         entity::Entity,
@@ -15,20 +10,14 @@ use bevy::{
     math::{DQuat, Mat4, Vec4},
     prelude::{Color, Transform},
 };
-use bevy_geo_frames::{GeoContext, GeoFrame, GeoRotation};
-use eql;
-use impeller2_bevy::{CommandsExt, ComponentMetadataRegistry, EntityMap};
-use impeller2_wkt::LastUpdated;
-use impeller2_wkt::{ComponentValue, EntityMetadata, GetTimeSeries, Line3d};
+use bevy_geo_frames::GeoRotation;
+use impeller2_bevy::ComponentMetadataRegistry;
+use impeller2_wkt::Line3d;
 
 use gpu::{LineConfig, LineUniform};
 
 use super::plot::{CollectedGraphData, Line, PlotDataComponent};
-use crate::{
-    EqlContext,
-    object_3d::{CompiledExpr, EditableEQL, compile_eql_expr},
-    ui::schematic::EqlExt,
-};
+use crate::{EqlContext, ui::schematic::EqlExt};
 
 pub mod gpu;
 
@@ -55,12 +44,10 @@ pub fn sync_line_plot_3d(
         (&Line3d, &mut LineUniform, &mut gpu::LineTrailColors),
         With<gpu::LineHandles>,
     >,
-    mut lines: ResMut<Assets<Line>>,
     mut commands: Commands,
     eql_ctx: Res<EqlContext>,
     mut collected_graph_data: ResMut<CollectedGraphData>,
     metadata_store: Res<ComponentMetadataRegistry>,
-    geo_ctx: Option<Res<GeoContext>>,
 ) {
     for (entity, line_plot) in line_plot_3d_query.iter() {
         // Parse and compile the EQL expression


### PR DESCRIPTION
> [chore/line3D-warnings-707](https://github.com/elodin-sys/elodin/tree/chore/line3D-warnings-707) (current) based on [fix/line3d-704](https://github.com/elodin-sys/elodin/tree/fix/line3d-704) (see #706).

---

## Summary

`libs/elodin-editor/src/ui/plot_3d/mod.rs` carried a module-wide `#![allow(warnings)]`. Because lint levels cascade into child modules, it also silenced `plot_3d/gpu.rs`, so `cargo clippy -Dwarnings` reported a false "clean" for the whole 3D line/trail rendering code.

This PR removes that blanket allow and fixes every warning it was hiding.

## Changes

**`plot_3d/mod.rs`**
- Removed the `#![allow(warnings)]` attribute.
- Removed dead imports (`BTreeMap`, `Startup`, `animation::graph`, `GeoFrame`, `eql`, `CommandsExt`, `EntityMap`, `LastUpdated`, `ComponentValue`, `EntityMetadata`, `GetTimeSeries`, `CompiledExpr`, `EditableEQL`, `compile_eql_expr`, `GeoContext`).
- Dropped two unused system params from `sync_line_plot_3d`: `lines` (`ResMut<Assets<Line>>`) and `geo_ctx` (`Option<Res<GeoContext>>`).

**`plot_3d/gpu.rs`**
- Removed dead imports (`std::mem`, `LineHandle`, `Bundle`, `ContainsEntity`, `Deref`, `RetainedViewEntity`).
- Removed an unnecessary `mut` on the `build_gpu_line` closure.
- Removed the never-read `GpuLine::index_buffers` field (the `BindGroup` keeps the underlying buffers alive, so this is safe).
- Fixed `clippy::type_complexity` by factoring the `SystemState` tuple into an `ExtractLinesParams` type alias.

No behavior changed.