### PR TITLE
Improve generate real time behavior under load

### DIFF
--- a/examples/betaflight-sitl/config.py
+++ b/examples/betaflight-sitl/config.py
@@ -144,9 +144,9 @@ class DroneConfig:
 
     # Physics simulation rate in Hz (8kHz for high-performance Betaflight PID loop)
     # simulation_rate: float = 8000.0  # 125µs
-    simulation_rate: float = 4000.0  # 250µs
+    # simulation_rate: float = 4000.0  # 250µs
     # simulation_rate: float = 2000.0  # 500µs
-    # simulation_rate: float = 1000.0  # 1000µs
+    simulation_rate: float = 1500.0  # 667µs
 
     # Total simulation time in seconds
     simulation_time: float = 15.0

--- a/examples/betaflight-sitl/config.py
+++ b/examples/betaflight-sitl/config.py
@@ -145,8 +145,9 @@ class DroneConfig:
     # Physics simulation rate in Hz (8kHz for high-performance Betaflight PID loop)
     # simulation_rate: float = 8000.0  # 125µs
     # simulation_rate: float = 4000.0  # 250µs
-    # simulation_rate: float = 2000.0  # 500µs
-    simulation_rate: float = 1500.0  # 667µs
+    simulation_rate: float = 2000.0  # 500µs
+    # simulation_rate: float = 1500.0  # 667µs
+    # simulation_rate: float = 1000.0  # 1000µs
 
     # Total simulation time in seconds
     simulation_time: float = 15.0

--- a/examples/monte-carlo/README.md
+++ b/examples/monte-carlo/README.md
@@ -47,6 +47,14 @@ aggregate/average per-run wall time, worker parallel efficiency, disk usage,
 CPU/RAM resource rollups, promoted hook metrics, invalid-run counts, and the
 merged simulation phase summary.
 
+This campaign is intentionally not all-green. It samples a tiny point-mass plant
+with a simple saturated PD controller over a range that includes recoverable and
+missed cases. The default scoring hook treats the vehicle as "captured" when
+the final position is within `8.5 m` of the target, which should produce a
+mostly-successful campaign with a visible failure tail (roughly 70-85 passes out
+of 100 on the default spec). Set `ELODIN_MONTE_CARLO_CAPTURE_RADIUS_M` to make
+the score stricter or looser while preserving the raw `error` metric.
+
 ## Scaling vs. Memory Profiles
 
 The example has two useful modes:

--- a/examples/monte-carlo/hooks/report.py
+++ b/examples/monte-carlo/hooks/report.py
@@ -2,30 +2,102 @@ from __future__ import annotations
 
 import csv
 import json
+import math
 from pathlib import Path
 
 
+def _to_float(value, default: float | None = None) -> float | None:
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return default
+    return result if math.isfinite(result) else default
+
+
+def _percentile(values: list[float], q: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    idx = (len(ordered) - 1) * q
+    lo = math.floor(idx)
+    hi = math.ceil(idx)
+    if lo == hi:
+        return ordered[lo]
+    return ordered[lo] * (hi - idx) + ordered[hi] * (idx - lo)
+
+
+def _fmt(value: float | None, suffix: str = "") -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:.3f}{suffix}"
+
+
 def post_campaign(ctx):
-    results = Path(ctx.out_dir) / "results.csv"
-    passed = 0
-    total = 0
-    errors = []
+    out_dir = Path(ctx.out_dir)
+    results = out_dir / "results.csv"
+    rows = []
     if results.exists():
-        with results.open() as f:
-            for row in csv.DictReader(f):
-                total += 1
-                if row.get("passed") == "true":
-                    passed += 1
-                if row.get("error"):
-                    errors.append(float(row["error"]))
+        with results.open(newline="") as f:
+            rows = list(csv.DictReader(f))
+    total = len(rows)
+    passed = sum(1 for row in rows if row.get("passed") == "true")
+    errors = [error for row in rows if (error := _to_float(row.get("error"))) is not None]
+    capture_radius = next(
+        (value for row in rows if (value := _to_float(row.get("capture_radius_m"))) is not None),
+        None,
+    )
+    worst = []
+    for row in rows:
+        error = _to_float(row.get("error"))
+        if error is None:
+            continue
+        context_path = out_dir / "runs" / row.get("run_id", "") / "post_run_context.json"
+        try:
+            context = json.loads(context_path.read_text())
+        except OSError:
+            context = {}
+        worst.append((error, row.get("run_id", ""), context.get("params", {})))
+    worst.sort(reverse=True, key=lambda item: item[0])
+
     summary = json.loads(Path(ctx.summary).read_text())
     report = Path(ctx.out_dir) / "post_campaign" / "report.txt"
     report.parent.mkdir(parents=True, exist_ok=True)
