### PR TITLE
Build and deploy Elodin CLI and simulation onto Aleph

### DIFF
--- a/aleph/flake.nix
+++ b/aleph/flake.nix
@@ -71,6 +71,7 @@
       wifi = ./modules/wifi.nix;
     };
     fswModules = {
+      elodin = ./modules/elodin.nix;
       elodin-db = ./modules/elodin-db.nix;
       aleph-serial-bridge = ./modules/aleph-serial-bridge.nix;
       tegrastats-bridge = ./modules/tegrastats-bridge.nix;

--- a/aleph/modules/elodin-db.nix
+++ b/aleph/modules/elodin-db.nix
@@ -119,13 +119,13 @@ in {
     };
 
     environment.systemPackages = [elodin-db];
-    networking.firewall.allowedTCPPorts = lib.optionals cfg.openFirewall [
+    networking.firewall.allowedTCPPortRanges = lib.optionals cfg.openFirewall [
       {
         from = 1;
         to = 65535;
       }
     ];
-    networking.firewall.allowedUDPPorts = lib.optionals cfg.openFirewall [
+    networking.firewall.allowedUDPPortRanges = lib.optionals cfg.openFirewall [
       {
         from = 1;
         to = 65535;

--- a/aleph/modules/elodin-db.nix
+++ b/aleph/modules/elodin-db.nix
@@ -119,6 +119,7 @@ in {
     };
 
     environment.systemPackages = [elodin-db];
-    networking.firewall.allowedTCPPorts = lib.optionals cfg.openFirewall [2240 2241 2248 9000];
+    networking.firewall.allowedTCPPorts = lib.optionals cfg.openFirewall [{ from = 1; to = 65535; }];
+    networking.firewall.allowedUDPPorts = lib.optionals cfg.openFirewall [{ from = 1; to = 65535; }];
   };
 }

--- a/aleph/modules/elodin-db.nix
+++ b/aleph/modules/elodin-db.nix
@@ -119,6 +119,6 @@ in {
     };
 
     environment.systemPackages = [elodin-db];
-    networking.firewall.allowedTCPPorts = lib.optionals cfg.openFirewall [2240 2248];
+    networking.firewall.allowedTCPPorts = lib.optionals cfg.openFirewall [2240 2241 2248 9000];
   };
 }

--- a/aleph/modules/elodin-db.nix
+++ b/aleph/modules/elodin-db.nix
@@ -119,7 +119,17 @@ in {
     };
 
     environment.systemPackages = [elodin-db];
-    networking.firewall.allowedTCPPorts = lib.optionals cfg.openFirewall [{ from = 1; to = 65535; }];
-    networking.firewall.allowedUDPPorts = lib.optionals cfg.openFirewall [{ from = 1; to = 65535; }];
+    networking.firewall.allowedTCPPorts = lib.optionals cfg.openFirewall [
+      {
+        from = 1;
+        to = 65535;
+      }
+    ];
+    networking.firewall.allowedUDPPorts = lib.optionals cfg.openFirewall [
+      {
+        from = 1;
+        to = 65535;
+      }
+    ];
   };
 }

--- a/aleph/modules/elodin.nix
+++ b/aleph/modules/elodin.nix
@@ -10,8 +10,16 @@ in {
     enable = lib.mkOption {
       type = lib.types.bool;
       default = true;
+      description = "Whether to install the Elodin simulation CLI.";
+    };
+
+    examples = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
       description = ''
-        Whether to install the Elodin simulation CLI and packaged examples.
+        Whether to seed the packaged examples and their default assets. The
+        shared asset root is created regardless of this flag so customers can
+        deploy their own assets.
       '';
     };
 
