### PR TITLE
fix: Make line_3d work with ECEF.

### DIFF
--- a/examples/geo-frames/main.py
+++ b/examples/geo-frames/main.py
@@ -4,6 +4,7 @@ import math
 
 import elodin as el
 import jax.numpy as jnp
+import numpy as np
 
 SIM_RATE = 60.0
 
@@ -15,8 +16,11 @@ WGS84_E2 = 6.6943799901413165e-3
 WGS84_B_M = WGS84_A_M * math.sqrt(1.0 - WGS84_E2)
 CUBE_SIZE_M = 500_000.0
 CUBE_SEPARATION_M = 1_500_000.0
+ASSET_MESH_SCALE_M = 1_000_000.0
 AXIS_ARROW_SCALE_M = 1_000_000.0
 AXIS_ARROW_THICKNESS = 2500.0
+ORBIT_RADIUS_M = WGS84_A_M + 1_200_000.0
+ORBIT_PERIOD_S = 20.0
 SPIN_RATE_RAD_S = math.radians(10.0)
 PURPLE = "156 39 176"
 ECEF_MARKERS = (
@@ -75,6 +79,12 @@ def _ecef_marker_objects() -> str:
             box x={CUBE_SIZE_M} y={CUBE_SIZE_M} z={CUBE_SIZE_M} {{
                 color {PURPLE}
             }}
+            icon builtin="location_on" size=48 {{
+                color {PURPLE}
+            }}
+        }}
+        object_3d frame="ECEF" {name}.world_pos {{
+            glb path="compass.glb" scale={ASSET_MESH_SCALE_M}
         }}""".rstrip()
         for name, _ in ECEF_MARKERS
     )
@@ -96,6 +106,7 @@ def world() -> el.World:
     for name, pos in ECEF_MARKERS:
         world.spawn(_body(jnp.array(pos)), name=name)
     world.spawn(_body(jnp.array([0.0, 0.0, 0.0])), name="earth")
+    world.spawn(_body(jnp.array([ORBIT_RADIUS_M, 0.0, 0.0])), name="ecef_orbit_line")
 
     world.schematic(
         f"""
@@ -110,21 +121,50 @@ def world() -> el.World:
 
         object_3d frame="ECEF" earth.world_pos {{
             glb path="earth.glb"
+            icon builtin="public" size=64 {{
+                color 255 255 255
+            }}
         }}
         {_ecef_marker_objects()}
         object_3d frame="NED" ned_origin.world_pos {{
             box x={CUBE_SIZE_M} y={CUBE_SIZE_M} z={CUBE_SIZE_M} {{
                 color 244 67 54
             }}
+            icon builtin="my_location" size=56 {{
+                color 244 67 54
+            }}
+        }}
+        object_3d frame="NED" ned_origin.world_pos {{
+            glb path="compass.glb" scale={ASSET_MESH_SCALE_M}
         }}
         object_3d frame="ENU" enu_far_east.world_pos {{
             box x={CUBE_SIZE_M} y={CUBE_SIZE_M} z={CUBE_SIZE_M} {{
                 color 33 150 243
             }}
+            icon builtin="explore" size=56 {{
+                color 33 150 243
+            }}
+        }}
+        object_3d frame="ENU" enu_far_east.world_pos {{
+            glb path="compass.glb" scale={ASSET_MESH_SCALE_M}
         }}
         object_3d frame="ECEF" ecef_far_up.world_pos {{
             box x={CUBE_SIZE_M} y={CUBE_SIZE_M} z={CUBE_SIZE_M} {{
                 color 76 175 80
+            }}
+            icon builtin="gps_fixed" size=56 {{
+                color 76 175 80
+            }}
+        }}
+        object_3d frame="ECEF" ecef_far_up.world_pos {{
+            glb path="compass.glb" scale={ASSET_MESH_SCALE_M}
+        }}
+        object_3d frame="ECEF" ecef_orbit_line.world_pos {{
+            sphere radius={CUBE_SIZE_M * 0.25} {{
+                color cyan
+            }}
+            icon builtin="satellite_alt" size=48 {{
+                color cyan
             }}
         }}
 
@@ -136,6 +176,9 @@ def world() -> el.World:
         }}
         line_3d frame="ECEF" ecef_far_up.world_pos line_width=2.0 {{
             color 76 175 80
+        }}
+        line_3d frame="ECEF" ecef_orbit_line.world_pos line_width=4.0 perspective=#false {{
+            color cyan
         }}
 
         vector_arrow frame="NED" "(0, 1, 0)" origin="ned_origin.world_pos" scale={AXIS_ARROW_SCALE_M} normalize=#true arrow_thickness={AXIS_ARROW_THICKNESS} label_position=0.0 name="NED Y-axis" show_name=#true body_frame=#true {{
@@ -162,5 +205,21 @@ def system() -> el.System:
     return el.six_dof(sys=no_force)
 
 
+def post_step(tick: int, ctx: el.StepContext) -> None:
+    angle = 2.0 * math.pi * (tick / SIM_RATE) / ORBIT_PERIOD_S
+    pos = np.array(
+        [
+            ORBIT_RADIUS_M * math.cos(angle),
+            ORBIT_RADIUS_M * math.sin(angle),
+            0.0,
+        ],
+        dtype=np.float64,
+    )
+    ctx.write_component(
+        "ecef_orbit_line.world_pos",
+        np.array([0.0, 0.0, 0.0, 1.0, pos[0], pos[1], pos[2]], dtype=np.float64),
+    )
+
+
 if __name__ == "__main__":