-    report.write_text(
-        f"completed={total}\n"
-        f"passed={passed}\n"
-        f"failed={summary.get('failed', 0)}\n"
-        f"invalid={summary.get('invalid', 0)}\n"
-        f"mean_error={sum(errors) / len(errors) if errors else float('nan')}\n"
+    lines = [
+        "Native Monte Carlo SITL report",
+        "==============================",
+        "",
+        f"runs completed: {total}",
+        f"passed: {passed}/{total}",
+        f"pass rate: {_fmt((passed / total * 100.0) if total else None, '%')}",
+        f"failed: {summary.get('failed', 0)}",
+        f"invalid: {summary.get('invalid', 0)}",
+        f"capture radius: {_fmt(capture_radius, ' m')}",
+        "",
+        "Final position error",
+        f"  mean: {_fmt((sum(errors) / len(errors)) if errors else None, ' m')}",
+        f"  p50:  {_fmt(_percentile(errors, 0.50), ' m')}",
+        f"  p80:  {_fmt(_percentile(errors, 0.80), ' m')}",
+        f"  p95:  {_fmt(_percentile(errors, 0.95), ' m')}",
+        f"  max:  {_fmt(max(errors) if errors else None, ' m')}",
+        "",
+        "Worst misses",
+    ]
+    for error, run_id, params in worst[:5]:
+        param_text = ", ".join(f"{key}={value:.3g}" for key, value in sorted(params.items()))
+        lines.append(f"  {run_id}: error={error:.3f} m ({param_text})")
+    lines.extend(
+        [
+            "",
+            "Interpretation",
+            "  This example intentionally uses a tiny point-mass plant and simple saturated PD controller. Failures are scored misses near the sampled envelope boundary, not infrastructure failures.",
+        ]
     )
-    return {"completed": total, "passed": passed}
+    text = "\n".join(lines) + "\n"
+    report.write_text(text)
+    print(text)
+    return {
+        "completed": total,
+        "passed": passed,
+        "pass_rate": (passed / total) if total else None,
+        "capture_radius_m": capture_radius,
+    }

--- a/examples/monte-carlo/hooks/report.py
+++ b/examples/monte-carlo/hooks/report.py
@@ -54,7 +54,7 @@ def post_campaign(ctx):
         context_path = out_dir / "runs" / row.get("run_id", "") / "post_run_context.json"
         try:
             context = json.loads(context_path.read_text())
-        except OSError:
+        except (OSError, json.JSONDecodeError):
             context = {}
         worst.append((error, row.get("run_id", ""), context.get("params", {})))
     worst.sort(reverse=True, key=lambda item: item[0])

--- a/examples/monte-carlo/hooks/score.py
+++ b/examples/monte-carlo/hooks/score.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+import math
+import os
+
+CAPTURE_RADIUS_ENV = "ELODIN_MONTE_CARLO_CAPTURE_RADIUS_M"
+DEFAULT_CAPTURE_RADIUS_M = 8.5
+
 
 def post_run(ctx):
     result = {}
@@ -12,8 +18,11 @@ def post_run(ctx):
     except OSError:
         pass
     error = float(result.get("error", float("inf")))
+    capture_radius = float(os.environ.get(CAPTURE_RADIUS_ENV, DEFAULT_CAPTURE_RADIUS_M))
+    valid = bool(result) and math.isfinite(error)
     return {
         "error": error,
-        "valid": bool(result),
-        "pass": error < 2.0,
+        "capture_radius_m": capture_radius,
+        "valid": valid,
+        "pass": valid and error < capture_radius,
     }

--- a/examples/monte-carlo/hooks/score.py
+++ b/examples/monte-carlo/hooks/score.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import math
 import os
 
@@ -7,18 +8,32 @@ CAPTURE_RADIUS_ENV = "ELODIN_MONTE_CARLO_CAPTURE_RADIUS_M"
 DEFAULT_CAPTURE_RADIUS_M = 8.5
 
 
+def _float_env(name: str, default: float) -> float:
+    try:
+        value = float(os.environ.get(name, default))
+    except (TypeError, ValueError):
+        return default
+    return value if math.isfinite(value) and value > 0.0 else default
+
+
+def _finite_float(value, default: float) -> float:
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return default
+    return result if math.isfinite(result) else default
+
+
 def post_run(ctx):
     result = {}
     result_path = ctx.run_dir + "/result.json"
     try:
-        import json
-
         with open(result_path) as f:
             result = json.load(f)
-    except OSError:
+    except (OSError, json.JSONDecodeError):
         pass
-    error = float(result.get("error", float("inf")))
-    capture_radius = float(os.environ.get(CAPTURE_RADIUS_ENV, DEFAULT_CAPTURE_RADIUS_M))
+    error = _finite_float(result.get("error"), float("inf"))
+    capture_radius = _float_env(CAPTURE_RADIUS_ENV, DEFAULT_CAPTURE_RADIUS_M)
     valid = bool(result) and math.isfinite(error)
     return {
         "error": error,

--- a/libs/elodin-editor/src/run.rs
+++ b/libs/elodin-editor/src/run.rs
@@ -64,10 +64,38 @@ pub async fn run_recipe(
         pin_render_server_recipe(&mut recipe, &exe);
     }
 
-    recipe
-        .watch("sim".to_string(), false, cancel_token.clone(), None)
-        .await?;
+    // Run the whole sim stack (sim + Betaflight/controller/render-server) inside
+    // one prioritized cgroup so it is scheduled promptly under contention
+    // (Linux `cpu.weight`; a no-op on macOS/Windows, which are dev-only). Every
+    // spawned recipe process is added to this cgroup by s10. Best-effort:
+    // priority is never allowed to fail the run.
+    let cgroup = if s10::priority_enabled() {
+        let _ = s10::CgroupScope::reap_prefix("elodin-sim-");
+        let scope = s10::CgroupScope::create(format!("elodin-sim-{}", std::process::id()))
+            .ok()
+            .flatten();
+        if let Some(scope) = &scope {
+            scope.set_cpu_weight(s10::sim_cpu_weight());
+        }
+        scope
+    } else {
+        None
+    };
+
+    let result = recipe
+        .watch(
+            "sim".to_string(),
+            false,
+            cancel_token.clone(),
+            cgroup.clone(),
+        )
+        .await;
     cancel_token.cancel();
+    if let Some(scope) = cgroup {
+        let _ = scope.kill();
+        let _ = scope.remove();
+    }
+    result?;
     Ok(())
 }
 

--- a/libs/elodin-editor/src/run.rs
+++ b/libs/elodin-editor/src/run.rs
@@ -70,10 +70,14 @@ pub async fn run_recipe(
     // spawned recipe process is added to this cgroup by s10. Best-effort:
     // priority is never allowed to fail the run.
     let cgroup = if s10::priority_enabled() {
-        let _ = s10::CgroupScope::reap_prefix("elodin-sim-");
-        let scope = s10::CgroupScope::create(format!("elodin-sim-{}", std::process::id()))
-            .ok()
-            .flatten();
+        let created_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or_default();
+        let scope =
+            s10::CgroupScope::create(format!("elodin-sim-{}-{created_ns}", std::process::id()))
+                .ok()
+                .flatten();
         if let Some(scope) = &scope {
             scope.set_cpu_weight(s10::sim_cpu_weight());
         }

--- a/libs/monte-carlo/src/lib.rs
+++ b/libs/monte-carlo/src/lib.rs
@@ -866,6 +866,13 @@ async fn execute_campaign(params: ExecuteParams) -> Result<()> {
     }
     let campaign_cgroup =
         s10::CgroupScope::create(format!("elodin-mc-{}", std::process::id())).into_diagnostic()?;
+    // Prioritize the campaign's sims over background work under contention
+    // (Linux cgroup cpu.weight; best-effort, no-op elsewhere).
+    if s10::priority_enabled()
+        && let Some(scope) = &campaign_cgroup
+    {
+        scope.set_cpu_weight(s10::sim_cpu_weight());
+    }
     let base_recipe = plan_recipe(&sim_path, &out_dir).await?;
     let recipe_weight = s10::admission::recipe_weight(&base_recipe);
     let admission_max = s10::admission::max_inflight();

--- a/libs/nox-py/src/impeller2_server.rs
+++ b/libs/nox-py/src/impeller2_server.rs
@@ -1130,6 +1130,8 @@ async fn tick(
         }
         if !db.recording_cell.is_playing() {
             next_tick_deadline = None;
+            first_pacing_at = None;
+            rate_win_start = None;
             let _ = futures_lite::future::race(db.recording_cell.wait(), async {
                 cancel_token.wait().await;
                 false

--- a/libs/nox-py/src/impeller2_server.rs
+++ b/libs/nox-py/src/impeller2_server.rs
@@ -1061,10 +1061,54 @@ async fn tick(
         world.profiler_mut().detailed_timing = true;
         info!("detailed timing enabled (ELODIN_DETAILED_TIMING)");
     }
+    // Real-time pacing lead buffer: aim to wake this far *before* each tick
+    // deadline so the sim runs slightly ahead of wall-clock. A transient slow
+    // cycle (e.g. a lockstep `post_step` round-trip that overruns one period)
+    // then spends the buffer instead of crossing the deadline and logging
+    // "cannot achieve real-time". The schedule stays anchored, so the sim is
+    // bounded to at most `lead` ahead of real-time — data is available a few ms
+    // early, which is harmless for telemetry/SITL. It is an absolute time
+    // buffer (may span several ticks for high-rate sims, which is the point).
+    // Default covers the observed lockstep tail; `ELODIN_PACING_LEAD_US`
+    // overrides. Sanity-capped at 1s to swallow pathological env values.
+    let pacing_lead: Duration = std::env::var("ELODIN_PACING_LEAD_US")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .map(Duration::from_micros)
+        .unwrap_or(Duration::from_micros(2000))
+        .min(Duration::from_secs(1));
+    // Startup grace: suppress real-time warnings for this long after pacing
+    // begins, so a slow SITL/controller boot (e.g. Betaflight's multi-second
+    // init) doesn't fire a spurious "cannot achieve real-time". Overridable via
+    // `ELODIN_PACING_GRACE_US`.
+    let pacing_grace: Duration = std::env::var("ELODIN_PACING_GRACE_US")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .map(Duration::from_micros)
+        .unwrap_or(Duration::from_secs(5));
+    // Summary warmup: discard the first `warmup_ticks` ticks from the end-of-run
+    // stats so the simulator/SITL spin-up (the first cycle can stall for seconds
+    // while a flight controller boots) doesn't poison mean cycle / post_step /
+    // lateness. Overridable via `ELODIN_SIM_WARMUP_TICKS`; 0 disables.
+    let warmup_ticks: u64 = std::env::var("ELODIN_SIM_WARMUP_TICKS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(100);
+    let mut warmup_done = warmup_ticks == 0;
     #[rustfmt::skip]
     let should_cancel = || { is_cancelled() || cancel_token.is_cancelled() };
     let mut next_tick_deadline: Option<Instant> = None;
     let mut last_behind_warning: Option<Instant> = None;
+    // Trustworthy-warning state. The honest "cannot achieve real-time" signal is
+    // the *achieved cycle rate vs target* measured over a recent window — it is
+    // immune to the per-cycle jitter, the lead buffer, and the drift-cap resets
+    // that confound an instantaneous "now > deadline" check. We skip a startup
+    // grace (the SITL boot stall) and then, each window, warn if the sim is
+    // running materially slower than real-time.
+    let mut first_pacing_at: Option<Instant> = None;
+    let mut rate_win_start: Option<Instant> = None;
+    let mut rate_win_start_cycles: u64 = 0;
+    let mut pacing_cycles: u64 = 0;
     let mut last_timing_log: Option<Instant> = None;
     // Always-on per-phase timing summary. Dropping `metrics` prints
     // the one-block stdout summary on any exit (cancel, max_tick,
@@ -1102,6 +1146,12 @@ async fn tick(
             // Deadline is set after effective_batch is known for this iteration.
         }
         let tick = tick_counter.load(Ordering::SeqCst);
+        // Once past warmup, discard the spin-up samples so the summary reflects
+        // steady state (do this before this cycle's phases are observed).
+        if !warmup_done && tick >= warmup_ticks {
+            metrics.reset_after_warmup(tick);
+            warmup_done = true;
+        }
         let tick_nanos = time_step.as_nanos() * (tick as u128);
         let tick_duration = Duration::from_nanos(tick_nanos.min(u64::MAX as u128) as u64);
         let timestamp = start_timestamp + tick_duration;
@@ -1215,38 +1265,92 @@ async fn tick(
         metrics.observe_post_step(post_step_start.elapsed());
         if generate_real_time && let Some(deadline) = next_tick_deadline.as_mut() {
             let pacing_start = Instant::now();
-            let now = Instant::now();
-            if now > *deadline {
-                let should_warn = last_behind_warning
-                    .map(|last| now.duration_since(last) >= Duration::from_secs(1))
-                    .unwrap_or(true);
-                if should_warn {
-                    let behind_ms = now.duration_since(*deadline).as_secs_f64() * 1000.0;
-                    let target_ms = effective_batch_time_step.as_secs_f64() * 1000.0;
-                    let factor = if target_ms > 0.0 {
-                        (behind_ms + target_ms) / target_ms
-                    } else {
-                        0.0
-                    };
-                    info!(
-                        "simulation cannot achieve real-time; {:.2}ms behind target {:.2}ms/tick ({:.2}x behind)",
-                        behind_ms, target_ms, factor
-                    );
-                    last_behind_warning = Some(now);
+            let now = pacing_start;
+            // Signed deadline error: negative = ahead of schedule (we will
+            // sleep), positive = already behind (we will skip the sleep).
+            let deadline_err_ns: i64 = if now >= *deadline {
+                i64::try_from(now.duration_since(*deadline).as_nanos()).unwrap_or(i64::MAX)
+            } else {
+                -i64::try_from(deadline.duration_since(now).as_nanos()).unwrap_or(i64::MAX)
+            };
+            // Lateness vs the *true* deadline (the real-time violation). Warn
+            // only when it is SUSTAINED (a run of late cycles persisting past
+            // `warn_window`) and beyond a tolerance, so transient jitter and the
+            // boot stall — which the lead buffer + a fast recovery absorb — do
+            // not spam the log. The message reports the achieved-vs-target rate
+            // and mean lateness over the run, not a single instantaneous miss.
+            // Drift cap: re-anchor the schedule on a large one-time gap (the SITL
+            // boot stall, a pause/resume, a render-bridge connection) so we don't
+            // sprint a long burst of fast ticks to catch up. Transient slow cycles
+            // below this stay on the fixed schedule (the lead buffer absorbs them).
+            let was_reset = now > *deadline + effective_batch_time_step * 2;
+
+            // Trustworthy warning: compare achieved cycle rate to the target over
+            // a recent window, after a startup grace. This is the honest
+            // real-time signal and ignores per-cycle jitter / resets / the lead.
+            pacing_cycles += 1;
+            if first_pacing_at.is_none() {
+                first_pacing_at = Some(now);
+            }
+            let in_grace = now.duration_since(first_pacing_at.unwrap_or(now)) < pacing_grace;
+            if in_grace || rate_win_start.is_none() {
+                // Pin the window to `now` during grace so it starts clean after.
+                rate_win_start = Some(now);
+                rate_win_start_cycles = pacing_cycles;
+            } else if let Some(win_start) = rate_win_start {
+                let win_elapsed = now.duration_since(win_start);
+                // Evaluate over a 3 s window and only warn below 85% of target,
+                // so a transient stall doesn't trip a "cannot achieve real-time"
+                // — it fires only on a genuine, sustained deficit (a sim that is
+                // basically keeping up, e.g. ~95%, stays quiet).
+                if win_elapsed >= Duration::from_secs(3) {
+                    let cycles_in_win = pacing_cycles - rate_win_start_cycles;
+                    let achieved_hz = cycles_in_win as f64 / win_elapsed.as_secs_f64();
+                    let target_hz = 1.0 / effective_batch_time_step.as_secs_f64();
+                    if achieved_hz < 0.85 * target_hz {
+                        let should_warn = last_behind_warning
+                            .map(|last| now.duration_since(last) >= Duration::from_secs(1))
+                            .unwrap_or(true);
+                        if should_warn {
+                            info!(
+                                "simulation cannot achieve real-time; {:.0}/{:.0} cycles/s ({:.0}% of real-time)",
+                                achieved_hz,
+                                target_hz,
+                                100.0 * achieved_hz / target_hz,
+                            );
+                            last_behind_warning = Some(now);
+                        }
+                    }
+                    rate_win_start = Some(now);
+                    rate_win_start_cycles = pacing_cycles;
                 }
             }
-            // Cap deadline drift: if we're more than 2 tick periods behind,
-            // reset the deadline to now. This prevents a burst of fast ticks
-            // (visible as timeline stutter in the editor) when a one-time
-            // delay occurs, such as the initial render bridge connection.
-            if now > *deadline + effective_batch_time_step * 2 {
+            if was_reset {
                 *deadline = now;
             }
-            if *deadline > now {
-                stellarator::sleep(*deadline - now).await;
+            // Pace to `deadline - lead` (run slightly ahead) rather than to the
+            // deadline itself, so a transient slow cycle spends the lead buffer
+            // instead of crossing the deadline. `requested` is the sleep we ask
+            // the runtime for; `actual` is what really elapsed (their difference
+            // is the timer/OS oversleep we record as a diagnostic).
+            let target = deadline.checked_sub(pacing_lead).unwrap_or(*deadline);
+            let mut requested = Duration::ZERO;
+            let mut actual = Duration::ZERO;
+            if target > now {
+                requested = target.duration_since(now);
+                let sleep_start = Instant::now();
+                stellarator::sleep(requested).await;
+                actual = sleep_start.elapsed();
             }
             *deadline += effective_batch_time_step;
             metrics.observe_real_time_pacing(pacing_start.elapsed());
+            metrics.observe_pacing(
+                pacing_start.duration_since(start),
+                requested,
+                actual,
+                deadline_err_ns,
+                was_reset,
+            );
         }
         if detailed_timing {
             let now = Instant::now();

--- a/libs/nox-py/src/impeller2_server.rs
+++ b/libs/nox-py/src/impeller2_server.rs
@@ -1146,12 +1146,6 @@ async fn tick(
             // Deadline is set after effective_batch is known for this iteration.
         }
         let tick = tick_counter.load(Ordering::SeqCst);
-        // Once past warmup, discard the spin-up samples so the summary reflects
-        // steady state (do this before this cycle's phases are observed).
-        if !warmup_done && tick >= warmup_ticks {
-            metrics.reset_after_warmup(tick);
-            warmup_done = true;
-        }
         let tick_nanos = time_step.as_nanos() * (tick as u128);
         let tick_duration = Duration::from_nanos(tick_nanos.min(u64::MAX as u128) as u64);
         let timestamp = start_timestamp + tick_duration;
@@ -1188,6 +1182,15 @@ async fn tick(
             db.last_updated.store(Timestamp(i64::MIN));
             next_tick_deadline = None;
             continue;
+        }
+
+        // Once past warmup, discard the spin-up samples so the summary reflects
+        // steady state. Wait until after pre_step/rollback handling so
+        // StepContext::truncate() does not mark warmup complete for a run that is
+        // about to restart from tick 0.
+        if !warmup_done && tick >= warmup_ticks {
+            metrics.reset_after_warmup(tick);
+            warmup_done = true;
         }
 
         let copy_in_start = Instant::now();

--- a/libs/nox-py/src/impeller2_server.rs
+++ b/libs/nox-py/src/impeller2_server.rs
@@ -1130,8 +1130,11 @@ async fn tick(
         }
         if !db.recording_cell.is_playing() {
             next_tick_deadline = None;
+            last_behind_warning = None;
             first_pacing_at = None;
             rate_win_start = None;
+            rate_win_start_cycles = 0;
+            pacing_cycles = 0;
             let _ = futures_lite::future::race(db.recording_cell.wait(), async {
                 cancel_token.wait().await;
                 false
@@ -1193,6 +1196,11 @@ async fn tick(
         if !warmup_done && tick >= warmup_ticks {
             metrics.reset_after_warmup(tick);
             warmup_done = true;
+            last_behind_warning = None;
+            first_pacing_at = None;
+            rate_win_start = None;
+            rate_win_start_cycles = 0;
+            pacing_cycles = 0;
         }
 
         let copy_in_start = Instant::now();
@@ -1297,7 +1305,8 @@ async fn tick(
             if first_pacing_at.is_none() {
                 first_pacing_at = Some(now);
             }
-            let in_grace = now.duration_since(first_pacing_at.unwrap_or(now)) < pacing_grace;
+            let in_grace =
+                !warmup_done || now.duration_since(first_pacing_at.unwrap_or(now)) < pacing_grace;
             if in_grace || rate_win_start.is_none() {
                 // Pin the window to `now` during grace so it starts clean after.
                 rate_win_start = Some(now);

--- a/libs/nox-py/src/tick_metrics.rs
+++ b/libs/nox-py/src/tick_metrics.rs
@@ -83,9 +83,15 @@ pub struct TickSummaryJson {
     wait_for_write: PhaseStatsSnapshot,
     post_step: PhaseStatsSnapshot,
     real_time_pacing: PhaseStatsSnapshot,
+    real_time_oversleep: PhaseStatsSnapshot,
+    real_time_behind: PhaseStatsSnapshot,
+    pacing_behind_events: u64,
+    pacing_resets: u64,
+    pacing_no_sleep: u64,
     total_cycle: PhaseStatsSnapshot,
     cycles: u64,
     steps: u64,
+    warmup_excluded_ticks: u64,
     simulation_rate_hz: f64,
     telemetry_rate_hz: f64,
     wall_ns: u64,
@@ -184,6 +190,78 @@ impl PhaseStats {
     }
 }
 
+/// One row of the optional per-cycle pacing trace. Compact (40 bytes)
+/// so a long run's worth fits comfortably in the pre-sized buffer.
+#[derive(Clone, Copy)]
+struct PacingSample {
+    /// Compute time for the cycle (loop-top to pacing-block entry):
+    /// pre_step + read + tick + commit + wait_for_write + post_step.
+    work_ns: u64,
+    /// Sleep duration we *asked* for (`deadline - now`), 0 if behind.
+    requested_sleep_ns: u64,
+    /// Sleep duration that actually elapsed on the wall clock.
+    actual_sleep_ns: u64,
+    /// Signed deadline error at the pacing check: `now - deadline`.
+    /// Negative = ahead of schedule (good), positive = behind.
+    deadline_err_ns: i64,
+    /// Whether the drift cap reset the deadline forward this cycle.
+    reset: bool,
+}
+
+/// Pre-allocated ring of pacing samples plus the CSV destination.
+struct PacingTrace {
+    path: PathBuf,
+    samples: Vec<PacingSample>,
+    /// Cap so unbounded (interactive) runs can't grow without limit.
+    max: usize,
+}
+
+impl PacingTrace {
+    fn from_env() -> Option<Self> {
+        let path = std::env::var("ELODIN_PACING_TRACE").ok()?;
+        let max = std::env::var("ELODIN_PACING_TRACE_MAX")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(2_000_000usize);
+        Some(Self {
+            path: PathBuf::from(path),
+            samples: Vec::with_capacity(max.min(1_000_000)),
+            max,
+        })
+    }
+
+    #[inline]
+    fn push(&mut self, sample: PacingSample) {
+        if self.samples.len() < self.max {
+            self.samples.push(sample);
+        }
+    }
+
+    fn flush(&self) {
+        if let Some(parent) = self.path.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        let mut out = String::with_capacity(self.samples.len() * 48 + 64);
+        out.push_str(
+            "cycle,work_ns,requested_sleep_ns,actual_sleep_ns,oversleep_ns,deadline_err_ns,reset\n",
+        );
+        for (i, s) in self.samples.iter().enumerate() {
+            let oversleep = s.actual_sleep_ns.saturating_sub(s.requested_sleep_ns);
+            out.push_str(&format!(
+                "{},{},{},{},{},{},{}\n",
+                i,
+                s.work_ns,
+                s.requested_sleep_ns,
+                s.actual_sleep_ns,
+                oversleep,
+                s.deadline_err_ns,
+                s.reset as u8,
+            ));
+        }
+        let _ = fs::write(&self.path, out);
+    }
+}
+
 /// Owner of one simulation loop's per-phase statistics. Dropping
 /// this struct prints the final summary to stdout; the `tick` async
 /// fn binds one of these at the top of the function so the summary
@@ -197,6 +275,30 @@ pub struct TickMetrics {
     pub wait_for_write: PhaseStats,
     pub post_step: PhaseStats,
     pub real_time_pacing: PhaseStats,
+    /// Real-time pacing diagnostics (only populated when
+    /// `generate_real_time` is on). `real_time_oversleep` is the
+    /// amount each pacing sleep ran *past* the duration we asked for
+    /// (`actual_sleep - requested_sleep`); it isolates timer / OS /
+    /// executor wakeup jitter from the intended sleep. `real_time_behind`
+    /// records, for the cycles where we entered the pacing block already
+    /// past the deadline, how far past we were (the positive lateness).
+    pub real_time_oversleep: PhaseStats,
+    pub real_time_behind: PhaseStats,
+    /// Count of cycles where, at the pacing check, wall time had already
+    /// passed the per-cycle deadline (i.e. the "cannot achieve real-time"
+    /// warning condition was true for that cycle).
+    pub pacing_behind_events: u64,
+    /// Count of cycles where the deadline was reset forward to `now`
+    /// because we were more than two tick-periods behind (drift cap).
+    pub pacing_resets: u64,
+    /// Count of cycles where no sleep happened because the deadline had
+    /// already elapsed (we were behind and trying to catch up).
+    pub pacing_no_sleep: u64,
+    /// Optional per-cycle pacing trace. Allocated up front (capacity from
+    /// `ELODIN_PACING_TRACE_MAX`) and flushed to the CSV path in
+    /// `ELODIN_PACING_TRACE` on drop. `None` unless the env var is set, so
+    /// default runs allocate nothing and stay on the zero-I/O hot path.
+    pacing_trace: Option<PacingTrace>,
     /// Wall-clock duration of one simulation cycle (from immediately
     /// after the cancel / paused checks down to just before the next
     /// iteration starts). Feeds the "mean cycle" header and
@@ -219,6 +321,11 @@ pub struct TickMetrics {
     started_at: Instant,
     started_unix_ns: u64,
     loop_end_unix_ns: Option<u64>,
+    /// Number of initial ticks excluded from the stats as "warmup" (the
+    /// simulator/SITL spin-up). Set by [`Self::reset_after_warmup`]; shown in
+    /// the summary header so the reader knows the boot was not measured. 0 means
+    /// no warmup reset happened (e.g. a run shorter than the warmup window).
+    warmup_excluded_ticks: u64,
     /// Suppresses the `Drop` summary (e.g. when no cycles ever ran).
     /// Currently unused — the summary itself gracefully handles
     /// zero-cycle cases — but kept as an escape hatch for callers
@@ -236,6 +343,12 @@ impl TickMetrics {
             wait_for_write: PhaseStats::default(),
             post_step: PhaseStats::default(),
             real_time_pacing: PhaseStats::default(),
+            real_time_oversleep: PhaseStats::default(),
+            real_time_behind: PhaseStats::default(),
+            pacing_behind_events: 0,
+            pacing_resets: 0,
+            pacing_no_sleep: 0,
+            pacing_trace: PacingTrace::from_env(),
             total_cycle: PhaseStats::default(),
             cycles: 0,
             steps: 0,
@@ -244,12 +357,41 @@ impl TickMetrics {
             started_at: Instant::now(),
             started_unix_ns: unix_now_ns(),
             loop_end_unix_ns: None,
+            warmup_excluded_ticks: 0,
             silent: false,
         }
     }
 
     pub fn mark_loop_end(&mut self) {
         self.loop_end_unix_ns.get_or_insert_with(unix_now_ns);
+    }
+
+    /// Discard everything accumulated so far and restart the clock, so the
+    /// final summary reflects steady state rather than the simulator/SITL
+    /// spin-up (the first cycle can stall for seconds while a flight controller
+    /// boots, which otherwise poisons mean cycle / post_step / lateness). Called
+    /// once by the loop after the warmup tick threshold is crossed. The
+    /// per-cycle pacing trace (if enabled) is intentionally kept intact so the
+    /// boot is still visible for offline debugging.
+    pub fn reset_after_warmup(&mut self, excluded_ticks: u64) {
+        self.pre_step = PhaseStats::default();
+        self.copy_db_to_world = PhaseStats::default();
+        self.world_run = PhaseStats::default();
+        self.commit = PhaseStats::default();
+        self.wait_for_write = PhaseStats::default();
+        self.post_step = PhaseStats::default();
+        self.real_time_pacing = PhaseStats::default();
+        self.real_time_oversleep = PhaseStats::default();
+        self.real_time_behind = PhaseStats::default();
+        self.total_cycle = PhaseStats::default();
+        self.pacing_behind_events = 0;
+        self.pacing_resets = 0;
+        self.pacing_no_sleep = 0;
+        self.cycles = 0;
+        self.steps = 0;
+        self.started_at = Instant::now();
+        self.started_unix_ns = unix_now_ns();
+        self.warmup_excluded_ticks = excluded_ticks;
     }
 
     /// Feed the configured rates so `print_summary` can show the
@@ -292,6 +434,45 @@ impl TickMetrics {
     #[inline]
     pub fn observe_total_cycle(&mut self, d: Duration) {
         self.total_cycle.observe(d);
+    }
+
+    /// Record one real-time pacing cycle. `work` is the cycle's compute
+    /// time, `requested` the sleep we asked for (`Duration::ZERO` when we
+    /// were behind and skipped sleeping), `actual` the sleep that actually
+    /// elapsed, `deadline_err_ns` the signed `now - deadline` at the pacing
+    /// check (negative = ahead), and `reset` whether the drift cap fired.
+    #[inline]
+    pub fn observe_pacing(
+        &mut self,
+        work: Duration,
+        requested: Duration,
+        actual: Duration,
+        deadline_err_ns: i64,
+        reset: bool,
+    ) {
+        if deadline_err_ns > 0 {
+            self.pacing_behind_events += 1;
+            self.real_time_behind
+                .observe(Duration::from_nanos(deadline_err_ns as u64));
+        }
+        if reset {
+            self.pacing_resets += 1;
+        }
+        if requested.is_zero() {
+            self.pacing_no_sleep += 1;
+        } else {
+            self.real_time_oversleep
+                .observe(actual.saturating_sub(requested));
+        }
+        if let Some(trace) = self.pacing_trace.as_mut() {
+            trace.push(PacingSample {
+                work_ns: u64::try_from(work.as_nanos()).unwrap_or(u64::MAX),
+                requested_sleep_ns: u64::try_from(requested.as_nanos()).unwrap_or(u64::MAX),
+                actual_sleep_ns: u64::try_from(actual.as_nanos()).unwrap_or(u64::MAX),
+                deadline_err_ns,
+                reset,
+            });
+        }
     }
 
     /// Format a ns duration into a compact human-readable cell
@@ -342,6 +523,12 @@ impl TickMetrics {
         let wall = self.started_at.elapsed();
         println!();
         println!("──── elodin simulation summary ────");
+        if self.warmup_excluded_ticks > 0 {
+            println!(
+                "  (excluding first {} ticks as warmup / spin-up)",
+                format_commas(self.warmup_excluded_ticks),
+            );
+        }
         println!("  wall time:          {:.3} s", wall.as_secs_f64());
         if self.cycles == 0 {
             println!("  simulation cycles:  0  (no cycles executed)");
@@ -394,7 +581,43 @@ impl TickMetrics {
             "{}",
             Self::fmt_row("real-time pacing", &self.real_time_pacing)
         );
+        self.print_pacing_diagnostics();
         println!("───────────────────────────────────");
+    }
+
+    /// Extra real-time pacing diagnostics, printed only when pacing was
+    /// active. Surfaces *why* a sim with compute headroom can still slip
+    /// behind wall-clock: sleep oversleep (timer/OS jitter), how often we
+    /// crossed the deadline, and how often the drift cap reset.
+    fn print_pacing_diagnostics(&self) {
+        if self.real_time_pacing.count == 0 {
+            return;
+        }
+        let paced = self.cycles.max(1);
+        let behind_pct = 100.0 * self.pacing_behind_events as f64 / paced as f64;
+        println!();
+        println!("  real-time pacing diagnostics:");
+        println!(
+            "{}",
+            Self::fmt_row("  oversleep (jitter)", &self.real_time_oversleep)
+        );
+        println!(
+            "{}",
+            Self::fmt_row("  lateness when behind", &self.real_time_behind)
+        );
+        println!(
+            "    {:<18} {} cycles ({:.1}% of {})",
+            "behind-deadline:",
+            format_commas(self.pacing_behind_events),
+            behind_pct,
+            format_commas(paced),
+        );
+        println!(
+            "    {:<18} {}    skipped sleep: {}",
+            "drift resets:",
+            format_commas(self.pacing_resets),
+            format_commas(self.pacing_no_sleep),
+        );
     }
 
     pub fn summary_json(&self) -> TickSummaryJson {
@@ -407,9 +630,15 @@ impl TickMetrics {
             wait_for_write: (&self.wait_for_write).into(),
             post_step: (&self.post_step).into(),
             real_time_pacing: (&self.real_time_pacing).into(),
+            real_time_oversleep: (&self.real_time_oversleep).into(),
+            real_time_behind: (&self.real_time_behind).into(),
+            pacing_behind_events: self.pacing_behind_events,
+            pacing_resets: self.pacing_resets,
+            pacing_no_sleep: self.pacing_no_sleep,
             total_cycle: (&self.total_cycle).into(),
             cycles: self.cycles,
             steps: self.steps,
+            warmup_excluded_ticks: self.warmup_excluded_ticks,
             simulation_rate_hz: self.simulation_rate_hz,
             telemetry_rate_hz: self.telemetry_rate_hz,
             wall_ns: u64::try_from(self.started_at.elapsed().as_nanos()).unwrap_or(u64::MAX),
@@ -474,6 +703,9 @@ impl Drop for TickMetrics {
         self.mark_loop_end();
         self.print_summary();
         self.write_summary_json_from_env();
+        if let Some(trace) = self.pacing_trace.as_ref() {
+            trace.flush();
+        }
     }
 }
 

--- a/libs/nox-py/src/tick_metrics.rs
+++ b/libs/nox-py/src/tick_metrics.rs
@@ -291,8 +291,10 @@ pub struct TickMetrics {
     /// Count of cycles where the deadline was reset forward to `now`
     /// because we were more than two tick-periods behind (drift cap).
     pub pacing_resets: u64,
-    /// Count of cycles where no sleep happened because the deadline had
-    /// already elapsed (we were behind and trying to catch up).
+    /// Count of cycles where no sleep happened because the *real* deadline had
+    /// already elapsed (we were behind and trying to catch up). Does not count
+    /// cycles that only consumed the lead buffer (`deadline - lead` target in
+    /// the past while the real deadline is still in the future).
     pub pacing_no_sleep: u64,
     /// Optional per-cycle pacing trace. Allocated up front (capacity from
     /// `ELODIN_PACING_TRACE_MAX`) and flushed to the CSV path in
@@ -436,11 +438,12 @@ impl TickMetrics {
         self.total_cycle.observe(d);
     }
 
-    /// Record one real-time pacing cycle. `work` is the cycle's compute
-    /// time, `requested` the sleep we asked for (`Duration::ZERO` when we
-    /// were behind and skipped sleeping), `actual` the sleep that actually
-    /// elapsed, `deadline_err_ns` the signed `now - deadline` at the pacing
-    /// check (negative = ahead), and `reset` whether the drift cap fired.
+    /// Record one real-time pacing cycle. `work` is the cycle's compute time,
+    /// `requested` the sleep we asked for (`Duration::ZERO` when either the
+    /// lead-buffer target or the real deadline was already past), `actual` the
+    /// sleep that actually elapsed, `deadline_err_ns` the signed `now -
+    /// deadline` at the pacing check (negative = ahead), and `reset` whether
+    /// the drift cap fired.
     #[inline]
     pub fn observe_pacing(
         &mut self,
@@ -458,9 +461,9 @@ impl TickMetrics {
         if reset {
             self.pacing_resets += 1;
         }
-        if requested.is_zero() {
+        if requested.is_zero() && deadline_err_ns > 0 {
             self.pacing_no_sleep += 1;
-        } else {
+        } else if !requested.is_zero() {
             self.real_time_oversleep
                 .observe(actual.saturating_sub(requested));
         }
@@ -613,7 +616,7 @@ impl TickMetrics {
             format_commas(paced),
         );
         println!(
-            "    {:<18} {}    skipped sleep: {}",
+            "    {:<18} {}    catch-up no sleep: {}",
             "drift resets:",
             format_commas(self.pacing_resets),
             format_commas(self.pacing_no_sleep),
@@ -832,5 +835,31 @@ mod tests {
         m.set_rates(300.0, 100.0);
         assert_eq!(m.simulation_rate_hz, 300.0);
         assert_eq!(m.telemetry_rate_hz, 100.0);
+    }
+
+    #[test]
+    fn no_sleep_counts_only_when_behind_real_deadline() {
+        let mut m = TickMetrics::new();
+        m.silent = true;
+
+        // Lead target already elapsed, but the real deadline is still ahead.
+        m.observe_pacing(
+            Duration::from_micros(500),
+            Duration::ZERO,
+            Duration::ZERO,
+            -1_000,
+            false,
+        );
+        assert_eq!(m.pacing_no_sleep, 0);
+
+        // Real deadline elapsed: this is a catch-up no-sleep cycle.
+        m.observe_pacing(
+            Duration::from_micros(500),
+            Duration::ZERO,
+            Duration::ZERO,
+            1_000,
+            false,
+        );
+        assert_eq!(m.pacing_no_sleep, 1);
     }
 }

--- a/libs/s10/src/cgroup.rs
+++ b/libs/s10/src/cgroup.rs
@@ -1,5 +1,7 @@
+#[cfg(target_os = "linux")]
+use std::fs;
 use std::{
-    fs, io,
+    io,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -66,6 +68,28 @@ impl CgroupScope {
         Ok(())
     }
 
+    /// Give every process in this cgroup a larger share of the CPU under
+    /// contention (cgroup-v2 `cpu.weight`, 1..=10000, default 100), so the
+    /// real-time simulation stack is scheduled promptly when other work (an
+    /// editor render loop, co-located services) competes for cores.
+    ///
+    /// Entirely best-effort: the `cpu.weight` knob only exists when the `cpu`
+    /// controller is delegated to this cgroup (we try to enable it in the
+    /// parent's `cgroup.subtree_control` first), and we never fail a simulation
+    /// because priority could not be raised. A no-op on non-Linux and on hosts
+    /// where the controller isn't available.
+    #[cfg(target_os = "linux")]
+    pub fn set_cpu_weight(&self, weight: u32) {
+        let weight = weight.clamp(1, 10_000);
+        if let Some(parent) = self.path.parent() {
+            let _ = fs::write(parent.join("cgroup.subtree_control"), "+cpu");
+        }
+        let _ = fs::write(self.path.join("cpu.weight"), weight.to_string());
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub fn set_cpu_weight(&self, _weight: u32) {}
+
     #[cfg(target_os = "linux")]
     pub fn kill(&self) -> io::Result<()> {
         match fs::write(self.path.join("cgroup.kill"), "1") {
@@ -130,6 +154,27 @@ impl CgroupScope {
     pub fn reap_prefix(_prefix: &str) -> io::Result<()> {
         Ok(())
     }
+}
+
+/// Whether s10 should prioritize the simulation stack (via cgroup `cpu.weight`).
+/// On by default; set `ELODIN_S10_PRIORITY=off` to disable (for A/B comparison
+/// or debugging).
+pub fn priority_enabled() -> bool {
+    !matches!(
+        std::env::var("ELODIN_S10_PRIORITY").as_deref(),
+        Ok("off") | Ok("0") | Ok("false")
+    )
+}
+
+/// cgroup-v2 `cpu.weight` to apply to the simulation stack. Defaults to the
+/// maximum share (the sim is latency-critical but low-duty, so a high weight
+/// gets it scheduled promptly without meaningfully starving others). Override
+/// with `ELODIN_S10_CPU_WEIGHT`.
+pub fn sim_cpu_weight() -> u32 {
+    std::env::var("ELODIN_S10_CPU_WEIGHT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(10_000)
 }
 
 #[cfg(target_os = "linux")]

--- a/libs/stellarator/examples/sleep_bench.rs
+++ b/libs/stellarator/examples/sleep_bench.rs
@@ -1,0 +1,129 @@
+//! Microbench for `stellarator::sleep` accuracy vs an absolute deadline.
+//!
+//! Investigation I1 for the real-time pacing work: how much does a requested
+//! short sleep overshoot on the actual stellarator runtime (maitake timer
+//! wheel + poll/kqueue reactor), idle vs under CPU contention? This is the
+//! authoritative measurement the pacing loop depends on (the libc `time.sleep`
+//! proxy overstated it).
+//!
+//! Usage:
+//!   cargo run -p stellarator --release --example sleep_bench -- [period_us] [iters] [load_threads]
+//!
+//! It paces with an absolute deadline (deadline += period; sleep until it),
+//! exactly like the sim loop, and reports per-cycle oversleep (actual sleep -
+//! requested sleep) plus how often a cycle ends up behind its deadline. A
+//! `sleep-until(deadline - 300us) + busy-spin` variant is also measured to show
+//! the precision a hybrid pacer reaches on the same runtime.
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread,
+    time::{Duration, Instant},
+};
+
+fn percentile(sorted: &[f64], q: f64) -> f64 {
+    if sorted.is_empty() {
+        return 0.0;
+    }
+    let idx = ((q * sorted.len() as f64) as usize).min(sorted.len() - 1);
+    sorted[idx]
+}
+
+fn report(label: &str, mut xs_ms: Vec<f64>) {
+    xs_ms.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let mean = xs_ms.iter().sum::<f64>() / xs_ms.len().max(1) as f64;
+    println!(
+        "  {label:22} mean={mean:7.3}  p50={:7.3}  p95={:7.3}  p99={:7.3}  max={:8.3}  (ms)",
+        percentile(&xs_ms, 0.50),
+        percentile(&xs_ms, 0.95),
+        percentile(&xs_ms, 0.99),
+        percentile(&xs_ms, 1.0),
+    );
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let period_us: u64 = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(667);
+    let iters: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(5000);
+    let load_threads: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(0);
+    let period = Duration::from_micros(period_us);
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let mut handles = Vec::new();
+    for _ in 0..load_threads {
+        let stop = stop.clone();
+        handles.push(thread::spawn(move || {
+            let mut x: u64 = 0;
+            while !stop.load(Ordering::Relaxed) {
+                x = x.wrapping_mul(6364136223846793005).wrapping_add(1);
+                std::hint::black_box(x);
+            }
+        }));
+    }
+
+    println!("period={period_us}us  iters={iters}  load_threads={load_threads}\n");
+
+    stellarator::run(|| async move {
+        // Pure absolute-deadline pacing (mirrors the sim loop).
+        let mut oversleep_ms = Vec::with_capacity(iters);
+        let mut behind = 0usize;
+        let mut deadline = Instant::now() + period;
+        for _ in 0..iters {
+            let now = Instant::now();
+            if now >= deadline {
+                behind += 1;
+            } else {
+                let requested = deadline - now;
+                let start = Instant::now();
+                stellarator::sleep(requested).await;
+                let actual = start.elapsed();
+                oversleep_ms.push((actual.saturating_sub(requested)).as_secs_f64() * 1e3);
+            }
+            deadline += period;
+        }
+        report("oversleep (sleep)", oversleep_ms);
+        println!(
+            "  behind-deadline: {behind} / {iters} ({:.1}%)\n",
+            100.0 * behind as f64 / iters as f64
+        );
+
+        // Hybrid: sleep until deadline-300us, then busy-spin to the deadline.
+        let margin = Duration::from_micros(300);
+        let mut over_ms = Vec::with_capacity(iters);
+        let mut behind2 = 0usize;
+        let mut deadline = Instant::now() + period;
+        for _ in 0..iters {
+            let now = Instant::now();
+            if now >= deadline {
+                behind2 += 1;
+            } else {
+                let requested = deadline - now;
+                let start = Instant::now();
+                if let Some(sleep_dur) = requested.checked_sub(margin) {
+                    if !sleep_dur.is_zero() {
+                        stellarator::sleep(sleep_dur).await;
+                    }
+                }
+                while Instant::now() < deadline {
+                    std::hint::spin_loop();
+                }
+                let actual = start.elapsed();
+                over_ms.push((actual.saturating_sub(requested)).as_secs_f64() * 1e3);
+            }
+            deadline += period;
+        }
+        report("oversleep (sleep+spin)", over_ms);
+        println!(
+            "  behind-deadline: {behind2} / {iters} ({:.1}%)",
+            100.0 * behind2 as f64 / iters as f64
+        );
+    });
+
+    stop.store(true, Ordering::Relaxed);
+    for h in handles {
+        let _ = h.join();
+    }
+}


### PR DESCRIPTION
Improvements to reduce extraneous real time pacing, and conduct better measurement:

```sh
m ──── elodin simulation summary ────
sim   (excluding first 100 ticks as warmup / spin-up)
sim   wall time:          16.363 s
sim   simulation cycles:  29,900    mean cycle: 547.2 µs  (effective 1827 cycles/s)
sim 
sim   per-cycle phase timing (mean / p95 / max):
sim     pre_step               24 ns      62 ns    17.6 µs
sim     read (db → world)     4.3 µs    13.0 µs   336.1 µs
sim     tick function         3.5 µs     8.5 µs   346.2 µs
sim     commit world          8.2 µs    18.5 µs   682.8 µs
sim     wait_for_write         24 ns      62 ns    12.5 µs
sim     post_step           355.3 µs     1.5 ms     8.8 ms
sim     real-time pacing    174.9 µs   477.0 µs   477.0 µs
sim 
sim   real-time pacing diagnostics:
sim       oversleep (jitter)   24.1 µs    55.0 µs   187.9 µs
sim       lateness when behind  668.7 µs     2.4 ms     8.9 ms
sim     behind-deadline:   3,784 cycles (12.7% of 29,900)
sim     drift resets:      744    skipped sleep: 12,932
sim ───────────────────────────────────
sim Betaflight SITL: betaflight_SITL.elf
sim Simulation: 15.0s at 2000Hz PID loop
sim Sensor rates: gyro=8000Hz, accel=4800Hz, baro=480Hz, mag=200Hz
```

[realtime-pacing-investigation.md](https://github.com/user-attachments/files/29299584/realtime-pacing-investigation.md)
[s10-realtime-priority-recommendation.md](https://github.com/user-attachments/files/29299588/s10-realtime-priority-recommendation.md)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the hot-path real-time pacing loop and warning semantics in the Python sim server, plus cgroup CPU weight on Linux; failures are mostly best-effort, but mis-tuning could hide real-time deficits or affect scheduling under contention.
> 
> **Overview**
> **Real-time simulation pacing** is reworked so lockstep SITL runs stay closer to wall clock under load without noisy false alarms. The tick loop sleeps to `deadline - lead` (default 2 ms via `ELODIN_PACING_LEAD_US`), uses a startup grace (`ELODIN_PACING_GRACE_US`) and optional warmup exclusion (`ELODIN_SIM_WARMUP_TICKS`) before stats, and warns on sustained low achieved cycle rate (~85% over 3 s) instead of instant “behind deadline” checks. **TickMetrics** adds oversleep/lateness counters, stdout pacing diagnostics, JSON fields, and optional per-cycle CSV via `ELODIN_PACING_TRACE`.
> 
> **Linux scheduling**: s10 gains best-effort cgroup-v2 `cpu.weight` (`set_cpu_weight`, `ELODIN_S10_PRIORITY` / `ELODIN_S10_CPU_WEIGHT`). The editor wraps the full sim recipe in one prioritized cgroup; Monte Carlo sets weight on the campaign cgroup. A **stellarator `sleep_bench`** example documents sleep overshoot for pacing tuning.
> 
> **Monte Carlo example**: pass/fail uses an **8.5 m capture radius** (`ELODIN_MONTE_CARLO_CAPTURE_RADIUS_M`); README documents intentional partial failures; **post_campaign** report adds percentiles and worst misses.
> 
> **Betaflight SITL** default `simulation_rate` switches from 4 kHz to **2 kHz**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9af24b0ead49523506e749949d5f6eb341bb46a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->