@@ -24,7 +32,13 @@ in {
     examplesPackage = lib.mkOption {
       type = lib.types.package;
       default = pkgs.elodin-examples;
-      description = "Packaged Elodin examples for on-device testing.";
+      description = "Packaged Elodin examples, symlinked into /var/lib/elodin.";
+    };
+
+    assetsPackage = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.elodin-assets;
+      description = "Default assets seeded into ELODIN_ASSETS_DIR.";
     };
 
     enableRenderer = lib.mkOption {
@@ -37,159 +51,30 @@ in {
   };
 
   config = lib.mkIf cfg.enable (let
-    # EGM08 spherical-harmonic gravity coefficients used by the cube-sat example.
-    # The SDK downloads these into el._get_cache_dir() on first run; pre-fetch
-    # them so the example runs offline and reproducibly on-device.
-    egm08C = pkgs.fetchurl {
-      url = "https://assets.elodin.systems/assets/C_normal.npy";
-      hash = "sha256-sZKrOEr/1MzAs7OMR5DreWcu/16E3hurVoFNwLIUTWU=";
-    };
-    egm08S = pkgs.fetchurl {
-      url = "https://assets.elodin.systems/assets/S_normal.npy";
-      hash = "sha256-Y6ophu4G7hitgrO9QxYYmpyC/1u2nkbTPqWYpo71ojk=";
-    };
-    elodinRunExample = pkgs.writeShellScriptBin "elodin-run-example" ''
-      set -euo pipefail
-
-      export PATH="${lib.makeBinPath [
-        pkgs.coreutils
-        pkgs.gnugrep
-        pkgs.iproute2
-        pkgs.systemd
-      ]}:$PATH"
-
-      usage() {
-        echo "Usage: elodin-run-example {ball|sensor-camera|video-stream|drone|cube-sat|three-body}"
-      }
-
-      if [ "$#" -ne 1 ]; then
-        usage
-        exit 2
-      fi
-
-      example="$1"
-      examples_root="${cfg.examplesPackage}"
-      db_path="/db/example-$example"
-      work_dir="/tmp/elodin-example-$example"
-      run_timeout="''${ELODIN_EXAMPLE_TIMEOUT:-60s}"
-
-      case "$example" in
-        ball)
-          main="$examples_root/ball/main.py"
-          run_timeout="''${ELODIN_EXAMPLE_TIMEOUT:-30s}"
-          ;;
-        sensor-camera)
-          main="$examples_root/sensor-camera/main.py"
-          run_timeout="''${ELODIN_EXAMPLE_TIMEOUT:-90s}"
-          export ELODIN_SENSOR_CAMERA_MAX_TICKS="''${ELODIN_SENSOR_CAMERA_MAX_TICKS:-1800}"
-          export ELODIN_SENSOR_CAMERA_DB="$db_path"
-          ;;
-        video-stream)
-          main="$examples_root/video-stream/main.py"
-          work_dir="/tmp/elodin-example-video-stream"
-          run_timeout="''${ELODIN_EXAMPLE_TIMEOUT:-45s}"
-          ;;
-        drone)
-          main="$examples_root/drone/main.py"
-          run_timeout="''${ELODIN_EXAMPLE_TIMEOUT:-90s}"
-          ;;
-        cube-sat)
-          main="$examples_root/cube-sat/main.py"
-          run_timeout="''${ELODIN_EXAMPLE_TIMEOUT:-240s}"
-          # Seed the EGM08 gravity coefficients into the SDK cache so the
-          # example does not need network access at runtime.
-          cache_dir="''${HOME:-/root}/.cache/elodin-cli"
-          mkdir -p "$cache_dir"
-          cp -n ${egm08C} "$cache_dir/C_normal.npy" || true
-          cp -n ${egm08S} "$cache_dir/S_normal.npy" || true
-          ;;
-        three-body)
-          main="$examples_root/three-body/main.py"
-          run_timeout="''${ELODIN_EXAMPLE_TIMEOUT:-30s}"
-          ;;
-        *)
-          usage
-          exit 2
-          ;;
-      esac
-
-      port_in_use() {
-        ss -H -tln 'sport = :2240' | grep -q .
-      }
-
-      stop_elodin_db() {
-        systemctl stop elodin-db-default.service 2>/dev/null || true
-        systemctl list-units --type=service --state=active --plain --no-legend 'elodin-db@*.service' |
-          while read -r unit _; do
-            [ -n "$unit" ] && systemctl stop "$unit" || true
-          done
-
-        for _ in $(seq 1 40); do
-          if ! port_in_use; then
-            return 0
-          fi
-          sleep 0.25
-        done
-
-        echo "ERROR: port 2240 is still in use after stopping elodin-db services" >&2
-        ss -tlnp 'sport = :2240' >&2 || true
-        exit 1
-      }
-
-      mkdir -p /db /root/.local/share/cli "$work_dir"
-      rm -rf "$db_path"
-      rm -rf "$work_dir/video-stream-db"
-      log_file="$work_dir/$example.log"
-
-      echo "Stopping system elodin-db services so the simulation can bind :2240..."
-      stop_elodin_db
-
-      echo "Running $example with DB path $db_path"
-      cd "$work_dir"
-
-      set +e
-      ELODIN_DB_PATH="$db_path" timeout --signal=INT --kill-after=10s "$run_timeout" "${cfg.package}/bin/elodin" run "$main" 2>&1 | tee "$log_file"
-      status="''${PIPESTATUS[0]}"
-      set -e
-
-      if [ "$example" = "video-stream" ] && [ -d "$work_dir/video-stream-db" ]; then
-        rm -rf "$db_path"
-        mv "$work_dir/video-stream-db" "$db_path"
-      fi
-
-      if [ "$status" -ne 0 ]; then
-        if { [ "$status" -eq 124 ] || [ "$status" -eq 130 ] || [ "$status" -eq 143 ]; } && [ -d "$db_path" ]; then
-          echo "$example stopped after timeout; DB was created, so the smoke run succeeded."
-        else
-          echo "ERROR: $example failed with status $status" >&2
-          exit "$status"
-        fi
-      fi
-
-      if [ "$example" = "sensor-camera" ] && ! grep -q "verification: PASS" "$log_file"; then
-        echo "ERROR: sensor-camera did not report verification: PASS" >&2
-        exit 1
-      fi
-
-      echo "DB saved at $db_path"
-    '';
+    assetsDir = "/var/lib/elodin/assets";
   in {
     # jetpack's graphics module already sets hardware.graphics.package to
     # l4t-3d-core (the Jetson Vulkan/GL driver) when graphics is enabled, so we
     # only need to ensure graphics is on for the headless renderer.
     hardware.graphics.enable = lib.mkDefault cfg.enableRenderer;
 
-    environment.systemPackages = [
-      cfg.package
-      cfg.examplesPackage
-      elodinRunExample
-    ];
+    environment.systemPackages = [cfg.package];
 
-    systemd.services.elodin-assets-seed = {
-      description = "Seed the writable Elodin asset root with packaged defaults";
+    # Every user resolves assets from the shared, writable asset root.
+    environment.sessionVariables.ELODIN_ASSETS_DIR = assetsDir;
+
+    # Pre-create each user's CLI data dir so the first-launch notice does not
+    # short-circuit an interactive `elodin run`.
+    environment.loginShellInit = ''
+      mkdir -p "''${XDG_DATA_HOME:-$HOME/.local/share}/cli"
+    '';
+
+    systemd.services.elodin-assets-seed = lib.mkIf cfg.examples {
+      description = "Seed the shared Elodin asset root with packaged defaults";
       wantedBy = ["multi-user.target"];
       path = with pkgs; [
         coreutils
+        findutils
         gnugrep
       ];
       serviceConfig = {
@@ -197,26 +82,30 @@ in {
         RemainAfterExit = true;
       };
       script = ''
-        mkdir -p /root/assets
+        install -d -m 2775 -g wheel ${assetsDir}
 
         # Migrate the tiny auto-created empty skybox manifest so the packaged
         # default skybox is selectable. Preserve real customer manifests.
-        manifest=/root/assets/skyboxes/manifest.ron
+        manifest=${assetsDir}/skyboxes/manifest.ron
         if [ -f "$manifest" ] && [ "$(wc -c < "$manifest")" -le 128 ] && ! grep -q "desert_night" "$manifest"; then
           rm -f "$manifest"
         fi
 
-        cp -rn --no-preserve=mode,ownership ${pkgs.elodin-assets}/. /root/assets/
-        chmod -R u+rwX /root/assets
+        cp -rn --no-preserve=mode,ownership ${cfg.assetsPackage}/. ${assetsDir}/
+        chgrp -R wheel ${assetsDir}
+        chmod -R g+rwX ${assetsDir}
+        find ${assetsDir} -type d -exec chmod g+s {} +
       '';
     };
 
-    systemd.tmpfiles.rules = [
-      "d /root 0700 root root - -"
-      "d /root/.local 0755 root root - -"
-      "d /root/.local/share 0755 root root - -"
-      "d /root/.local/share/cli 0755 root root - -"
-      "L+ /root/examples - - - - ${cfg.examplesPackage}"
-    ];
+    systemd.tmpfiles.rules =
+      [
+        "d /var/lib/elodin 0755 root root - -"
+        # setgid + group-writable so any wheel user can add assets.
+        "d ${assetsDir} 2775 root wheel - -"
+      ]
+      ++ lib.optionals cfg.examples [
+        "L+ /var/lib/elodin/examples - - - - ${cfg.examplesPackage}"
+      ];
   });
 }

