### PR TITLE
refactor(timeline-inspector): expose `line_3d KDL` fields.

### DIFF
--- a/docs/public/content/reference/schematic.md
+++ b/docs/public/content/reference/schematic.md
@@ -170,9 +170,9 @@ object_3d lander.world_pos {
 - Positional `eql`: required; expects 3 values (or 7 where the last 3 are XYZ).
 - `frame`: optional; `ENU`, `NED`, or `ECEF`. Specifies the coordinate frame for interpreting the line points. Inherits from global `coordinate` if omitted.
 - `line_width`: default 1.0.
-- The trail is split into a *played* segment (up to the current playback time) and a *future* segment (ahead of it). The future segment is always faded by the timeline's `future_trail_alpha`.
-- `color`: color of the played segment. When omitted, falls back to the timeline `played_color` (default `yalk`). If set without `future_color`, it also colors the future segment — a single `color` paints the whole line.
-- `future_color`: color of the future segment. When omitted, falls back to `color` (if set), otherwise the timeline `future_color` (default `white`).
+- The trail is split into a *played* segment (up to the current playback time) and a *future* segment (ahead of it). When no `future_color` is set, the future segment is dimmed by a default fade so it reads as lighter than the played segment.
+- `color`: color of the played segment. When omitted, falls back to the timeline `played_color` (default `yalk`). It does not affect the future segment.
+- `future_color`: color of the future segment, independent of `color`. Its alpha sets the future opacity and is used as-is (no extra fade). When omitted, falls back to the timeline `future_color` (default `white`, faded).
 - `perspective`: default true (set false for screen-space lines).
 
 ### vector_arrow

--- a/libs/elodin-editor/src/ui/button.rs
+++ b/libs/elodin-editor/src/ui/button.rs
@@ -109,6 +109,7 @@ pub struct ECheckboxButton {
     on_color: egui::Color32,
     off_color: egui::Color32,
     text_color: egui::Color32,
+    border_color: Option<egui::Color32>,
     margin: egui::Margin,
     is_on: bool,
     label: String,
@@ -122,6 +123,7 @@ impl ECheckboxButton {
             on_color: get_scheme().text_primary,
             off_color: get_scheme().bg_secondary,
             text_color: get_scheme().text_primary,
+            border_color: None,
             margin: egui::Margin::same(8),
             is_on,
             label: label.to_string(),
@@ -137,6 +139,13 @@ impl ECheckboxButton {
 
     pub fn on_color(mut self, color: egui::Color32) -> Self {
         self.on_color = color;
+        self
+    }
+
+    /// Resting border color. Defaults to `on_color` (the box is monochrome);
+    /// set this to keep a fixed border while the fill shows a different color.
+    pub fn border_color(mut self, color: egui::Color32) -> Self {
+        self.border_color = Some(color);
         self
     }
 
@@ -173,7 +182,8 @@ impl ECheckboxButton {
         // Paint the UI
         if ui.is_rect_visible(rect) {
             let style = ui.style_mut();
-            style.visuals.widgets.inactive.bg_stroke = egui::Stroke::new(1.0, self.on_color);
+            style.visuals.widgets.inactive.bg_stroke =
+                egui::Stroke::new(1.0, self.border_color.unwrap_or(self.on_color));
             let visuals = ui.style().interact(&response);
 
             let inner_rect = rect.shrink4(self.margin);

--- a/libs/elodin-editor/src/ui/inspector/line3d.rs
+++ b/libs/elodin-editor/src/ui/inspector/line3d.rs
@@ -1,0 +1,169 @@
+use bevy_egui::egui::{self, RichText};
+use impeller2_wkt::{Color, Line3d, SchematicElem};
+
+use crate::ui::colors::{EColor, get_scheme};
+use crate::ui::inspector::color_popup;
+use crate::ui::plot_3d::gpu::DEFAULT_FUTURE_TRAIL_ALPHA;
+use crate::ui::schematic::CurrentSchematic;
+
+/// Field editors for a single `line_3d`. `played_timeline`/`future_timeline` are
+/// the inherited timeline colors shown in the swatches when the line has no
+/// per-line override. Returns `true` if any value changed.
+pub fn line3d_controls(
+    ui: &mut egui::Ui,
+    line: &mut Line3d,
+    played_timeline: Color,
+    future_timeline: Color,
+) -> bool {
+    let scheme = get_scheme();
+    let mut changed = false;
+
+    // Sober gray piping for the box-like inputs (drag value, checkbox).
+    ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::new(1.0, scheme.border_primary);
+
+    ui.label(RichText::new("Line Width").color(scheme.text_secondary));
+    changed |= ui
+        .add(
+            egui::DragValue::new(&mut line.line_width)
+                .speed(0.05)
+                .range(0.1..=100.0),
+        )
+        .changed();
+    ui.separator();
+
+    // Played color: the swatch shows the per-line override, else the inherited
+    // timeline color. Editing it materializes the override.
+    let mut played = line.color.unwrap_or(played_timeline);
+    if color_square(ui, "Played Color", &mut played) {
+        line.color = Some(played);
+        changed = true;
+    }
+
+    // Future color: shows the override, else the inherited timeline future color
+    // (white by default) at the default fade. The picker alpha sets opacity.
+    let mut future = line.future_color.unwrap_or(Color {
+        a: DEFAULT_FUTURE_TRAIL_ALPHA,
+        ..future_timeline
+    });
+    if color_square(ui, "Future Color", &mut future) {
+        line.future_color = Some(future);
+        changed = true;
+    }
+    ui.separator();
+
+    changed |= ui
+        .checkbox(&mut line.perspective, "Perspective (screen-space width)")
+        .changed();
+
+    changed
+}
+
+/// A plain color square (label left, swatch right) that opens the shared color
+/// popup. Returns `true` only when the popup actually edits the color, so it
+/// never spuriously materializes an inherited color from a redraw.
+fn color_square(ui: &mut egui::Ui, label: &str, color: &mut Color) -> bool {
+    let scheme = get_scheme();
+    let mut egui_color = color.into_color32();
+
+    let resp = ui
+        .horizontal(|ui| {
+            ui.label(RichText::new(label).color(scheme.text_secondary));
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                let (rect, resp) =
+                    ui.allocate_exact_size(egui::vec2(36.0, 16.0), egui::Sense::click());
+                if ui.is_rect_visible(rect) {
+                    ui.painter().rect(
+                        rect,
+                        egui::CornerRadius::same(3),
+                        egui_color,
+                        egui::Stroke::new(1.0, scheme.border_primary),
+                        egui::StrokeKind::Inside,
+                    );
+                }
+                resp.on_hover_cursor(egui::CursorIcon::PointingHand)
+            })
+            .inner
+        })
+        .inner;
+    ui.separator();
+
+    let popup_id = ui.auto_id_with(("line3d_color", label));
+    if resp.clicked() {
+        egui::Popup::toggle_id(ui.ctx(), popup_id);
+    }
+
+    let before = egui_color;
+    color_popup(ui, &mut egui_color, popup_id, &resp);
+    if egui_color != before {
+        *color = Color::from_color32(egui_color);
+        true
+    } else {
+        false
+    }
+}
+
+/// Mirror the edited fields back into `CurrentSchematic` so they survive a
+/// schematic save/reload (rendering reads the live component directly).
+pub fn persist_to_schematic(schematic: &mut CurrentSchematic, line: &Line3d) {
+    for elem in &mut schematic.elems {
+        if let SchematicElem::Line3d(elem) = elem
+            && elem.node_id == line.node_id
+        {
+            elem.line_width = line.line_width;
+            elem.color = line.color;
+            elem.future_color = line.future_color;
+            elem.perspective = line.perspective;
+            break;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use impeller2_wkt::{NodeId, Schematic};
+
+    fn line(node_id: u64, eql: &str) -> Line3d {
+        Line3d {
+            eql: eql.to_string(),
+            line_width: 1.0,
+            color: None,
+            future_color: None,
+            perspective: false,
+            frame: None,
+            node_id: NodeId(node_id),
+        }
+    }
+
+    #[test]
+    fn persist_updates_only_the_matching_line() {
+        let mut schematic = CurrentSchematic(Schematic {
+            elems: vec![
+                SchematicElem::Line3d(line(1, "a")),
+                SchematicElem::Line3d(line(2, "b")),
+            ],
+            ..Default::default()
+        });
+
+        let mut edited = line(2, "b");
+        edited.line_width = 5.0;
+        edited.color = Some(Color::rgba(1.0, 0.0, 0.0, 0.5));
+        edited.future_color = Some(Color::rgba(0.0, 1.0, 0.0, 0.25));
+        edited.perspective = true;
+        persist_to_schematic(&mut schematic, &edited);
+
+        let SchematicElem::Line3d(first) = &schematic.elems[0] else {
+            panic!("expected line3d");
+        };
+        assert_eq!(first.line_width, 1.0);
+        assert!(first.color.is_none());
+
+        let SchematicElem::Line3d(second) = &schematic.elems[1] else {
+            panic!("expected line3d");
+        };
+        assert_eq!(second.line_width, 5.0);
+        assert_eq!(second.color, Some(Color::rgba(1.0, 0.0, 0.0, 0.5)));
+        assert_eq!(second.future_color, Some(Color::rgba(0.0, 1.0, 0.0, 0.25)));
+        assert!(second.perspective);
+    }
+}

--- a/libs/elodin-editor/src/ui/inspector/line3d.rs
+++ b/libs/elodin-editor/src/ui/inspector/line3d.rs
@@ -1,14 +1,15 @@
 use bevy_egui::egui::{self, RichText};
-use impeller2_wkt::{Color, Line3d, SchematicElem};
+use impeller2_wkt::{Color, Line3d};
 
 use crate::ui::colors::{EColor, get_scheme};
 use crate::ui::inspector::color_popup;
 use crate::ui::plot_3d::gpu::DEFAULT_FUTURE_TRAIL_ALPHA;
-use crate::ui::schematic::CurrentSchematic;
 
 /// Field editors for a single `line_3d`. `played_timeline`/`future_timeline` are
 /// the inherited timeline colors shown in the swatches when the line has no
-/// per-line override. Returns `true` if any value changed.
+/// per-line override. Edits mutate the live `Line3d` component, which
+/// `tiles_to_schematic` mirrors into `CurrentSchematic` each frame (and thus to
+/// KDL on save). Returns `true` if any value changed.
 pub fn line3d_controls(
     ui: &mut egui::Ui,
     line: &mut Line3d,
@@ -41,8 +42,9 @@ pub fn line3d_controls(
 
     // Future color: shows the override, else the inherited timeline future color
     // (white by default) at the default fade. The picker alpha sets opacity.
+    // Mirror the render fade (timeline alpha * default) so the preview matches.
     let mut future = line.future_color.unwrap_or(Color {
-        a: DEFAULT_FUTURE_TRAIL_ALPHA,
+        a: future_timeline.a * DEFAULT_FUTURE_TRAIL_ALPHA,
         ..future_timeline
     });
     if color_square(ui, "Future Color", &mut future) {
@@ -51,9 +53,7 @@ pub fn line3d_controls(
     }
     ui.separator();
 
-    changed |= ui
-        .checkbox(&mut line.perspective, "Perspective (screen-space width)")
-        .changed();
+    changed |= ui.checkbox(&mut line.perspective, "Perspective").changed();
 
     changed
 }
@@ -94,68 +94,3 @@ fn color_square(ui: &mut egui::Ui, label: &str, color: &mut Color) -> bool {
     }
 }
 
-/// Mirror the edited fields back into `CurrentSchematic` so they survive a
-/// schematic save/reload (rendering reads the live component directly).
-pub fn persist_to_schematic(schematic: &mut CurrentSchematic, line: &Line3d) {
-    for elem in &mut schematic.elems {
-        if let SchematicElem::Line3d(elem) = elem
-            && elem.node_id == line.node_id
-        {
-            elem.line_width = line.line_width;
-            elem.color = line.color;
-            elem.future_color = line.future_color;
-            elem.perspective = line.perspective;
-            break;
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use impeller2_wkt::{NodeId, Schematic};
-
-    fn line(node_id: u64, eql: &str) -> Line3d {
-        Line3d {
-            eql: eql.to_string(),
-            line_width: 1.0,
-            color: None,
-            future_color: None,
-            perspective: false,
-            frame: None,
-            node_id: NodeId(node_id),
-        }
-    }
-
-    #[test]
-    fn persist_updates_only_the_matching_line() {
-        let mut schematic = CurrentSchematic(Schematic {
-            elems: vec![
-                SchematicElem::Line3d(line(1, "a")),
-                SchematicElem::Line3d(line(2, "b")),
-            ],
-            ..Default::default()
-        });
-
-        let mut edited = line(2, "b");
-        edited.line_width = 5.0;
-        edited.color = Some(Color::rgba(1.0, 0.0, 0.0, 0.5));
-        edited.future_color = Some(Color::rgba(0.0, 1.0, 0.0, 0.25));
-        edited.perspective = true;
-        persist_to_schematic(&mut schematic, &edited);
-
-        let SchematicElem::Line3d(first) = &schematic.elems[0] else {
-            panic!("expected line3d");
-        };
-        assert_eq!(first.line_width, 1.0);
-        assert!(first.color.is_none());
-
-        let SchematicElem::Line3d(second) = &schematic.elems[1] else {
-            panic!("expected line3d");
-        };
-        assert_eq!(second.line_width, 5.0);
-        assert_eq!(second.color, Some(Color::rgba(1.0, 0.0, 0.0, 0.5)));
-        assert_eq!(second.future_color, Some(Color::rgba(0.0, 1.0, 0.0, 0.25)));
-        assert!(second.perspective);
-    }
-}

--- a/libs/elodin-editor/src/ui/inspector/line3d.rs
+++ b/libs/elodin-editor/src/ui/inspector/line3d.rs
@@ -93,4 +93,3 @@ fn color_square(ui: &mut egui::Ui, label: &str, color: &mut Color) -> bool {
         false
     }
 }
-

--- a/libs/elodin-editor/src/ui/inspector/line3d.rs
+++ b/libs/elodin-editor/src/ui/inspector/line3d.rs
@@ -58,33 +58,25 @@ pub fn line3d_controls(
     changed
 }
 
-/// A plain color square (label left, swatch right) that opens the shared color
-/// popup. Returns `true` only when the popup actually edits the color, so it
-/// never spuriously materializes an inherited color from a redraw.
+/// A plain color square below its label that opens the shared color popup.
+/// Returns `true` only when the popup actually edits the color, so it never
+/// spuriously materializes an inherited color from a redraw.
 fn color_square(ui: &mut egui::Ui, label: &str, color: &mut Color) -> bool {
     let scheme = get_scheme();
     let mut egui_color = color.into_color32();
 
-    let resp = ui
-        .horizontal(|ui| {
-            ui.label(RichText::new(label).color(scheme.text_secondary));
-            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                let (rect, resp) =
-                    ui.allocate_exact_size(egui::vec2(36.0, 16.0), egui::Sense::click());
-                if ui.is_rect_visible(rect) {
-                    ui.painter().rect(
-                        rect,
-                        egui::CornerRadius::same(3),
-                        egui_color,
-                        egui::Stroke::new(1.0, scheme.border_primary),
-                        egui::StrokeKind::Inside,
-                    );
-                }
-                resp.on_hover_cursor(egui::CursorIcon::PointingHand)
-            })
-            .inner
-        })
-        .inner;
+    ui.label(RichText::new(label).color(scheme.text_secondary));
+    let (rect, resp) = ui.allocate_exact_size(egui::vec2(24.0, 24.0), egui::Sense::click());
+    if ui.is_rect_visible(rect) {
+        ui.painter().rect(
+            rect,
+            egui::CornerRadius::same(3),
+            egui_color,
+            egui::Stroke::new(1.0, scheme.border_primary),
+            egui::StrokeKind::Inside,
+        );
+    }
+    let resp = resp.on_hover_cursor(egui::CursorIcon::PointingHand);
     ui.separator();
 
     let popup_id = ui.auto_id_with(("line3d_color", label));

--- a/libs/elodin-editor/src/ui/inspector/mod.rs
+++ b/libs/elodin-editor/src/ui/inspector/mod.rs
@@ -21,6 +21,7 @@ pub mod action;
 pub mod data_overview;
 pub mod entity;
 pub mod graph;
+pub mod line3d;
 pub mod monitor;
 pub mod object3d;
 pub mod query_table;

--- a/libs/elodin-editor/src/ui/inspector/timeline.rs
+++ b/libs/elodin-editor/src/ui/inspector/timeline.rs
@@ -1,20 +1,25 @@
 use bevy::ecs::system::{SystemParam, SystemState};
 use bevy::prelude::*;
 use bevy_egui::egui;
+use impeller2_wkt::Line3d;
 
 use crate::ui::colors::get_scheme;
+use crate::ui::schematic::CurrentSchematic;
 use crate::ui::timeline::TimelineSettings;
 use crate::ui::widgets::WidgetSystem;
 use crate::ui::{label::ELabel, utils::MarginSides};
 
+use super::line3d::{line3d_controls, persist_to_schematic};
 use super::node_color_picker;
 
 #[derive(SystemParam)]
-pub struct InspectorTimeline<'w> {
+pub struct InspectorTimeline<'w, 's> {
     timeline_settings: ResMut<'w, TimelineSettings>,
+    lines: Query<'w, 's, (Entity, &'static mut Line3d)>,
+    schematic: ResMut<'w, CurrentSchematic>,
 }
 
-impl WidgetSystem for InspectorTimeline<'_> {
+impl WidgetSystem for InspectorTimeline<'_, '_> {
     type Args = ();
     type Output = ();
 
@@ -27,40 +32,69 @@ impl WidgetSystem for InspectorTimeline<'_> {
         let scheme = get_scheme();
         let InspectorTimeline {
             mut timeline_settings,
+            mut lines,
+            mut schematic,
         } = state.get_mut(world);
 
         ui.spacing_mut().item_spacing.y = 8.0;
-        ui.add(
-            ELabel::new("Timeline")
-                .padding(egui::Margin::same(8).bottom(24.0))
-                .bottom_stroke(egui::Stroke {
-                    color: scheme.border_primary,
-                    width: 1.0,
-                })
-                .margin(egui::Margin::same(0).bottom(16.0)),
-        );
 
+        // ── Timeline: global played/future trail colors ──────────────────
+        section_header(ui, "TIMELINE", scheme.border_primary);
         node_color_picker(ui, "PLAYED COLOR", &mut timeline_settings.played_color);
         node_color_picker(ui, "FUTURE COLOR", &mut timeline_settings.future_color);
 
-        egui::Frame::NONE
-            .inner_margin(egui::Margin::symmetric(0, 8))
-            .show(ui, |ui| {
-                ui.label(egui::RichText::new("FUTURE TRAIL OPACITY").color(scheme.text_secondary));
+        // ── Line 3D: per-line overrides for every `line_3d` in the schematic ─
+        let mut lines: Vec<(Entity, Mut<Line3d>)> = lines.iter_mut().collect();
+        if lines.is_empty() {
+            return;
+        }
+        lines.sort_by(|(_, a), (_, b)| a.eql.cmp(&b.eql));
 
-                ui.label(
-                    egui::RichText::new(format!("{:.2}", timeline_settings.future_trail_alpha))
-                        .monospace()
-                        .color(scheme.text_primary),
-                );
+        ui.add_space(16.0);
+        section_header(ui, "LINE 3D", scheme.border_primary);
 
-                ui.add_space(8.0);
-                ui.style_mut().visuals.widgets.inactive.bg_fill = scheme.bg_secondary;
-                ui.add_sized(
-                    [140.0, ui.spacing().interact_size.y],
-                    egui::Slider::new(&mut timeline_settings.future_trail_alpha, 0.0..=1.0)
-                        .show_value(false),
-                );
-            });
+        let single_line = lines.len() == 1;
+        let played_tl = timeline_settings.played_color;
+        let future_tl = timeline_settings.future_color;
+        // Subtle white piping around each line so multiple `line_3d` entries read
+        // as distinct, roomy cards.
+        let border = egui::Stroke {
+            width: 1.0,
+            color: crate::ui::colors::with_opacity(egui::Color32::WHITE, 0.4),
+        };
+        for (entity, line) in lines.iter_mut() {
+            egui::Frame::NONE
+                .stroke(border)
+                .corner_radius(egui::CornerRadius::same(6))
+                .inner_margin(egui::Margin::same(12))
+                .outer_margin(egui::Margin::symmetric(0, 6))
+                .show(ui, |ui| {
+                    egui::CollapsingHeader::new(
+                        egui::RichText::new(line.eql.clone())
+                            .monospace()
+                            .color(scheme.text_primary),
+                    )
+                    .id_salt(("line3d_inspector", *entity))
+                    .default_open(single_line)
+                    .show(ui, |ui| {
+                        if line3d_controls(ui, line, played_tl, future_tl) {
+                            persist_to_schematic(&mut schematic, line);
+                        }
+                    });
+                });
+        }
     }
+}
+
+/// Section title with an underline, used to separate Timeline from Line 3D.
+fn section_header(ui: &mut egui::Ui, title: &str, border: egui::Color32) {
+    ui.add(
+        ELabel::new(title)
+            .padding(egui::Margin::same(8).bottom(24.0))
+            .bottom_stroke(egui::Stroke {
+                color: border,
+                width: 1.0,
+            })
+            .margin(egui::Margin::same(0).bottom(8.0)),
+    );
 }

--- a/libs/elodin-editor/src/ui/inspector/timeline.rs
+++ b/libs/elodin-editor/src/ui/inspector/timeline.rs
@@ -4,19 +4,17 @@ use bevy_egui::egui;
 use impeller2_wkt::Line3d;
 
 use crate::ui::colors::get_scheme;
-use crate::ui::schematic::CurrentSchematic;
 use crate::ui::timeline::TimelineSettings;
 use crate::ui::widgets::WidgetSystem;
 use crate::ui::{label::ELabel, utils::MarginSides};
 
-use super::line3d::{line3d_controls, persist_to_schematic};
+use super::line3d::line3d_controls;
 use super::node_color_picker;
 
 #[derive(SystemParam)]
 pub struct InspectorTimeline<'w, 's> {
     timeline_settings: ResMut<'w, TimelineSettings>,
     lines: Query<'w, 's, (Entity, &'static mut Line3d)>,
-    schematic: ResMut<'w, CurrentSchematic>,
 }
 
 impl WidgetSystem for InspectorTimeline<'_, '_> {
@@ -33,7 +31,6 @@ impl WidgetSystem for InspectorTimeline<'_, '_> {
         let InspectorTimeline {
             mut timeline_settings,
             mut lines,
-            mut schematic,
         } = state.get_mut(world);
 
         ui.spacing_mut().item_spacing.y = 8.0;
@@ -77,9 +74,9 @@ impl WidgetSystem for InspectorTimeline<'_, '_> {
                     .id_salt(("line3d_inspector", *entity))
                     .default_open(single_line)
                     .show(ui, |ui| {
-                        if line3d_controls(ui, line, played_tl, future_tl) {
-                            persist_to_schematic(&mut schematic, line);
-                        }
+                        // Edits mutate the live `Line3d`; `tiles_to_schematic`
+                        // mirrors it into `CurrentSchematic` (and KDL on save).
+                        line3d_controls(ui, line, played_tl, future_tl);
                     });
                 });
         }

--- a/libs/elodin-editor/src/ui/inspector/widgets.rs
+++ b/libs/elodin-editor/src/ui/inspector/widgets.rs
@@ -257,6 +257,7 @@ pub fn node_color_picker(ui: &mut egui::Ui, label: &str, color: &mut impeller2_w
         ECheckboxButton::new(label, true)
             .margin(egui::Margin::symmetric(0, 8))
             .on_color(egui_color)
+            .border_color(get_scheme().text_primary)
             .text_color(get_scheme().text_secondary)
             .left_label(true),
     );

--- a/libs/elodin-editor/src/ui/plot_3d/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/gpu.rs
@@ -165,11 +165,17 @@ fn update_uniform_model(mut query: Query<(&mut LineUniform, &GlobalTransform)>) 
 #[require(SyncToRenderWorld)]
 pub struct LineHandles(pub [Handle<Line>; 3]);
 
+/// Default opacity applied to the future (not-yet-played) trail segment when a
+/// line does not set its own `future_color`, so the future reads as dimmer than
+/// the played segment. A per-line `future_color` overrides this with its own
+/// alpha.
+pub const DEFAULT_FUTURE_TRAIL_ALPHA: f32 = 0.35;
+
 /// Per-line trail colors resolved from the KDL `color`/`future_color`.
 ///
-/// Each is linear RGBA; `None` falls back to the timeline trail colors. A line
-/// with only `color` set leaves `future = None`, so the future segment reuses
-/// `played` (the whole line takes that color, just faded).
+/// Each is linear RGBA; `None` falls back to the timeline trail colors. The
+/// played and future segments are independent: a line with only `color` set
+/// keeps the timeline future color (faded) for its future segment.
 #[derive(Component, Debug, Clone, Copy, Default)]
 pub struct LineTrailColors {
     pub played: Option<Vec4>,
@@ -180,11 +186,10 @@ impl LineTrailColors {
     /// Resolve the played/future segment colors against the timeline fallbacks.
     ///
     /// - played: explicit `played`, else the timeline played color.
-    /// - future: explicit `future`, else explicit `played` (a lone KDL `color`
-    ///   paints the whole line), else the timeline future color.
-    ///
-    /// The future segment's alpha fade (`future_alpha`) is applied uniformly,
-    /// regardless of where the color came from.
+    /// - future: explicit `future` is authoritative (its alpha is the per-line
+    ///   opacity, used as-is); otherwise the timeline future color, faded by
+    ///   `future_alpha` so the not-yet-played segment reads dimmer. The future
+    ///   does not inherit the played color.
     fn resolve(
         &self,
         played_timeline: Vec4,
@@ -192,8 +197,14 @@ impl LineTrailColors {
         future_alpha: f32,
     ) -> (Vec4, Vec4) {
         let played = self.played.unwrap_or(played_timeline);
-        let mut future = self.future.or(self.played).unwrap_or(future_timeline);
-        future.w *= future_alpha;
+        let future = match self.future {
+            Some(future) => future,
+            None => {
+                let mut fallback = future_timeline;
+                fallback.w *= future_alpha;
+                fallback
+            }
+        };
         (played, future)
     }
 }
@@ -510,9 +521,9 @@ fn extract_lines(
         } else {
             selected_range.clone()
         };
-        let future_trail_alpha = timeline_settings.future_trail_alpha;
+        let future_trail_alpha = DEFAULT_FUTURE_TRAIL_ALPHA;
         // Fallback colors for lines without explicit KDL colors. Kept unfaded
-        // here; the future segment's alpha fade is applied uniformly below.
+        // here; the default future fade is applied only to fallback futures.
         let played_timeline_color = wkt_color_linear(timeline_settings.played_color);
         let future_timeline_color = wkt_color_linear(timeline_settings.future_color);
 
@@ -818,32 +829,47 @@ mod tests {
     }
 
     #[test]
-    fn color_only_paints_whole_line() {
+    fn color_only_keeps_timeline_future() {
+        // A lone played color leaves the future on the timeline future color
+        // (faded); the future does not inherit the played color.
         let (played, future) = resolve(LineTrailColors {
             played: Some(G),
             future: None,
         });
         assert_eq!(played, G);
-        assert_eq!(future, faded(G));
+        assert_eq!(future, faded(FUTURE_TL));
     }
 
     #[test]
     fn color_and_future_color_are_independent() {
+        // An explicit future color is authoritative: its alpha is used as-is.
         let (played, future) = resolve(LineTrailColors {
             played: Some(G),
             future: Some(W),
         });
         assert_eq!(played, G);
-        assert_eq!(future, faded(W));
+        assert_eq!(future, W);
     }
 
     #[test]
     fn future_color_only_keeps_timeline_played() {
+        // Explicit future color keeps its own alpha (no global fade applied).
         let (played, future) = resolve(LineTrailColors {
             played: None,
             future: Some(W),
         });
         assert_eq!(played, PLAYED_TL);
-        assert_eq!(future, faded(W));
+        assert_eq!(future, W);
+    }
+
+    #[test]
+    fn explicit_future_alpha_is_not_faded() {
+        // A half-opaque future color renders at exactly that opacity.
+        let half = Vec4::new(1.0, 1.0, 1.0, 0.5);
+        let (_, future) = resolve(LineTrailColors {
+            played: Some(G),
+            future: Some(half),
+        });
+        assert_eq!(future, half);
     }
 }

--- a/libs/elodin-editor/src/ui/plot_3d/mod.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/mod.rs
@@ -23,8 +23,9 @@ pub mod gpu;
 
 /// Convert a schematic (sRGB) color into the linear RGBA the line pipeline
 /// renders, keeping it consistent with meshes/gizmos. Alpha is preserved so a
-/// KDL `color`/`future_color` can set per-line opacity (the future segment is
-/// additionally faded by the timeline `future_trail_alpha`).
+/// KDL `color`/`future_color` can set per-line opacity. An explicit
+/// `future_color` alpha is used as-is; only fallback futures get the default
+/// fade (see `LineTrailColors::resolve`).
 fn line_color_linear(color: &impeller2_wkt::Color) -> Vec4 {
     let linear = Color::srgba(color.r, color.g, color.b, color.a).to_linear();
     Vec4::new(linear.red, linear.green, linear.blue, linear.alpha)
@@ -156,8 +157,8 @@ mod tests {
     #[test]
     fn line_color_linear_preserves_alpha() {
         // A KDL color/future_color alpha must survive into the line uniform
-        // (sRGB->linear leaves alpha untouched); only the timeline
-        // future_trail_alpha should fade it further, applied in `resolve`.
+        // (sRGB->linear leaves alpha untouched). An explicit future_color keeps
+        // this alpha as-is; fallback futures get the default fade in `resolve`.
         let color = impeller2_wkt::Color::rgba(1.0, 1.0, 1.0, 0.25);
         assert_eq!(line_color_linear(&color).w, 0.25);
     }

--- a/libs/elodin-editor/src/ui/schematic/tree.rs
+++ b/libs/elodin-editor/src/ui/schematic/tree.rs
@@ -97,7 +97,7 @@ impl WidgetSystem for TreeWidget<'_, '_> {
                             *selected_object = SelectedObject::Object3D { entity };
                         }
                     }
-                    impeller2_wkt::SchematicElem::Line3d(_line3d) => {}
+                    impeller2_wkt::SchematicElem::Line3d(_line_3d) => {}
                     impeller2_wkt::SchematicElem::VectorArrow(_arrow) => {}
                     impeller2_wkt::SchematicElem::WorldMesh(_world_mesh) => {}
                     impeller2_wkt::SchematicElem::Window(_window) => {}

--- a/libs/elodin-editor/src/ui/timeline/mod.rs
+++ b/libs/elodin-editor/src/ui/timeline/mod.rs
@@ -62,7 +62,6 @@ pub struct LatestFollow(pub bool);
 pub struct TimelineSettings {
     pub played_color: impeller2_wkt::Color,
     pub future_color: impeller2_wkt::Color,
-    pub future_trail_alpha: f32,
     pub follow_latest: bool,
 }
 
@@ -77,7 +76,6 @@ impl From<impeller2_wkt::TimelineConfig> for TimelineSettings {
         Self {
             played_color: value.played_color,
             future_color: value.future_color,
-            future_trail_alpha: 0.35,
             follow_latest: value.follow_latest,
         }
     }


### PR DESCRIPTION
> Current branch based on #718

---

## Content

Exposes a `line_3d`'s KDL fields in the **timeline inspector** under a new **LINE 3D** section: edit `color`, `future_color`, `line_width` and `perspective` inline, persisted back to the schematic.

Supports **every `line_3d` in the simulation** — each gets its own card, listed one after another (labeled by its EQL).

Played and future colors are now independent: with no explicit `future_color`, the future inherits the timeline future color (white by default, faded).

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/b289b5c1-0793-4c31-9e0f-5d5da42b26f4" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes 3D trail color resolution for existing schematics (e.g. `color`-only lines no longer tint the future segment) and adds inspector persistence paths for `Line3d` data.
> 
> **Overview**
> Adds a **LINE 3D** section to the timeline inspector so every `line_3d` in the schematic can be edited inline (`line_width`, `color`, `future_color`, `perspective`), with one collapsible card per line (labeled by EQL). Changes write through the live `Line3d` component and persist via the schematic/KDL save path.
> 
> **Trail coloring** is decoupled: a lone `color` only affects the played segment; the future segment uses the timeline future color (with a fixed **0.35** default fade) unless `future_color` is set. Explicit `future_color` alpha is honored as-is—no extra global fade. The timeline inspector **future trail opacity** slider and `TimelineSettings::future_trail_alpha` are removed in favor of that constant.
> 
> Docs for `line_3d` are updated to match. `ECheckboxButton` gains optional `border_color` so timeline color swatches keep a stable border when the fill shows the picked color.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b51eb4dbc3be00c332f11cc6194996fd5b81f0d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->