### PR TITLE
Elodin on Aleph Tweaks

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -6,7 +6,7 @@ If you run `nix develop` and it looks like this:
 ```sh
 $ nix develop
 warning: Git tree '/Users/shane/Projects/elodin' has uncommitted changes
-warning: ignoring untrusted substituter 'https://elodin-nix-cache.s3.us-west-2.amazonaws.com', you are not a trusted user.
+warning: ignoring untrusted substituter 'https://s3-us-west-2.amazonaws.com/elodin-nix-cache', you are not a trusted user.
 ...
 ```
 Edit the following files to look like this:
@@ -14,7 +14,7 @@ Edit the following files to look like this:
 ```sh
 $ cat /etc/nix/nix.custom.conf
 trusted-users = root YOUR-USER-NAME-HERE
-extra-trusted-substituters = https://elodin-nix-cache.s3.us-west-2.amazonaws.com
+extra-trusted-substituters = https://s3-us-west-2.amazonaws.com/elodin-nix-cache
 extra-trusted-public-keys = elodin-cache-1:vvbmIQvTOjcBjIs8Ri7xlT2I3XAmeJyF5mNlWB+fIwM=
 ```
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ git lfs install
 
 After installing these packages, follow the same `just install` and `uvx maturin` local build steps above.
 
+
 ## Additional Resources
 
 - [Elodin App Documentation](apps/elodin/README.md)