-    world().run(system(), simulation_rate=SIM_RATE, max_ticks=1200)
+    world().run(system(), simulation_rate=SIM_RATE, max_ticks=1200, post_step=post_step)

--- a/libs/elodin-editor/src/ui/plot_3d/mod.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/mod.rs
@@ -13,7 +13,6 @@ use bevy::{
         system::{Commands, Query, Res, ResMut},
     },
     math::{DQuat, Mat4, Vec4},
-    prelude::Transform,
 };
 use bevy_geo_frames::{GeoContext, GeoFrame, GeoRotation};
 use eql;
@@ -96,9 +95,6 @@ pub fn sync_line_plot_3d(
                 LineConfig {
                     render_layers: RenderLayers::layer(crate::plugins::gizmos::GIZMO_RENDER_LAYER),
                 },
-                Transform::default(),
-                #[cfg(feature = "big_space")]
-                crate::spatial::GridCell::default(),
             ));
             if let Some(frame) = line_plot.frame {
                 // Absolute: the line's vertex data is raw frame coordinates, so

--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -662,7 +662,13 @@ impl LoadSchematicParams<'_, '_> {
     pub fn spawn_line_3d(&mut self, line_3d: Line3d) {
         let frame = line_3d.frame;
         let mut spawn = self.commands.spawn(line_3d);
-        spawn.insert(Name::new("line_3d"));
+        spawn.insert((
+            Name::new("line_3d"),
+            Transform::default(),
+            GlobalTransform::default(),
+            #[cfg(feature = "big_space")]
+            crate::spatial::GridCell::default(),
+        ));
 
         // Add GeoPosition and GeoRotation; use ENU if no frame is specified.
         // The rotation is Absolute: the line's vertex data is raw frame
@@ -1529,6 +1535,35 @@ mod tests {
 
         load_schematic(&mut app, &Schematic::default());
         assert_eq!(app.world().resource::<crate::Coordinate>().0, None);
+    }
+
+    #[test]
+    fn line_3d_spawns_with_frame_and_transform_components() {
+        let mut app = test_app();
+        let schematic = Schematic::from_kdl(
+            r#"
+            line_3d frame="ECEF" "sat.world_pos"
+            "#,
+        )
+        .expect("parse test schematic");
+
+        load_schematic(&mut app, &schematic);
+
+        let mut query = app.world_mut().query::<(
+            &impeller2_wkt::Line3d,
+            &GeoPosition,
+            &GeoRotation,
+            &Transform,
+            &GlobalTransform,
+        )>();
+        let (line, geo_pos, geo_rot, _, _) = query
+            .iter(app.world())
+            .next()
+            .expect("line_3d should spawn");
+
+        assert_eq!(line.frame, Some(GeoFrame::ECEF));
+        assert_eq!(geo_pos.0, GeoFrame::ECEF);
+        assert_eq!(geo_rot.0, GeoFrame::ECEF);
     }
 
     #[test]

--- a/libs/s10/src/cgroup.rs
+++ b/libs/s10/src/cgroup.rs
@@ -1,5 +1,7 @@
+#[cfg(target_os = "linux")]
+use std::fs;
 use std::{
-    fs, io,
+    io,
     path::{Path, PathBuf},
     sync::Arc,
 };


### PR DESCRIPTION
Add an orbit line to geo-frames example. This fixes #703.

# Verification

See the geo-frames example. It now has an orbit that demonstrates the fix.

## Before
<img width="2460" height="1554" alt="before" src="https://github.com/user-attachments/assets/72ae7d5f-5e11-4654-a8f8-04c982f63df3" />

## After

<img width="2460" height="1554" alt="after" src="https://github.com/user-attachments/assets/f4001677-786c-4478-ba77-f95963833c41" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches 3D line spawning and geo-frame transforms in the editor render path; behavior change is localized to line_3d but affects all framed trails.
> 
> **Overview**
> Fixes **`line_3d`** when a schematic uses **ECEF** (and other geo frames): spawned line entities now get **`Transform` / `GlobalTransform`** (and **`GridCell`** when `big_space` is on) together with **`GeoPosition`** and **`GeoRotation::absolute`**, so the frame→Bevy basis is applied on the same entity that holds the trail. **`sync_line_plot_3d`** no longer attaches a duplicate transform on GPU setup—it only adds line handles, uniforms, and **`GeoRotation`** when a frame is set.
> 
> The **geo-frames** example adds a cyan **ECEF orbit** (`line_3d` + moving `ecef_orbit_line.world_pos` via **`post_step`**), plus icons/compass GLBs for visual context. A unit test asserts ECEF **`line_3d`** spawns with the expected geo and transform components.
> 
> Unrelated: **`libs/s10/cgroup.rs`** gates **`std::fs`** behind **`#[cfg(target_os = "linux")]`** so non-Linux builds don’t pull unused imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dffd7e60dfe9fac884372c4aaf4bcc80e12a7844. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->