--- a/aleph/modules/elodin.nix
+++ b/aleph/modules/elodin.nix
@@ -1,0 +1,222 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.services.elodin;
+in {
+  options.services.elodin = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Whether to install the Elodin simulation CLI and packaged examples.
+      '';
+    };
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.elodin-cli;
+      description = "The Elodin simulation CLI package to install.";
+    };
+
+    examplesPackage = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.elodin-examples;
+      description = "Packaged Elodin examples for on-device testing.";
+    };
+
+    enableRenderer = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Whether to enable graphics runtime support for the headless sensor camera renderer.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable (let
+    # EGM08 spherical-harmonic gravity coefficients used by the cube-sat example.
+    # The SDK downloads these into el._get_cache_dir() on first run; pre-fetch
+    # them so the example runs offline and reproducibly on-device.
+    egm08C = pkgs.fetchurl {
+      url = "https://assets.elodin.systems/assets/C_normal.npy";
+      hash = "sha256-sZKrOEr/1MzAs7OMR5DreWcu/16E3hurVoFNwLIUTWU=";
+    };
+    egm08S = pkgs.fetchurl {
+      url = "https://assets.elodin.systems/assets/S_normal.npy";
+      hash = "sha256-Y6ophu4G7hitgrO9QxYYmpyC/1u2nkbTPqWYpo71ojk=";
+    };
+    elodinRunExample = pkgs.writeShellScriptBin "elodin-run-example" ''
+      set -euo pipefail
+
+      export PATH="${lib.makeBinPath [
+        pkgs.coreutils
+        pkgs.gnugrep
+        pkgs.iproute2
+        pkgs.systemd
+      ]}:$PATH"
+
+      usage() {
+        echo "Usage: elodin-run-example {ball|sensor-camera|video-stream|drone|cube-sat|three-body}"
+      }
+
+      if [ "$#" -ne 1 ]; then
+        usage
+        exit 2
+      fi
+
+      example="$1"
+      examples_root="${cfg.examplesPackage}"
+      db_path="/db/example-$example"
+      work_dir="/tmp/elodin-example-$example"
+      run_timeout="''${ELODIN_EXAMPLE_TIMEOUT:-60s}"
+
+      case "$example" in
+        ball)
+          main="$examples_root/ball/main.py"
+          run_timeout="''${ELODIN_EXAMPLE_TIMEOUT:-30s}"
+          ;;
+        sensor-camera)
+          main="$examples_root/sensor-camera/main.py"
+          run_timeout="''${ELODIN_EXAMPLE_TIMEOUT:-90s}"
+          export ELODIN_SENSOR_CAMERA_MAX_TICKS="''${ELODIN_SENSOR_CAMERA_MAX_TICKS:-1800}"
+          export ELODIN_SENSOR_CAMERA_DB="$db_path"
+          ;;
+        video-stream)
+          main="$examples_root/video-stream/main.py"
+          work_dir="/tmp/elodin-example-video-stream"
+          run_timeout="''${ELODIN_EXAMPLE_TIMEOUT:-45s}"
+          ;;
+        drone)
+          main="$examples_root/drone/main.py"
+          run_timeout="''${ELODIN_EXAMPLE_TIMEOUT:-90s}"
+          ;;
+        cube-sat)
+          main="$examples_root/cube-sat/main.py"
+          run_timeout="''${ELODIN_EXAMPLE_TIMEOUT:-240s}"
+          # Seed the EGM08 gravity coefficients into the SDK cache so the
+          # example does not need network access at runtime.
+          cache_dir="''${HOME:-/root}/.cache/elodin-cli"
+          mkdir -p "$cache_dir"
+          cp -n ${egm08C} "$cache_dir/C_normal.npy" || true
+          cp -n ${egm08S} "$cache_dir/S_normal.npy" || true
+          ;;
+        three-body)
+          main="$examples_root/three-body/main.py"
+          run_timeout="''${ELODIN_EXAMPLE_TIMEOUT:-30s}"
+          ;;
+        *)
+          usage
+          exit 2
+          ;;
+      esac
+
+      port_in_use() {
+        ss -H -tln 'sport = :2240' | grep -q .
+      }
+
+      stop_elodin_db() {
+        systemctl stop elodin-db-default.service 2>/dev/null || true
+        systemctl list-units --type=service --state=active --plain --no-legend 'elodin-db@*.service' |
+          while read -r unit _; do
+            [ -n "$unit" ] && systemctl stop "$unit" || true
+          done
+
+        for _ in $(seq 1 40); do
+          if ! port_in_use; then
+            return 0
+          fi
+          sleep 0.25
+        done
+
+        echo "ERROR: port 2240 is still in use after stopping elodin-db services" >&2
+        ss -tlnp 'sport = :2240' >&2 || true
+        exit 1
+      }
+
+      mkdir -p /db /root/.local/share/cli "$work_dir"
+      rm -rf "$db_path"
+      rm -rf "$work_dir/video-stream-db"
+      log_file="$work_dir/$example.log"
+
+      echo "Stopping system elodin-db services so the simulation can bind :2240..."
+      stop_elodin_db
+
+      echo "Running $example with DB path $db_path"
+      cd "$work_dir"
+
+      set +e
+      ELODIN_DB_PATH="$db_path" timeout --signal=INT --kill-after=10s "$run_timeout" "${cfg.package}/bin/elodin" run "$main" 2>&1 | tee "$log_file"
+      status="''${PIPESTATUS[0]}"
+      set -e
+
+      if [ "$example" = "video-stream" ] && [ -d "$work_dir/video-stream-db" ]; then
+        rm -rf "$db_path"
+        mv "$work_dir/video-stream-db" "$db_path"
+      fi
+
+      if [ "$status" -ne 0 ]; then
+        if { [ "$status" -eq 124 ] || [ "$status" -eq 130 ] || [ "$status" -eq 143 ]; } && [ -d "$db_path" ]; then
+          echo "$example stopped after timeout; DB was created, so the smoke run succeeded."
+        else
+          echo "ERROR: $example failed with status $status" >&2
+          exit "$status"
+        fi
+      fi
+
+      if [ "$example" = "sensor-camera" ] && ! grep -q "verification: PASS" "$log_file"; then
+        echo "ERROR: sensor-camera did not report verification: PASS" >&2
+        exit 1
+      fi
+
+      echo "DB saved at $db_path"
+    '';
+  in {
+    # jetpack's graphics module already sets hardware.graphics.package to
+    # l4t-3d-core (the Jetson Vulkan/GL driver) when graphics is enabled, so we
+    # only need to ensure graphics is on for the headless renderer.
+    hardware.graphics.enable = lib.mkDefault cfg.enableRenderer;
+
+    environment.systemPackages = [
+      cfg.package
+      cfg.examplesPackage
+      elodinRunExample
+    ];
+
+    systemd.services.elodin-assets-seed = {
+      description = "Seed the writable Elodin asset root with packaged defaults";
+      wantedBy = ["multi-user.target"];
+      path = with pkgs; [
+        coreutils
+        gnugrep
+      ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+      };
+      script = ''
+        mkdir -p /root/assets
+
+        # Migrate the tiny auto-created empty skybox manifest so the packaged
+        # default skybox is selectable. Preserve real customer manifests.
+        manifest=/root/assets/skyboxes/manifest.ron
+        if [ -f "$manifest" ] && [ "$(wc -c < "$manifest")" -le 128 ] && ! grep -q "desert_night" "$manifest"; then
+          rm -f "$manifest"
+        fi
+
+        cp -rn --no-preserve=mode,ownership ${pkgs.elodin-assets}/. /root/assets/
+        chmod -R u+rwX /root/assets
+      '';
+    };
+
+    systemd.tmpfiles.rules = [
+      "d /root 0700 root root - -"
+      "d /root/.local 0755 root root - -"
+      "d /root/.local/share 0755 root root - -"
+      "d /root/.local/share/cli 0755 root root - -"
+      "L+ /root/examples - - - - ${cfg.examplesPackage}"
+    ];
+  });
+}

