### PR TITLE
Fix manual editor DB connect msg channel setup

### DIFF
--- a/libs/elodin-editor/src/ui/startup_window.rs
+++ b/libs/elodin-editor/src/ui/startup_window.rs
@@ -8,8 +8,8 @@ use bevy_egui::{EguiContexts, EguiTextureHandle};
 use egui::{Color32, CornerRadius, RichText, Stroke, load::SizedTexture};
 use hifitime::Epoch;
 use impeller2_bevy::{
-    ConnectionAddr, ConnectionStatus, CurrentStreamId, PacketRx, PacketTx, ThreadConnectionStatus,
-    spawn_tcp_connect,
+    ConnectionAddr, ConnectionStatus, CurrentStreamId, MsgPacketRx, MsgPacketTx, PacketRx,
+    PacketTx, ThreadConnectionStatus, spawn_msg_tcp_connect, spawn_tcp_connect,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -125,6 +125,8 @@ pub struct StartupLayout<'w, 's> {
     modal_state: Local<'s, ModalState>,
     packet_tx: ResMut<'w, PacketTx>,
     packet_rx: ResMut<'w, PacketRx>,
+    msg_packet_tx: ResMut<'w, MsgPacketTx>,
+    msg_packet_rx: ResMut<'w, MsgPacketRx>,
     current_stream_id: ResMut<'w, CurrentStreamId>,
     status: ResMut<'w, ThreadConnectionStatus>,
     recent_files: ResMut<'w, RecentItems>,
@@ -190,7 +192,9 @@ impl StartupLayout<'_, '_> {
     fn connect(&mut self, addr: SocketAddr, reconnect: bool) -> ThreadConnectionStatus {
         let (packet_tx, packet_rx, outgoing_packet_rx, incoming_packet_tx) =
             impeller2_bevy::channels();
+        let (msg_tx, msg_rx, msg_outgoing_rx, msg_incoming_tx) = impeller2_bevy::msg_channels();
         let stream_id = fastrand::u64(..);
+        spawn_msg_tcp_connect(addr, msg_outgoing_rx, msg_incoming_tx);
         let status = spawn_tcp_connect(
             addr,
             outgoing_packet_rx,
@@ -202,6 +206,8 @@ impl StartupLayout<'_, '_> {
         *self.current_stream_id = CurrentStreamId(stream_id);
         *self.packet_tx = packet_tx;
         *self.packet_rx = packet_rx;
+        *self.msg_packet_tx = msg_tx;
+        *self.msg_packet_rx = msg_rx;
         *self.status = status.clone();
         status
     }

--- a/libs/impeller2/bevy/src/tcp.rs
+++ b/libs/impeller2/bevy/src/tcp.rs
@@ -24,14 +24,11 @@ impl TcpImpellerPlugin {
 impl Plugin for TcpImpellerPlugin {
     fn build(&self, app: &mut bevy::prelude::App) {
         let (packet_tx, packet_rx, outgoing_packet_rx, incoming_packet_tx) = channels();
+        let (msg_tx, msg_rx, msg_outgoing_rx, msg_incoming_tx) = msg_channels();
         let stream_id = fastrand::u64(..);
         let status = if let Some(addr) = self.addr {
             app.insert_resource(ConnectionAddr(addr));
-            let (msg_tx, msg_rx, msg_outgoing_rx, msg_incoming_tx) = msg_channels();
             spawn_msg_tcp_connect(addr, msg_outgoing_rx, msg_incoming_tx);
-            app.insert_resource(msg_tx)
-                .insert_resource(msg_rx)
-                .add_systems(PreUpdate, msg_sink);
             spawn_tcp_connect(
                 addr,
                 outgoing_packet_rx,
@@ -44,9 +41,11 @@ impl Plugin for TcpImpellerPlugin {
         };
         app.insert_resource(packet_tx)
             .insert_resource(packet_rx)
+            .insert_resource(msg_tx)
+            .insert_resource(msg_rx)
             .insert_resource(CurrentStreamId(stream_id))
             .insert_resource(status)
-            .add_systems(PreUpdate, sink);
+            .add_systems(PreUpdate, (sink, msg_sink));
     }
 }
 


### PR DESCRIPTION
Manual startup-window DB connections only spawned the main telemetry TCP connection. The editor’s TelemetryCache backfill uses the secondary msg connection, so object_3d/vector_arrow playback missed historical samples while line_3d still worked through its separate main-connection query path.

Install msg channel resources/sink for disconnected startup and spawn/replace the msg TCP connection when connecting manually, matching the working CLI-connected editor path.

Fixes #623 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core impeller2 Bevy networking setup for all editor sessions; wrong channel wiring could affect telemetry backfill or duplicate connection behavior.
> 
> **Overview**
> Manual connections from the startup window now bring up the **secondary msg TCP connection** and install **`MsgPacketTx` / `MsgPacketRx`** alongside the main telemetry link, matching the CLI-connected editor path.
> 
> **`TcpImpellerPlugin`** always creates msg channel resources and runs **`msg_sink`** in `PreUpdate`, including when the app starts with no address (startup window). Previously msg setup only ran when an addr was provided at plugin init, so backfill over the msg connection could not work after a manual connect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a9f176532127117127c0181c186aea6a1b6f23e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->