### PR TITLE
Bundle Elodin and Aleph in Nix for faster builds

### DIFF
--- a/aleph/flake.lock
+++ b/aleph/flake.lock
@@ -104,6 +104,7 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "rev": "77a8263847fb02dc49dbe377278ef6b952f1c6bb",
         "type": "github"
       }
     }

--- a/aleph/flake.nix
+++ b/aleph/flake.nix
@@ -1,6 +1,6 @@
 {
   nixConfig = {
-    extra-substituters = ["https://s3-us-west-2.amazonaws.com/elodin-nix-cache"];
+    extra-substituters = ["https://elodin-nix-cache.s3.us-west-2.amazonaws.com"];
     extra-trusted-public-keys = [
       "elodin-cache-1:vvbmIQvTOjcBjIs8Ri7xlT2I3XAmeJyF5mNlWB+fIwM="
     ];
@@ -10,7 +10,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
     jetpack.url = "github:anduril/jetpack-nixos/4a4e93a7b3fbe1915870ec54002c616f01367195";
-    rust-overlay.url = "github:oxalica/rust-overlay";
+    rust-overlay.url = "github:oxalica/rust-overlay/77a8263847fb02dc49dbe377278ef6b952f1c6bb";
 
     jetpack.inputs.nixpkgs.follows = "nixpkgs";
     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,53 @@
 {
   "nodes": {
+    "aleph": {
+      "inputs": {
+        "jetpack": "jetpack",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "rust-overlay": [
+          "rust-overlay"
+        ]
+      },
+      "locked": {
+        "path": "./aleph",
+        "type": "path"
+      },
+      "original": {
+        "path": "./aleph",
+        "type": "path"
+      },
+      "parent": []
+    },
+    "cuda-legacy": {
+      "inputs": {
+        "flake-parts": [
+          "aleph",
+          "jetpack",
+          "cuda-legacy"
+        ],
+        "nixpkgs": [
+          "aleph",
+          "jetpack",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768505959,
+        "narHash": "sha256-oFCx/ApQ+S1/apUKWsvT9vq+Eo1m2vINWEDkW7/nckA=",
+        "owner": "nixos-cuda",
+        "repo": "cuda-legacy",
+        "rev": "86ad7e2c2e314f0234539cbbc66b5cd7746bcd32",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos-cuda",
+        "repo": "cuda-legacy",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": [
@@ -20,6 +68,29 @@
         "type": "github"
       }
     },
+    "jetpack": {
+      "inputs": {
+        "cuda-legacy": "cuda-legacy",
+        "nixpkgs": [
+          "aleph",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780334549,
+        "narHash": "sha256-SVmtu81BtkU+3+6CQvarnijlwLunY64CVH+e3GsSl8s=",
+        "owner": "anduril",
+        "repo": "jetpack-nixos",
+        "rev": "4a4e93a7b3fbe1915870ec54002c616f01367195",
+        "type": "github"
+      },
+      "original": {
+        "owner": "anduril",
+        "repo": "jetpack-nixos",
+        "rev": "4a4e93a7b3fbe1915870ec54002c616f01367195",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1782116945,
@@ -36,8 +107,25 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
+        "aleph": "aleph",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay",
@@ -61,6 +149,7 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "rev": "77a8263847fb02dc49dbe377278ef6b952f1c6bb",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   nixConfig = {
-    extra-substituters = ["https://s3-us-west-2.amazonaws.com/elodin-nix-cache"];
+    extra-substituters = ["https://elodin-nix-cache.s3.us-west-2.amazonaws.com"];
     extra-trusted-public-keys = [
       "elodin-cache-1:vvbmIQvTOjcBjIs8Ri7xlT2I3XAmeJyF5mNlWB+fIwM="
     ];
@@ -9,12 +9,17 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     systems.url = "github:nix-systems/default";
     rust-overlay = {
-      url = "github:oxalica/rust-overlay";
+      url = "github:oxalica/rust-overlay/77a8263847fb02dc49dbe377278ef6b952f1c6bb";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     flake-utils = {
       url = "github:numtide/flake-utils";
       inputs.systems.follows = "systems";
+    };
+    aleph = {
+      url = "path:./aleph";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.rust-overlay.follows = "rust-overlay";
     };
   };
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Nix flake and lockfile-only changes affecting substituter URLs and input pinning; no application runtime logic.
> 
> **Overview**
> Wires the **`aleph`** subtree into the **root flake** as a `path:./aleph` input, with **`nixpkgs`** and **`rust-overlay`** deduplicated via `follows`, and refreshes **`flake.lock`** so the root lock records Aleph plus its transitive inputs (e.g. **jetpack**, **cuda-legacy**, **nixpkgs-unstable**).
> 
> Both **root** and **`aleph/flake.nix`** now use the **virtual-hosted S3** binary cache URL (`elodin-nix-cache.s3.us-west-2.amazonaws.com` instead of the path-style host) and **pin `rust-overlay`** to rev `77a8263847fb02dc49dbe377278ef6b952f1c6bb` (including matching **`aleph/flake.lock`** metadata).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17a8f0f0ee0b5cbcc7996e7d859ba1682e7c0301. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->