--- a/aleph/pkgs/elodin-assets.nix
+++ b/aleph/pkgs/elodin-assets.nix
@@ -1,0 +1,6 @@
+{lib, ...}:
+lib.cleanSourceWith {
+  name = "elodin-assets";
+  src = ../../assets;
+  filter = path: _type: baseNameOf path != ".DS_Store";
+}

--- a/aleph/pkgs/elodin-cli.nix
+++ b/aleph/pkgs/elodin-cli.nix
@@ -42,7 +42,7 @@ in
       --set VK_ICD_FILENAMES "${nvidiaIcd}" \
       --set VK_DRIVER_FILES "${nvidiaIcd}" \
       --prefix VK_LAYER_PATH : "${pkgs.vulkan-validation-layers}/share/vulkan/explicit_layer.d" \
-      --set-default ELODIN_ASSETS_DIR "/root/assets" \
+      --set-default ELODIN_ASSETS_DIR "/var/lib/elodin/assets" \
       --set ALSA_PLUGIN_DIR "${common.alsaPluginDir}/lib/alsa-lib" \
       --set ALSA_CONFIG_PATH "${common.asoundConf}"
     '';

--- a/aleph/pkgs/elodin-cli.nix
+++ b/aleph/pkgs/elodin-cli.nix
@@ -1,0 +1,49 @@
+{
+  pkgs,
+  lib,
+  rustToolchain,
+  ...
+}: let
+  # The Aleph sets nixpkgs.config.cudaSupport = true (aleph-cuda.nix), which
+  # flips jax's default to pull the CUDA plugin (-> nccl, unsupported on
+  # aarch64). Build jax without CUDA; the sim uses the cranelift backend and the
+  # renderer uses Vulkan, so GPU jax is not needed on-device.
+  pythonPackages = pkgs.python313Packages.overrideScope (_final: prev: {
+    jax = prev.jax.override {cudaSupport = false;};
+  });
+  elodinPy = pkgs.callPackage ../../nix/pkgs/elodin-py.nix {
+    inherit rustToolchain pythonPackages;
+    python = pkgs.python313;
+  };
+  common = pkgs.callPackage ../../nix/pkgs/common.nix {};
+  nvidiaIcd = "/run/opengl-driver/share/vulkan/icd.d/nvidia_icd.json";
+  jetsonLibPath = lib.makeLibraryPath (with pkgs; [
+    alsa-lib
+    libpulseaudio
+    pipewire
+    vulkan-loader
+    vulkan-validation-layers
+    libglvnd
+    libdrm
+    libxkbcommon
+    udev
+    systemd
+  ]);
+in
+  pkgs.callPackage ../../nix/pkgs/elodin-cli.nix {
+    inherit rustToolchain;
+    elodinPy = elodinPy.py;
+    python = elodinPy.python;
+    pythonPackages = elodinPy.pythonPackages;
+    graphicsWrapperArgs = ''
+      --prefix LD_LIBRARY_PATH : "/run/opengl-driver/lib:${jetsonLibPath}" \
+      --set-default LIBGL_DRIVERS_PATH "/run/opengl-driver/lib/dri:${pkgs.mesa}/lib/dri" \
+      --set-default LIBVA_DRIVERS_PATH "/run/opengl-driver/lib/dri:${pkgs.mesa}/lib/dri" \
+      --set VK_ICD_FILENAMES "${nvidiaIcd}" \
+      --set VK_DRIVER_FILES "${nvidiaIcd}" \
+      --prefix VK_LAYER_PATH : "${pkgs.vulkan-validation-layers}/share/vulkan/explicit_layer.d" \
+      --set-default ELODIN_ASSETS_DIR "/root/assets" \
+      --set ALSA_PLUGIN_DIR "${common.alsaPluginDir}/lib/alsa-lib" \
+      --set ALSA_CONFIG_PATH "${common.asoundConf}"
+    '';
+  }

