### PR TITLE
fix: DB skybox/asset mirroring (#701, #702, #705, #714).

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5537,6 +5537,7 @@ dependencies = [
  "stacker",
  "stellarator",
  "strum 0.27.2",
+ "tempfile",
  "test-case",
  "thiserror 2.0.18",
  "tokio",

--- a/docs/public/content/reference/schematic.md
+++ b/docs/public/content/reference/schematic.md
@@ -170,9 +170,9 @@ object_3d lander.world_pos {
 - Positional `eql`: required; expects 3 values (or 7 where the last 3 are XYZ).
 - `frame`: optional; `ENU`, `NED`, or `ECEF`. Specifies the coordinate frame for interpreting the line points. Inherits from global `coordinate` if omitted.
 - `line_width`: default 1.0.
-- The trail is split into a *played* segment (up to the current playback time) and a *future* segment (ahead of it). The future segment is always faded by the timeline's `future_trail_alpha`.
-- `color`: color of the played segment. When omitted, falls back to the timeline `played_color` (default `yalk`). If set without `future_color`, it also colors the future segment — a single `color` paints the whole line.
-- `future_color`: color of the future segment. When omitted, falls back to `color` (if set), otherwise the timeline `future_color` (default `white`).
+- The trail is split into a *played* segment (up to the current playback time) and a *future* segment (ahead of it). When no `future_color` is set, the future segment is dimmed by a default fade so it reads as lighter than the played segment.
+- `color`: color of the played segment. When omitted, falls back to the timeline `played_color` (default `yalk`). It does not affect the future segment.
+- `future_color`: color of the future segment, independent of `color`. Its alpha sets the future opacity and is used as-is (no extra fade). When omitted, falls back to the timeline `future_color` (default `white`, faded).
 - `perspective`: default true (set false for screen-space lines).
 
 ### vector_arrow

--- a/libs/bevy_ai_skybox/src/lib.rs
+++ b/libs/bevy_ai_skybox/src/lib.rs
@@ -203,14 +203,22 @@ impl SkyboxManifest {
         Self::from_ron_str(&contents)
     }
 
+    pub fn to_ron_string(&self) -> Result<String> {
+        Ok(format!(
+            "{}\n",
+            ron::ser::to_string_pretty(self, ron::ser::PrettyConfig::default())?
+        ))
+    }
+
+    pub fn to_ron_bytes(&self) -> Result<Vec<u8>> {
+        Ok(self.to_ron_string()?.into_bytes())
+    }
+
     pub fn write_atomic(&self, path: &Path) -> Result<()> {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
-        let contents = format!(
-            "{}\n",
-            ron::ser::to_string_pretty(self, ron::ser::PrettyConfig::default())?
-        );
+        let contents = self.to_ron_string()?;
         let mut tmp = path.to_path_buf();
         let extension = path
             .extension()

--- a/libs/db/src/assets_http.rs
+++ b/libs/db/src/assets_http.rs
@@ -297,7 +297,9 @@ async fn get_asset(
     match tokio::task::spawn_blocking(move || std::fs::read(full)).await {
         Ok(Ok(bytes)) => Ok(bytes),
         Ok(Err(err)) if err.kind() == io::ErrorKind::NotFound => {
-            tracing::warn!(asset = %path, "asset http 404 (not found)");
+            // A 404 is a routine client outcome (e.g. a mirror polling for an
+            // asset still being uploaded), not a server fault — log at info.
+            tracing::info!(asset = %path, "asset http 404 (not found)");
             Err(StatusCode::NOT_FOUND)
         }
         Ok(Err(err)) => {

--- a/libs/db/src/lib.rs
+++ b/libs/db/src/lib.rs
@@ -3336,7 +3336,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let db = DB::create(dir.path().join("db")).unwrap();
 
-        db.store_asset("skyboxes/manifest.ron", b"manifest").unwrap();
+        db.store_asset("skyboxes/manifest.ron", b"manifest")
+            .unwrap();
 
         let assets_dir = crate::assets_http::assets_dir(&db.path);
         assert_eq!(

--- a/libs/db/src/lib.rs
+++ b/libs/db/src/lib.rs
@@ -1555,16 +1555,22 @@ impl Server {
     pub async fn handle_udp(addr: SocketAddr, db: Arc<DB>) -> Result<(), Error> {
         let socket = UdpSocket::bind(addr)?;
         let (rx, tx) = socket.split();
-        let rx = PacketStream::new(rx);
+        let rx = PacketStream::new(rx).with_max_len(MAX_PACKET_LEN);
         let tx = Arc::new(Mutex::new(PacketSink::new(tx)));
         handle_conn_inner(tx, rx, db).await?;
         Ok(())
     }
 }
 
+/// Upper bound on a single inbound packet. Large asset uploads (e.g. skybox
+/// cubemaps, several MB) arrive as one [`StoreAsset`] message, so the
+/// per-connection read buffer grows on demand; this caps that growth to bound
+/// memory and reject malformed/hostile length prefixes.
+const MAX_PACKET_LEN: usize = 256 * 1024 * 1024;
+
 pub async fn handle_conn(stream: TcpStream, db: Arc<DB>) {
     let (rx, tx) = stream.split();
-    let rx = PacketStream::new(rx);
+    let rx = PacketStream::new(rx).with_max_len(MAX_PACKET_LEN);
     let tx = Arc::new(Mutex::new(PacketSink::new(tx)));
     match handle_conn_inner(tx, rx, db).await {
         Ok(_) => {}
@@ -1585,7 +1591,9 @@ async fn handle_conn_inner<A: AsyncRead + AsyncWrite + Send + Sync + 'static>(
     let mut resp_pkt = LenPacket::new(PacketTy::Msg, [0, 0], RESPONSE_PACKET_CAPACITY);
     let mut silent = false;
     loop {
-        let pkt = rx.next(buf).await?;
+        // `next_grow` lets the buffer grow past its initial 8 MiB for large
+        // asset uploads; `with_max_len` above bounds that growth.
+        let pkt = rx.next_grow(buf).await?;
         let req_id = pkt.req_id();
         let mut pkt_tx = PacketTx {
             req_id,

--- a/libs/db/src/lib.rs
+++ b/libs/db/src/lib.rs
@@ -379,6 +379,16 @@ impl DB {
         Ok(needs_asset_sync)
     }
 
+    /// Store an uploaded asset at `{db}/assets/<key>`.
+    ///
+    /// `key` is sanitized (rejects `..` and absolute paths) by
+    /// `assets_http::write_asset_file`, so an out-of-tree key is refused rather
+    /// than escaping the assets directory.
+    pub fn store_asset(&self, key: &str, bytes: &[u8]) -> std::io::Result<()> {
+        let assets_dir = crate::assets_http::assets_dir(&self.path);
+        crate::assets_http::write_asset_file(&assets_dir, key, bytes)
+    }
+
     pub fn flush_all(&self) -> Result<(), Error> {
         self.with_state(|state| -> Result<(), Error> {
             // Ensure time-series data is fully flushed
@@ -2000,6 +2010,18 @@ async fn handle_packet<A: AsyncWrite + Send + Sync + 'static>(
             db.apply_set_db_config(update)?;
             tx.send_msg(&db.db_config()).await?;
         }
+        Packet::Msg(m) if m.id == StoreAsset::ID => {
+            let StoreAsset { key, bytes } = m.parse::<StoreAsset>()?;
+            // A bad/unwritable asset is logged but must not drop the connection.
+            match db.store_asset(&key, &bytes) {
+                Ok(()) => {
+                    tracing::info!(asset = %key, len = bytes.len(), "stored uploaded asset")
+                }
+                Err(err) => {
+                    tracing::warn!(asset = %key, ?err, "failed to store uploaded asset")
+                }
+            }
+        }
         Packet::Msg(m) if m.id == GetEarliestTimestamp::ID => {
             tx.send_msg(&EarliestTimestamp(db.earliest_timestamp.latest()))
                 .await?;
@@ -3307,5 +3329,29 @@ mod tests {
             db.with_state(|s| s.db_config.schematic_content().map(str::to_owned)),
             None
         );
+    }
+
+    #[test]
+    fn store_asset_writes_into_assets_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = DB::create(dir.path().join("db")).unwrap();
+
+        db.store_asset("skyboxes/manifest.ron", b"manifest").unwrap();
+
+        let assets_dir = crate::assets_http::assets_dir(&db.path);
+        assert_eq!(
+            std::fs::read(assets_dir.join("skyboxes/manifest.ron")).unwrap(),
+            b"manifest".to_vec()
+        );
+    }
+
+    #[test]
+    fn store_asset_rejects_path_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = DB::create(dir.path().join("db")).unwrap();
+
+        let err = db.store_asset("../escape.bin", b"x").unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(!dir.path().join("escape.bin").exists());
     }
 }

--- a/libs/elodin-editor/Cargo.toml
+++ b/libs/elodin-editor/Cargo.toml
@@ -181,3 +181,4 @@ pic-scale = "0.6"
 
 [dev-dependencies]
 test-case = "*"
+tempfile = "3"

--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -360,9 +360,14 @@ impl Plugin for EditorPlugin {
             )
             .add_systems(Update, ui::log_stream::connect_streams)
             .add_systems(PostUpdate, ui::video_stream::set_visibility)
+            .init_resource::<skybox_db_assets::DbSkyboxUploaded>()
             .add_systems(
                 PostUpdate,
                 skybox_db_assets::sync_db_skybox_assets_from_config,
+            )
+            .add_systems(
+                PostUpdate,
+                skybox_db_assets::upload_active_skybox_assets_to_db,
             )
             .add_systems(PostUpdate, set_clear_color)
             .insert_resource(WireframeConfig {

--- a/libs/elodin-editor/src/skybox_db_assets.rs
+++ b/libs/elodin-editor/src/skybox_db_assets.rs
@@ -151,10 +151,13 @@ pub fn sync_db_skybox_assets_from_config(
                         }
                     },
                     Err(error) => {
-                        tracing::warn!(
+                        // Transient while the editor is still uploading the
+                        // cubemap to the db; the mirror retries and recovers,
+                        // so this is info rather than a warning.
+                        tracing::info!(
                             skybox = %key.skybox,
                             error = %error,
-                            "failed to mirror skybox assets from database"
+                            "skybox assets not yet available in database, will retry"
                         );
                         mirror.last_failed = Some((key, Instant::now()));
                     }

--- a/libs/elodin-editor/src/skybox_db_assets.rs
+++ b/libs/elodin-editor/src/skybox_db_assets.rs
@@ -220,11 +220,26 @@ pub fn sync_db_skybox_assets_from_config(
     }));
 }
 
-/// Tracks the `(addr, skybox)` whose local assets were last uploaded to the DB,
-/// so we push each active skybox's bytes at most once per session.
+/// Tracks the upload of the active skybox's local assets to the DB.
+///
+/// [`StoreAsset`] is fire-and-forget (the channel can drop on backpressure, the
+/// server only logs store failures, and a mid-upload disconnect is silent), so
+/// we don't trust the send alone: we mark an `(addr, skybox)` done only once the
+/// DB asset server actually serves the bytes back, and otherwise re-send with a
+/// backoff.
 #[derive(Resource, Default)]
 pub struct DbSkyboxUploaded {
-    uploaded: Option<MirrorKey>,
+    /// `(addr, skybox)` confirmed queryable from the DB asset server.
+    confirmed: Option<MirrorKey>,
+    /// Last (re)send attempt, throttles retries until the upload is confirmed.
+    last_attempt: Option<(MirrorKey, Instant)>,
+    /// In-flight probe verifying the DB actually serves the uploaded assets.
+    verify: Option<DbSkyboxUploadVerify>,
+}
+
+struct DbSkyboxUploadVerify {
+    key: MirrorKey,
+    task: Task<Result<bool, String>>,
 }
 
 /// Counterpart to [`sync_db_skybox_assets_from_config`]: mirror the active
@@ -251,7 +266,9 @@ pub fn upload_active_skybox_assets_to_db(
     let desired = match desired_skybox_from_config(&config) {
         Some(Some(name)) => name,
         Some(None) => {
-            uploaded.uploaded = None;
+            uploaded.confirmed = None;
+            uploaded.last_attempt = None;
+            uploaded.verify = None;
             return;
         }
         None => return,
@@ -261,7 +278,42 @@ pub fn upload_active_skybox_assets_to_db(
         addr: connection_addr.0,
         skybox: desired.clone(),
     };
-    if uploaded.uploaded.as_ref() == Some(&key) {
+    if uploaded.confirmed.as_ref() == Some(&key) {
+        return;
+    }
+
+    // Poll a pending verification probe; only latch `confirmed` once the DB
+    // actually serves the assets back, otherwise fall through to re-send.
+    if let Some(verify) = uploaded.verify.as_mut() {
+        if verify.key != key {
+            uploaded.verify = None; // desired skybox changed
+        } else if let Some(result) = future::block_on(future::poll_once(&mut verify.task)) {
+            uploaded.verify = None;
+            match result {
+                Ok(true) => {
+                    uploaded.confirmed = Some(key);
+                    uploaded.last_attempt = None;
+                    return;
+                }
+                Ok(false) => {} // not present yet — re-send after backoff below
+                Err(error) => {
+                    tracing::info!(
+                        skybox = %desired,
+                        error = %error,
+                        "could not verify skybox upload in database, will retry"
+                    );
+                }
+            }
+        } else {
+            return; // still verifying
+        }
+    }
+
+    // Throttle (re)attempts so a slow/failing upload doesn't resend every frame.
+    if let Some((attempted, at)) = &uploaded.last_attempt
+        && attempted == &key
+        && at.elapsed() < RETRY_DELAY
+    {
         return;
     }
 
@@ -282,10 +334,23 @@ pub fn upload_active_skybox_assets_to_db(
 
     match skybox_upload_payload(&settings, &cubemap_file) {
         Ok(uploads) => {
-            for (key, bytes) in uploads {
-                tx.send_msg(StoreAsset { key, bytes });
+            for (asset_key, bytes) in uploads {
+                tx.send_msg(StoreAsset {
+                    key: asset_key,
+                    bytes,
+                });
             }
-            uploaded.uploaded = Some(key);
+            uploaded.last_attempt = Some((key.clone(), Instant::now()));
+            let addr = connection_addr.0;
+            let probe_skybox = desired.clone();
+            uploaded.verify = Some(DbSkyboxUploadVerify {
+                key,
+                task: IoTaskPool::get().spawn(async move {
+                    tokio::runtime::Runtime::new()
+                        .map_err(|err| err.to_string())?
+                        .block_on(verify_db_skybox_assets(&probe_skybox, addr))
+                }),
+            });
         }
         Err(error) => {
             tracing::warn!(
@@ -293,6 +358,7 @@ pub fn upload_active_skybox_assets_to_db(
                 error = %error,
                 "failed to read local skybox assets for db upload"
             );
+            uploaded.last_attempt = Some((key, Instant::now()));
         }
     }
 }
@@ -361,6 +427,59 @@ async fn download_db_skybox_assets(
         entry,
         cubemap_bytes,
     })
+}
+
+/// Confirms the DB asset server actually serves the active skybox's manifest
+/// entry and cubemap. `Ok(false)` means the assets aren't present yet (caller
+/// re-sends); `Err` is an unexpected failure (caller retries).
+async fn verify_db_skybox_assets(
+    skybox: &str,
+    connection_addr: SocketAddr,
+) -> Result<bool, String> {
+    let client = reqwest::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .build()
+        .map_err(|err| err.to_string())?;
+    let base = assets_http_base(connection_addr);
+
+    let manifest_url = format!("{base}/{}", impeller2_kdl::SKYBOX_MANIFEST_ASSET_NAME);
+    let manifest_resp = client
+        .get(&manifest_url)
+        .send()
+        .await
+        .map_err(|err| format!("{manifest_url}: {err}"))?;
+    if manifest_resp.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok(false);
+    }
+    let manifest_bytes = manifest_resp
+        .error_for_status()
+        .map_err(|err| format!("{manifest_url}: {err}"))?
+        .bytes()
+        .await
+        .map_err(|err| format!("{manifest_url}: {err}"))?;
+    let manifest = std::str::from_utf8(&manifest_bytes).map_err(|err| err.to_string())?;
+    let manifest = SkyboxManifest::from_ron_str(manifest).map_err(|err| err.to_string())?;
+    let Some(entry) = manifest.get(skybox) else {
+        return Ok(false);
+    };
+
+    let cubemap_name = impeller2_kdl::skybox_cubemap_asset_name(&entry.cubemap_file)
+        .ok_or_else(|| format!("invalid skybox cubemap file path `{}`", entry.cubemap_file))?;
+    let cubemap_url = format!("{base}/{cubemap_name}");
+    // HEAD avoids transferring the (large) cubemap just to check presence;
+    // axum serves HEAD for `get` routes automatically.
+    let cubemap_resp = client
+        .head(&cubemap_url)
+        .send()
+        .await
+        .map_err(|err| format!("{cubemap_url}: {err}"))?;
+    if cubemap_resp.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok(false);
+    }
+    cubemap_resp
+        .error_for_status()
+        .map_err(|err| format!("{cubemap_url}: {err}"))?;
+    Ok(true)
 }
 
 fn cubemap_cache_path(cache_dir: &Path, cubemap_file: &str) -> Result<PathBuf, String> {

--- a/libs/elodin-editor/src/skybox_db_assets.rs
+++ b/libs/elodin-editor/src/skybox_db_assets.rs
@@ -224,22 +224,62 @@ pub fn sync_db_skybox_assets_from_config(
 ///
 /// [`StoreAsset`] is fire-and-forget (the channel can drop on backpressure, the
 /// server only logs store failures, and a mid-upload disconnect is silent), so
-/// we don't trust the send alone: we mark an `(addr, skybox)` done only once the
-/// DB asset server actually serves the bytes back, and otherwise re-send with a
-/// backoff.
+/// we don't trust the send alone: we mark an `(addr, skybox, content)` done only
+/// once the DB asset server actually serves the bytes back, and otherwise
+/// re-send with a backoff. The content fingerprint ensures that regenerating a
+/// skybox under the same name re-uploads the new bytes.
 #[derive(Resource, Default)]
 pub struct DbSkyboxUploaded {
-    /// `(addr, skybox)` confirmed queryable from the DB asset server.
-    confirmed: Option<MirrorKey>,
+    /// `(addr, skybox, fingerprint)` confirmed queryable from the DB.
+    confirmed: Option<(MirrorKey, UploadFingerprint)>,
     /// Last (re)send attempt, throttles retries until the upload is confirmed.
     last_attempt: Option<(MirrorKey, Instant)>,
-    /// In-flight probe verifying the DB actually serves the uploaded assets.
-    verify: Option<DbSkyboxUploadVerify>,
+    /// In-flight upload/verify state machine for the active skybox.
+    in_flight: Option<DbSkyboxUpload>,
 }
 
-struct DbSkyboxUploadVerify {
+struct DbSkyboxUpload {
     key: MirrorKey,
-    task: Task<Result<bool, String>>,
+    fingerprint: UploadFingerprint,
+    phase: UploadPhase,
+}
+
+/// `(db asset key, bytes)` pairs ready to send as [`StoreAsset`] messages.
+type UploadPayload = Vec<(String, Vec<u8>)>;
+
+enum UploadPhase {
+    /// Fetching the DB manifest and merging our entry off the main thread.
+    Preparing(Task<Result<UploadPayload, String>>),
+    /// Confirming the DB now serves the uploaded assets.
+    Verifying(Task<Result<bool, String>>),
+}
+
+/// Identifies the on-disk cubemap content, so a same-name regeneration (new
+/// bytes) invalidates a prior confirmed upload.
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct UploadFingerprint {
+    len: u64,
+    modified: Option<Duration>,
+}
+
+fn cubemap_fingerprint(path: &Path) -> Option<UploadFingerprint> {
+    let meta = std::fs::metadata(path).ok()?;
+    let modified = meta
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok());
+    Some(UploadFingerprint {
+        len: meta.len(),
+        modified,
+    })
+}
+
+fn spawn_skybox_verify(skybox: String, addr: SocketAddr) -> Task<Result<bool, String>> {
+    IoTaskPool::get().spawn(async move {
+        tokio::runtime::Runtime::new()
+            .map_err(|err| err.to_string())?
+            .block_on(verify_db_skybox_assets(&skybox, addr))
+    })
 }
 
 /// Counterpart to [`sync_db_skybox_assets_from_config`]: mirror the active
@@ -268,44 +308,89 @@ pub fn upload_active_skybox_assets_to_db(
         Some(None) => {
             uploaded.confirmed = None;
             uploaded.last_attempt = None;
-            uploaded.verify = None;
+            uploaded.in_flight = None;
             return;
         }
         None => return,
     };
 
+    let addr = connection_addr.0;
     let key = MirrorKey {
-        addr: connection_addr.0,
+        addr,
         skybox: desired.clone(),
     };
-    if uploaded.confirmed.as_ref() == Some(&key) {
+
+    // Local entry + cubemap must be on disk before we can upload.
+    let Some(entry) = cache.manifest.get(&desired).cloned() else {
+        return;
+    };
+    let cubemap_path = settings.cache_dir.join(&entry.cubemap_file);
+    let Some(fingerprint) = cubemap_fingerprint(&cubemap_path) else {
+        return; // bytes not on disk yet (e.g. generation still running)
+    };
+    if !settings.manifest_path().exists() {
         return;
     }
 
-    // Poll a pending verification probe; only latch `confirmed` once the DB
-    // actually serves the assets back, otherwise fall through to re-send.
-    if let Some(verify) = uploaded.verify.as_mut() {
-        if verify.key != key {
-            uploaded.verify = None; // desired skybox changed
-        } else if let Some(result) = future::block_on(future::poll_once(&mut verify.task)) {
-            uploaded.verify = None;
-            match result {
-                Ok(true) => {
-                    uploaded.confirmed = Some(key);
-                    uploaded.last_attempt = None;
-                    return;
-                }
-                Ok(false) => {} // not present yet — re-send after backoff below
-                Err(error) => {
-                    tracing::info!(
-                        skybox = %desired,
-                        error = %error,
-                        "could not verify skybox upload in database, will retry"
-                    );
-                }
-            }
+    if uploaded
+        .confirmed
+        .as_ref()
+        .is_some_and(|(confirmed, fp)| confirmed == &key && *fp == fingerprint)
+    {
+        return;
+    }
+
+    // Drive the upload/verify state machine.
+    if let Some(up) = uploaded.in_flight.as_mut() {
+        if up.key != key || up.fingerprint != fingerprint {
+            uploaded.in_flight = None; // desired skybox or local content changed
         } else {
-            return; // still verifying
+            match &mut up.phase {
+                UploadPhase::Preparing(task) => match future::block_on(future::poll_once(task)) {
+                    Some(Ok(uploads)) => {
+                        for (asset_key, bytes) in uploads {
+                            tx.send_msg(StoreAsset {
+                                key: asset_key,
+                                bytes,
+                            });
+                        }
+                        up.phase =
+                            UploadPhase::Verifying(spawn_skybox_verify(desired.clone(), addr));
+                        return;
+                    }
+                    Some(Err(error)) => {
+                        tracing::warn!(
+                            skybox = %desired,
+                            error = %error,
+                            "failed to prepare skybox assets for db upload"
+                        );
+                        uploaded.in_flight = None;
+                        uploaded.last_attempt = Some((key, Instant::now()));
+                        return;
+                    }
+                    None => return, // still preparing
+                },
+                UploadPhase::Verifying(task) => match future::block_on(future::poll_once(task)) {
+                    Some(Ok(true)) => {
+                        uploaded.confirmed = Some((key, fingerprint));
+                        uploaded.last_attempt = None;
+                        uploaded.in_flight = None;
+                        return;
+                    }
+                    Some(Ok(false)) => {
+                        uploaded.in_flight = None; // not present yet — re-send below
+                    }
+                    Some(Err(error)) => {
+                        tracing::info!(
+                            skybox = %desired,
+                            error = %error,
+                            "could not verify skybox upload in database, will retry"
+                        );
+                        uploaded.in_flight = None;
+                    }
+                    None => return, // still verifying
+                },
+            }
         }
     }
 
@@ -317,66 +402,37 @@ pub fn upload_active_skybox_assets_to_db(
         return;
     }
 
-    let Some(cubemap_file) = cache
-        .manifest
-        .get(&desired)
-        .map(|entry| entry.cubemap_file.clone())
-    else {
-        return; // no local manifest entry for the active skybox yet
-    };
-
-    let manifest_path = settings.manifest_path();
-    let cubemap_path = settings.cache_dir.join(&cubemap_file);
-    if !manifest_path.exists() || !cubemap_path.exists() {
-        // Bytes not on disk yet (e.g. generation still running) — retry later.
-        return;
-    }
-
-    match skybox_upload_payload(&settings, &cubemap_file) {
-        Ok(uploads) => {
-            for (asset_key, bytes) in uploads {
-                tx.send_msg(StoreAsset {
-                    key: asset_key,
-                    bytes,
-                });
-            }
-            uploaded.last_attempt = Some((key.clone(), Instant::now()));
-            let addr = connection_addr.0;
-            let probe_skybox = desired.clone();
-            uploaded.verify = Some(DbSkyboxUploadVerify {
-                key,
-                task: IoTaskPool::get().spawn(async move {
-                    tokio::runtime::Runtime::new()
-                        .map_err(|err| err.to_string())?
-                        .block_on(verify_db_skybox_assets(&probe_skybox, addr))
-                }),
-            });
-        }
-        Err(error) => {
-            tracing::warn!(
-                skybox = %desired,
-                error = %error,
-                "failed to read local skybox assets for db upload"
-            );
-            uploaded.last_attempt = Some((key, Instant::now()));
-        }
-    }
+    uploaded.last_attempt = Some((key.clone(), Instant::now()));
+    uploaded.in_flight = Some(DbSkyboxUpload {
+        key,
+        fingerprint,
+        phase: UploadPhase::Preparing(IoTaskPool::get().spawn(async move {
+            tokio::runtime::Runtime::new()
+                .map_err(|err| err.to_string())?
+                .block_on(prepare_skybox_upload(addr, entry, cubemap_path))
+        })),
+    });
 }
 
-/// Reads the local skybox `manifest.ron` and cubemap, returning `(db key, bytes)`
-/// pairs ready to send as [`StoreAsset`] messages.
-fn skybox_upload_payload(
-    settings: &SkyboxAssetSettings,
-    cubemap_file: &str,
-) -> Result<Vec<(String, Vec<u8>)>, String> {
-    let cubemap_name = impeller2_kdl::skybox_cubemap_asset_name(cubemap_file)
-        .ok_or_else(|| format!("invalid skybox cubemap file path `{cubemap_file}`"))?;
-    let manifest_path = settings.manifest_path();
-    let manifest_bytes = std::fs::read(&manifest_path)
-        .map_err(|err| format!("{}: {err}", manifest_path.display()))?;
-    let cubemap_path = settings.cache_dir.join(cubemap_file);
+/// Prepares the `(db key, bytes)` pairs to upload for the active skybox.
+///
+/// The manifest is **merged** into the DB's current copy rather than sent
+/// wholesale, so entries written by `persist_schematic_assets` or other clients
+/// are preserved instead of being clobbered by the editor's local manifest.
+async fn prepare_skybox_upload(
+    connection_addr: SocketAddr,
+    entry: ManifestEntry,
+    cubemap_path: PathBuf,
+) -> Result<UploadPayload, String> {
+    let cubemap_name = impeller2_kdl::skybox_cubemap_asset_name(&entry.cubemap_file)
+        .ok_or_else(|| format!("invalid skybox cubemap file path `{}`", entry.cubemap_file))?;
     let cubemap_bytes =
         std::fs::read(&cubemap_path).map_err(|err| format!("{}: {err}", cubemap_path.display()))?;
+
+    let mut manifest = fetch_db_skybox_manifest(connection_addr).await?;
+    manifest.upsert(entry);
+    let manifest_bytes = manifest.to_ron_bytes().map_err(|err| err.to_string())?;
+
     Ok(vec![
         (
             impeller2_kdl::SKYBOX_MANIFEST_ASSET_NAME.to_string(),
@@ -384,6 +440,32 @@ fn skybox_upload_payload(
         ),
         (cubemap_name, cubemap_bytes),
     ])
+}
+
+/// Fetches the DB's current skybox manifest, or an empty one if absent.
+async fn fetch_db_skybox_manifest(connection_addr: SocketAddr) -> Result<SkyboxManifest, String> {
+    let client = reqwest::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .build()
+        .map_err(|err| err.to_string())?;
+    let base = assets_http_base(connection_addr);
+    let url = format!("{base}/{}", impeller2_kdl::SKYBOX_MANIFEST_ASSET_NAME);
+    let response = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|err| format!("{url}: {err}"))?;
+    if response.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok(SkyboxManifest::default());
+    }
+    let bytes = response
+        .error_for_status()
+        .map_err(|err| format!("{url}: {err}"))?
+        .bytes()
+        .await
+        .map_err(|err| format!("{url}: {err}"))?;
+    let text = std::str::from_utf8(&bytes).map_err(|err| err.to_string())?;
+    SkyboxManifest::from_ron_str(text).map_err(|err| err.to_string())
 }
 
 async fn fetch_asset(client: &reqwest::Client, url: &str) -> Result<Vec<u8>, String> {

--- a/libs/elodin-editor/src/skybox_db_assets.rs
+++ b/libs/elodin-editor/src/skybox_db_assets.rs
@@ -4,9 +4,9 @@ use bevy_ai_skybox::{
     ManifestEntry, SkyboxManifest,
     prelude::{SetActiveSkybox, SkyboxAssetSettings, SkyboxCache},
 };
-use impeller2_bevy::ConnectionAddr;
+use impeller2_bevy::{ConnectionAddr, PacketTx};
 use impeller2_kdl::FromKdl;
-use impeller2_wkt::{DbConfig, Schematic};
+use impeller2_wkt::{DbConfig, Schematic, StoreAsset};
 use std::{
     net::SocketAddr,
     path::{Path, PathBuf},
@@ -217,6 +217,106 @@ pub fn sync_db_skybox_assets_from_config(
     }));
 }
 
+/// Tracks the `(addr, skybox)` whose local assets were last uploaded to the DB,
+/// so we push each active skybox's bytes at most once per session.
+#[derive(Resource, Default)]
+pub struct DbSkyboxUploaded {
+    uploaded: Option<MirrorKey>,
+}
+
+/// Counterpart to [`sync_db_skybox_assets_from_config`]: mirror the active
+/// skybox's local `manifest.ron` + cubemap *up* to the DB via [`StoreAsset`].
+///
+/// Skyboxes added at runtime (default, command palette, AI generation) only
+/// have their bytes on the editor's local cache; without this the DB asset
+/// server 404s and the render-server/followers cannot mirror them.
+pub fn upload_active_skybox_assets_to_db(
+    config: Res<DbConfig>,
+    connection_addr: Option<Res<ConnectionAddr>>,
+    settings: Option<Res<SkyboxAssetSettings>>,
+    cache: Option<Res<SkyboxCache>>,
+    tx: Option<Res<PacketTx>>,
+    mut uploaded: ResMut<DbSkyboxUploaded>,
+) {
+    let Some(connection_addr) = connection_addr else {
+        return;
+    };
+    let (Some(settings), Some(cache), Some(tx)) = (settings, cache, tx) else {
+        return;
+    };
+
+    let desired = match desired_skybox_from_config(&config) {
+        Some(Some(name)) => name,
+        Some(None) => {
+            uploaded.uploaded = None;
+            return;
+        }
+        None => return,
+    };
+
+    let key = MirrorKey {
+        addr: connection_addr.0,
+        skybox: desired.clone(),
+    };
+    if uploaded.uploaded.as_ref() == Some(&key) {
+        return;
+    }
+
+    let Some(cubemap_file) = cache
+        .manifest
+        .get(&desired)
+        .map(|entry| entry.cubemap_file.clone())
+    else {
+        return; // no local manifest entry for the active skybox yet
+    };
+
+    let manifest_path = settings.manifest_path();
+    let cubemap_path = settings.cache_dir.join(&cubemap_file);
+    if !manifest_path.exists() || !cubemap_path.exists() {
+        // Bytes not on disk yet (e.g. generation still running) — retry later.
+        return;
+    }
+
+    match skybox_upload_payload(&settings, &cubemap_file) {
+        Ok(uploads) => {
+            for (key, bytes) in uploads {
+                tx.send_msg(StoreAsset { key, bytes });
+            }
+            uploaded.uploaded = Some(key);
+        }
+        Err(error) => {
+            tracing::warn!(
+                skybox = %desired,
+                error = %error,
+                "failed to read local skybox assets for db upload"
+            );
+        }
+    }
+}
+
+/// Reads the local skybox `manifest.ron` and cubemap, returning `(db key, bytes)`
+/// pairs ready to send as [`StoreAsset`] messages.
+fn skybox_upload_payload(
+    settings: &SkyboxAssetSettings,
+    cubemap_file: &str,
+) -> Result<Vec<(String, Vec<u8>)>, String> {
+    let cubemap_name = impeller2_kdl::skybox_cubemap_asset_name(cubemap_file)
+        .ok_or_else(|| format!("invalid skybox cubemap file path `{cubemap_file}`"))?;
+    let manifest_path = settings.manifest_path();
+    let manifest_bytes = std::fs::read(&manifest_path)
+        .map_err(|err| format!("{}: {err}", manifest_path.display()))?;
+    let cubemap_path = settings.cache_dir.join(cubemap_file);
+    let cubemap_bytes =
+        std::fs::read(&cubemap_path).map_err(|err| format!("{}: {err}", cubemap_path.display()))?;
+    Ok(vec![
+        (
+            impeller2_kdl::SKYBOX_MANIFEST_ASSET_NAME.to_string(),
+            manifest_bytes,
+        ),
+        (cubemap_name, cubemap_bytes),
+    ])
+}
+
 async fn fetch_asset(client: &reqwest::Client, url: &str) -> Result<Vec<u8>, String> {
     let response = client
         .get(url)
@@ -328,6 +428,41 @@ mod tests {
     #[test]
     fn cubemap_cache_path_rejects_traversal() {
         assert!(cubemap_cache_path(Path::new("cache"), "../bad.ktx2").is_err());
+    }
+
+    #[test]
+    fn skybox_upload_payload_reads_manifest_and_cubemap() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache_dir = dir.path().join("skyboxes");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        std::fs::write(cache_dir.join("manifest.ron"), b"manifest").unwrap();
+        std::fs::write(cache_dir.join("desert_night.cubemap.ktx2"), b"ktx2").unwrap();
+
+        let settings = SkyboxAssetSettings {
+            cache_dir,
+            ..Default::default()
+        };
+
+        let uploads = skybox_upload_payload(&settings, "desert_night.cubemap.ktx2").unwrap();
+        assert_eq!(
+            uploads,
+            vec![
+                (
+                    impeller2_kdl::SKYBOX_MANIFEST_ASSET_NAME.to_string(),
+                    b"manifest".to_vec()
+                ),
+                (
+                    "skyboxes/desert_night.cubemap.ktx2".to_string(),
+                    b"ktx2".to_vec()
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn skybox_upload_payload_rejects_cubemap_traversal() {
+        let settings = SkyboxAssetSettings::default();
+        assert!(skybox_upload_payload(&settings, "../escape.ktx2").is_err());
     }
 
     #[test]

--- a/libs/elodin-editor/src/skybox_db_assets.rs
+++ b/libs/elodin-editor/src/skybox_db_assets.rs
@@ -260,7 +260,7 @@ enum UploadPhase {
 }
 
 /// Size + content hash of a cubemap, to detect stale vs. freshly uploaded bytes.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct CubemapDigest {
     len: u64,
     hash: u64,
@@ -453,11 +453,8 @@ async fn prepare_skybox_upload(
     entry: ManifestEntry,
     cubemap_path: PathBuf,
 ) -> Result<PrepareOutput, String> {
-    let cubemap_name = impeller2_kdl::skybox_cubemap_asset_name(&entry.cubemap_file)
-        .ok_or_else(|| format!("invalid skybox cubemap file path `{}`", entry.cubemap_file))?;
-    let cubemap_bytes =
-        std::fs::read(&cubemap_path).map_err(|err| format!("{}: {err}", cubemap_path.display()))?;
-    let digest = digest_bytes(&cubemap_bytes);
+    let (cubemap_name, cubemap_bytes, digest) =
+        read_local_cubemap(&entry.cubemap_file, &cubemap_path)?;
 
     let mut manifest = fetch_db_skybox_manifest(connection_addr).await?;
     manifest.upsert(entry);
@@ -473,6 +470,20 @@ async fn prepare_skybox_upload(
         ],
         digest,
     ))
+}
+
+/// Local (no-network) portion of an upload: validates the cubemap file path,
+/// reads its bytes, and returns the db asset key, bytes, and content digest.
+fn read_local_cubemap(
+    cubemap_file: &str,
+    cubemap_path: &Path,
+) -> Result<(String, Vec<u8>, CubemapDigest), String> {
+    let cubemap_name = impeller2_kdl::skybox_cubemap_asset_name(cubemap_file)
+        .ok_or_else(|| format!("invalid skybox cubemap file path `{cubemap_file}`"))?;
+    let cubemap_bytes =
+        std::fs::read(cubemap_path).map_err(|err| format!("{}: {err}", cubemap_path.display()))?;
+    let digest = digest_bytes(&cubemap_bytes);
+    Ok((cubemap_name, cubemap_bytes, digest))
 }
 
 /// Fetches the DB's current skybox manifest, or an empty one if absent.
@@ -679,38 +690,28 @@ mod tests {
     }
 
     #[test]
-    fn skybox_upload_payload_reads_manifest_and_cubemap() {
+    fn read_local_cubemap_reads_bytes_name_and_digest() {
         let dir = tempfile::tempdir().unwrap();
-        let cache_dir = dir.path().join("skyboxes");
-        std::fs::create_dir_all(&cache_dir).unwrap();
-        std::fs::write(cache_dir.join("manifest.ron"), b"manifest").unwrap();
-        std::fs::write(cache_dir.join("desert_night.cubemap.ktx2"), b"ktx2").unwrap();
+        let cubemap_path = dir.path().join("desert_night.cubemap.ktx2");
+        std::fs::write(&cubemap_path, b"ktx2").unwrap();
 
-        let settings = SkyboxAssetSettings {
-            cache_dir,
-            ..Default::default()
-        };
-
-        let uploads = skybox_upload_payload(&settings, "desert_night.cubemap.ktx2").unwrap();
-        assert_eq!(
-            uploads,
-            vec![
-                (
-                    impeller2_kdl::SKYBOX_MANIFEST_ASSET_NAME.to_string(),
-                    b"manifest".to_vec()
-                ),
-                (
-                    "skyboxes/desert_night.cubemap.ktx2".to_string(),
-                    b"ktx2".to_vec()
-                ),
-            ]
-        );
+        let (name, bytes, digest) =
+            read_local_cubemap("desert_night.cubemap.ktx2", &cubemap_path).unwrap();
+        assert_eq!(name, "skyboxes/desert_night.cubemap.ktx2");
+        assert_eq!(bytes, b"ktx2".to_vec());
+        assert_eq!(digest, digest_bytes(b"ktx2"));
     }
 
     #[test]
-    fn skybox_upload_payload_rejects_cubemap_traversal() {
-        let settings = SkyboxAssetSettings::default();
-        assert!(skybox_upload_payload(&settings, "../escape.ktx2").is_err());
+    fn read_local_cubemap_rejects_cubemap_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(read_local_cubemap("../escape.ktx2", &dir.path().join("escape.ktx2")).is_err());
+    }
+
+    #[test]
+    fn cubemap_digest_changes_with_content() {
+        assert_ne!(digest_bytes(b"old-cubemap"), digest_bytes(b"new-cubemap"));
+        assert_eq!(digest_bytes(b"same"), digest_bytes(b"same"));
     }
 
     #[test]

--- a/libs/elodin-editor/src/skybox_db_assets.rs
+++ b/libs/elodin-editor/src/skybox_db_assets.rs
@@ -247,11 +247,33 @@ struct DbSkyboxUpload {
 /// `(db asset key, bytes)` pairs ready to send as [`StoreAsset`] messages.
 type UploadPayload = Vec<(String, Vec<u8>)>;
 
+/// Output of the prepare step: the messages to send plus the digest of the
+/// cubemap bytes, used to confirm the *fresh* bytes (not a stale same-named
+/// file) actually landed in the DB.
+type PrepareOutput = (UploadPayload, CubemapDigest);
+
 enum UploadPhase {
     /// Fetching the DB manifest and merging our entry off the main thread.
-    Preparing(Task<Result<UploadPayload, String>>),
+    Preparing(Task<Result<PrepareOutput, String>>),
     /// Confirming the DB now serves the uploaded assets.
     Verifying(Task<Result<bool, String>>),
+}
+
+/// Size + content hash of a cubemap, to detect stale vs. freshly uploaded bytes.
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct CubemapDigest {
+    len: u64,
+    hash: u64,
+}
+
+fn digest_bytes(bytes: &[u8]) -> CubemapDigest {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    bytes.hash(&mut hasher);
+    CubemapDigest {
+        len: bytes.len() as u64,
+        hash: hasher.finish(),
+    }
 }
 
 /// Identifies the on-disk cubemap content, so a same-name regeneration (new
@@ -274,11 +296,15 @@ fn cubemap_fingerprint(path: &Path) -> Option<UploadFingerprint> {
     })
 }
 
-fn spawn_skybox_verify(skybox: String, addr: SocketAddr) -> Task<Result<bool, String>> {
+fn spawn_skybox_verify(
+    skybox: String,
+    addr: SocketAddr,
+    digest: CubemapDigest,
+) -> Task<Result<bool, String>> {
     IoTaskPool::get().spawn(async move {
         tokio::runtime::Runtime::new()
             .map_err(|err| err.to_string())?
-            .block_on(verify_db_skybox_assets(&skybox, addr))
+            .block_on(verify_db_skybox_assets(&skybox, addr, digest))
     })
 }
 
@@ -347,15 +373,18 @@ pub fn upload_active_skybox_assets_to_db(
         } else {
             match &mut up.phase {
                 UploadPhase::Preparing(task) => match future::block_on(future::poll_once(task)) {
-                    Some(Ok(uploads)) => {
+                    Some(Ok((uploads, digest))) => {
                         for (asset_key, bytes) in uploads {
                             tx.send_msg(StoreAsset {
                                 key: asset_key,
                                 bytes,
                             });
                         }
-                        up.phase =
-                            UploadPhase::Verifying(spawn_skybox_verify(desired.clone(), addr));
+                        up.phase = UploadPhase::Verifying(spawn_skybox_verify(
+                            desired.clone(),
+                            addr,
+                            digest,
+                        ));
                         return;
                     }
                     Some(Err(error)) => {
@@ -423,23 +452,27 @@ async fn prepare_skybox_upload(
     connection_addr: SocketAddr,
     entry: ManifestEntry,
     cubemap_path: PathBuf,
-) -> Result<UploadPayload, String> {
+) -> Result<PrepareOutput, String> {
     let cubemap_name = impeller2_kdl::skybox_cubemap_asset_name(&entry.cubemap_file)
         .ok_or_else(|| format!("invalid skybox cubemap file path `{}`", entry.cubemap_file))?;
     let cubemap_bytes =
         std::fs::read(&cubemap_path).map_err(|err| format!("{}: {err}", cubemap_path.display()))?;
+    let digest = digest_bytes(&cubemap_bytes);
 
     let mut manifest = fetch_db_skybox_manifest(connection_addr).await?;
     manifest.upsert(entry);
     let manifest_bytes = manifest.to_ron_bytes().map_err(|err| err.to_string())?;
 
-    Ok(vec![
-        (
-            impeller2_kdl::SKYBOX_MANIFEST_ASSET_NAME.to_string(),
-            manifest_bytes,
-        ),
-        (cubemap_name, cubemap_bytes),
-    ])
+    Ok((
+        vec![
+            (
+                impeller2_kdl::SKYBOX_MANIFEST_ASSET_NAME.to_string(),
+                manifest_bytes,
+            ),
+            (cubemap_name, cubemap_bytes),
+        ],
+        digest,
+    ))
 }
 
 /// Fetches the DB's current skybox manifest, or an empty one if absent.
@@ -512,11 +545,14 @@ async fn download_db_skybox_assets(
 }
 
 /// Confirms the DB asset server actually serves the active skybox's manifest
-/// entry and cubemap. `Ok(false)` means the assets aren't present yet (caller
-/// re-sends); `Err` is an unexpected failure (caller retries).
+/// entry and the *freshly uploaded* cubemap bytes (matched by digest, so a
+/// stale same-named cubemap or a manifest that lands ahead of the new bytes
+/// does not pass). `Ok(false)` means not ready yet (caller re-sends); `Err` is
+/// an unexpected failure (caller retries).
 async fn verify_db_skybox_assets(
     skybox: &str,
     connection_addr: SocketAddr,
+    expected: CubemapDigest,
 ) -> Result<bool, String> {
     let client = reqwest::Client::builder()
         .timeout(REQUEST_TIMEOUT)
@@ -548,20 +584,28 @@ async fn verify_db_skybox_assets(
     let cubemap_name = impeller2_kdl::skybox_cubemap_asset_name(&entry.cubemap_file)
         .ok_or_else(|| format!("invalid skybox cubemap file path `{}`", entry.cubemap_file))?;
     let cubemap_url = format!("{base}/{cubemap_name}");
-    // HEAD avoids transferring the (large) cubemap just to check presence;
+
+    // Cheap precheck: a HEAD reveals presence + length without transferring the
+    // (large) cubemap; a length mismatch means the fresh bytes haven't landed.
     // axum serves HEAD for `get` routes automatically.
-    let cubemap_resp = client
+    let head = client
         .head(&cubemap_url)
         .send()
         .await
         .map_err(|err| format!("{cubemap_url}: {err}"))?;
-    if cubemap_resp.status() == reqwest::StatusCode::NOT_FOUND {
+    if head.status() == reqwest::StatusCode::NOT_FOUND {
         return Ok(false);
     }
-    cubemap_resp
+    let head = head
         .error_for_status()
         .map_err(|err| format!("{cubemap_url}: {err}"))?;
-    Ok(true)
+    if head.content_length().is_some_and(|len| len != expected.len) {
+        return Ok(false);
+    }
+
+    // Confirm the served bytes are exactly the ones we uploaded.
+    let cubemap_bytes = fetch_asset(&client, &cubemap_url).await?;
+    Ok(digest_bytes(&cubemap_bytes) == expected)
 }
 
 fn cubemap_cache_path(cache_dir: &Path, cubemap_file: &str) -> Result<PathBuf, String> {

--- a/libs/elodin-editor/src/ui/button.rs
+++ b/libs/elodin-editor/src/ui/button.rs
@@ -109,6 +109,7 @@ pub struct ECheckboxButton {
     on_color: egui::Color32,
     off_color: egui::Color32,
     text_color: egui::Color32,
+    border_color: Option<egui::Color32>,
     margin: egui::Margin,
     is_on: bool,
     label: String,
@@ -122,6 +123,7 @@ impl ECheckboxButton {
             on_color: get_scheme().text_primary,
             off_color: get_scheme().bg_secondary,
             text_color: get_scheme().text_primary,
+            border_color: None,
             margin: egui::Margin::same(8),
             is_on,
             label: label.to_string(),
@@ -137,6 +139,13 @@ impl ECheckboxButton {
 
     pub fn on_color(mut self, color: egui::Color32) -> Self {
         self.on_color = color;
+        self
+    }
+
+    /// Resting border color. Defaults to `on_color` (the box is monochrome);
+    /// set this to keep a fixed border while the fill shows a different color.
+    pub fn border_color(mut self, color: egui::Color32) -> Self {
+        self.border_color = Some(color);
         self
     }
 
@@ -173,7 +182,8 @@ impl ECheckboxButton {
         // Paint the UI
         if ui.is_rect_visible(rect) {
             let style = ui.style_mut();
-            style.visuals.widgets.inactive.bg_stroke = egui::Stroke::new(1.0, self.on_color);
+            style.visuals.widgets.inactive.bg_stroke =
+                egui::Stroke::new(1.0, self.border_color.unwrap_or(self.on_color));
             let visuals = ui.style().interact(&response);
 
             let inner_rect = rect.shrink4(self.margin);

--- a/libs/elodin-editor/src/ui/inspector/line3d.rs
+++ b/libs/elodin-editor/src/ui/inspector/line3d.rs
@@ -1,0 +1,95 @@
+use bevy_egui::egui::{self, RichText};
+use impeller2_wkt::{Color, Line3d};
+
+use crate::ui::colors::{EColor, get_scheme};
+use crate::ui::inspector::color_popup;
+use crate::ui::plot_3d::gpu::DEFAULT_FUTURE_TRAIL_ALPHA;
+
+/// Field editors for a single `line_3d`. `played_timeline`/`future_timeline` are
+/// the inherited timeline colors shown in the swatches when the line has no
+/// per-line override. Edits mutate the live `Line3d` component, which
+/// `tiles_to_schematic` mirrors into `CurrentSchematic` each frame (and thus to
+/// KDL on save). Returns `true` if any value changed.
+pub fn line3d_controls(
+    ui: &mut egui::Ui,
+    line: &mut Line3d,
+    played_timeline: Color,
+    future_timeline: Color,
+) -> bool {
+    let scheme = get_scheme();
+    let mut changed = false;
+
+    // Sober gray piping for the box-like inputs (drag value, checkbox).
+    ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::new(1.0, scheme.border_primary);
+
+    ui.label(RichText::new("Line Width").color(scheme.text_secondary));
+    changed |= ui
+        .add(
+            egui::DragValue::new(&mut line.line_width)
+                .speed(0.05)
+                .range(0.1..=100.0),
+        )
+        .changed();
+    ui.separator();
+
+    // Played color: the swatch shows the per-line override, else the inherited
+    // timeline color. Editing it materializes the override.
+    let mut played = line.color.unwrap_or(played_timeline);
+    if color_square(ui, "Played Color", &mut played) {
+        line.color = Some(played);
+        changed = true;
+    }
+
+    // Future color: shows the override, else the inherited timeline future color
+    // (white by default) at the default fade. The picker alpha sets opacity.
+    // Mirror the render fade (timeline alpha * default) so the preview matches.
+    let mut future = line.future_color.unwrap_or(Color {
+        a: future_timeline.a * DEFAULT_FUTURE_TRAIL_ALPHA,
+        ..future_timeline
+    });
+    if color_square(ui, "Future Color", &mut future) {
+        line.future_color = Some(future);
+        changed = true;
+    }
+    ui.separator();
+
+    changed |= ui.checkbox(&mut line.perspective, "Perspective").changed();
+
+    changed
+}
+
+/// A plain color square below its label that opens the shared color popup.
+/// Returns `true` only when the popup actually edits the color, so it never
+/// spuriously materializes an inherited color from a redraw.
+fn color_square(ui: &mut egui::Ui, label: &str, color: &mut Color) -> bool {
+    let scheme = get_scheme();
+    let mut egui_color = color.into_color32();
+
+    ui.label(RichText::new(label).color(scheme.text_secondary));
+    let (rect, resp) = ui.allocate_exact_size(egui::vec2(24.0, 24.0), egui::Sense::click());
+    if ui.is_rect_visible(rect) {
+        ui.painter().rect(
+            rect,
+            egui::CornerRadius::same(3),
+            egui_color,
+            egui::Stroke::new(1.0, scheme.border_primary),
+            egui::StrokeKind::Inside,
+        );
+    }
+    let resp = resp.on_hover_cursor(egui::CursorIcon::PointingHand);
+    ui.separator();
+
+    let popup_id = ui.auto_id_with(("line3d_color", label));
+    if resp.clicked() {
+        egui::Popup::toggle_id(ui.ctx(), popup_id);
+    }
+
+    let before = egui_color;
+    color_popup(ui, &mut egui_color, popup_id, &resp);
+    if egui_color != before {
+        *color = Color::from_color32(egui_color);
+        true
+    } else {
+        false
+    }
+}

--- a/libs/elodin-editor/src/ui/inspector/mod.rs
+++ b/libs/elodin-editor/src/ui/inspector/mod.rs
@@ -21,6 +21,7 @@ pub mod action;
 pub mod data_overview;
 pub mod entity;
 pub mod graph;
+pub mod line3d;
 pub mod monitor;
 pub mod object3d;
 pub mod query_table;

--- a/libs/elodin-editor/src/ui/inspector/timeline.rs
+++ b/libs/elodin-editor/src/ui/inspector/timeline.rs
@@ -1,20 +1,23 @@
 use bevy::ecs::system::{SystemParam, SystemState};
 use bevy::prelude::*;
 use bevy_egui::egui;
+use impeller2_wkt::Line3d;
 
 use crate::ui::colors::get_scheme;
 use crate::ui::timeline::TimelineSettings;
 use crate::ui::widgets::WidgetSystem;
 use crate::ui::{label::ELabel, utils::MarginSides};
 
+use super::line3d::line3d_controls;
 use super::node_color_picker;
 
 #[derive(SystemParam)]
-pub struct InspectorTimeline<'w> {
+pub struct InspectorTimeline<'w, 's> {
     timeline_settings: ResMut<'w, TimelineSettings>,
+    lines: Query<'w, 's, (Entity, &'static mut Line3d)>,
 }
 
-impl WidgetSystem for InspectorTimeline<'_> {
+impl WidgetSystem for InspectorTimeline<'_, '_> {
     type Args = ();
     type Output = ();
 
@@ -27,40 +30,68 @@ impl WidgetSystem for InspectorTimeline<'_> {
         let scheme = get_scheme();
         let InspectorTimeline {
             mut timeline_settings,
+            mut lines,
         } = state.get_mut(world);
 
         ui.spacing_mut().item_spacing.y = 8.0;
-        ui.add(
-            ELabel::new("Timeline")
-                .padding(egui::Margin::same(8).bottom(24.0))
-                .bottom_stroke(egui::Stroke {
-                    color: scheme.border_primary,
-                    width: 1.0,
-                })
-                .margin(egui::Margin::same(0).bottom(16.0)),
-        );
 
+        // ── Timeline: global played/future trail colors ──────────────────
+        section_header(ui, "TIMELINE", scheme.border_primary);
         node_color_picker(ui, "PLAYED COLOR", &mut timeline_settings.played_color);
         node_color_picker(ui, "FUTURE COLOR", &mut timeline_settings.future_color);
 
-        egui::Frame::NONE
-            .inner_margin(egui::Margin::symmetric(0, 8))
-            .show(ui, |ui| {
-                ui.label(egui::RichText::new("FUTURE TRAIL OPACITY").color(scheme.text_secondary));
+        // ── Line 3D: per-line overrides for every `line_3d` in the schematic ─
+        let mut lines: Vec<(Entity, Mut<Line3d>)> = lines.iter_mut().collect();
+        if lines.is_empty() {
+            return;
+        }
+        lines.sort_by(|(_, a), (_, b)| a.eql.cmp(&b.eql));
 
-                ui.label(
-                    egui::RichText::new(format!("{:.2}", timeline_settings.future_trail_alpha))
-                        .monospace()
-                        .color(scheme.text_primary),
-                );
+        ui.add_space(16.0);
+        section_header(ui, "LINE 3D", scheme.border_primary);
 
-                ui.add_space(8.0);
-                ui.style_mut().visuals.widgets.inactive.bg_fill = scheme.bg_secondary;
-                ui.add_sized(
-                    [140.0, ui.spacing().interact_size.y],
-                    egui::Slider::new(&mut timeline_settings.future_trail_alpha, 0.0..=1.0)
-                        .show_value(false),
-                );
-            });
+        let single_line = lines.len() == 1;
+        let played_tl = timeline_settings.played_color;
+        let future_tl = timeline_settings.future_color;
+        // Subtle white piping around each line so multiple `line_3d` entries read
+        // as distinct, roomy cards.
+        let border = egui::Stroke {
+            width: 1.0,
+            color: crate::ui::colors::with_opacity(egui::Color32::WHITE, 0.4),
+        };
+        for (entity, line) in lines.iter_mut() {
+            egui::Frame::NONE
+                .stroke(border)
+                .corner_radius(egui::CornerRadius::same(6))
+                .inner_margin(egui::Margin::same(12))
+                .outer_margin(egui::Margin::symmetric(0, 6))
+                .show(ui, |ui| {
+                    egui::CollapsingHeader::new(
+                        egui::RichText::new(line.eql.clone())
+                            .monospace()
+                            .color(scheme.text_primary),
+                    )
+                    .id_salt(("line3d_inspector", *entity))
+                    .default_open(single_line)
+                    .show(ui, |ui| {
+                        // Edits mutate the live `Line3d`; `tiles_to_schematic`
+                        // mirrors it into `CurrentSchematic` (and KDL on save).
+                        line3d_controls(ui, line, played_tl, future_tl);
+                    });
+                });
+        }
     }
+}
+
+/// Section title with an underline, used to separate Timeline from Line 3D.
+fn section_header(ui: &mut egui::Ui, title: &str, border: egui::Color32) {
+    ui.add(
+        ELabel::new(title)
+            .padding(egui::Margin::same(8).bottom(24.0))
+            .bottom_stroke(egui::Stroke {
+                color: border,
+                width: 1.0,
+            })
+            .margin(egui::Margin::same(0).bottom(8.0)),
+    );
 }

--- a/libs/elodin-editor/src/ui/inspector/viewport.rs
+++ b/libs/elodin-editor/src/ui/inspector/viewport.rs
@@ -1029,6 +1029,7 @@ mod tests {
     /// commands applying (e.g. skybox generation reloads the schematic). The
     /// queued command must be silenced rather than panic on the dead entity.
     #[test]
+    #[allow(clippy::type_complexity)]
     fn sync_viewport_focus_pick_targets_survives_despawned_target() {
         let mut world = World::new();
         let parent = world.spawn(focus_object_state("e.world_pos")).id();

--- a/libs/elodin-editor/src/ui/inspector/viewport.rs
+++ b/libs/elodin-editor/src/ui/inspector/viewport.rs
@@ -550,16 +550,19 @@ pub fn sync_viewport_focus_pick_targets(
         }
     }
 
+    // `try_*` variants silence the command if the entity was despawned between
+    // building the target set and applying these deferred commands (e.g. a
+    // schematic reload triggered by skybox generation despawns Object3D meshes).
     for entity in current_targets.difference(&desired_targets) {
         commands
             .entity(*entity)
-            .remove::<(Pickable, ViewportFocusPickTarget)>();
+            .try_remove::<(Pickable, ViewportFocusPickTarget)>();
     }
 
     for entity in desired_targets.difference(&current_targets) {
         commands
             .entity(*entity)
-            .insert((Pickable::default(), ViewportFocusPickTarget));
+            .try_insert((Pickable::default(), ViewportFocusPickTarget));
     }
 }
 
@@ -980,5 +983,86 @@ mod tests {
             let glam_quat = Quat::from_mat3(&g(glam_mat));
             assert_eq_quat!(nox_quat_bevy.as_quat(), glam_quat, "case {i} second");
         }
+    }
+
+    fn focus_object_state(eql: &str) -> Object3DState {
+        use impeller2_wkt::{Object3D, Object3DMesh};
+        Object3DState {
+            compiled_expr: None,
+            scale_expr: None,
+            scale_error: None,
+            error_covariance_cholesky_expr: None,
+            joint_animations: Vec::new(),
+            data: Object3D {
+                eql: eql.to_string(),
+                mesh: Object3DMesh::glb("model.glb"),
+                frame: None,
+                icon: None,
+                thrusters: Vec::new(),
+                mesh_visibility_range: None,
+                node_id: Default::default(),
+            },
+        }
+    }
+
+    fn focus_viewport(eql: &str, parent_entity: Entity) -> Viewport {
+        Viewport {
+            parent_entity,
+            pos: EditableEQL {
+                eql: String::new(),
+                compiled_expr: None,
+            },
+            look_at: EditableEQL {
+                eql: eql.to_string(),
+                compiled_expr: None,
+            },
+            up: EditableEQL {
+                eql: String::new(),
+                compiled_expr: None,
+            },
+            frame: None,
+        }
+    }
+
+    /// Regression for the panic where a focus mesh entity is despawned between
+    /// `sync_viewport_focus_pick_targets` queueing its `insert` and the deferred
+    /// commands applying (e.g. skybox generation reloads the schematic). The
+    /// queued command must be silenced rather than panic on the dead entity.
+    #[test]
+    fn sync_viewport_focus_pick_targets_survives_despawned_target() {
+        let mut world = World::new();
+        let parent = world.spawn(focus_object_state("e.world_pos")).id();
+        let mesh = world.spawn(Mesh3d(Handle::default())).id();
+        world.entity_mut(parent).add_child(mesh);
+        let viewport_parent = world.spawn_empty().id();
+        world.spawn(focus_viewport("e.world_pos", viewport_parent));
+
+        let mut state: SystemState<(
+            Commands,
+            Query<&Viewport>,
+            Query<(Entity, &Object3DState)>,
+            Query<&Children>,
+            Query<(), With<Mesh3d>>,
+            Query<Entity, With<ViewportFocusPickTarget>>,
+        )> = SystemState::new(&mut world);
+
+        {
+            let (commands, viewports, objects, children, mesh_entities, current_targets) =
+                state.get_mut(&mut world);
+            sync_viewport_focus_pick_targets(
+                commands,
+                viewports,
+                objects,
+                children,
+                mesh_entities,
+                current_targets,
+            );
+        }
+
+        // Despawn the target after the insert is queued but before it applies.
+        world.entity_mut(mesh).despawn();
+        state.apply(&mut world);
+
+        assert!(world.get_entity(mesh).is_err());
     }
 }

--- a/libs/elodin-editor/src/ui/inspector/widgets.rs
+++ b/libs/elodin-editor/src/ui/inspector/widgets.rs
@@ -257,6 +257,7 @@ pub fn node_color_picker(ui: &mut egui::Ui, label: &str, color: &mut impeller2_w
         ECheckboxButton::new(label, true)
             .margin(egui::Margin::symmetric(0, 8))
             .on_color(egui_color)
+            .border_color(get_scheme().text_primary)
             .text_color(get_scheme().text_secondary)
             .left_label(true),
     );

--- a/libs/elodin-editor/src/ui/plot_3d/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/gpu.rs
@@ -165,11 +165,17 @@ fn update_uniform_model(mut query: Query<(&mut LineUniform, &GlobalTransform)>) 
 #[require(SyncToRenderWorld)]
 pub struct LineHandles(pub [Handle<Line>; 3]);
 
+/// Default opacity applied to the future (not-yet-played) trail segment when a
+/// line does not set its own `future_color`, so the future reads as dimmer than
+/// the played segment. A per-line `future_color` overrides this with its own
+/// alpha.
+pub const DEFAULT_FUTURE_TRAIL_ALPHA: f32 = 0.35;
+
 /// Per-line trail colors resolved from the KDL `color`/`future_color`.
 ///
-/// Each is linear RGBA; `None` falls back to the timeline trail colors. A line
-/// with only `color` set leaves `future = None`, so the future segment reuses
-/// `played` (the whole line takes that color, just faded).
+/// Each is linear RGBA; `None` falls back to the timeline trail colors. The
+/// played and future segments are independent: a line with only `color` set
+/// keeps the timeline future color (faded) for its future segment.
 #[derive(Component, Debug, Clone, Copy, Default)]
 pub struct LineTrailColors {
     pub played: Option<Vec4>,
@@ -180,11 +186,10 @@ impl LineTrailColors {
     /// Resolve the played/future segment colors against the timeline fallbacks.
     ///
     /// - played: explicit `played`, else the timeline played color.
-    /// - future: explicit `future`, else explicit `played` (a lone KDL `color`
-    ///   paints the whole line), else the timeline future color.
-    ///
-    /// The future segment's alpha fade (`future_alpha`) is applied uniformly,
-    /// regardless of where the color came from.
+    /// - future: explicit `future` is authoritative (its alpha is the per-line
+    ///   opacity, used as-is); otherwise the timeline future color, faded by
+    ///   `future_alpha` so the not-yet-played segment reads dimmer. The future
+    ///   does not inherit the played color.
     fn resolve(
         &self,
         played_timeline: Vec4,
@@ -192,8 +197,14 @@ impl LineTrailColors {
         future_alpha: f32,
     ) -> (Vec4, Vec4) {
         let played = self.played.unwrap_or(played_timeline);
-        let mut future = self.future.or(self.played).unwrap_or(future_timeline);
-        future.w *= future_alpha;
+        let future = match self.future {
+            Some(future) => future,
+            None => {
+                let mut fallback = future_timeline;
+                fallback.w *= future_alpha;
+                fallback
+            }
+        };
         (played, future)
     }
 }
@@ -510,9 +521,9 @@ fn extract_lines(
         } else {
             selected_range.clone()
         };
-        let future_trail_alpha = timeline_settings.future_trail_alpha;
+        let future_trail_alpha = DEFAULT_FUTURE_TRAIL_ALPHA;
         // Fallback colors for lines without explicit KDL colors. Kept unfaded
-        // here; the future segment's alpha fade is applied uniformly below.
+        // here; the default future fade is applied only to fallback futures.
         let played_timeline_color = wkt_color_linear(timeline_settings.played_color);
         let future_timeline_color = wkt_color_linear(timeline_settings.future_color);
 
@@ -818,32 +829,47 @@ mod tests {
     }
 
     #[test]
-    fn color_only_paints_whole_line() {
+    fn color_only_keeps_timeline_future() {
+        // A lone played color leaves the future on the timeline future color
+        // (faded); the future does not inherit the played color.
         let (played, future) = resolve(LineTrailColors {
             played: Some(G),
             future: None,
         });
         assert_eq!(played, G);
-        assert_eq!(future, faded(G));
+        assert_eq!(future, faded(FUTURE_TL));
     }
 
     #[test]
     fn color_and_future_color_are_independent() {
+        // An explicit future color is authoritative: its alpha is used as-is.
         let (played, future) = resolve(LineTrailColors {
             played: Some(G),
             future: Some(W),
         });
         assert_eq!(played, G);
-        assert_eq!(future, faded(W));
+        assert_eq!(future, W);
     }
 
     #[test]
     fn future_color_only_keeps_timeline_played() {
+        // Explicit future color keeps its own alpha (no global fade applied).
         let (played, future) = resolve(LineTrailColors {
             played: None,
             future: Some(W),
         });
         assert_eq!(played, PLAYED_TL);
-        assert_eq!(future, faded(W));
+        assert_eq!(future, W);
+    }
+
+    #[test]
+    fn explicit_future_alpha_is_not_faded() {
+        // A half-opaque future color renders at exactly that opacity.
+        let half = Vec4::new(1.0, 1.0, 1.0, 0.5);
+        let (_, future) = resolve(LineTrailColors {
+            played: Some(G),
+            future: Some(half),
+        });
+        assert_eq!(future, half);
     }
 }

--- a/libs/elodin-editor/src/ui/plot_3d/mod.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/mod.rs
@@ -23,8 +23,9 @@ pub mod gpu;
 
 /// Convert a schematic (sRGB) color into the linear RGBA the line pipeline
 /// renders, keeping it consistent with meshes/gizmos. Alpha is preserved so a
-/// KDL `color`/`future_color` can set per-line opacity (the future segment is
-/// additionally faded by the timeline `future_trail_alpha`).
+/// KDL `color`/`future_color` can set per-line opacity. An explicit
+/// `future_color` alpha is used as-is; only fallback futures get the default
+/// fade (see `LineTrailColors::resolve`).
 fn line_color_linear(color: &impeller2_wkt::Color) -> Vec4 {
     let linear = Color::srgba(color.r, color.g, color.b, color.a).to_linear();
     Vec4::new(linear.red, linear.green, linear.blue, linear.alpha)
@@ -156,8 +157,8 @@ mod tests {
     #[test]
     fn line_color_linear_preserves_alpha() {
         // A KDL color/future_color alpha must survive into the line uniform
-        // (sRGB->linear leaves alpha untouched); only the timeline
-        // future_trail_alpha should fade it further, applied in `resolve`.
+        // (sRGB->linear leaves alpha untouched). An explicit future_color keeps
+        // this alpha as-is; fallback futures get the default fade in `resolve`.
         let color = impeller2_wkt::Color::rgba(1.0, 1.0, 1.0, 0.25);
         assert_eq!(line_color_linear(&color).w, 0.25);
     }

--- a/libs/elodin-editor/src/ui/schematic/tree.rs
+++ b/libs/elodin-editor/src/ui/schematic/tree.rs
@@ -97,7 +97,7 @@ impl WidgetSystem for TreeWidget<'_, '_> {
                             *selected_object = SelectedObject::Object3D { entity };
                         }
                     }
-                    impeller2_wkt::SchematicElem::Line3d(_line3d) => {}
+                    impeller2_wkt::SchematicElem::Line3d(_line_3d) => {}
                     impeller2_wkt::SchematicElem::VectorArrow(_arrow) => {}
                     impeller2_wkt::SchematicElem::WorldMesh(_world_mesh) => {}
                     impeller2_wkt::SchematicElem::Window(_window) => {}

--- a/libs/elodin-editor/src/ui/timeline/mod.rs
+++ b/libs/elodin-editor/src/ui/timeline/mod.rs
@@ -62,7 +62,6 @@ pub struct LatestFollow(pub bool);
 pub struct TimelineSettings {
     pub played_color: impeller2_wkt::Color,
     pub future_color: impeller2_wkt::Color,
-    pub future_trail_alpha: f32,
     pub follow_latest: bool,
 }
 
@@ -77,7 +76,6 @@ impl From<impeller2_wkt::TimelineConfig> for TimelineSettings {
         Self {
             played_color: value.played_color,
             future_color: value.future_color,
-            future_trail_alpha: 0.35,
             follow_latest: value.follow_latest,
         }
     }

--- a/libs/impeller2/stellar/src/lib.rs
+++ b/libs/impeller2/stellar/src/lib.rs
@@ -34,6 +34,14 @@ impl<R: AsyncRead> PacketStream<R> {
         Self { reader }
     }
 
+    /// Reject packets whose length prefix exceeds `max` bytes (see
+    /// [`LengthDelReader::with_max_len`]). Bounds memory for [`Self::next_grow`].
+    pub fn with_max_len(self, max: usize) -> Self {
+        Self {
+            reader: self.reader.with_max_len(max),
+        }
+    }
+
     pub async fn next<B: IoBufMut>(&mut self, buf: B) -> Result<OwnedPacket<Slice<B>>, Error> {
         let packet_buf = self.reader.recv(buf).await?;
         OwnedPacket::parse(packet_buf).map_err(Error::from)

--- a/libs/impeller2/wkt/src/msgs.rs
+++ b/libs/impeller2/wkt/src/msgs.rs
@@ -270,6 +270,22 @@ impl Msg for SetDbConfig {
     const ID: PacketId = [224, 19];
 }
 
+/// Editor→DB asset upload: stores `bytes` at `{db}/assets/<key>`.
+///
+/// `key` is sanitized server-side (rejects `..` and absolute paths). Used to
+/// mirror assets added at runtime (e.g. a generated skybox's `manifest.ron`
+/// and cubemap) so followers and the render-server can fetch them over the DB
+/// asset HTTP server. It is a generic asset feature, not skybox-specific.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct StoreAsset {
+    pub key: String,
+    pub bytes: Vec<u8>,
+}
+
+impl Msg for StoreAsset {
+    const ID: PacketId = [224, 40];
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[cfg_attr(feature = "bevy", derive(bevy::prelude::Resource))]
 pub struct DbConfig {

--- a/libs/nox-py/src/impeller2_server.rs
+++ b/libs/nox-py/src/impeller2_server.rs
@@ -101,7 +101,7 @@ pub fn prime_schematic_assets(
     };
     match impeller2_kdl::parse_schematic(&content) {
         Ok(mut schematic) => {
-            persist_schematic_assets(db, &mut schematic, world.metadata.schematic_path.as_deref())?;
+            persist_schematic_assets(db, &mut schematic, world.metadata.schematic_path.as_deref());
             world.metadata.schematic = Some(impeller2_kdl::serialize_schematic(&schematic));
         }
         Err(err) => {
@@ -266,64 +266,62 @@ fn read_local_asset_file(
     }))
 }
 
-fn skybox_manifest_error(error: impl std::fmt::Display) -> elodin_db::Error {
-    elodin_db::Error::Io(io::Error::new(
-        io::ErrorKind::InvalidData,
-        error.to_string(),
-    ))
-}
-
+/// Best-effort: append the active skybox's `manifest.ron` and cubemap to
+/// `local_paths`. A missing/unreadable manifest or an absent skybox entry is
+/// logged and skipped so it never blocks the mandatory meshes/icons.
 fn add_local_skybox_cubemap_path(
     local_paths: &mut Vec<String>,
     schematic: &Schematic,
     schematic_path: Option<&Path>,
     active_skybox_name: Option<&str>,
-) -> Result<(), elodin_db::Error> {
+) {
     let skybox_name =
         active_skybox_name.or_else(|| schematic.skybox.as_ref().map(|skybox| skybox.name.as_str()));
     let Some(skybox_name) = skybox_name else {
-        return Ok(());
+        return;
     };
     local_paths.push(impeller2_kdl::SKYBOX_MANIFEST_ASSET_NAME.to_string());
     let manifest_data =
-        read_local_asset_file(impeller2_kdl::SKYBOX_MANIFEST_ASSET_NAME, schematic_path).map_err(
-            |(path, err)| {
+        match read_local_asset_file(impeller2_kdl::SKYBOX_MANIFEST_ASSET_NAME, schematic_path) {
+            Ok(data) => data,
+            Err((path, err)) => {
                 tracing::warn!(
                     ?err,
                     path = %path.display(),
                     skybox = %skybox_name,
-                    "failed to read local skybox manifest for db upload"
+                    "skipping skybox cubemap: local manifest unreadable for db upload"
                 );
-                elodin_db::Error::Io(err)
-            },
-        )?;
-    let manifest = std::str::from_utf8(&manifest_data).map_err(skybox_manifest_error)?;
-    let Some(cubemap_path) =
-        impeller2_kdl::skybox_manifest_cubemap_asset_name(manifest, skybox_name)
-            .map_err(skybox_manifest_error)?
-    else {
-        return Err(skybox_manifest_error(format!(
-            "skybox `{skybox_name}` is not present in {}",
-            impeller2_kdl::SKYBOX_MANIFEST_ASSET_NAME
-        )));
-    };
-    local_paths.push(cubemap_path);
-    Ok(())
-}
-
-fn rollback_stored_assets(assets_dir: &Path, names: &[String]) {
-    for name in names {
-        if let Ok(rel) = elodin_db::assets_http::sanitize_asset_path(name) {
-            let _ = std::fs::remove_file(assets_dir.join(rel));
+                return;
+            }
+        };
+    let manifest = match std::str::from_utf8(&manifest_data) {
+        Ok(manifest) => manifest,
+        Err(err) => {
+            tracing::warn!(%err, skybox = %skybox_name, "skipping skybox cubemap: manifest is not utf-8");
+            return;
         }
+    };
+    match impeller2_kdl::skybox_manifest_cubemap_asset_name(manifest, skybox_name) {
+        Ok(Some(cubemap_path)) => local_paths.push(cubemap_path),
+        Ok(None) => tracing::warn!(
+            skybox = %skybox_name,
+            "skipping skybox cubemap: skybox not present in {}",
+            impeller2_kdl::SKYBOX_MANIFEST_ASSET_NAME
+        ),
+        Err(err) => tracing::warn!(
+            %err,
+            skybox = %skybox_name,
+            "skipping skybox cubemap: failed to resolve from local manifest"
+        ),
     }
 }
 
-fn persist_schematic_assets(
-    db: &DB,
-    schematic: &mut Schematic,
-    schematic_path: Option<&Path>,
-) -> Result<(), elodin_db::Error> {
+/// Copy schematic-referenced files into `{db}/assets/`, rewriting only the
+/// successfully stored ones to `db:`. Per-asset read/write failures are
+/// non-fatal (logged and skipped) so one bad file cannot block the rest; a
+/// skipped asset keeps its original local path rather than gaining a dangling
+/// `db:` reference.
+fn persist_schematic_assets(db: &DB, schematic: &mut Schematic, schematic_path: Option<&Path>) {
     let assets_dir = elodin_db::assets_http::assets_dir(&db.path);
     let active_skybox = db.with_state(|state| state.db_config.skybox_active_desired());
     let mut local_paths = impeller2_kdl::collect_local_asset_paths(schematic);
@@ -332,45 +330,44 @@ fn persist_schematic_assets(
         schematic,
         schematic_path,
         active_skybox.as_ref().and_then(|name| name.as_deref()),
-    )?;
+    );
     local_paths.sort();
     local_paths.dedup();
 
-    let mut staged = Vec::new();
+    let mut stored: HashSet<String> = HashSet::new();
     for local_path in &local_paths {
         let Some(name) = impeller2_kdl::local_asset_name(local_path) else {
             continue;
         };
-        let data = read_local_asset_file(local_path, schematic_path).map_err(|(path, err)| {
-            tracing::warn!(
-                ?err,
-                path = %path.display(),
-                "failed to read local asset for db upload"
-            );
-            elodin_db::Error::Io(err)
-        })?;
-        staged.push((name, data));
-    }
-
-    let mut written = Vec::new();
-    for (name, data) in staged {
+        let data = match read_local_asset_file(local_path, schematic_path) {
+            Ok(data) => data,
+            Err((path, err)) => {
+                tracing::warn!(
+                    ?err,
+                    path = %path.display(),
+                    asset = %name,
+                    "skipping unreadable local asset for db upload"
+                );
+                continue;
+            }
+        };
         if let Err(err) = elodin_db::assets_http::write_asset_file(&assets_dir, &name, &data) {
             tracing::warn!(
                 ?err,
                 asset = %name,
-                "failed to write asset into database assets folder"
+                "skipping asset that failed to write into database assets folder"
             );
-            rollback_stored_assets(&assets_dir, &written);
-            return Err(elodin_db::Error::Io(err));
+            continue;
         }
         tracing::info!(asset = %name, "stored schematic asset in database");
-        written.push(name);
+        stored.insert(name);
     }
 
     impeller2_kdl::rewrite_asset_paths(schematic, |path| {
-        impeller2_kdl::local_asset_name(path).map(|name| format!("db:{name}"))
+        impeller2_kdl::local_asset_name(path)
+            .filter(|name| stored.contains(name))
+            .map(|name| format!("db:{name}"))
     });
-    Ok(())
 }
 
 #[cfg(test)]
@@ -493,7 +490,7 @@ mod asset_tests {
         };
 
         let _guard = EnvVarGuard::set("ELODIN_ASSETS_DIR", assets_dir.to_str().unwrap());
-        persist_schematic_assets(&db, &mut schematic, Some(Path::new("bdx.kdl"))).unwrap();
+        persist_schematic_assets(&db, &mut schematic, Some(Path::new("bdx.kdl")));
 
         let stored_assets = elodin_db::assets_http::assets_dir(&db.path);
         assert_eq!(
@@ -536,8 +533,7 @@ mod asset_tests {
             &db,
             &mut schematic,
             Some(dir.path().join("schematic.kdl").as_path()),
-        )
-        .unwrap();
+        );
 
         let assets_dir = elodin_db::assets_http::assets_dir(&db.path);
         assert_eq!(
@@ -569,8 +565,7 @@ mod asset_tests {
             &db,
             &mut schematic,
             Some(dir.path().join("schematic.kdl").as_path()),
-        )
-        .unwrap();
+        );
 
         let assets_dir = elodin_db::assets_http::assets_dir(&db.path);
         assert_eq!(
@@ -587,7 +582,7 @@ mod asset_tests {
     }
 
     #[test]
-    fn persist_missing_glb_returns_io_error() {
+    fn persist_missing_glb_is_skipped_without_error() {
         let dir = tempdir().unwrap();
         let db = DB::create(dir.path().join("db")).unwrap();
         let mut schematic = Schematic {
@@ -595,19 +590,19 @@ mod asset_tests {
             ..Default::default()
         };
 
-        let err = persist_schematic_assets(
+        persist_schematic_assets(
             &db,
             &mut schematic,
             Some(dir.path().join("schematic.kdl").as_path()),
-        )
-        .unwrap_err();
-        assert!(matches!(err, elodin_db::Error::Io(_)));
+        );
         let SchematicElem::Object3d(obj) = &schematic.elems[0] else {
             panic!("expected object_3d");
         };
         let Object3DMesh::Glb { path, .. } = &obj.mesh else {
             panic!("expected glb");
         };
+        // A missing asset is skipped (non-fatal) and keeps its local path so it
+        // never gains a dangling `db:` reference.
         assert_eq!(path, "missing.glb");
         assert!(
             !elodin_db::assets_http::assets_dir(&db.path)
@@ -617,7 +612,7 @@ mod asset_tests {
     }
 
     #[test]
-    fn persist_rolls_back_assets_when_later_local_file_missing() {
+    fn persist_continues_after_missing_local_file() {
         let dir = tempdir().unwrap();
         let db = DB::create(dir.path().join("db")).unwrap();
         std::fs::write(dir.path().join("first.glb"), b"first").unwrap();
@@ -627,16 +622,19 @@ mod asset_tests {
             ..Default::default()
         };
 
-        let err = persist_schematic_assets(
+        persist_schematic_assets(
             &db,
             &mut schematic,
             Some(dir.path().join("schematic.kdl").as_path()),
-        )
-        .unwrap_err();
-        assert!(matches!(err, elodin_db::Error::Io(_)));
+        );
 
+        // The readable asset is persisted; the missing one is skipped without
+        // aborting or rolling back the rest.
         let assets_dir = elodin_db::assets_http::assets_dir(&db.path);
-        assert!(!assets_dir.join("first.glb").exists());
+        assert_eq!(
+            std::fs::read(assets_dir.join("first.glb")).unwrap(),
+            b"first".to_vec()
+        );
         assert!(!assets_dir.join("missing.glb").exists());
 
         let paths: Vec<_> = schematic
@@ -652,9 +650,10 @@ mod asset_tests {
                 path.clone()
             })
             .collect();
+        // Only the stored asset is rewritten to `db:`; the skipped one stays local.
         assert_eq!(
             paths,
-            vec!["first.glb".to_string(), "missing.glb".to_string()]
+            vec!["db:first.glb".to_string(), "missing.glb".to_string()]
         );
     }
 
@@ -675,8 +674,7 @@ object_3d "rocket.world_pos" {
             &db,
             &mut schematic,
             Some(dir.path().join("schematic.kdl").as_path()),
-        )
-        .unwrap();
+        );
 
         let serialized = impeller2_kdl::serialize_schematic(&schematic);
         assert!(
@@ -712,8 +710,7 @@ object_3d "rocket.world_pos" {
             &db,
             &mut schematic,
             Some(dir.path().join("schematic.kdl").as_path()),
-        )
-        .unwrap();
+        );
 
         let assets_dir = elodin_db::assets_http::assets_dir(&db.path);
         assert_eq!(
@@ -771,8 +768,7 @@ object_3d "rocket.world_pos" {
             &db,
             &mut schematic,
             Some(dir.path().join("schematic.kdl").as_path()),
-        )
-        .unwrap();
+        );
 
         let assets_dir = elodin_db::assets_http::assets_dir(&db.path);
         assert_eq!(
@@ -828,8 +824,7 @@ object_3d "rocket.world_pos" {
             &db,
             &mut schematic,
             Some(dir.path().join("schematic.kdl").as_path()),
-        )
-        .unwrap();
+        );
 
         let assets_dir = elodin_db::assets_http::assets_dir(&db.path);
         assert_eq!(
@@ -897,8 +892,7 @@ object_3d "rocket.world_pos" {
             &db,
             &mut schematic,
             Some(dir.path().join("schematic.kdl").as_path()),
-        )
-        .unwrap();
+        );
 
         let assets_dir = elodin_db::assets_http::assets_dir(&db.path);
         assert_eq!(
@@ -914,6 +908,43 @@ object_3d "rocket.world_pos" {
                 .join("skyboxes/desert_night.cubemap.ktx2")
                 .exists()
         );
+    }
+
+    #[test]
+    fn persist_missing_skybox_does_not_block_glb() {
+        let dir = tempdir().unwrap();
+        let db = DB::create(dir.path().join("db")).unwrap();
+        std::fs::write(dir.path().join("rocket.glb"), b"rocket").unwrap();
+        // Note: no skyboxes/manifest.ron on disk.
+
+        let mut schematic = Schematic {
+            skybox: Some(SkyboxConfig {
+                name: "desert_night".into(),
+            }),
+            elems: vec![glb_object("rocket.glb")],
+            ..Default::default()
+        };
+
+        persist_schematic_assets(
+            &db,
+            &mut schematic,
+            Some(dir.path().join("schematic.kdl").as_path()),
+        );
+
+        let assets_dir = elodin_db::assets_http::assets_dir(&db.path);
+        // The mandatory mesh is persisted and rewritten despite the missing skybox.
+        assert_eq!(
+            std::fs::read(assets_dir.join("rocket.glb")).unwrap(),
+            b"rocket".to_vec()
+        );
+        assert!(!assets_dir.join("skyboxes/manifest.ron").exists());
+        let SchematicElem::Object3d(obj) = &schematic.elems[0] else {
+            panic!("expected object_3d");
+        };
+        let Object3DMesh::Glb { path, .. } = &obj.mesh else {
+            panic!("expected glb");
+        };
+        assert_eq!(path, "db:rocket.glb");
     }
 }
 

--- a/libs/stellarator/src/io.rs
+++ b/libs/stellarator/src/io.rs
@@ -56,6 +56,10 @@ pub trait AsyncWrite {
 pub struct LengthDelReader<A: AsyncRead, L = u32> {
     reader: A,
     scratch: VecDeque<u8>,
+    /// Optional upper bound on a single packet's length. When set, a length
+    /// prefix exceeding it fails with [`Error::PacketTooLarge`] before any
+    /// buffer growth, bounding per-connection memory for growable reads.
+    max_len: Option<usize>,
     phantom_data: PhantomData<L>,
 }
 
@@ -64,8 +68,15 @@ impl<A: AsyncRead, L: Length> LengthDelReader<A, L> {
         Self {
             reader,
             scratch: VecDeque::default(),
+            max_len: None,
             phantom_data: PhantomData,
         }
+    }
+
+    /// Reject packets whose length prefix exceeds `max` bytes.
+    pub fn with_max_len(mut self, max: usize) -> Self {
+        self.max_len = Some(max);
+        self
     }
 
     async fn read<B: IoBufMut>(&mut self, mut buf: B) -> BufResult<usize, B> {
@@ -115,6 +126,11 @@ impl<A: AsyncRead, L: Length> LengthDelReader<A, L> {
             .expect("slice wasn't L::SIZE long");
         let len = L::from_le_bytes(len);
         let len = len.as_usize();
+        if let Some(max) = self.max_len
+            && len > max
+        {
+            return Err(Error::PacketTooLarge { len, max });
+        }
         let required_len = len.checked_add(L::SIZE).ok_or(Error::IntegerOverflow)?;
         buf.grow(required_len);
         while total_read < required_len {
@@ -317,6 +333,52 @@ mod tests {
         let buf = out.into_inner();
         let out = stream.recv(buf).await.unwrap();
         assert_eq!(&out[..], &[0xff]);
+
+        handle.await.unwrap();
+    }
+
+    #[test]
+    async fn recv_growable_grows_past_initial_buffer() {
+        let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0))).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let payload = vec![0xab_u8; 100];
+        let payload_for_server = payload.clone();
+        let handle = crate::spawn(async move {
+            let stream = listener.accept().await.unwrap();
+            let prefix = (payload_for_server.len() as u32).to_le_bytes().to_vec();
+            stream.write(prefix).await.0.unwrap();
+            stream.write(payload_for_server).await.0.unwrap();
+        });
+        let stream = TcpStream::connect(addr).await.unwrap();
+        let mut stream = LengthDelReader::<_, u32>::new(stream);
+
+        // Initial buffer is far smaller than the 100-byte packet; the growable
+        // path must resize it rather than overflow.
+        let out = stream.recv_growable(vec![0u8; 8]).await.unwrap();
+        assert_eq!(&out[..], &payload[..]);
+
+        handle.await.unwrap();
+    }
+
+    #[test]
+    async fn with_max_len_rejects_oversized_packet() {
+        let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0))).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = crate::spawn(async move {
+            let stream = listener.accept().await.unwrap();
+            // Length prefix declares 100 bytes; the cap check fires before any
+            // payload read, so we only need to send the prefix.
+            stream
+                .write((100u32).to_le_bytes().to_vec())
+                .await
+                .0
+                .unwrap();
+        });
+        let stream = TcpStream::connect(addr).await.unwrap();
+        let mut stream = LengthDelReader::<_, u32>::new(stream).with_max_len(10);
+
+        let err = stream.recv_growable(vec![0u8; 8]).await.unwrap_err();
+        assert!(matches!(err, Error::PacketTooLarge { len: 100, max: 10 }));
 
         handle.await.unwrap();
     }

--- a/libs/stellarator/src/lib.rs
+++ b/libs/stellarator/src/lib.rs
@@ -70,6 +70,8 @@ pub enum Error {
 
     #[error("buffer overflow")]
     BufferOverflow,
+    #[error("packet length {len} exceeds maximum {max}")]
+    PacketTooLarge { len: usize, max: usize },
     #[error("end of file")]
     EOF,
     #[error("integer overflow")]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the DB wire protocol (large packets, new StoreAsset handler) and asset persistence semantics; path sanitization and caps mitigate abuse, but followers depend on the new upload/verify path for runtime skyboxes.
> 
> **Overview**
> **DB asset mirroring** adds a generic [`StoreAsset`](libs/impeller2/wkt/src/msgs.rs) editor→DB message, `DB::store_asset`, and connection handling that stores bytes under `{db}/assets/` with sanitized keys (failures log but do not drop the connection). TCP/UDP readers use **`next_grow`** with a **256 MiB** `MAX_PACKET_LEN` cap and `PacketTooLarge` in stellarator so multi‑MB skybox uploads work without unbounded memory.
> 
> The **editor** mirrors the active skybox **up** to the DB (`upload_active_skybox_assets_to_db`): merge local manifest into the DB copy via `SkyboxManifest::to_ron_bytes`, send cubemap + manifest, then **HTTP verify** (HEAD length + content digest) with retries until followers can fetch assets. Download-side mirror logging treats transient 404s as **info**. **Python** `persist_schematic_assets` is now **best-effort** (skip bad files, only rewrite paths to `db:` for assets actually written; missing skybox no longer blocks GLBs).
> 
> **3D trails:** played and future `line_3d` colors are **independent** (lone `color` no longer tints the future segment); future fallback uses fixed `DEFAULT_FUTURE_TRAIL_ALPHA` instead of a timeline slider. The **Timeline inspector** gains per-`line_3d` editors (width, played/future colors, perspective) and drops the global future-trail opacity control. **Viewport focus** pick targets use `try_insert`/`try_remove` to avoid panics when meshes despawn during schematic reload.
> 
> Docs update **schematic** `line_3d` color semantics; minor UI: checkbox **border_color** for timeline color swatches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aab7f91b3479406a284b0c8702fe8cf81b3d8500. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->