### PR TITLE
Disable Aleph JAX Cuda

### DIFF
--- a/aleph/flake.nix
+++ b/aleph/flake.nix
@@ -62,7 +62,14 @@
       })
       // (rust-overlay.overlays.default final prev)
       // (secureBzip2Overlay final prev)
-      // (gitReposOverlay final prev);
+      // (gitReposOverlay final prev)
+      // {
+        # cudaSupport (aleph-cuda.nix) pulls jax-cuda12-plugin -> nccl (badPlatforms
+        # aarch64), unused (sim=cranelift, render=Vulkan). Force CPU jax everywhere.
+        pythonPackagesExtensions =
+          (prev.pythonPackagesExtensions or [])
+          ++ [(_pyfinal: pyprev: {jax = pyprev.jax.override {cudaSupport = false;};})];
+      };
 
     baseModules = {
       default = defaultModule;

--- a/aleph/pkgs/elodin-cli.nix
+++ b/aleph/pkgs/elodin-cli.nix
@@ -4,15 +4,11 @@
   rustToolchain,
   ...
 }: let
-  # The Aleph sets nixpkgs.config.cudaSupport = true (aleph-cuda.nix), which
-  # flips jax's default to pull the CUDA plugin (-> nccl, unsupported on
-  # aarch64). Build jax without CUDA; the sim uses the cranelift backend and the
-  # renderer uses Vulkan, so GPU jax is not needed on-device.
-  pythonPackages = pkgs.python313Packages.overrideScope (_final: prev: {
-    jax = prev.jax.override {cudaSupport = false;};
-  });
+  # jax is forced CPU by the aleph overlay (pythonPackagesExtensions); cudaSupport
+  # (aleph-cuda.nix) would otherwise pull jax-cuda12-plugin -> nccl (unused).
   elodinPy = pkgs.callPackage ../../nix/pkgs/elodin-py.nix {
-    inherit rustToolchain pythonPackages;
+    inherit rustToolchain;
+    pythonPackages = pkgs.python313Packages;
     python = pkgs.python313;
   };
   common = pkgs.callPackage ../../nix/pkgs/common.nix {};


### PR DESCRIPTION
For Aleph and downstream consumers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Nix packaging change only; narrows Python deps to CPU JAX without touching runtime auth or application logic.
> 
> **Overview**
> **Centralizes disabling JAX CUDA** for the Aleph flake so every Python package set gets CPU-only `jax`, not just `elodin-cli`.
> 
> The Aleph overlay now appends a `pythonPackagesExtensions` entry that sets `jax.override { cudaSupport = false; }`. That avoids the CUDA JAX plugin chain (`jax-cuda12-plugin` → `nccl`) when `aleph-cuda.nix` turns on `nixpkgs.config.cudaSupport`, which is problematic on aarch64 and unused for on-device sim (cranelift) and rendering (Vulkan).
> 
> `elodin-cli.nix` drops its local `python313Packages.overrideScope` for JAX and uses stock `pkgs.python313Packages`, relying on the shared overlay instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fd6a752d00df95c6ecce5819c20022607afb354. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->