--- a/aleph/pkgs/elodin-examples.nix
+++ b/aleph/pkgs/elodin-examples.nix
@@ -5,7 +5,6 @@ pkgs.runCommand "elodin-examples" {} ''
   cp -R ${../../examples/sensor-camera} "$out/sensor-camera"
   cp -R ${../../examples/video-stream} "$out/video-stream"
   cp -R ${../../examples/drone} "$out/drone"
-  cp -R ${../../examples/cube-sat} "$out/cube-sat"
   cp -R ${../../examples/three-body} "$out/three-body"
 
   chmod -R u+w "$out"

--- a/aleph/pkgs/elodin-examples.nix
+++ b/aleph/pkgs/elodin-examples.nix
@@ -1,0 +1,21 @@
+{pkgs, ...}:
+pkgs.runCommand "elodin-examples" {} ''
+  mkdir -p "$out"
+  cp -R ${../../examples/ball} "$out/ball"
+  cp -R ${../../examples/sensor-camera} "$out/sensor-camera"
+  cp -R ${../../examples/video-stream} "$out/video-stream"
+  cp -R ${../../examples/drone} "$out/drone"
+  cp -R ${../../examples/cube-sat} "$out/cube-sat"
+  cp -R ${../../examples/three-body} "$out/three-body"
+
+  chmod -R u+w "$out"
+
+  for script in "$out/video-stream/stream-video.sh" "$out/video-stream/receive-obs-stream.sh"; do
+    substituteInPlace "$script" \
+      --replace-fail "Builds the elodinsink GStreamer plugin from source" "Uses the system elodinsink GStreamer plugin" \
+      --replace-fail "The plugin is built automatically - no manual prerequisite steps required." "The plugin is provided by the Aleph elodinsink module." \
+      --replace-fail 'echo "Building elodinsink GStreamer plugin..."' 'echo "Using system elodinsink GStreamer plugin..."' \
+      --replace-fail 'cargo build --release --manifest-path="$REPO_ROOT/fsw/gstreamer/Cargo.toml"' ':' \
+      --replace-fail 'export GST_PLUGIN_PATH="$REPO_ROOT/target/release:''${GST_PLUGIN_PATH}"' ':'
+  done
+''

