### PR TITLE
Fix windows build errors

### DIFF
--- a/apps/elodin/Cargo.toml
+++ b/apps/elodin/Cargo.toml
@@ -50,6 +50,7 @@ ring = "0.17"
 # machine id
 machine-uid = "0.5.1"
 
+[target.'cfg(not(target_os = "windows"))'.dependencies]
 s10.path = "../../libs/s10"
 monte-carlo.path = "../../libs/monte-carlo"
 

--- a/apps/elodin/src/cli/mod.rs
+++ b/apps/elodin/src/cli/mod.rs
@@ -3,6 +3,7 @@ use miette::Context;
 use miette::IntoDiagnostic;
 use tracing_subscriber::{EnvFilter, fmt::time::ChronoLocal, prelude::*};
 mod editor;
+#[cfg(not(target_os = "windows"))]
 mod monte_carlo;
 
 #[derive(Parser, Clone)]

--- a/justfile
+++ b/justfile
@@ -84,6 +84,15 @@ public-changelog:
     fi
   EOF
 
+build-windows-gnu:
+  #!/usr/bin/env sh
+  env \
+    CC_x86_64_pc_windows_gnu=x86_64-w64-mingw32-gcc-posix \
+    CXX_x86_64_pc_windows_gnu=x86_64-w64-mingw32-g++-posix \
+    AR_x86_64_pc_windows_gnu=x86_64-w64-mingw32-gcc-ar-posix \
+    CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER=x86_64-w64-mingw32-gcc-posix \
+    cargo build --release -p elodin --target x86_64-pc-windows-gnu
+
 install target="all":
   #!/usr/bin/env sh
   set -e

--- a/libs/elodin-editor/Cargo.toml
+++ b/libs/elodin-editor/Cargo.toml
@@ -139,7 +139,6 @@ tokio = { version = "1.34", features = ["rt-multi-thread", "net"] }
 # os
 directories = "5.0"
 rfd = "0.15.2"
-s10.path = "../s10"
 
 # async
 stellarator.path = "../../libs/stellarator"
@@ -171,6 +170,9 @@ winapi = { version = "0.3", features = ["winuser", "dwmapi", "uxtheme"] }
 image.version = "0.25"
 image.default-features = false
 image.features = ["png"]
+
+[target.'cfg(all(not(target_family = "wasm"), not(target_os = "windows")))'.dependencies]
+s10.path = "../s10"
 
 # non-macos
 [target.'cfg(not(target_os = "macos"))'.dependencies]

--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -111,6 +111,7 @@ pub(crate) fn skybox_generation_plugin() -> bevy_ai_skybox::prelude::BlockadeSky
     }
 }
 
+#[cfg(all(not(target_family = "wasm"), target_family = "unix"))]
 pub(crate) fn skybox_asset_plugin_headless() -> bevy_ai_skybox::prelude::SkyboxAssetPlugin {
     let mut plugin = skybox_asset_plugin();
     plugin.watch_manifest = true;

--- a/libs/elodin-editor/src/skybox_db_assets.rs
+++ b/libs/elodin-editor/src/skybox_db_assets.rs
@@ -67,6 +67,7 @@ fn skybox_in_flight_still_desired(
 }
 
 /// Returns `true` when DB skybox assets were mirrored and activation was already dispatched.
+#[cfg(any(test, all(not(target_family = "wasm"), target_family = "unix")))]
 pub fn db_skybox_mirror_synced(
     connection_addr: SocketAddr,
     skybox: &str,
@@ -79,6 +80,7 @@ pub fn db_skybox_mirror_synced(
 }
 
 /// Returns `true` while headless (or other consumers) should wait before activating a DB skybox.
+#[cfg(any(test, all(not(target_family = "wasm"), target_family = "unix")))]
 pub fn db_skybox_mirror_pending(
     connection_addr: SocketAddr,
     skybox: &str,


### PR DESCRIPTION
s10 is supposed to be disabled for windows. Restores that behavior.

Also added a justfile snippet for building the `pc-windows-gnu` target. We're not currently covering that in CI, but it's what I use because I cross-compile from Linux, so it's useful to have.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Platform-specific Cargo and cfg changes only; no auth, data, or runtime logic changes on non-Windows targets.
> 
> **Overview**
> Restores **Windows builds** by keeping **`s10`** and **`monte-carlo`** out of Windows dependency graphs in **`elodin`** and **`elodin-editor`**, and by **`cfg(not(target_os = "windows"))`**-gating the Monte Carlo CLI module so Windows only builds the editor path.
> 
> **Headless / DB skybox helpers** (`skybox_asset_plugin_headless`, `db_skybox_mirror_synced`, `db_skybox_mirror_pending`) are now compiled only on **non-wasm Unix**, matching that headless stack is not used on Windows.
> 
> Adds a **`just build-windows-gnu`** recipe to release-build **`elodin`** for **`x86_64-pc-windows-gnu`** with MinGW linker env vars for Linux cross-compile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0282a70b5cb4ffad02c69c46900bf93a1b2c27b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->