--- a/aleph/flake.lock
+++ b/aleph/flake.lock
@@ -49,11 +49,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780902259,
-        "narHash": "sha256-q8yYEC5f1mFlQO9RGna4LTc9QrcvWunX6FYp83munkQ=",
+        "lastModified": 1782116945,
+        "narHash": "sha256-G3tw/IXmaH6IQ2upZvhuN9sG8CkuX+BLuJDpE8hz0Ds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bd0ff2d3eac24699c3664d5966b9ef36f388e2ca",
+        "rev": "34268251cf5547d39063f2c5ea9a196246f7f3a6",
         "type": "github"
       },
       "original": {
@@ -65,11 +65,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1774709303,
-        "narHash": "sha256-D3Q07BbIA2KnTcSXIqqu9P586uWxN74zNoCH3h2ESHg=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8110df5ad7abf5d4c0f6fb0f8f978390e77f9685",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {
@@ -94,11 +94,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779160702,
-        "narHash": "sha256-frUihZLlBLdcFN95mq5QiQmxF2M16nxtmw1GH4rhZmg=",
+        "lastModified": 1782357464,
+        "narHash": "sha256-mXgoT1qDHCdSfF9IvhMtEEFNy9dxrmUfSViwP7RpzOQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8cd592658d4448c57326aaa819e1c2f91086eb40",
+        "rev": "77a8263847fb02dc49dbe377278ef6b952f1c6bb",
         "type": "github"
       },
       "original": {

--- a/aleph/flake.nix
+++ b/aleph/flake.nix
@@ -31,6 +31,10 @@
 
     rustToolchain = p: p.rust-bin.fromRustupToolchainFile ../rust-toolchain.toml;
     gitJSONOverlay = builtins.fromJSON (builtins.readFile ./gitrepos.json);
+    secureBzip2Overlay = _final: prev: {
+      # JetPack only needs a non-ancient unpacker; avoid nixpkgs' insecure 1.1 snapshot.
+      bzip2_1_1 = prev.bzip2;
+    };
     gitReposOverlay = final: prev: {
       # Our packing of deepstream7 still needs nvidia sources, so we can't use upstream nixpkgs yet!
       # Start with upstream nixpkgs _cuda/manifests and overlay jetpack ones (where prevCuda is jetpack-nixos cuda)
@@ -40,8 +44,6 @@
           (import "${nixpkgs}/pkgs/development/cuda-modules/_cuda/manifests" {inherit (final) lib;})
           prevCuda.manifests;
       });
-      # JetPack only needs a non-ancient unpacker; avoid nixpkgs' insecure 1.1 snapshot.
-      bzip2_1_1 = prev.bzip2;
       # Override jetpack-nixos gitrepos with other sources specific to the aleph carrier board configuration
       nvidia-jetpack6 = prev.nvidia-jetpack6.overrideScope (jetpackFinal: jetpackPrev: {
         gitRepos =
@@ -59,6 +61,7 @@
         callPackage = path: args: final.callPackage path (args // {inherit rustToolchain;});
       })
       // (rust-overlay.overlays.default final prev)
+      // (secureBzip2Overlay final prev)
       // (gitReposOverlay final prev);
 
     baseModules = {
@@ -191,6 +194,7 @@
         flash-cross = jetpack.nixosConfigurations."orin-nx-devkit".extendModules {
           modules = [
             {nixpkgs.buildPlatform.system = "x86_64-linux";}
+            {nixpkgs.overlays = [secureBzip2Overlay];}
           ];
         };
       in {

--- a/aleph/flake.nix
+++ b/aleph/flake.nix
@@ -40,6 +40,8 @@
           (import "${nixpkgs}/pkgs/development/cuda-modules/_cuda/manifests" {inherit (final) lib;})
           prevCuda.manifests;
       });
+      # JetPack only needs a non-ancient unpacker; avoid nixpkgs' insecure 1.1 snapshot.
+      bzip2_1_1 = prev.bzip2;
       # Override jetpack-nixos gitrepos with other sources specific to the aleph carrier board configuration
       nvidia-jetpack6 = prev.nvidia-jetpack6.overrideScope (jetpackFinal: jetpackPrev: {
         gitRepos =

--- a/aleph/flake.nix
+++ b/aleph/flake.nix
@@ -1,6 +1,6 @@
 {
   nixConfig = {
-    extra-substituters = ["https://elodin-nix-cache.s3.us-west-2.amazonaws.com"];
+    extra-substituters = ["https://s3-us-west-2.amazonaws.com/elodin-nix-cache"];
     extra-trusted-public-keys = [
       "elodin-cache-1:vvbmIQvTOjcBjIs8Ri7xlT2I3XAmeJyF5mNlWB+fIwM="
     ];

--- a/aleph/template/flake.nix
+++ b/aleph/template/flake.nix
@@ -1,6 +1,6 @@
 {
   nixConfig = {
-    extra-substituters = ["https://elodin-nix-cache.s3.us-west-2.amazonaws.com"];
+    extra-substituters = ["https://s3-us-west-2.amazonaws.com/elodin-nix-cache"];
     extra-trusted-public-keys = [
       "elodin-cache-1:vvbmIQvTOjcBjIs8Ri7xlT2I3XAmeJyF5mNlWB+fIwM="
     ];

--- a/apps/elodin/src/cli/mod.rs
+++ b/apps/elodin/src/cli/mod.rs
@@ -1,6 +1,4 @@
 use clap::{Parser, Subcommand};
-use miette::Context;
-use miette::IntoDiagnostic;
 use tracing_subscriber::{EnvFilter, fmt::time::ChronoLocal, prelude::*};
 mod editor;
 mod monte_carlo;
@@ -97,11 +95,6 @@ impl Cli {
             .build()
             .expect("tokio runtime failed to start");
 
-        if let Err(err) = self.first_launch() {
-            eprintln!("Error: {:#}", err);
-            std::process::exit(1);
-        }
-
         match &self.command {
             Some(Commands::Editor(args)) => self.clone().editor(args.clone(), rt),
             #[cfg(not(target_os = "windows"))]
@@ -112,29 +105,6 @@ impl Cli {
             Some(Commands::RenderServer(args)) => self.clone().render_server(args.clone()),
             None => self.clone().editor(editor::Args::default(), rt),
         }
-    }
-
-    fn first_launch(&self) -> miette::Result<()> {
-        let dirs = self.dirs().into_diagnostic()?;
-        let data_dir = dirs.data_dir();
-        let is_first_launch = !data_dir.exists();
-        std::fs::create_dir_all(data_dir)
-            .into_diagnostic()
-            .context("failed to create data directory")?;
-
-        if is_first_launch {
-            println!("This is your first use of the Elodin CLI!\n");
-
-            println!(
-                "Ensure the Elodin Python SDK is installed in your preferred Python virtual environment:"
-            );
-            println!("    pip install -U elodin\n");
-
-            println!("Check out our docs (at https://docs.elodin.systems) for more information.");
-            std::process::exit(0);
-        }
-
-        Ok(())
     }
 
     fn is_dev(&self) -> bool {

--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780902259,
-        "narHash": "sha256-q8yYEC5f1mFlQO9RGna4LTc9QrcvWunX6FYp83munkQ=",
+        "lastModified": 1782116945,
+        "narHash": "sha256-G3tw/IXmaH6IQ2upZvhuN9sG8CkuX+BLuJDpE8hz0Ds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bd0ff2d3eac24699c3664d5966b9ef36f388e2ca",
+        "rev": "34268251cf5547d39063f2c5ea9a196246f7f3a6",
         "type": "github"
       },
       "original": {
@@ -51,11 +51,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779160702,
-        "narHash": "sha256-frUihZLlBLdcFN95mq5QiQmxF2M16nxtmw1GH4rhZmg=",
+        "lastModified": 1782271078,
+        "narHash": "sha256-Ukpyd+syDTr+ky+nI+SbUnWySfiqNRzA3gzFZYWepeg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8cd592658d4448c57326aaa819e1c2f91086eb40",
+        "rev": "b7286019daa89e4e192c8913c3ec7002976034d0",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -51,11 +51,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782271078,
-        "narHash": "sha256-Ukpyd+syDTr+ky+nI+SbUnWySfiqNRzA3gzFZYWepeg=",
+        "lastModified": 1782357464,
+        "narHash": "sha256-mXgoT1qDHCdSfF9IvhMtEEFNy9dxrmUfSViwP7RpzOQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b7286019daa89e4e192c8913c3ec7002976034d0",
+        "rev": "77a8263847fb02dc49dbe377278ef6b952f1c6bb",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   nixConfig = {
-    extra-substituters = ["https://elodin-nix-cache.s3.us-west-2.amazonaws.com"];
+    extra-substituters = ["https://s3-us-west-2.amazonaws.com/elodin-nix-cache"];
     extra-trusted-public-keys = [
       "elodin-cache-1:vvbmIQvTOjcBjIs8Ri7xlT2I3XAmeJyF5mNlWB+fIwM="
     ];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small CLI UX change and Nix dependency/cache URL updates with no auth or simulation logic changes.
> 
> **Overview**
> Removes the Elodin CLI **first-launch** path: startup no longer calls `first_launch()`, so the process won’t exit early with pip/docs messaging or create the data directory before running a command. Data/cache directory setup still happens where the editor needs it (e.g. window state). Unused `miette::Context` / `IntoDiagnostic` imports in `mod.rs` are dropped with that code.
> 
> Nix flake config switches the binary cache **substituter** URL to the `s3-us-west-2.amazonaws.com/elodin-nix-cache` form. **`flake.lock`** bumps **nixpkgs** and **rust-overlay** to newer revisions on the same input refs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f7a3cd1d86f2a496f93306f6f5001898b00f7b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->