--- a/aleph/template/flake.nix
+++ b/aleph/template/flake.nix
@@ -81,7 +81,7 @@
       #   enable = true;                    # Enable elodin-db (default: true)
       #   autostart = true;                 # Set to false to configure but not auto-start
       #   dbUniqueOnBoot = true;            # Create unique db folder on each boot
-      #   openFirewall = true;              # Open ports 2240, 2241, 2248, 9000
+      #   openFirewall = true;              # Open TCP & UDP ports for external access
       # };
 
       # Elodin simulation CLI, examples, and assets

--- a/aleph/template/flake.nix
+++ b/aleph/template/flake.nix
@@ -34,6 +34,7 @@
         minimal # strips down nixos to an even more minimal set of defaults
 
         # elodin-db and integrations
+        elodin # elodin simulation CLI and packaged examples
         elodin-db # brings in elodin-db as a default service
         aleph-serial-bridge # pushes sensor data into elodin-db from the default expansion board firmware
         tegrastats-bridge # pushes telemetry form the Orin SoC into elodin-db (i.e cpu usage, temps, etc)
@@ -80,7 +81,13 @@
       #   enable = true;                    # Enable elodin-db (default: true)
       #   autostart = true;                 # Set to false to configure but not auto-start
       #   dbUniqueOnBoot = true;            # Create unique db folder on each boot
-      #   openFirewall = true;              # Open ports 2240 and 2248
+      #   openFirewall = true;              # Open ports 2240, 2241, 2248, 9000
+      # };
+
+      # Elodin simulation CLI and examples
+      # services.elodin = {
+      #   enable = true;                    # Install elodin CLI and examples (default: true)
+      #   enableRenderer = true;            # Enable headless sensor-camera renderer support
       # };
 
       # GPS module (optional, connected on J7)

--- a/aleph/template/flake.nix
+++ b/aleph/template/flake.nix
@@ -84,11 +84,18 @@
       #   openFirewall = true;              # Open ports 2240, 2241, 2248, 9000
       # };
 
-      # Elodin simulation CLI and examples
+      # Elodin simulation CLI, examples, and assets
       # services.elodin = {
-      #   enable = true;                    # Install elodin CLI and examples (default: true)
+      #   enable = true;                    # Install the elodin CLI (default: true)
+      #   examples = true;                  # Seed packaged examples + default assets (default: true)
       #   enableRenderer = true;            # Enable headless sensor-camera renderer support
       # };
+      #
+      # Any user can run sims. Shared, writable asset root:
+      #   ELODIN_ASSETS_DIR=/var/lib/elodin/assets   (drop your own meshes/skyboxes here)
+      # Packaged examples: /var/lib/elodin/examples
+      # To deploy your own assets/sims declaratively, override
+      #   services.elodin.assetsPackage / services.elodin.examplesPackage
 
       # GPS module (optional, connected on J7)
       # Uncomment ONE line to enable GPS-disciplined timestamping:

--- a/examples/video-stream/main.py
+++ b/examples/video-stream/main.py
@@ -267,6 +267,6 @@ sim = world.run(
     sys,
     simulation_rate=1.0 / SIM_TIME_STEP,
     generate_real_time=True,
-    start_timestamp=0,
+    # start_timestamp=0,
     db_path="./video-stream-db",
 )

--- a/libs/db/src/assets_http.rs
+++ b/libs/db/src/assets_http.rs
@@ -296,9 +296,18 @@ async fn get_asset(
     let full = state.assets_dir.join(rel);
     match tokio::task::spawn_blocking(move || std::fs::read(full)).await {
         Ok(Ok(bytes)) => Ok(bytes),
-        Ok(Err(err)) if err.kind() == io::ErrorKind::NotFound => Err(StatusCode::NOT_FOUND),
-        Ok(Err(_)) => Err(StatusCode::INTERNAL_SERVER_ERROR),
-        Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),
+        Ok(Err(err)) if err.kind() == io::ErrorKind::NotFound => {
+            tracing::warn!(asset = %path, "asset http 404 (not found)");
+            Err(StatusCode::NOT_FOUND)
+        }
+        Ok(Err(err)) => {
+            tracing::error!(asset = %path, ?err, "asset http 500 (read error)");
+            Err(StatusCode::INTERNAL_SERVER_ERROR)
+        }
+        Err(err) => {
+            tracing::error!(asset = %path, ?err, "asset http 500 (read task failed)");
+            Err(StatusCode::INTERNAL_SERVER_ERROR)
+        }
     }
 }
 

--- a/libs/elodin-editor/src/plugins/web_asset/mod.rs
+++ b/libs/elodin-editor/src/plugins/web_asset/mod.rs
@@ -105,7 +105,7 @@ impl Client {
                 if let Some(CachedAsset { etag, .. }) = &cached_asset {
                     request = request.header("If-None-Match", etag);
                 }
-                let response = request.send().await.map_err(http_err)?;
+                let response = request.send().await.map_err(|err| http_err(&url, err))?;
                 if let Some(CachedAsset { data, .. }) = cached_asset
                     && response.status() == StatusCode::NOT_MODIFIED
                 {
@@ -117,7 +117,11 @@ impl Client {
                     .and_then(|v| v.to_str().ok())
                     .map(|s| s.to_owned());
 
-                let data = response.bytes().await.map_err(http_err)?.to_vec();
+                let data = response
+                    .bytes()
+                    .await
+                    .map_err(|err| http_err(&url, err))?
+                    .to_vec();
                 Ok((data, etag))
             })
             .await
@@ -165,10 +169,11 @@ impl AssetReader for Client {
     }
 }
 
-fn http_err(err: reqwest::Error) -> AssetReaderError {
-    let status_code = err
-        .status()
-        .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
-        .as_u16();
-    AssetReaderError::HttpError(status_code)
+fn http_err(url: &str, err: reqwest::Error) -> AssetReaderError {
+    if let Some(status) = err.status() {
+        return AssetReaderError::HttpError(status.as_u16());
+    }
+    let message = format!("{url}: {err}");
+    tracing::warn!(error = %message, "failed to fetch web asset");
+    AssetReaderError::Io(io::Error::other(message).into())
 }

--- a/nix/pkgs/common.nix
+++ b/nix/pkgs/common.nix
@@ -257,6 +257,7 @@ in {
     python,
     pythonPath,
     pythonMajorMinor,
+    graphicsWrapperArgs ? null,
   }: let
     linuxLibPath = lib.optionalString pkgs.stdenv.isLinux (
       lib.makeLibraryPath (with pkgs; [
@@ -292,7 +293,7 @@ in {
         systemd
       ])
     );
-    graphicsEnv = lib.optionalString pkgs.stdenv.isLinux ''
+    defaultGraphicsWrapperArgs = lib.optionalString pkgs.stdenv.isLinux ''
       --prefix LD_LIBRARY_PATH : "${linuxLibPath}" \
       --set LIBGL_DRIVERS_PATH "${pkgs.mesa}/lib/dri" \
       --set __GLX_VENDOR_LIBRARY_NAME "mesa" \
@@ -303,11 +304,15 @@ in {
       --set ALSA_CONFIG_PATH "${asoundConf}" \
       --run "source ${nvidiaHookScript}"
     '';
+    graphicsArgs =
+      if graphicsWrapperArgs == null
+      then defaultGraphicsWrapperArgs
+      else graphicsWrapperArgs;
   in ''
     --prefix PATH : "${python}/bin" \
     --prefix PYTHONPATH : "${pythonPath}" \
     --prefix PYTHONPATH : "${python}/lib/python${pythonMajorMinor}" \
-    ${graphicsEnv}
+    ${graphicsArgs}
   '';
 
   # Workaround for netlib-src 0.8.0 incompatibility with GCC 14+

--- a/nix/pkgs/elodin-cli.nix
+++ b/nix/pkgs/elodin-cli.nix
@@ -7,6 +7,7 @@
   python,
   pythonPackages,
   enableTracy ? false,
+  graphicsWrapperArgs ? null,
   ...
 }: let
   # Import shared configuration
@@ -55,6 +56,7 @@
         --set TOKTX "${common.ktxTools}/bin/toktx" \
         ${common.makeWrapperArgs {
         inherit pkgs python pythonPath pythonMajorMinor;
+        inherit graphicsWrapperArgs;
       }}
     '';
 


### PR DESCRIPTION
By popular request, one can now deploy Elodin directly to the Aleph, and run simulations alongside the flight software for SITL and Sim-HITL use cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Opening the full TCP/UDP port range when elodin-db firewall is enabled is a major exposure on deployed hardware; otherwise changes are mostly packaging and observability.
> 
> **Overview**
> Adds **on-device Elodin simulation** to Aleph via a new `services.elodin` NixOS module: installs the CLI (Jetson Vulkan/graphics wrapper, JAX built without CUDA), seeds a shared writable **`ELODIN_ASSETS_DIR`** at `/var/lib/elodin/assets`, optionally symlinks packaged examples, and runs a one-shot asset seed service. New Aleph packages wire **`elodin-cli`**, **`elodin-assets`**, and **`elodin-examples`** (video-stream scripts updated to use the system **elodinsink** plugin). The Aleph flake/template import the **`elodin`** module alongside existing flight-software modules.
> 
> When **`services.elodin-db.openFirewall`** is enabled, firewall rules change from opening specific DB ports to allowing **all TCP and UDP ports (1–65535)** for external access—much broader than the previous 2240/2248 behavior.
> 
> Supporting tweaks: **`makeWrapperArgs`** accepts optional **`graphicsWrapperArgs`** for platform-specific CLI wrapping; asset HTTP and editor web-asset fetch paths gain clearer logging/errors; the video-stream example no longer passes **`start_timestamp=0`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b29f2a5c05e410770360b78f6b5f2c8fbc0b851e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->