### PR TITLE
DB-Centric Assets: Phase 0 & 1.

### DIFF
--- a/libs/db/src/assets.rs
+++ b/libs/db/src/assets.rs
@@ -1,0 +1,566 @@
+//! DB-centric asset ingest (RFD #724, Phase 0).
+//!
+//! A single boundary copies a source `assets/` tree into `{db}/assets/` exactly
+//! once, at DB creation. Downstream the simulation and editor are pure network
+//! consumers of the DB Asset Server. This replaces the selective, type-aware copy
+//! that previously lived in `nox-py`.
+
+use std::io;
+use std::path::{Component, Path, PathBuf};
+
+use crate::assets_http::{assets_dir, write_asset_file};
+
+/// Marker written into `{db}/assets/` after a successful ingest. Its presence is
+/// the copy-once guard and carries provenance for `elodin-db info`.
+pub const INGEST_MARKER: &str = ".elodin-ingested";
+
+/// Result of an [`ingest_asset_dir`] call.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct IngestReport {
+    /// Source tree that was copied in.
+    pub source_root: PathBuf,
+    /// Number of files copied (0 when skipped).
+    pub file_count: usize,
+    /// Total bytes copied (0 when skipped).
+    pub byte_count: u64,
+    /// True when the copy-once guard tripped and nothing was copied.
+    #[serde(default)]
+    pub skipped: bool,
+}
+
+/// A single entry in the asset index.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct AssetEntry {
+    pub key: String,
+    pub size: u64,
+}
+
+/// Resolve the source assets root to ingest, in priority order:
+///   1. `$ELODIN_ASSETS` (explicit; absolute or cwd-relative)
+///   2. `<entry_dir>/assets` (next to the sim entry / `main.py`, when known)
+///   3. `<cwd>/assets`
+///   4. nearest ancestor of `entry_dir` containing an `assets/` directory
+///
+/// `entry` is the simulation entrypoint (a file or directory). An explicit
+/// `$ELODIN_ASSETS` is trusted and returned even if it does not exist yet; the
+/// other candidates are only returned when they exist.
+pub fn resolve_assets_root(entry: Option<&Path>) -> Option<PathBuf> {
+    if let Some(explicit) = std::env::var_os("ELODIN_ASSETS") {
+        let path = PathBuf::from(explicit);
+        return Some(if path.is_absolute() {
+            path
+        } else {
+            std::env::current_dir().unwrap_or_default().join(path)
+        });
+    }
+
+    let entry_dir = entry.and_then(|entry| {
+        if entry.is_dir() {
+            Some(entry.to_path_buf())
+        } else {
+            entry.parent().map(Path::to_path_buf)
+        }
+    });
+
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if let Some(dir) = &entry_dir {
+        candidates.push(dir.join("assets"));
+    }
+    if let Ok(cwd) = std::env::current_dir() {
+        let cwd_assets = cwd.join("assets");
+        if !candidates.contains(&cwd_assets) {
+            candidates.push(cwd_assets);
+        }
+    }
+    if let Some(dir) = &entry_dir {
+        for ancestor in dir.ancestors() {
+            let candidate = ancestor.join("assets");
+            if !candidates.contains(&candidate) {
+                candidates.push(candidate);
+            }
+        }
+    }
+
+    candidates.into_iter().find(|candidate| candidate.is_dir())
+}
+
+/// Copy every file under `source_root` into `{db}/assets/`, preserving relative
+/// paths. Copy-once: if the ingest marker already exists this is a no-op and the
+/// returned report has `skipped = true`. Path traversal is rejected by the
+/// shared `write_asset_file` sanitizer.
+///
+/// Until the marker is written no ingest has been committed, so the destination
+/// is wiped first: a previous run that failed (or crashed) part-way through
+/// cannot leave stale files that would otherwise merge with — and be locked in
+/// by — a later ingest from a different source tree.
+pub fn ingest_asset_dir(db_path: &Path, source_root: &Path) -> io::Result<IngestReport> {
+    let dest = assets_dir(db_path);
+    let marker = dest.join(INGEST_MARKER);
+    if marker.exists() {
+        return Ok(IngestReport {
+            source_root: source_root.to_path_buf(),
+            file_count: 0,
+            byte_count: 0,
+            skipped: true,
+        });
+    }
+
+    if !source_root.is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!(
+                "assets source root does not exist: {}",
+                source_root.display()
+            ),
+        ));
+    }
+
+    // No committed ingest yet: start from a clean slate so partial leftovers
+    // from a prior failed run never survive into this (possibly different) tree.
+    if dest.exists() {
+        std::fs::remove_dir_all(&dest)?;
+    }
+    std::fs::create_dir_all(&dest)?;
+
+    let mut keys = Vec::new();
+    collect_relative_keys(source_root, source_root, &mut keys)?;
+    // Skip keys reserved by the asset layer (the `.elodin-ingested` marker and
+    // the `__index__` listing namespace). Copying them would either trip the
+    // copy-once guard on a partial tree or shadow a stored asset behind the
+    // index route; `write_asset_file` rejects them anyway, so they must be
+    // filtered here to avoid aborting the whole ingest.
+    keys.retain(|key| !crate::assets_http::is_reserved_asset_key(key));
+
+    let mut byte_count = 0u64;
+    for key in &keys {
+        let data = std::fs::read(source_root.join(key))?;
+        byte_count += data.len() as u64;
+        write_asset_file(&dest, key, &data)?;
+    }
+
+    // Every schematic now lives in the DB, so rewrite the local asset paths
+    // inside each stored `.kdl` (window sub-schematics included) to `db:` refs.
+    // Done before the marker so a genuine I/O failure aborts without committing
+    // copy-once: the next ingest wipes and retries rather than locking in stale
+    // local paths.
+    rewrite_stored_schematics(&dest)?;
+
+    let report = IngestReport {
+        source_root: source_root.to_path_buf(),
+        file_count: keys.len(),
+        byte_count,
+        skipped: false,
+    };
+    write_ingest_marker(&marker, &report)?;
+    Ok(report)
+}
+
+/// Rewrite local asset paths in a single schematic KDL document to `db:`
+/// references, keeping only those whose bytes are present under `assets_dir`.
+///
+/// Returns the rewritten KDL, or `None` when the content is not a valid
+/// schematic (callers store it verbatim) or already needs no change. This is the
+/// single rewrite entry point shared by tree ingest and `StoreAsset` uploads, so
+/// every `.kdl` that enters the DB routes its assets through the Asset Server
+/// regardless of how it got there. Idempotent: a path already in `db:` form maps
+/// to `None` via `local_asset_name` and is left as-is.
+pub fn rewrite_schematic_kdl_to_db(assets_dir: &Path, content: &str) -> Option<String> {
+    let mut schematic = impeller2_kdl::parse_schematic(content).ok()?;
+    impeller2_kdl::rewrite_asset_paths(&mut schematic, |path| {
+        let name = impeller2_kdl::local_asset_name(path)?;
+        assets_dir
+            .join(&name)
+            .is_file()
+            .then(|| format!("db:{name}"))
+    });
+    let serialized = impeller2_kdl::serialize_schematic(&schematic);
+    (serialized != content).then_some(serialized)
+}
+
+/// Rewrite local asset paths inside every stored `.kdl` schematic under `dir` to
+/// `db:` references, so nested `glb`/`icon` paths in window sub-schematics also
+/// resolve through the DB Asset Server. Only paths whose bytes are actually
+/// present in the tree are rewritten (mirrors the active-schematic rewrite).
+///
+/// A `.kdl` that is not a valid schematic is intentionally left untouched (a
+/// non-schematic file is not an error). Genuine I/O failures (read/write) are
+/// propagated so the caller does not commit the copy-once marker over a tree
+/// whose schematics were only partially rewritten.
+fn rewrite_stored_schematics(dir: &Path) -> io::Result<()> {
+    let mut keys = Vec::new();
+    collect_relative_keys(dir, dir, &mut keys)?;
+    for key in keys {
+        if !key.ends_with(".kdl") {
+            continue;
+        }
+        let content = std::fs::read_to_string(dir.join(&key))?;
+        if let Some(serialized) = rewrite_schematic_kdl_to_db(dir, &content) {
+            write_asset_file(dir, &key, serialized.as_bytes())?;
+        }
+    }
+    Ok(())
+}
+
+/// Read the ingest provenance marker, if present.
+pub fn ingest_report(db_path: &Path) -> Option<IngestReport> {
+    let marker = assets_dir(db_path).join(INGEST_MARKER);
+    let bytes = std::fs::read(marker).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+/// True once an asset tree has been ingested into this DB.
+pub fn assets_ingested(db_path: &Path) -> bool {
+    assets_dir(db_path).join(INGEST_MARKER).exists()
+}
+
+/// List the assets stored under `{db}/assets/`, optionally filtered to a key
+/// prefix. Hidden dotfiles (e.g. the ingest marker) are excluded. Keys use
+/// forward slashes regardless of platform.
+pub fn index_assets(db_path: &Path, prefix: Option<&str>) -> io::Result<Vec<AssetEntry>> {
+    index_assets_in(&assets_dir(db_path), prefix)
+}
+
+/// Like [`index_assets`] but operating directly on an `assets/` directory.
+pub fn index_assets_in(dir: &Path, prefix: Option<&str>) -> io::Result<Vec<AssetEntry>> {
+    if !dir.is_dir() {
+        return Ok(Vec::new());
+    }
+    let mut keys = Vec::new();
+    collect_relative_keys(dir, dir, &mut keys)?;
+    let mut entries = Vec::new();
+    for key in keys {
+        if key.split('/').any(|segment| segment.starts_with('.')) {
+            continue;
+        }
+        if let Some(prefix) = prefix
+            && !key.starts_with(prefix)
+        {
+            continue;
+        }
+        let size = std::fs::metadata(dir.join(&key))
+            .map(|m| m.len())
+            .unwrap_or(0);
+        entries.push(AssetEntry { key, size });
+    }
+    entries.sort_by(|a, b| a.key.cmp(&b.key));
+    Ok(entries)
+}
+
+fn write_ingest_marker(marker: &Path, report: &IngestReport) -> io::Result<()> {
+    let json = serde_json::to_vec_pretty(report).map_err(io::Error::other)?;
+    if let Some(parent) = marker.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let tmp = marker.with_extension("elodin-upload");
+    std::fs::write(&tmp, &json)?;
+    std::fs::rename(&tmp, marker)?;
+    Ok(())
+}
+
+/// Recursively collect file paths under `dir` as `/`-joined keys relative to
+/// `root`. Symlinks are skipped to avoid escaping the tree.
+fn collect_relative_keys(root: &Path, dir: &Path, out: &mut Vec<String>) -> io::Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let path = entry.path();
+        // Skip symlinks so the walk cannot follow a link out of the assets
+        // root. `DirEntry::file_type` does not traverse links, so a symlinked
+        // dir/file reports neither `is_dir` nor `is_file`; reject it explicitly.
+        if file_type.is_symlink() {
+            continue;
+        }
+        if file_type.is_dir() {
+            collect_relative_keys(root, &path, out)?;
+        } else if file_type.is_file() {
+            let Ok(rel) = path.strip_prefix(root) else {
+                continue;
+            };
+            let key = rel
+                .components()
+                .filter_map(|component| match component {
+                    Component::Normal(part) => Some(part.to_string_lossy().into_owned()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+                .join("/");
+            if !key.is_empty() {
+                out.push(key);
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn write(path: &Path, data: &[u8]) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, data).unwrap();
+    }
+
+    #[test]
+    fn ingest_copies_whole_tree_preserving_paths() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("src_assets");
+        write(&src.join("meshes/rocket.glb"), b"glb");
+        write(&src.join("schematics/main.kdl"), b"kdl");
+        write(&src.join("terrains/planar/region.toml"), b"toml");
+
+        let db = dir.path().join("db");
+        let report = ingest_asset_dir(&db, &src).unwrap();
+        assert!(!report.skipped);
+        assert_eq!(report.file_count, 3);
+        assert_eq!(
+            report.byte_count,
+            (b"glb".len() + b"kdl".len() + b"toml".len()) as u64
+        );
+
+        let assets = assets_dir(&db);
+        assert_eq!(
+            std::fs::read(assets.join("meshes/rocket.glb")).unwrap(),
+            b"glb"
+        );
+        assert_eq!(
+            std::fs::read(assets.join("schematics/main.kdl")).unwrap(),
+            b"kdl"
+        );
+        assert_eq!(
+            std::fs::read(assets.join("terrains/planar/region.toml")).unwrap(),
+            b"toml"
+        );
+    }
+
+    #[test]
+    fn ingest_is_copy_once() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("src_assets");
+        write(&src.join("meshes/rocket.glb"), b"glb");
+        let db = dir.path().join("db");
+
+        let first = ingest_asset_dir(&db, &src).unwrap();
+        assert!(!first.skipped);
+        assert!(assets_ingested(&db));
+
+        // Mutating the source after ingest must not change the DB.
+        write(&src.join("meshes/rocket.glb"), b"changed");
+        let second = ingest_asset_dir(&db, &src).unwrap();
+        assert!(second.skipped);
+        assert_eq!(
+            std::fs::read(assets_dir(&db).join("meshes/rocket.glb")).unwrap(),
+            b"glb"
+        );
+    }
+
+    #[test]
+    fn ingest_wipes_uncommitted_leftovers_before_copying() {
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("db");
+
+        // Simulate a prior failed/partial run: files under {db}/assets without a
+        // committed marker.
+        let dest = assets_dir(&db);
+        write(&dest.join("meshes/stale.glb"), b"stale");
+        assert!(!assets_ingested(&db));
+
+        // A fresh ingest from a different source must not merge the leftover.
+        let src = dir.path().join("src_assets");
+        write(&src.join("meshes/new.glb"), b"new");
+        let report = ingest_asset_dir(&db, &src).unwrap();
+        assert!(!report.skipped);
+        assert_eq!(report.file_count, 1);
+
+        assert!(dest.join("meshes/new.glb").is_file());
+        assert!(
+            !dest.join("meshes/stale.glb").exists(),
+            "leftover from an uncommitted run must be wiped, not merged"
+        );
+        assert!(assets_ingested(&db));
+    }
+
+    #[test]
+    fn ingest_ignores_source_file_named_like_marker() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("src_assets");
+        // A source tree that happens to contain a file with the marker's name.
+        write(&src.join(INGEST_MARKER), b"not-our-marker");
+        write(&src.join("meshes/a.glb"), b"a");
+
+        let db = dir.path().join("db");
+        let report = ingest_asset_dir(&db, &src).unwrap();
+        assert!(!report.skipped);
+        // The marker-named source file is excluded from the copy.
+        assert_eq!(report.file_count, 1);
+        assert!(assets_dir(&db).join("meshes/a.glb").is_file());
+
+        // The committed marker is our report, not the source file's content.
+        let stored = ingest_report(&db).expect("marker should parse as our report");
+        assert_eq!(stored.file_count, 1);
+
+        // And copy-once still holds afterwards.
+        let second = ingest_asset_dir(&db, &src).unwrap();
+        assert!(second.skipped);
+    }
+
+    #[test]
+    fn ingest_skips_index_namespace_source_files() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("src_assets");
+        // A source file under the `__index__` listing namespace would be shadowed
+        // by the index route, so it must be dropped rather than stored.
+        write(&src.join("__index__/foo.glb"), b"shadow");
+        write(&src.join("meshes/a.glb"), b"a");
+
+        let db = dir.path().join("db");
+        let report = ingest_asset_dir(&db, &src).unwrap();
+        assert!(!report.skipped);
+        // Only the real asset is copied; the reserved key is dropped.
+        assert_eq!(report.file_count, 1);
+        assert!(assets_dir(&db).join("meshes/a.glb").is_file());
+        assert!(!assets_dir(&db).join("__index__/foo.glb").exists());
+    }
+
+    #[test]
+    fn ingest_rewrites_nested_paths_in_window_schematics() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("src_assets");
+        write(&src.join("meshes/drone.glb"), b"glb");
+        // A window sub-schematic with a nested, filesystem-relative glb path.
+        write(
+            &src.join("schematics/telemetry.kdl"),
+            b"object_3d \"drone.world_pos\" {\n    glb path=\"meshes/drone.glb\"\n}\n",
+        );
+
+        let db = dir.path().join("db");
+        ingest_asset_dir(&db, &src).unwrap();
+
+        // The stored window schematic's nested path now points at the DB asset.
+        let stored =
+            std::fs::read_to_string(assets_dir(&db).join("schematics/telemetry.kdl")).unwrap();
+        assert!(
+            stored.contains("path=\"db:meshes/drone.glb\""),
+            "nested window asset path should be rewritten to db:, got:\n{stored}"
+        );
+    }
+
+    #[test]
+    fn ingest_leaves_nested_path_local_when_asset_absent() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("src_assets");
+        // Window references a glb that does not exist in the tree.
+        write(
+            &src.join("schematics/telemetry.kdl"),
+            b"object_3d \"drone.world_pos\" {\n    glb path=\"meshes/missing.glb\"\n}\n",
+        );
+
+        let db = dir.path().join("db");
+        ingest_asset_dir(&db, &src).unwrap();
+
+        let stored =
+            std::fs::read_to_string(assets_dir(&db).join("schematics/telemetry.kdl")).unwrap();
+        assert!(
+            stored.contains("path=\"meshes/missing.glb\""),
+            "absent nested asset must stay local, got:\n{stored}"
+        );
+        assert!(!stored.contains("db:meshes/missing.glb"));
+    }
+
+    #[test]
+    fn ingest_commits_marker_despite_unparsable_kdl() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("src_assets");
+        // Not a schematic: parse fails, but that must not abort ingest.
+        write(&src.join("notes/readme.kdl"), b"blah \"not a schematic\"\n");
+        write(&src.join("meshes/a.glb"), b"a");
+
+        let db = dir.path().join("db");
+        let report = ingest_asset_dir(&db, &src).unwrap();
+        assert!(!report.skipped);
+        assert!(
+            assets_ingested(&db),
+            "an unparsable .kdl is non-fatal; the marker must still commit"
+        );
+        // The non-schematic file is left exactly as-is.
+        assert_eq!(
+            std::fs::read(assets_dir(&db).join("notes/readme.kdl")).unwrap(),
+            b"blah \"not a schematic\"\n"
+        );
+    }
+
+    #[test]
+    fn ingest_missing_source_errors() {
+        let dir = tempdir().unwrap();
+        let err = ingest_asset_dir(&dir.path().join("db"), &dir.path().join("nope")).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn index_excludes_marker_and_filters_prefix() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("src_assets");
+        write(&src.join("meshes/rocket.glb"), b"glb");
+        write(&src.join("schematics/main.kdl"), b"kdl");
+        write(&src.join("schematics/overview.kdl"), b"kdl2");
+        let db = dir.path().join("db");
+        ingest_asset_dir(&db, &src).unwrap();
+
+        let all = index_assets(&db, None).unwrap();
+        let keys: Vec<_> = all.iter().map(|e| e.key.as_str()).collect();
+        assert_eq!(
+            keys,
+            vec![
+                "meshes/rocket.glb",
+                "schematics/main.kdl",
+                "schematics/overview.kdl"
+            ]
+        );
+        assert!(!keys.iter().any(|k| k.starts_with('.')));
+
+        let schematics = index_assets(&db, Some("schematics/")).unwrap();
+        assert_eq!(schematics.len(), 2);
+        assert!(schematics.iter().all(|e| e.key.starts_with("schematics/")));
+    }
+
+    #[test]
+    fn resolve_prefers_explicit_env() {
+        temp_env_assets(Some("/tmp/explicit-assets"), || {
+            assert_eq!(
+                resolve_assets_root(None),
+                Some(PathBuf::from("/tmp/explicit-assets"))
+            );
+        });
+    }
+
+    #[test]
+    fn resolve_finds_assets_next_to_entry() {
+        let dir = tempdir().unwrap();
+        let sim = dir.path().join("simulation");
+        std::fs::create_dir_all(sim.join("assets")).unwrap();
+        let main = sim.join("main.py");
+        std::fs::write(&main, b"# sim").unwrap();
+
+        temp_env_assets(None, || {
+            assert_eq!(resolve_assets_root(Some(&main)), Some(sim.join("assets")));
+        });
+    }
+
+    /// Serialize env access for the two tests that read `ELODIN_ASSETS`.
+    fn temp_env_assets(value: Option<&str>, f: impl FnOnce()) {
+        use std::sync::Mutex;
+        static LOCK: Mutex<()> = Mutex::new(());
+        let _guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var_os("ELODIN_ASSETS");
+        match value {
+            Some(value) => unsafe { std::env::set_var("ELODIN_ASSETS", value) },
+            None => unsafe { std::env::remove_var("ELODIN_ASSETS") },
+        }
+        f();
+        match prev {
+            Some(prev) => unsafe { std::env::set_var("ELODIN_ASSETS", prev) },
+            None => unsafe { std::env::remove_var("ELODIN_ASSETS") },
+        }
+    }
+}

--- a/libs/db/src/assets_http.rs
+++ b/libs/db/src/assets_http.rs
@@ -1,7 +1,8 @@
+use axum::Json;
 use axum::Router;
 use axum::extract::{Path as AxumPath, State};
 use axum::http::StatusCode;
-use axum::response::IntoResponse;
+use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use miette::IntoDiagnostic;
 use std::collections::HashSet;
@@ -178,13 +179,40 @@ async fn sync_one_schematic_asset(
 
 /// Fetches schematic `db:` assets from a source DB Asset Server into `db`'s local `assets/` dir.
 pub async fn sync_schematic_assets_for_db_from_source(source_tcp: SocketAddr, db: &DB) {
-    let (content, db_config) = db.with_state(|s| {
+    let (active_key, content, db_config) = db.with_state(|s| {
         (
+            s.db_config.schematic_active().map(str::to_owned),
             s.db_config.schematic_content().map(str::to_owned),
             s.db_config.clone(),
         )
     });
-    let Some(content) = content else {
+
+    // Fetch the active schematic file itself so this follower's asset server
+    // serves the same `schematics/main.kdl` the source advertises. Replication
+    // forwards the `schematic.active` pointer and the mirrored content, but not
+    // the asset file, so without this an editor following this DB could load a
+    // stale or missing active schematic over HTTP.
+    let mut fetched_active = None;
+    if let Some(key) = active_key.as_deref() {
+        let base = assets_http_base_url(source_tcp);
+        let assets_dir = assets_dir(&db.path);
+        if let Err(err) = std::fs::create_dir_all(&assets_dir) {
+            warn!(
+                ?err,
+                "failed to create assets dir for active schematic sync"
+            );
+        } else if let Ok(client) = sync_http_client()
+            && let Some(bytes) = sync_one_schematic_asset(&client, &base, &assets_dir, key).await
+        {
+            fetched_active = String::from_utf8(bytes).ok();
+        }
+    }
+
+    // Resolve `db:` dependencies (meshes, window sub-schematics, skybox) from
+    // the freshly-fetched active schematic when we have it — it is the source of
+    // truth. The inline `schematic.content` mirror is only a fallback: it may be
+    // absent or lag the active file, which would skip referenced assets.
+    let Some(content) = fetched_active.or(content) else {
         return;
     };
     if let Err(err) =
@@ -269,6 +297,12 @@ pub fn sanitize_asset_path(path: &str) -> Result<PathBuf, SanitizeError> {
 }
 
 pub fn write_asset_file(assets_dir: &Path, name: &str, data: &[u8]) -> io::Result<()> {
+    if is_reserved_asset_key(name) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "reserved asset key",
+        ));
+    }
     let rel = sanitize_asset_path(name)
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid asset path"))?;
     std::fs::create_dir_all(assets_dir)?;
@@ -288,27 +322,71 @@ pub fn read_asset_file(assets_dir: &Path, name: &str) -> io::Result<Vec<u8>> {
     std::fs::read(assets_dir.join(rel))
 }
 
+/// Reserved key prefix for the asset index listing (network replacement for a
+/// filesystem `read_dir`): `GET /__index__` or `GET /__index__/<prefix>`.
+pub(crate) const INDEX_KEY: &str = "__index__";
+
+/// Keys reserved by the DB asset layer that must never be stored as real
+/// assets. Storing them would be unservable: the index namespace (`__index__`,
+/// `__index__/…`) is shadowed by the listing route, and the ingest marker
+/// (`.elodin-ingested`) would forge the copy-once guard. Enforced at every write
+/// path (uploads, skybox sync, ingest) and skipped when copying a source tree.
+pub(crate) fn is_reserved_asset_key(key: &str) -> bool {
+    key == crate::assets::INGEST_MARKER
+        || key == INDEX_KEY
+        || key
+            .strip_prefix(INDEX_KEY)
+            .is_some_and(|rest| rest.starts_with('/'))
+}
+
 async fn get_asset(
     AxumPath(path): AxumPath<String>,
     State(state): State<Arc<AssetsState>>,
-) -> Result<impl IntoResponse, StatusCode> {
-    let rel = sanitize_asset_path(&path).map_err(|_| StatusCode::BAD_REQUEST)?;
+) -> Response {
+    if path == INDEX_KEY || path == "__index__/" {
+        return index_response(state.assets_dir.clone(), None).await;
+    }
+    if let Some(prefix) = path.strip_prefix("__index__/") {
+        return index_response(state.assets_dir.clone(), Some(prefix.to_string())).await;
+    }
+
+    let Ok(rel) = sanitize_asset_path(&path) else {
+        return StatusCode::BAD_REQUEST.into_response();
+    };
     let full = state.assets_dir.join(rel);
     match tokio::task::spawn_blocking(move || std::fs::read(full)).await {
-        Ok(Ok(bytes)) => Ok(bytes),
+        Ok(Ok(bytes)) => bytes.into_response(),
         Ok(Err(err)) if err.kind() == io::ErrorKind::NotFound => {
             // A 404 is a routine client outcome (e.g. a mirror polling for an
             // asset still being uploaded), not a server fault — log at info.
             tracing::info!(asset = %path, "asset http 404 (not found)");
-            Err(StatusCode::NOT_FOUND)
+            StatusCode::NOT_FOUND.into_response()
         }
         Ok(Err(err)) => {
             tracing::error!(asset = %path, ?err, "asset http 500 (read error)");
-            Err(StatusCode::INTERNAL_SERVER_ERROR)
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
         }
         Err(err) => {
             tracing::error!(asset = %path, ?err, "asset http 500 (read task failed)");
-            Err(StatusCode::INTERNAL_SERVER_ERROR)
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+    }
+}
+
+async fn index_response(assets_dir: PathBuf, prefix: Option<String>) -> Response {
+    let walk = tokio::task::spawn_blocking(move || {
+        crate::assets::index_assets_in(&assets_dir, prefix.as_deref())
+    })
+    .await;
+    match walk {
+        Ok(Ok(entries)) => Json(entries).into_response(),
+        Ok(Err(err)) => {
+            tracing::error!(?err, "asset index 500 (walk error)");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+        Err(err) => {
+            tracing::error!(?err, "asset index 500 (walk task failed)");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
         }
     }
 }
@@ -867,6 +945,73 @@ viewport "main" { }
             std::fs::read(assets_dir(&follower_db).join("skyboxes/alpine.cubemap.ktx2")).unwrap(),
             b"alpine".to_vec()
         );
+    }
+
+    #[tokio::test]
+    async fn index_endpoint_lists_assets_and_filters_prefix() {
+        use crate::assets::AssetEntry;
+
+        let dir = tempdir().unwrap();
+        let assets = dir.path().join("assets");
+        write_asset_file(&assets, "meshes/rocket.glb", b"glb").unwrap();
+        write_asset_file(&assets, "schematics/main.kdl", b"kdl").unwrap();
+        // The marker is a reserved key; create it directly to exercise the
+        // index's dotfile exclusion without going through `write_asset_file`.
+        std::fs::write(assets.join(".elodin-ingested"), b"{}").unwrap();
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let bound = listener.local_addr().unwrap();
+        let state = Arc::new(AssetsState {
+            assets_dir: assets.clone(),
+        });
+        let app = Router::new()
+            .route("/{*path}", get(get_asset))
+            .with_state(state);
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let client = reqwest::Client::new();
+        let all_bytes = client
+            .get(format!("http://{bound}/__index__"))
+            .send()
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        let all: Vec<AssetEntry> = serde_json::from_slice(&all_bytes).unwrap();
+        let keys: Vec<_> = all.iter().map(|e| e.key.as_str()).collect();
+        assert_eq!(keys, vec!["meshes/rocket.glb", "schematics/main.kdl"]);
+
+        let schematics_bytes = client
+            .get(format!("http://{bound}/__index__/schematics/"))
+            .send()
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        let schematics: Vec<AssetEntry> = serde_json::from_slice(&schematics_bytes).unwrap();
+        assert_eq!(schematics.len(), 1);
+        assert_eq!(schematics[0].key, "schematics/main.kdl");
+    }
+
+    #[test]
+    fn write_asset_file_rejects_reserved_keys() {
+        let dir = tempdir().unwrap();
+        let assets = dir.path().join("assets");
+
+        for key in ["__index__", "__index__/foo", ".elodin-ingested"] {
+            let err = write_asset_file(&assets, key, b"x").unwrap_err();
+            assert_eq!(err.kind(), io::ErrorKind::InvalidInput, "key {key} allowed");
+            assert!(!assets.join(key).exists(), "key {key} was written");
+        }
+
+        // Names that merely share the prefix are normal assets.
+        write_asset_file(&assets, "__index__notreserved.glb", b"x").unwrap();
+        assert!(assets.join("__index__notreserved.glb").is_file());
     }
 
     #[tokio::test]

--- a/libs/db/src/assets_http.rs
+++ b/libs/db/src/assets_http.rs
@@ -1,6 +1,7 @@
 use axum::Json;
 use axum::Router;
-use axum::extract::{Path as AxumPath, State};
+use axum::body::Bytes;
+use axum::extract::{DefaultBodyLimit, Path as AxumPath, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
@@ -58,7 +59,14 @@ pub enum SanitizeError {
 #[derive(Clone)]
 struct AssetsState {
     assets_dir: PathBuf,
+    /// When false (e.g. on a follower replica), `PUT` uploads are rejected so
+    /// the read-only mirror cannot diverge from its source.
+    writable: bool,
 }
+
+/// Upper bound on a single `PUT` asset upload. Generous enough for large GLB
+/// meshes while bounding memory use from a hostile client.
+const MAX_ASSET_UPLOAD_BYTES: usize = 256 * 1024 * 1024;
 
 pub fn assets_http_addr(tcp: SocketAddr) -> SocketAddr {
     SocketAddr::new(tcp.ip(), tcp.port().saturating_add(ASSETS_HTTP_PORT_OFFSET))
@@ -373,6 +381,39 @@ async fn get_asset(
     }
 }
 
+/// `PUT /<key>` writes an asset, the network replacement for a filesystem
+/// write. Path sanitization and reserved-key rejection live in
+/// `write_asset_file`; here we add the write gate (`writable`) so a follower
+/// replica returns `405` instead of diverging from its source.
+async fn put_asset(
+    AxumPath(path): AxumPath<String>,
+    State(state): State<Arc<AssetsState>>,
+    body: Bytes,
+) -> Response {
+    if !state.writable {
+        tracing::warn!(asset = %path, "asset http PUT rejected (read-only server)");
+        return StatusCode::METHOD_NOT_ALLOWED.into_response();
+    }
+    let assets_dir = state.assets_dir.clone();
+    let name = path.clone();
+    match tokio::task::spawn_blocking(move || write_asset_file(&assets_dir, &name, &body)).await {
+        Ok(Ok(())) => StatusCode::NO_CONTENT.into_response(),
+        Ok(Err(err)) if err.kind() == io::ErrorKind::InvalidInput => {
+            // Reserved key or path escaping the assets root: a client fault.
+            tracing::warn!(asset = %path, ?err, "asset http PUT 400 (invalid key)");
+            StatusCode::BAD_REQUEST.into_response()
+        }
+        Ok(Err(err)) => {
+            tracing::error!(asset = %path, ?err, "asset http PUT 500 (write error)");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+        Err(err) => {
+            tracing::error!(asset = %path, ?err, "asset http PUT 500 (write task failed)");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+    }
+}
+
 async fn index_response(assets_dir: PathBuf, prefix: Option<String>) -> Response {
     let walk = tokio::task::spawn_blocking(move || {
         crate::assets::index_assets_in(&assets_dir, prefix.as_deref())
@@ -395,25 +436,34 @@ async fn serve_assets_with_listener(
     listener: tokio::net::TcpListener,
     addr: SocketAddr,
     assets_dir: PathBuf,
+    writable: bool,
 ) -> miette::Result<()> {
-    let state = Arc::new(AssetsState { assets_dir });
+    let state = Arc::new(AssetsState {
+        assets_dir,
+        writable,
+    });
     let app = Router::new()
-        .route("/{*path}", get(get_asset))
+        .route("/{*path}", get(get_asset).put(put_asset))
+        .layer(DefaultBodyLimit::max(MAX_ASSET_UPLOAD_BYTES))
         .with_state(state);
-    tracing::info!(?addr, "assets http server listening");
+    tracing::info!(?addr, writable, "assets http server listening");
     axum::serve(listener, app).await.into_diagnostic()?;
     Ok(())
 }
 
-pub async fn serve_assets(addr: SocketAddr, assets_dir: PathBuf) -> miette::Result<()> {
+pub async fn serve_assets(
+    addr: SocketAddr,
+    assets_dir: PathBuf,
+    writable: bool,
+) -> miette::Result<()> {
     std::fs::create_dir_all(&assets_dir).into_diagnostic()?;
     let listener = tokio::net::TcpListener::bind(addr)
         .await
         .into_diagnostic()?;
-    serve_assets_with_listener(listener, addr, assets_dir).await
+    serve_assets_with_listener(listener, addr, assets_dir, writable).await
 }
 
-pub fn spawn_assets_http(db_path: &Path, tcp_addr: SocketAddr) -> io::Result<()> {
+pub fn spawn_assets_http(db_path: &Path, tcp_addr: SocketAddr, writable: bool) -> io::Result<()> {
     let addr = assets_http_addr(tcp_addr);
     let assets_dir = assets_dir(db_path);
     std::fs::create_dir_all(&assets_dir)?;
@@ -424,7 +474,8 @@ pub fn spawn_assets_http(db_path: &Path, tcp_addr: SocketAddr) -> io::Result<()>
         match tokio::net::TcpListener::from_std(listener) {
             Ok(listener) => {
                 if ready_tx.send(Ok(())).is_ok()
-                    && let Err(err) = serve_assets_with_listener(listener, addr, assets_dir).await
+                    && let Err(err) =
+                        serve_assets_with_listener(listener, addr, assets_dir, writable).await
                 {
                     tracing::error!(?err, "assets http server failed");
                 }
@@ -496,7 +547,7 @@ mod tests {
         let assets_addr = assets_http_addr(bound);
         let _conflict = std::net::TcpListener::bind(assets_addr).unwrap();
 
-        let err = spawn_assets_http(dir.path(), bound).unwrap_err();
+        let err = spawn_assets_http(dir.path(), bound, true).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::AddrInUse);
     }
 
@@ -510,7 +561,7 @@ mod tests {
         let bound = listener.local_addr().unwrap();
         drop(listener);
 
-        spawn_assets_http(dir.path(), bound).unwrap();
+        spawn_assets_http(dir.path(), bound, true).unwrap();
 
         let assets_addr = assets_http_addr(bound);
         let response = reqwest::Client::new()
@@ -532,6 +583,7 @@ mod tests {
 
         let state = Arc::new(AssetsState {
             assets_dir: assets.clone(),
+            writable: true,
         });
         let app = Router::new()
             .route("/{*path}", get(get_asset))
@@ -564,7 +616,10 @@ mod tests {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let bound = listener.local_addr().unwrap();
 
-        let state = Arc::new(AssetsState { assets_dir: assets });
+        let state = Arc::new(AssetsState {
+            assets_dir: assets,
+            writable: true,
+        });
         let app = Router::new()
             .route("/{*path}", get(get_asset))
             .with_state(state);
@@ -581,6 +636,81 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    /// Builds an in-process asset server and returns its bound address.
+    #[cfg(test)]
+    async fn spawn_test_asset_server(assets_dir: PathBuf, writable: bool) -> SocketAddr {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let bound = listener.local_addr().unwrap();
+        let state = Arc::new(AssetsState {
+            assets_dir,
+            writable,
+        });
+        let app = Router::new()
+            .route("/{*path}", get(get_asset).put(put_asset))
+            .layer(DefaultBodyLimit::max(MAX_ASSET_UPLOAD_BYTES))
+            .with_state(state);
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        bound
+    }
+
+    #[tokio::test]
+    async fn put_then_get_round_trips_when_writable() {
+        let dir = tempdir().unwrap();
+        let assets = dir.path().join("assets");
+        let bound = spawn_test_asset_server(assets, true).await;
+
+        let client = reqwest::Client::new();
+        let put = client
+            .put(format!("http://{bound}/models/rocket.glb"))
+            .body(b"glb-bytes".to_vec())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(put.status(), StatusCode::NO_CONTENT);
+
+        let get = client
+            .get(format!("http://{bound}/models/rocket.glb"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(get.status(), StatusCode::OK);
+        assert_eq!(get.bytes().await.unwrap().as_ref(), b"glb-bytes");
+    }
+
+    #[tokio::test]
+    async fn put_rejected_on_read_only_server() {
+        let dir = tempdir().unwrap();
+        let assets = dir.path().join("assets");
+        let bound = spawn_test_asset_server(assets.clone(), false).await;
+
+        let put = reqwest::Client::new()
+            .put(format!("http://{bound}/models/rocket.glb"))
+            .body(b"glb-bytes".to_vec())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(put.status(), StatusCode::METHOD_NOT_ALLOWED);
+        assert!(!assets.join("models/rocket.glb").exists());
+    }
+
+    #[tokio::test]
+    async fn put_rejects_reserved_key() {
+        let dir = tempdir().unwrap();
+        let assets = dir.path().join("assets");
+        let bound = spawn_test_asset_server(assets, true).await;
+
+        let put = reqwest::Client::new()
+            .put(format!("http://{bound}/{INDEX_KEY}"))
+            .body(b"forged-index".to_vec())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(put.status(), StatusCode::BAD_REQUEST);
     }
 
     #[test]
@@ -637,6 +767,7 @@ mod tests {
 
         let state = Arc::new(AssetsState {
             assets_dir: source_assets.clone(),
+            writable: true,
         });
         let app = Router::new()
             .route("/{*path}", get(get_asset))
@@ -729,6 +860,7 @@ object_3d "rocket.world_pos" {
 
         let state = Arc::new(AssetsState {
             assets_dir: source_assets.clone(),
+            writable: true,
         });
         let app = Router::new()
             .route("/{*path}", get(get_asset))
@@ -822,6 +954,7 @@ object_3d "rocket.world_pos" {
 
         let state = Arc::new(AssetsState {
             assets_dir: source_assets.clone(),
+            writable: true,
         });
         let app = Router::new()
             .route("/{*path}", get(get_asset))
@@ -919,6 +1052,7 @@ object_3d "rocket.world_pos" {
 
         let state = Arc::new(AssetsState {
             assets_dir: source_assets.clone(),
+            writable: true,
         });
         let app = Router::new()
             .route("/{*path}", get(get_asset))
@@ -963,6 +1097,7 @@ viewport "main" { }
         let bound = listener.local_addr().unwrap();
         let state = Arc::new(AssetsState {
             assets_dir: assets.clone(),
+            writable: true,
         });
         let app = Router::new()
             .route("/{*path}", get(get_asset))
@@ -1012,36 +1147,5 @@ viewport "main" { }
         // Names that merely share the prefix are normal assets.
         write_asset_file(&assets, "__index__notreserved.glb", b"x").unwrap();
         assert!(assets.join("__index__notreserved.glb").is_file());
-    }
-
-    #[tokio::test]
-    async fn put_over_http_is_not_allowed() {
-        let dir = tempdir().unwrap();
-        let assets = dir.path().join("assets");
-        std::fs::create_dir_all(&assets).unwrap();
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let bound = listener.local_addr().unwrap();
-
-        let state = Arc::new(AssetsState {
-            assets_dir: assets.clone(),
-        });
-        let app = Router::new()
-            .route("/{*path}", get(get_asset))
-            .with_state(state);
-
-        tokio::spawn(async move {
-            axum::serve(listener, app).await.unwrap();
-        });
-
-        tokio::time::sleep(Duration::from_millis(50)).await;
-
-        let response = reqwest::Client::new()
-            .put(format!("http://{bound}/rocket.glb"))
-            .body(b"x".to_vec())
-            .send()
-            .await
-            .unwrap();
-        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
-        assert!(!assets.join("rocket.glb").exists());
     }
 }

--- a/libs/db/src/lib.rs
+++ b/libs/db/src/lib.rs
@@ -59,6 +59,8 @@ const RESPONSE_PACKET_CAPACITY: usize = 8 * 1024 * 1024;
 pub mod append_log;
 mod arrow;
 #[cfg(feature = "axum")]
+pub mod assets;
+#[cfg(feature = "axum")]
 pub mod assets_http;
 #[cfg(feature = "axum")]
 pub mod axum;
@@ -357,15 +359,57 @@ impl DB {
 
     /// Apply a `SetDbConfig` patch and persist.
     ///
-    /// Returns whether schematic assets should be re-synced (`schematic.content` or
-    /// `skybox.active` in the patch).
+    /// Returns whether schematic assets should be re-synced (`schematic.active`,
+    /// `schematic.content`, or `skybox.active` in the patch).
     pub fn apply_set_db_config(&self, update: SetDbConfig) -> Result<bool, Error> {
-        let needs_asset_sync = update.metadata.contains_key("schematic.content")
+        let needs_asset_sync = update.metadata.contains_key("schematic.active")
+            || update.metadata.contains_key("schematic.content")
             || update.metadata.contains_key("skybox.active");
         if let Some(recording) = update.recording {
             self.with_state_mut(|s| s.db_config.recording = recording);
             self.recording_cell.set_playing(recording);
         }
+        let active_key = update
+            .metadata
+            .get("schematic.active")
+            .filter(|key| !key.is_empty())
+            .cloned();
+        let has_inline_content = update.metadata.contains_key("schematic.content");
+        // When the patch carries the schematic bytes alongside the active
+        // pointer, persist them as the active asset so the asset file, the HTTP
+        // server, and the mirrored `schematic.content` all agree from this
+        // single (atomic) message — rather than depending on a separate,
+        // droppable `StoreAsset` upload landing first.
+        let stored_active = match (&active_key, has_inline_content) {
+            (Some(key), true) => {
+                match self.store_asset(key, update.metadata["schematic.content"].as_bytes()) {
+                    Ok(()) => true,
+                    Err(err) => {
+                        tracing::warn!(?err, key, "failed to store active schematic from config");
+                        false
+                    }
+                }
+            }
+            _ => false,
+        };
+        // Transition shim: mirror the stored active asset's (already
+        // `db:`-rewritten) bytes into the legacy `schematic.content` so consumers
+        // that still read it inline keep working until they fetch the active
+        // asset over HTTP. Only mirror when there is a consistent file to read:
+        // a pointer-only patch, or a store that just succeeded. On store
+        // failure we keep the patch's fresh inline content rather than clobber
+        // it with the stale on-disk bytes. Reads go through `read_asset_file`,
+        // which rejects `..`/absolute keys.
+        let should_mirror = active_key.is_some() && (!has_inline_content || stored_active);
+        let mirrored_content = match active_key.as_deref() {
+            Some(key) if should_mirror => {
+                let assets_dir = crate::assets_http::assets_dir(&self.path);
+                crate::assets_http::read_asset_file(&assets_dir, key)
+                    .ok()
+                    .and_then(|bytes| String::from_utf8(bytes).ok())
+            }
+            _ => None,
+        };
         self.with_state_mut(|s| {
             for (key, value) in update.metadata {
                 if value.is_empty() {
@@ -373,6 +417,9 @@ impl DB {
                 } else {
                     s.db_config.metadata.insert(key, value);
                 }
+            }
+            if let Some(content) = mirrored_content {
+                s.db_config.set_schematic_content(content);
             }
         });
         self.save_db_state()?;
@@ -384,9 +431,47 @@ impl DB {
     /// `key` is sanitized (rejects `..` and absolute paths) by
     /// `assets_http::write_asset_file`, so an out-of-tree key is refused rather
     /// than escaping the assets directory.
+    ///
+    /// A stored `.kdl` schematic has its local asset paths rewritten to `db:`
+    /// (same path as tree ingest), so uploads route their assets through the
+    /// Asset Server too. Unparsable or non-schematic `.kdl` is stored verbatim.
     pub fn store_asset(&self, key: &str, bytes: &[u8]) -> std::io::Result<()> {
         let assets_dir = crate::assets_http::assets_dir(&self.path);
+        if key.ends_with(".kdl")
+            && let Ok(content) = std::str::from_utf8(bytes)
+            && let Some(rewritten) =
+                crate::assets::rewrite_schematic_kdl_to_db(&assets_dir, content)
+        {
+            return crate::assets_http::write_asset_file(&assets_dir, key, rewritten.as_bytes());
+        }
         crate::assets_http::write_asset_file(&assets_dir, key, bytes)
+    }
+
+    /// Point `schematic.active` at a stored schematic and mirror its (already
+    /// `db:`-rewritten) bytes into the legacy `schematic.content`.
+    ///
+    /// The mirror is a transition shim: consumers that still read inline
+    /// `schematic.content` keep working until they fetch the active asset over
+    /// HTTP, after which the mirror is removed. `key` must already be stored via
+    /// [`store_asset`](Self::store_asset).
+    pub fn set_active_schematic(&self, key: &str) -> Result<(), Error> {
+        let assets_dir = crate::assets_http::assets_dir(&self.path);
+        let bytes = crate::assets_http::read_asset_file(&assets_dir, key)?;
+        let content = String::from_utf8(bytes)
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
+        self.with_state_mut(|s| {
+            s.db_config.set_schematic_active(key);
+            s.db_config.set_schematic_content(content);
+        });
+        self.save_db_state()
+    }
+
+    /// Set inline `schematic.content` and persist. Fallback for producers when
+    /// the active-asset path is unavailable, so consumers still receive the
+    /// schematic instead of seeing empty metadata.
+    pub fn set_schematic_content(&self, content: impl Into<String>) -> Result<(), Error> {
+        self.with_state_mut(|s| s.db_config.set_schematic_content(content.into()));
+        self.save_db_state()
     }
 
     pub fn flush_all(&self) -> Result<(), Error> {
@@ -3362,5 +3447,156 @@ mod tests {
         let err = db.store_asset("../escape.bin", b"x").unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
         assert!(!dir.path().join("escape.bin").exists());
+    }
+
+    #[test]
+    fn store_asset_rewrites_kdl_to_db() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = DB::create(dir.path().join("db")).unwrap();
+        let assets_dir = crate::assets_http::assets_dir(&db.path);
+
+        // The referenced asset must be present for the path to be rewritten.
+        db.store_asset("meshes/rocket.glb", b"glb").unwrap();
+        db.store_asset(
+            "schematics/main.kdl",
+            b"object_3d \"rocket.world_pos\" {\n    glb path=\"meshes/rocket.glb\"\n}\n",
+        )
+        .unwrap();
+
+        let stored = std::fs::read_to_string(assets_dir.join("schematics/main.kdl")).unwrap();
+        assert!(
+            stored.contains("path=\"db:meshes/rocket.glb\""),
+            "expected db: rewrite, got:\n{stored}"
+        );
+    }
+
+    #[test]
+    fn store_asset_keeps_kdl_local_when_asset_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = DB::create(dir.path().join("db")).unwrap();
+        let assets_dir = crate::assets_http::assets_dir(&db.path);
+
+        // No glb stored, so the path must NOT be rewritten (would 404).
+        db.store_asset(
+            "schematics/main.kdl",
+            b"object_3d \"rocket.world_pos\" {\n    glb path=\"meshes/rocket.glb\"\n}\n",
+        )
+        .unwrap();
+
+        let stored = std::fs::read_to_string(assets_dir.join("schematics/main.kdl")).unwrap();
+        assert!(stored.contains("path=\"meshes/rocket.glb\""));
+        assert!(!stored.contains("db:meshes/rocket.glb"));
+    }
+
+    #[test]
+    fn store_asset_stores_unparsable_kdl_verbatim() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = DB::create(dir.path().join("db")).unwrap();
+        let assets_dir = crate::assets_http::assets_dir(&db.path);
+
+        db.store_asset("schematics/broken.kdl", b"object_3d {\n")
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read(assets_dir.join("schematics/broken.kdl")).unwrap(),
+            b"object_3d {\n".to_vec()
+        );
+    }
+
+    #[test]
+    fn apply_set_db_config_mirrors_active_into_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = DB::create(dir.path().join("db")).unwrap();
+
+        db.store_asset("schematics/main.kdl", b"viewport {\n}\n")
+            .unwrap();
+        let needs_sync = db
+            .apply_set_db_config(SetDbConfig {
+                metadata: [(
+                    "schematic.active".to_string(),
+                    "schematics/main.kdl".to_string(),
+                )]
+                .into_iter()
+                .collect(),
+                ..Default::default()
+            })
+            .unwrap();
+
+        assert!(needs_sync);
+        db.with_state(|s| {
+            assert_eq!(s.db_config.schematic_active(), Some("schematics/main.kdl"));
+            // Transition shim mirrors the stored (normalized) bytes into the
+            // legacy inline content for consumers that still read it.
+            assert_eq!(s.db_config.schematic_content(), Some("viewport"));
+        });
+    }
+
+    #[test]
+    fn apply_set_db_config_stores_active_from_inline_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = DB::create(dir.path().join("db")).unwrap();
+        let assets_dir = crate::assets_http::assets_dir(&db.path);
+
+        // Referenced asset present so the inline schematic's path is rewritten.
+        db.store_asset("meshes/rocket.glb", b"glb").unwrap();
+
+        // A single atomic patch carries both the active pointer and the bytes.
+        db.apply_set_db_config(SetDbConfig {
+            metadata: [
+                (
+                    "schematic.active".to_string(),
+                    "schematics/main.kdl".to_string(),
+                ),
+                (
+                    "schematic.content".to_string(),
+                    "object_3d \"rocket.world_pos\" {\n    glb path=\"meshes/rocket.glb\"\n}\n"
+                        .to_string(),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        })
+        .unwrap();
+
+        // The bytes are persisted as the active asset (with db: rewrite) ...
+        let stored = std::fs::read_to_string(assets_dir.join("schematics/main.kdl")).unwrap();
+        assert!(
+            stored.contains("path=\"db:meshes/rocket.glb\""),
+            "expected stored active asset, got:\n{stored}"
+        );
+        // ... and the mirror reflects the stored (rewritten) file.
+        db.with_state(|s| {
+            assert_eq!(s.db_config.schematic_active(), Some("schematics/main.kdl"));
+            assert_eq!(s.db_config.schematic_content(), Some(stored.as_str()));
+        });
+    }
+
+    #[test]
+    fn apply_set_db_config_keeps_inline_content_when_store_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = DB::create(dir.path().join("db")).unwrap();
+
+        // An out-of-tree active key makes `store_asset` (and the sanitized
+        // mirror read) fail, so the fresh inline content must survive rather
+        // than being clobbered by stale on-disk bytes.
+        let content = "viewport\n";
+        db.apply_set_db_config(SetDbConfig {
+            metadata: [
+                ("schematic.active".to_string(), "../escape.kdl".to_string()),
+                ("schematic.content".to_string(), content.to_string()),
+            ]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        })
+        .unwrap();
+
+        db.with_state(|s| {
+            assert_eq!(s.db_config.schematic_active(), Some("../escape.kdl"));
+            assert_eq!(s.db_config.schematic_content(), Some(content));
+        });
+        // Nothing escaped the assets root.
+        assert!(!dir.path().join("escape.kdl").exists());
     }
 }

--- a/libs/db/src/main.rs
+++ b/libs/db/src/main.rs
@@ -90,6 +90,11 @@ struct RunArgs {
     http_addr: Option<SocketAddr>,
     #[clap(long, hide = true)]
     reset: bool,
+    #[clap(
+        long,
+        help = "Source assets/ tree to ingest into the DB on creation (overrides ELODIN_ASSETS)"
+    )]
+    assets: Option<PathBuf>,
     #[clap(long, help = "Follow another elodin-db instance, replicating all data")]
     follows: Option<SocketAddr>,
     #[clap(
@@ -394,6 +399,7 @@ async fn main() -> miette::Result<()> {
             path,
             config,
             reset,
+            assets,
             start_timestamp,
             follows,
             follow_packet_size,
@@ -432,6 +438,28 @@ async fn main() -> miette::Result<()> {
                 elodin_db::follow::prime_follower_state(config, &server.db)
                     .await
                     .into_diagnostic()?;
+            }
+            #[cfg(feature = "axum")]
+            if follow_config.is_none() {
+                let source = assets
+                    .clone()
+                    .or_else(|| elodin_db::assets::resolve_assets_root(None));
+                if let Some(source) = source {
+                    match elodin_db::assets::ingest_asset_dir(&path, &source) {
+                        Ok(report) if report.skipped => {
+                            info!(source = %source.display(), "assets already ingested; skipping")
+                        }
+                        Ok(report) => info!(
+                            source = %source.display(),
+                            files = report.file_count,
+                            bytes = report.byte_count,
+                            "ingested assets into db"
+                        ),
+                        Err(err) => {
+                            tracing::warn!(?err, source = %source.display(), "failed to ingest assets")
+                        }
+                    }
+                }
             }
             #[cfg(feature = "axum")]
             elodin_db::assets_http::spawn_assets_http(&path, addr).into_diagnostic()?;

--- a/libs/db/src/main.rs
+++ b/libs/db/src/main.rs
@@ -462,7 +462,10 @@ async fn main() -> miette::Result<()> {
                 }
             }
             #[cfg(feature = "axum")]
-            elodin_db::assets_http::spawn_assets_http(&path, addr).into_diagnostic()?;
+            // A follower mirrors its source read-only; only a primary DB accepts
+            // asset uploads.
+            elodin_db::assets_http::spawn_assets_http(&path, addr, follows.is_none())
+                .into_diagnostic()?;
             if let Some(start_timestamp) = start_timestamp {
                 server
                     .db

--- a/libs/elodin-editor/src/plugins/kdl_document/commands.rs
+++ b/libs/elodin-editor/src/plugins/kdl_document/commands.rs
@@ -1,4 +1,3 @@
-use super::types::WindowDocumentSave;
 use bevy::prelude::*;
 use std::path::PathBuf;
 
@@ -25,10 +24,3 @@ pub struct OpenDocumentFromActiveRequest {
 /// Matches the key the Python SDK primes, so editor saves overwrite the same
 /// active schematic.
 pub const ACTIVE_SCHEMATIC_KEY: &str = "schematics/main.kdl";
-
-#[derive(Message, Clone, Debug)]
-pub struct SaveCurrentDocumentRequest {
-    pub path: Option<PathBuf>,
-    pub root_kdl: String,
-    pub windows: Vec<WindowDocumentSave>,
-}

--- a/libs/elodin-editor/src/plugins/kdl_document/commands.rs
+++ b/libs/elodin-editor/src/plugins/kdl_document/commands.rs
@@ -11,6 +11,21 @@ pub struct OpenDocumentFromContentRequest {
     pub save_path: Option<PathBuf>,
 }
 
+/// Load the main schematic from `schematic.active` by fetching its asset bytes
+/// from the DB Asset Server over HTTP (RFD #724). `content_fallback` is the
+/// legacy inline `schematic.content` mirror, used only if the fetch fails.
+#[derive(Message, Clone, Debug)]
+pub struct OpenDocumentFromActiveRequest {
+    pub key: String,
+    pub content_fallback: Option<String>,
+    pub save_path: Option<PathBuf>,
+}
+
+/// Asset key under the DB Asset Server that holds the editor's active schematic.
+/// Matches the key the Python SDK primes, so editor saves overwrite the same
+/// active schematic.
+pub const ACTIVE_SCHEMATIC_KEY: &str = "schematics/main.kdl";
+
 #[derive(Message, Clone, Debug)]
 pub struct SaveCurrentDocumentRequest {
     pub path: Option<PathBuf>,

--- a/libs/elodin-editor/src/plugins/kdl_document/messages.rs
+++ b/libs/elodin-editor/src/plugins/kdl_document/messages.rs
@@ -14,18 +14,6 @@ pub struct DocumentCommandFailed {
     pub message: String,
 }
 
-#[derive(Clone, Debug)]
-pub struct SavedWindowInfo {
-    pub window_id: crate::ui::tiles::WindowId,
-    pub file_name: String,
-}
-
-#[derive(Message, Clone, Debug)]
-pub struct DocumentSaved {
-    pub save_path: PathBuf,
-    pub windows: Vec<SavedWindowInfo>,
-}
-
 #[derive(Message, Clone, Debug)]
 pub struct DocumentReloaded {
     pub save_path: Option<PathBuf>,

--- a/libs/elodin-editor/src/plugins/kdl_document/mod.rs
+++ b/libs/elodin-editor/src/plugins/kdl_document/mod.rs
@@ -24,6 +24,7 @@ pub(crate) fn plugin(app: &mut App) {
     .init_asset_loader::<SchematicDocumentLoader>()
     .add_message::<OpenDocumentRequest>()
     .add_message::<OpenDocumentFromContentRequest>()
+    .add_message::<OpenDocumentFromActiveRequest>()
     .add_message::<SaveCurrentDocumentRequest>()
     .add_message::<DocumentLoaded>()
     .add_message::<DocumentCommandFailed>()
@@ -36,6 +37,7 @@ pub(crate) fn plugin(app: &mut App) {
         (
             systems::handle_open_document_requests,
             systems::handle_open_document_from_content_requests,
+            systems::handle_open_document_from_active_requests,
             systems::handle_save_current_document_requests,
         )
             .chain()
@@ -57,8 +59,8 @@ pub(crate) fn plugin(app: &mut App) {
 mod tests {
     use super::{
         CurrentDocument, DocumentCleared, DocumentCommandFailed, DocumentLoaded, DocumentReloaded,
-        LastSyncedSchematicContent, OpenDocumentFromContentRequest, OpenDocumentRequest,
-        SchematicDocumentAsset,
+        LastSyncedSchematicContent, OpenDocumentFromActiveRequest, OpenDocumentFromContentRequest,
+        OpenDocumentRequest, SchematicDocumentAsset,
         operations::{open_document_from_content, sync_document_skybox},
         plugin,
     };
@@ -258,6 +260,7 @@ mod tests {
             .init_resource::<LastSyncedSchematicContent>()
             .add_message::<OpenDocumentRequest>()
             .add_message::<OpenDocumentFromContentRequest>()
+            .add_message::<OpenDocumentFromActiveRequest>()
             .add_message::<DocumentCleared>()
             .init_resource::<SeenOpenDocumentRequests>()
             .add_systems(

--- a/libs/elodin-editor/src/plugins/kdl_document/mod.rs
+++ b/libs/elodin-editor/src/plugins/kdl_document/mod.rs
@@ -8,6 +8,7 @@ mod types;
 pub use commands::*;
 pub use messages::*;
 pub use operations::{apply_initial_kdl_path, sync_document_from_config, sync_document_skybox};
+pub(crate) use operations::{plan_db_save, upload_db_save_plan};
 pub use types::*;
 
 use bevy::prelude::*;

--- a/libs/elodin-editor/src/plugins/kdl_document/mod.rs
+++ b/libs/elodin-editor/src/plugins/kdl_document/mod.rs
@@ -26,10 +26,8 @@ pub(crate) fn plugin(app: &mut App) {
     .add_message::<OpenDocumentRequest>()
     .add_message::<OpenDocumentFromContentRequest>()
     .add_message::<OpenDocumentFromActiveRequest>()
-    .add_message::<SaveCurrentDocumentRequest>()
     .add_message::<DocumentLoaded>()
     .add_message::<DocumentCommandFailed>()
-    .add_message::<DocumentSaved>()
     .add_message::<DocumentReloaded>()
     .add_message::<DocumentLoadFailed>()
     .add_message::<DocumentCleared>()
@@ -39,7 +37,6 @@ pub(crate) fn plugin(app: &mut App) {
             systems::handle_open_document_requests,
             systems::handle_open_document_from_content_requests,
             systems::handle_open_document_from_active_requests,
-            systems::handle_save_current_document_requests,
         )
             .chain()
             .in_set(KdlDocumentSet::Commands),

--- a/libs/elodin-editor/src/plugins/kdl_document/operations.rs
+++ b/libs/elodin-editor/src/plugins/kdl_document/operations.rs
@@ -242,55 +242,6 @@ fn put_db_asset(
     Ok(())
 }
 
-pub fn save_current_document(
-    path: Option<PathBuf>,
-    root_kdl: &str,
-    windows: &[WindowDocumentSave],
-    asset_server: &AssetServer,
-    current_document: &mut CurrentDocument,
-) -> Result<PathBuf, SaveCurrentDocumentError> {
-    let path = path
-        .or_else(|| current_document.save_path.clone())
-        .ok_or(SaveCurrentDocumentError::MissingSavePath)?;
-    let path = Path::new(&path).with_extension("kdl");
-    let dest = schematic_file(&path);
-
-    std::fs::write(&dest, root_kdl).map_err(|source| SaveCurrentDocumentError::WriteRoot {
-        path: dest.clone(),
-        source,
-    })?;
-    write_window_schematics(dest.parent().unwrap_or_else(|| Path::new(".")), windows)?;
-
-    let asset_path = filesystem_to_asset_path(&dest);
-    let handle: Handle<SchematicDocumentAsset> = asset_server.load(asset_path.clone());
-    let root_id = handle.id();
-    current_document.set_file(handle, asset_path, dest.clone());
-    current_document.suppress_ids.insert(root_id);
-    Ok(dest)
-}
-
-fn write_window_schematics(
-    base_dir: &Path,
-    windows: &[WindowDocumentSave],
-) -> Result<(), SaveCurrentDocumentError> {
-    for entry in windows {
-        let dest = base_dir.join(&entry.file_name);
-        if let Some(parent) = dest.parent() {
-            std::fs::create_dir_all(parent).map_err(|source| {
-                SaveCurrentDocumentError::CreateWindowDir {
-                    path: dest.clone(),
-                    source,
-                }
-            })?;
-        }
-
-        std::fs::write(&dest, &entry.kdl)
-            .map_err(|source| SaveCurrentDocumentError::WriteWindow { path: dest, source })?;
-    }
-
-    Ok(())
-}
-
 /// Applies `InitialKdlPath` to `DbConfig` so that document sync can load that file.
 /// Runs before `sync_document_from_config`. Re-applies when the path is missing or different (e.g.
 /// after the connection overwrote DbConfig with metadata) so the schematic loads.

--- a/libs/elodin-editor/src/plugins/kdl_document/operations.rs
+++ b/libs/elodin-editor/src/plugins/kdl_document/operations.rs
@@ -140,6 +140,108 @@ pub(crate) fn fetch_active_schematic_kdl(
     response.text().map_err(|err| format!("{url}: {err}"))
 }
 
+/// What to `PUT` to the DB Asset Server before pointing `schematic.active` at a
+/// freshly authored schematic (RFD #724 Phase 2).
+pub(crate) struct DbSavePlan {
+    /// `(asset key, bytes)` for window sub-schematics and, last, the active
+    /// schematic itself.
+    schematic_uploads: Vec<(String, Vec<u8>)>,
+    /// `(asset key, local source path)` for meshes/icons still referenced by a
+    /// local path; their bytes are read from disk at upload time.
+    local_assets: Vec<(String, String)>,
+}
+
+/// Normalizes a root schematic for DB-native storage: rewrites local mesh, icon
+/// and window references to `db:` keys and records what must be uploaded. Pure
+/// (no I/O) so the rewrite and keying stay unit-testable.
+pub(crate) fn plan_db_save(root: &Schematic, windows: &[WindowDocumentSave]) -> DbSavePlan {
+    use std::collections::HashMap;
+    let window_kdl: HashMap<&str, &str> = windows
+        .iter()
+        .map(|w| (w.file_name.as_str(), w.kdl.as_str()))
+        .collect();
+
+    let mut local_assets = Vec::new();
+    let mut window_keys = Vec::new();
+    let mut root = root.clone();
+    impeller2_kdl::rewrite_asset_paths(&mut root, |path| {
+        if !impeller2_kdl::is_local_asset_path(path) {
+            return None;
+        }
+        // A detached-window sub-schematic: store it under `schematics/<file>`
+        // and reference it there. Its bytes come from the in-memory window list,
+        // not from disk.
+        if window_kdl.contains_key(path) {
+            let key = format!("schematics/{path}");
+            window_keys.push(key.clone());
+            return Some(format!("db:{key}"));
+        }
+        // A local mesh/icon: key by its component path and upload its bytes from
+        // disk at PUT time.
+        let name = impeller2_kdl::local_asset_name(path)?;
+        local_assets.push((name.clone(), path.to_string()));
+        Some(format!("db:{name}"))
+    });
+
+    let mut schematic_uploads = Vec::new();
+    for key in &window_keys {
+        if let Some(file_name) = key.strip_prefix("schematics/")
+            && let Some(kdl) = window_kdl.get(file_name)
+        {
+            schematic_uploads.push((key.clone(), kdl.as_bytes().to_vec()));
+        }
+    }
+    // The active schematic is uploaded last so its dependencies are present
+    // before `schematic.active` is repointed at it.
+    schematic_uploads.push((ACTIVE_SCHEMATIC_KEY.to_string(), root.to_kdl().into_bytes()));
+
+    DbSavePlan {
+        schematic_uploads,
+        local_assets,
+    }
+}
+
+/// Uploads a [`DbSavePlan`] to the DB Asset Server over HTTP `PUT`. Returns `Ok`
+/// only when every upload was accepted, so the caller may then point
+/// `schematic.active` at the uploaded schematic with no torn-write window.
+pub(crate) fn upload_db_save_plan(
+    plan: &DbSavePlan,
+    connection_addr: Option<SocketAddr>,
+) -> Result<(), String> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .map_err(|err| err.to_string())?;
+
+    for (key, src) in &plan.local_assets {
+        let path = schematic_file(Path::new(src));
+        let bytes = std::fs::read(&path).map_err(|err| format!("{}: {err}", path.display()))?;
+        put_db_asset(&client, key, bytes, connection_addr)?;
+    }
+    for (key, bytes) in &plan.schematic_uploads {
+        put_db_asset(&client, key, bytes.clone(), connection_addr)?;
+    }
+    Ok(())
+}
+
+fn put_db_asset(
+    client: &reqwest::blocking::Client,
+    key: &str,
+    bytes: Vec<u8>,
+    connection_addr: Option<SocketAddr>,
+) -> Result<(), String> {
+    let url = crate::object_3d::resolve_db_asset_url(&format!("db:{key}"), connection_addr);
+    let response = client
+        .put(&url)
+        .body(bytes)
+        .send()
+        .map_err(|err| format!("{url}: {err}"))?;
+    if !response.status().is_success() {
+        return Err(format!("{url}: HTTP {}", response.status()));
+    }
+    Ok(())
+}
+
 pub fn save_current_document(
     path: Option<PathBuf>,
     root_kdl: &str,
@@ -323,4 +425,79 @@ pub fn sync_document_from_config(
 
     current_document.clear();
     cleared.write(DocumentCleared);
+}
+
+#[cfg(test)]
+mod db_save_tests {
+    use super::*;
+    use crate::ui::tiles::WindowId;
+    use impeller2_wkt::{Object3D, Object3DMesh, SchematicElem, WindowSchematic};
+
+    fn glb_object(eql: &str, mesh: &str) -> SchematicElem {
+        SchematicElem::Object3d(Object3D {
+            eql: eql.into(),
+            mesh: Object3DMesh::glb(mesh),
+            frame: None,
+            icon: None,
+            thrusters: Vec::new(),
+            mesh_visibility_range: None,
+            node_id: Default::default(),
+        })
+    }
+
+    #[test]
+    fn plan_db_save_rewrites_local_assets_and_windows() {
+        let root = Schematic {
+            elems: vec![
+                glb_object("a", "models/local.glb"),
+                glb_object("b", "db:models/remote.glb"),
+                SchematicElem::Window(WindowSchematic {
+                    title: Some("detail".into()),
+                    path: Some("detail.kdl".into()),
+                    screen: None,
+                    screen_rect: None,
+                }),
+            ],
+            ..Default::default()
+        };
+        let windows = vec![WindowDocumentSave {
+            window_id: WindowId(1),
+            file_name: "detail.kdl".into(),
+            kdl: "viewport {\n}\n".into(),
+        }];
+
+        let plan = plan_db_save(&root, &windows);
+
+        // The local mesh is queued for upload; the `db:` mesh is left untouched.
+        assert_eq!(
+            plan.local_assets,
+            vec![(
+                "models/local.glb".to_string(),
+                "models/local.glb".to_string()
+            )]
+        );
+
+        // Window content is stored under `schematics/<file>`, and the active
+        // schematic is uploaded last so its deps land first.
+        let keys: Vec<&str> = plan
+            .schematic_uploads
+            .iter()
+            .map(|(k, _)| k.as_str())
+            .collect();
+        assert_eq!(keys, vec!["schematics/detail.kdl", ACTIVE_SCHEMATIC_KEY]);
+
+        // Every reference in the active schematic is now a `db:` key.
+        let active = String::from_utf8(plan.schematic_uploads.last().unwrap().1.clone()).unwrap();
+        assert!(active.contains("db:models/local.glb"), "{active}");
+        assert!(active.contains("db:models/remote.glb"), "{active}");
+        assert!(active.contains("db:schematics/detail.kdl"), "{active}");
+    }
+
+    #[test]
+    fn plan_db_save_without_deps_uploads_only_active() {
+        let plan = plan_db_save(&Schematic::default(), &[]);
+        assert!(plan.local_assets.is_empty());
+        assert_eq!(plan.schematic_uploads.len(), 1);
+        assert_eq!(plan.schematic_uploads[0].0, ACTIVE_SCHEMATIC_KEY);
+    }
 }

--- a/libs/elodin-editor/src/plugins/kdl_document/operations.rs
+++ b/libs/elodin-editor/src/plugins/kdl_document/operations.rs
@@ -6,7 +6,9 @@ use impeller2_kdl::KdlSchematicError;
 use impeller2_kdl::env::schematic_file;
 use impeller2_kdl::{FromKdl, ToKdl};
 use impeller2_wkt::{DbConfig, Schematic, SkyboxConfig};
+use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use super::commands::*;
 use super::messages::*;
@@ -117,6 +119,27 @@ pub fn open_document_from_content(
     })
 }
 
+/// Fetch the active schematic's KDL from the DB Asset Server over HTTP. The
+/// request is bounded so an unreachable DB cannot hang the load.
+pub(crate) fn fetch_active_schematic_kdl(
+    key: &str,
+    connection_addr: Option<SocketAddr>,
+) -> Result<String, String> {
+    let url = crate::object_3d::resolve_db_asset_url(&format!("db:{key}"), connection_addr);
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .map_err(|err| format!("{url}: {err}"))?;
+    let response = client
+        .get(&url)
+        .send()
+        .map_err(|err| format!("{url}: {err}"))?;
+    if !response.status().is_success() {
+        return Err(format!("{url}: HTTP {}", response.status()));
+    }
+    response.text().map_err(|err| format!("{url}: {err}"))
+}
+
 pub fn save_current_document(
     path: Option<PathBuf>,
     root_kdl: &str,
@@ -215,12 +238,14 @@ pub(crate) fn schematic_content_equivalent(left: &str, right: &str) -> bool {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn sync_document_from_config(
     In(given_path): In<Option<PathBuf>>,
     config: Res<DbConfig>,
     last_synced_content: Res<LastSyncedSchematicContent>,
     mut current_document: ResMut<CurrentDocument>,
     mut open_document: MessageWriter<OpenDocumentRequest>,
+    mut open_document_from_active: MessageWriter<OpenDocumentFromActiveRequest>,
     mut open_document_from_content: MessageWriter<OpenDocumentFromContentRequest>,
     mut cleared: MessageWriter<DocumentCleared>,
 ) {
@@ -228,10 +253,8 @@ pub fn sync_document_from_config(
         return;
     }
 
-    let has_content_fallback = config.schematic_content().is_some();
-    let path_was_overridden = given_path.is_some();
-
-    if let Some(path) = given_path.or(config.schematic_path().map(PathBuf::from)) {
+    // An explicit path override (user opened a specific file) wins outright.
+    if let Some(path) = given_path {
         let resolved_path = schematic_file(&path);
         if resolved_path.try_exists().unwrap_or(false) {
             if current_document_matches_path(&current_document, &resolved_path) {
@@ -240,8 +263,42 @@ pub fn sync_document_from_config(
             open_document.write(OpenDocumentRequest(path));
             return;
         }
+        // Overridden path is missing: fall through to the DB-backed sources.
+    }
 
-        if has_content_fallback && !path_was_overridden {
+    // DB-centric load (RFD #724): when the DB advertises an active schematic it
+    // is authoritative (its KDL is `db:`-rewritten), so it must take precedence
+    // over any stale local on-disk file that still carries local asset paths.
+    // The mirrored `schematic.content` doubles as the change guard (the shim
+    // keeps it equal to the active asset) and as the offline fallback.
+    if let Some(active_key) = config.schematic_active() {
+        if let Some(mirror) = config.schematic_content()
+            && last_synced_content
+                .0
+                .as_deref()
+                .is_some_and(|last| schematic_content_equivalent(last, mirror))
+        {
+            return;
+        }
+        open_document_from_active.write(OpenDocumentFromActiveRequest {
+            key: active_key.to_string(),
+            content_fallback: config.schematic_content().map(str::to_string),
+            save_path: config.schematic_path().map(Path::new).map(schematic_file),
+        });
+        return;
+    }
+
+    // No active schematic: fall back to the configured local path if present.
+    if let Some(path) = config.schematic_path().map(PathBuf::from) {
+        let resolved_path = schematic_file(&path);
+        if resolved_path.try_exists().unwrap_or(false) {
+            if current_document_matches_path(&current_document, &resolved_path) {
+                return;
+            }
+            open_document.write(OpenDocumentRequest(path));
+            return;
+        }
+        if config.schematic_content().is_some() {
             bevy::log::info!(
                 "Schematic file {:?} not found; using embedded schematic content fallback",
                 resolved_path.display()

--- a/libs/elodin-editor/src/plugins/kdl_document/systems.rs
+++ b/libs/elodin-editor/src/plugins/kdl_document/systems.rs
@@ -6,7 +6,10 @@ use std::path::PathBuf;
 
 use super::commands::*;
 use super::messages::*;
-use super::operations::{open_document_from_content, open_document_path, save_current_document};
+use super::operations::{
+    fetch_active_schematic_kdl, open_document_from_content, open_document_path,
+    save_current_document,
+};
 use super::types::*;
 
 fn cloned_current_document_asset(
@@ -65,6 +68,51 @@ pub(super) fn handle_open_document_from_content_requests(
             Err(error) => {
                 failed.write(DocumentCommandFailed {
                     title: "Invalid Schematic".to_string(),
+                    message: error.to_string(),
+                });
+            }
+        }
+    }
+}
+
+pub(super) fn handle_open_document_from_active_requests(
+    mut requests: MessageReader<OpenDocumentFromActiveRequest>,
+    connection_addr: Option<Res<impeller2_bevy::ConnectionAddr>>,
+    mut current_document: ResMut<CurrentDocument>,
+    mut loaded: MessageWriter<DocumentLoaded>,
+    mut failed: MessageWriter<DocumentCommandFailed>,
+) {
+    let addr = connection_addr.as_deref().map(|c| c.0);
+    for request in requests.read() {
+        let content = match fetch_active_schematic_kdl(&request.key, addr) {
+            Ok(content) => content,
+            Err(error) => match request.content_fallback.as_deref() {
+                Some(fallback) => {
+                    bevy::log::warn!(
+                        "Active schematic fetch failed ({error}); using content mirror fallback"
+                    );
+                    fallback.to_string()
+                }
+                None => {
+                    failed.write(DocumentCommandFailed {
+                        title: "Failed to Load Active Schematic".to_string(),
+                        message: error,
+                    });
+                    continue;
+                }
+            },
+        };
+        match open_document_from_content(&content, request.save_path.clone(), &mut current_document)
+        {
+            Ok(document) => {
+                loaded.write(DocumentLoaded {
+                    save_path: current_document.save_path.clone(),
+                    document,
+                });
+            }
+            Err(error) => {
+                failed.write(DocumentCommandFailed {
+                    title: "Invalid Active Schematic".to_string(),
                     message: error.to_string(),
                 });
             }

--- a/libs/elodin-editor/src/plugins/kdl_document/systems.rs
+++ b/libs/elodin-editor/src/plugins/kdl_document/systems.rs
@@ -8,7 +8,6 @@ use super::commands::*;
 use super::messages::*;
 use super::operations::{
     fetch_active_schematic_kdl, open_document_from_content, open_document_path,
-    save_current_document,
 };
 use super::types::*;
 
@@ -113,44 +112,6 @@ pub(super) fn handle_open_document_from_active_requests(
             Err(error) => {
                 failed.write(DocumentCommandFailed {
                     title: "Invalid Active Schematic".to_string(),
-                    message: error.to_string(),
-                });
-            }
-        }
-    }
-}
-
-pub(super) fn handle_save_current_document_requests(
-    mut requests: MessageReader<SaveCurrentDocumentRequest>,
-    asset_server: Res<AssetServer>,
-    mut current_document: ResMut<CurrentDocument>,
-    mut saved: MessageWriter<DocumentSaved>,
-    mut failed: MessageWriter<DocumentCommandFailed>,
-) {
-    for request in requests.read() {
-        match save_current_document(
-            request.path.clone(),
-            &request.root_kdl,
-            &request.windows,
-            &asset_server,
-            &mut current_document,
-        ) {
-            Ok(save_path) => {
-                saved.write(DocumentSaved {
-                    save_path,
-                    windows: request
-                        .windows
-                        .iter()
-                        .map(|w| SavedWindowInfo {
-                            window_id: w.window_id,
-                            file_name: w.file_name.clone(),
-                        })
-                        .collect(),
-                });
-            }
-            Err(error) => {
-                failed.write(DocumentCommandFailed {
-                    title: "Failed to Save Schematic".to_string(),
                     message: error.to_string(),
                 });
             }

--- a/libs/elodin-editor/src/plugins/kdl_document/types.rs
+++ b/libs/elodin-editor/src/plugins/kdl_document/types.rs
@@ -110,27 +110,3 @@ pub enum SchematicDocumentLoaderError {
     #[error(transparent)]
     RootKdl(#[from] KdlSchematicError),
 }
-
-#[derive(Debug, Error)]
-pub enum SaveCurrentDocumentError {
-    #[error("No save path is available for the current document")]
-    MissingSavePath,
-    #[error("Could not save schematic to {path}: {source}")]
-    WriteRoot {
-        path: PathBuf,
-        #[source]
-        source: std::io::Error,
-    },
-    #[error("Could not create directory for window schematic {path}: {source}")]
-    CreateWindowDir {
-        path: PathBuf,
-        #[source]
-        source: std::io::Error,
-    },
-    #[error("Could not save window schematic to {path}: {source}")]
-    WriteWindow {
-        path: PathBuf,
-        #[source]
-        source: std::io::Error,
-    },
-}

--- a/libs/elodin-editor/src/skybox_generation.rs
+++ b/libs/elodin-editor/src/skybox_generation.rs
@@ -9,8 +9,8 @@ use impeller2_wkt::{DbConfig, SetDbConfig, SkyboxConfig};
 use std::collections::VecDeque;
 
 use crate::plugins::kdl_document::{
-    CurrentDocument, DocumentLoaded, DocumentReloaded, LastSyncedSchematicContent,
-    SchematicDocumentAsset, sync_document_skybox,
+    ACTIVE_SCHEMATIC_KEY, CurrentDocument, DocumentLoaded, DocumentReloaded,
+    LastSyncedSchematicContent, SchematicDocumentAsset, sync_document_skybox,
 };
 use crate::ui::schematic::CurrentSchematic;
 
@@ -184,7 +184,14 @@ pub(crate) fn push_skybox_db_sync(
 
 pub(crate) fn push_schematic_metadata(tx: &PacketTx, kdl: Option<String>, skybox: Option<&str>) {
     let mut metadata = std::collections::HashMap::new();
+    // DB-centric write-back (RFD #724): carry the schematic bytes and the active
+    // pointer in the same atomic SetDbConfig; the DB persists them as the active
+    // asset and mirrors them into `schematic.content`.
     if let Some(kdl) = kdl {
+        metadata.insert(
+            "schematic.active".to_string(),
+            ACTIVE_SCHEMATIC_KEY.to_string(),
+        );
         metadata.insert("schematic.content".to_string(), kdl);
     }
     metadata.insert(

--- a/libs/elodin-editor/src/ui/command_palette/palette_items.rs
+++ b/libs/elodin-editor/src/ui/command_palette/palette_items.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use crate::plugins::kdl_document::{
-    CurrentDocument, LastSyncedSchematicContent, SchematicDocumentAsset,
+    ACTIVE_SCHEMATIC_KEY, CurrentDocument, LastSyncedSchematicContent, SchematicDocumentAsset,
 };
 use crate::skybox_generation::{LocallyPushedSkyboxActive, SkyboxDocumentSyncMut};
 use bevy::{
@@ -994,10 +994,22 @@ pub fn save_schematic_db() -> PaletteItem {
          schematic: Res<CurrentSchematic>,
          skybox_cache: Option<Res<SkyboxCache>>| {
             let kdl = root_kdl_for_save(&schematic, skybox_cache.as_deref());
+            // DB-centric save (RFD #724): carry the schematic bytes and the
+            // active pointer in one atomic SetDbConfig. The DB persists the
+            // bytes as the active asset (rewriting local paths to `db:`) and
+            // mirrors them back into `schematic.content`. Sending the bytes
+            // inline avoids a separate, droppable StoreAsset that could leave
+            // the pointer claiming a save that never landed.
             tx.send_msg(SetDbConfig {
-                metadata: [("schematic.content".to_string(), kdl)]
-                    .into_iter()
-                    .collect(),
+                metadata: [
+                    (
+                        "schematic.active".to_string(),
+                        ACTIVE_SCHEMATIC_KEY.to_string(),
+                    ),
+                    ("schematic.content".to_string(), kdl),
+                ]
+                .into_iter()
+                .collect(),
                 ..Default::default()
             });
             PaletteEvent::Exit

--- a/libs/elodin-editor/src/ui/command_palette/palette_items.rs
+++ b/libs/elodin-editor/src/ui/command_palette/palette_items.rs
@@ -5,7 +5,8 @@ use std::{
 };
 
 use crate::plugins::kdl_document::{
-    ACTIVE_SCHEMATIC_KEY, CurrentDocument, LastSyncedSchematicContent, SchematicDocumentAsset,
+    ACTIVE_SCHEMATIC_KEY, CurrentDocument, DocumentCommandFailed, LastSyncedSchematicContent,
+    SchematicDocumentAsset, plan_db_save, upload_db_save_plan,
 };
 use crate::skybox_generation::{LocallyPushedSkyboxActive, SkyboxDocumentSyncMut};
 use bevy::{
@@ -989,32 +990,64 @@ pub fn save_schematic_db() -> PaletteItem {
     PaletteItem::new(
         "Save Schematic To DB",
         PRESETS_LABEL,
-        |_name: In<String>,
-         tx: Res<PacketTx>,
-         schematic: Res<CurrentSchematic>,
-         skybox_cache: Option<Res<SkyboxCache>>| {
-            let kdl = root_kdl_for_save(&schematic, skybox_cache.as_deref());
-            // DB-centric save (RFD #724): carry the schematic bytes and the
-            // active pointer in one atomic SetDbConfig. The DB persists the
-            // bytes as the active asset (rewriting local paths to `db:`) and
-            // mirrors them back into `schematic.content`. Sending the bytes
-            // inline avoids a separate, droppable StoreAsset that could leave
-            // the pointer claiming a save that never landed.
-            tx.send_msg(SetDbConfig {
-                metadata: [
-                    (
-                        "schematic.active".to_string(),
-                        ACTIVE_SCHEMATIC_KEY.to_string(),
-                    ),
-                    ("schematic.content".to_string(), kdl),
-                ]
-                .into_iter()
-                .collect(),
-                ..Default::default()
-            });
+        |_name: In<String>, mut commands: Commands| {
+            // Capture descriptors/screens and rebuild the schematic from the live
+            // UI, then write it back to the DB in a dedicated system.
+            commands.run_system_cached(crate::ui::capture_window_screens_oneoff);
+            commands.run_system_cached(crate::ui::schematic::tiles_to_schematic);
+            commands.run_system_cached(queue_save_schematic_db_now);
             PaletteEvent::Exit
         },
     )
+}
+
+/// DB-native save (RFD #724 Phase 2): upload the active schematic, its window
+/// sub-schematics and any newly added local assets to the DB Asset Server over
+/// HTTP `PUT`, then point `schematic.active` at the uploaded schematic. The
+/// `PUT`s are acknowledged and complete before `SetDbConfig` is sent, so the
+/// pointer never claims a save that did not land.
+fn queue_save_schematic_db_now(
+    tx: Res<PacketTx>,
+    schematic: Res<CurrentSchematic>,
+    window_schematics: Res<CurrentWindowSchematics>,
+    skybox_cache: Option<Res<SkyboxCache>>,
+    connection_addr: Option<Res<ConnectionAddr>>,
+    mut failed: MessageWriter<DocumentCommandFailed>,
+) {
+    let Some(addr) = connection_addr.as_ref().map(|c| c.0) else {
+        failed.write(DocumentCommandFailed {
+            title: "Failed to Save Schematic".to_string(),
+            message: "Not connected to a database.".to_string(),
+        });
+        return;
+    };
+
+    let mut root = schematic.0.clone();
+    if let Some(cache) = skybox_cache.as_deref() {
+        root.skybox = cache.active.as_ref().map(|active| SkyboxConfig {
+            name: active.clone(),
+        });
+    }
+    let windows = window_document_saves(&window_schematics);
+    let plan = plan_db_save(&root, &windows);
+
+    if let Err(err) = upload_db_save_plan(&plan, Some(addr)) {
+        failed.write(DocumentCommandFailed {
+            title: "Failed to Save Schematic".to_string(),
+            message: err,
+        });
+        return;
+    }
+
+    tx.send_msg(SetDbConfig {
+        metadata: [(
+            "schematic.active".to_string(),
+            ACTIVE_SCHEMATIC_KEY.to_string(),
+        )]
+        .into_iter()
+        .collect(),
+        ..Default::default()
+    });
 }
 
 pub fn clear_schematic() -> PaletteItem {

--- a/libs/elodin-editor/src/ui/command_palette/palette_items.rs
+++ b/libs/elodin-editor/src/ui/command_palette/palette_items.rs
@@ -1,8 +1,4 @@
-use std::{
-    collections::BTreeMap,
-    path::{Path, PathBuf},
-    str::FromStr,
-};
+use std::{collections::BTreeMap, str::FromStr};
 
 use crate::plugins::kdl_document::{
     ACTIVE_SCHEMATIC_KEY, CurrentDocument, DocumentCommandFailed, LastSyncedSchematicContent,
@@ -19,7 +15,7 @@ use bevy::{
     },
     log::error,
     pbr::{StandardMaterial, wireframe::WireframeConfig},
-    prelude::{Deref, DerefMut, Entity, In, MessageWriter, Mut, Resource, Transform},
+    prelude::{Entity, In, MessageWriter, Mut, Transform},
     window::PrimaryWindow,
 };
 use bevy_ai_skybox::prelude::{
@@ -35,7 +31,7 @@ use impeller2::types::Timestamp;
 use impeller2_bevy::{
     ComponentMetadataRegistry, ComponentPathRegistry, ConnectionAddr, EntityMap, PacketTx,
 };
-use impeller2_kdl::{ToKdl, env::schematic_dir_or_cwd};
+use impeller2_kdl::ToKdl;
 use impeller2_wkt::SkyboxConfig;
 use impeller2_wkt::{
     ComponentPath, ComponentValue, CurrentTimestamp, EarliestTimestamp, IsRecording, LastUpdated,
@@ -51,8 +47,7 @@ use crate::{
         command_palette::CommandPaletteState,
         plot::{GraphBundle, graph_lines_from_component},
         schematic::{
-            CurrentSchematic, CurrentWindowSchematics, LoadSchematicParams, OpenDocumentRequest,
-            SaveCurrentDocumentRequest, WindowDocumentSave,
+            CurrentSchematic, CurrentWindowSchematics, LoadSchematicParams, WindowDocumentSave,
         },
         tiles::{self, set_mode_all},
         timeline::{
@@ -62,16 +57,7 @@ use crate::{
     },
 };
 
-/// Stores a path to the last directory used in the schematic load dialog.
-///
-/// I would have preferred for this to be a `Local<Option<PathBuf>>`, but the
-/// `BoxedSystem` that PaletteItem stores is regenerated every time.
-#[derive(Debug, Default, Resource, Deref, DerefMut)]
-struct DialogLastPath(Option<PathBuf>);
-
-pub(crate) fn plugin(app: &mut bevy::app::App) {
-    app.init_resource::<DialogLastPath>();
-}
+pub(crate) fn plugin(_app: &mut bevy::app::App) {}
 
 pub struct PalettePage {
     items: Vec<PaletteItem>,
@@ -951,48 +937,13 @@ fn goto_tick() -> PaletteItem {
     })
 }
 
-pub fn save_schematic_as() -> PaletteItem {
-    PaletteItem::new(
-        "Save Schematic As...",
-        PRESETS_LABEL,
-        |_name: In<String>| PalettePage::new(vec![save_schematic_inner()]).into_event(),
-    )
-}
-
 pub fn save_schematic() -> PaletteItem {
     PaletteItem::new(
         "Save Schematic",
         PRESETS_LABEL,
         |_name: In<String>, mut commands: Commands| {
-            // Capture descriptors/screens, rebuild schematics, then serialize in a dedicated system.
-            commands.run_system_cached(crate::ui::capture_window_screens_oneoff);
-            commands.run_system_cached(crate::ui::schematic::tiles_to_schematic);
-            commands.run_system_cached(queue_save_schematic_now);
-            PaletteEvent::Exit
-        },
-    )
-}
-
-fn queue_save_schematic_now(
-    schematic: Res<CurrentSchematic>,
-    window_schematics: Res<CurrentWindowSchematics>,
-    skybox_cache: Option<Res<SkyboxCache>>,
-    mut requests: MessageWriter<SaveCurrentDocumentRequest>,
-) {
-    requests.write(SaveCurrentDocumentRequest {
-        path: None,
-        root_kdl: root_kdl_for_save(&schematic, skybox_cache.as_deref()),
-        windows: window_document_saves(&window_schematics),
-    });
-}
-
-pub fn save_schematic_db() -> PaletteItem {
-    PaletteItem::new(
-        "Save Schematic To DB",
-        PRESETS_LABEL,
-        |_name: In<String>, mut commands: Commands| {
             // Capture descriptors/screens and rebuild the schematic from the live
-            // UI, then write it back to the DB in a dedicated system.
+            // UI, then write it back to the DB in a dedicated system (RFD #724).
             commands.run_system_cached(crate::ui::capture_window_screens_oneoff);
             commands.run_system_cached(crate::ui::schematic::tiles_to_schematic);
             commands.run_system_cached(queue_save_schematic_db_now);
@@ -1022,12 +973,7 @@ fn queue_save_schematic_db_now(
         return;
     };
 
-    let mut root = schematic.0.clone();
-    if let Some(cache) = skybox_cache.as_deref() {
-        root.skybox = cache.active.as_ref().map(|active| SkyboxConfig {
-            name: active.clone(),
-        });
-    }
+    let root = root_schematic_for_save(&schematic, skybox_cache.as_deref());
     let windows = window_document_saves(&window_schematics);
     let plan = plan_db_save(&root, &windows);
 
@@ -1062,34 +1008,17 @@ pub fn clear_schematic() -> PaletteItem {
     )
 }
 
-pub fn save_schematic_inner() -> PaletteItem {
-    PaletteItem::new(
-        LabelSource::placeholder("Enter a name for the schematic"),
-        "",
-        move |In(name): In<String>,
-              schematic: Res<CurrentSchematic>,
-              window_schematics: Res<CurrentWindowSchematics>,
-              skybox_cache: Option<Res<SkyboxCache>>,
-              mut requests: MessageWriter<SaveCurrentDocumentRequest>| {
-            requests.write(SaveCurrentDocumentRequest {
-                path: Some(PathBuf::from(name)),
-                root_kdl: root_kdl_for_save(&schematic, skybox_cache.as_deref()),
-                windows: window_document_saves(&window_schematics),
-            });
-            PaletteEvent::Exit
-        },
-    )
-    .default()
-}
-
-fn root_kdl_for_save(schematic: &CurrentSchematic, skybox_cache: Option<&SkyboxCache>) -> String {
+fn root_schematic_for_save(
+    schematic: &CurrentSchematic,
+    skybox_cache: Option<&SkyboxCache>,
+) -> impeller2_wkt::Schematic {
     let mut root = schematic.0.clone();
     if let Some(cache) = skybox_cache {
         root.skybox = cache.active.as_ref().map(|active| SkyboxConfig {
             name: active.clone(),
         });
     }
-    root.to_kdl()
+    root
 }
 
 fn window_document_saves(window_schematics: &CurrentWindowSchematics) -> Vec<WindowDocumentSave> {
@@ -1102,78 +1031,6 @@ fn window_document_saves(window_schematics: &CurrentWindowSchematics) -> Vec<Win
             kdl: entry.schematic.to_kdl(),
         })
         .collect()
-}
-
-pub fn load_schematic() -> PaletteItem {
-    PaletteItem::new("Load Schematic", PRESETS_LABEL, |_: In<String>| {
-        let Ok(dir) = schematic_dir_or_cwd().inspect_err(|e| error!(?e, "getting schematic dir"))
-        else {
-            return PaletteEvent::Exit;
-        };
-        let elems = match std::fs::read_dir(&dir) {
-            Ok(x) => x,
-            Err(e) => {
-                error!(?e, "reading schematic dir {:?}", dir.display());
-                return PaletteEvent::Exit;
-            }
-        };
-
-        let mut items = vec![load_schematic_picker()];
-        let mut file = dir;
-        for elem in elems {
-            let Ok(elem) = elem else { continue };
-            let path = elem.path();
-            let Some(file_name) = path.file_name().and_then(|s| s.to_str()) else {
-                continue;
-            };
-            if path.extension().and_then(|e| e.to_str()) != Some("kdl") {
-                continue;
-            }
-            file.push(file_name);
-            if let Some(item) = load_schematic_inner(&file) {
-                items.push(item);
-            }
-            file.pop();
-        }
-        PalettePage::new(items).into()
-    })
-}
-
-pub fn load_schematic_picker() -> PaletteItem {
-    PaletteItem::new(
-        "Use File Dialog",
-        "",
-        |_: In<String>,
-         mut requests: MessageWriter<OpenDocumentRequest>,
-         mut last_dir: ResMut<DialogLastPath>| {
-            let mut dialog = rfd::FileDialog::new().add_filter("kdl", &["kdl"]);
-            if let Some(dir) = last_dir.take().or_else(|| schematic_dir_or_cwd().ok()) {
-                dialog = dialog.set_directory(dir);
-            }
-            if let Some(path) = dialog.pick_file() {
-                **last_dir = path.parent().map(PathBuf::from);
-                requests.write(OpenDocumentRequest(path));
-            }
-            PaletteEvent::Exit
-        },
-    )
-}
-
-fn load_schematic_inner(path: &Path) -> Option<PaletteItem> {
-    let name = path
-        .file_name()
-        .map(|name_os| name_os.to_string_lossy().into_owned());
-    let path = PathBuf::from(path);
-    name.map(|name| {
-        PaletteItem::new(
-            name,
-            "",
-            move |_: In<String>, mut requests: MessageWriter<OpenDocumentRequest>| {
-                requests.write(OpenDocumentRequest(path.clone()));
-                PaletteEvent::Exit
-            },
-        )
-    })
 }
 
 pub fn set_color_scheme() -> PaletteItem {
@@ -1835,9 +1692,6 @@ impl Default for PalettePage {
             create_data_overview(None),
             create_3d_object(),
             save_schematic(),
-            save_schematic_as(),
-            save_schematic_db(),
-            load_schematic(),
             clear_schematic(),
             skybox_menu(),
             set_color_scheme_mode(),
@@ -1861,6 +1715,7 @@ mod tests {
     use super::*;
     use impeller2_kdl::FromKdl;
     use impeller2_wkt::Schematic;
+    use std::path::PathBuf;
 
     fn parse_saved_schematic(kdl: &str) -> Schematic {
         Schematic::from_kdl(kdl).expect("saved KDL should parse")
@@ -1872,7 +1727,7 @@ mod tests {
         let mut cache = SkyboxCache::empty(PathBuf::from("manifest.ron"));
         cache.active = Some("mont_blanc_france".to_string());
 
-        let kdl = root_kdl_for_save(&schematic, Some(&cache));
+        let kdl = root_schematic_for_save(&schematic, Some(&cache)).to_kdl();
         let parsed = parse_saved_schematic(&kdl);
 
         assert_eq!(
@@ -1892,7 +1747,7 @@ mod tests {
         let mut cache = SkyboxCache::empty(PathBuf::from("manifest.ron"));
         cache.active = Some("mont_blanc_france".to_string());
 
-        let kdl = root_kdl_for_save(&schematic, Some(&cache));
+        let kdl = root_schematic_for_save(&schematic, Some(&cache)).to_kdl();
         let parsed = parse_saved_schematic(&kdl);
 
         assert_eq!(
@@ -1911,7 +1766,7 @@ mod tests {
         });
         let cache = SkyboxCache::empty(PathBuf::from("manifest.ron"));
 
-        let kdl = root_kdl_for_save(&schematic, Some(&cache));
+        let kdl = root_schematic_for_save(&schematic, Some(&cache)).to_kdl();
         let parsed = parse_saved_schematic(&kdl);
 
         assert!(parsed.skybox.is_none());
@@ -1926,7 +1781,7 @@ mod tests {
             ..Default::default()
         });
 
-        let kdl = root_kdl_for_save(&schematic, None);
+        let kdl = root_schematic_for_save(&schematic, None).to_kdl();
         let parsed = parse_saved_schematic(&kdl);
 
         assert_eq!(

--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -155,21 +155,63 @@ struct WindowDescriptors {
     windows: Vec<WindowDescriptor>,
 }
 
+/// True for window sub-schematics served by the DB Asset Server (`db:`) or a
+/// raw HTTP(S) URL, as opposed to a local filesystem path (RFD #724).
+fn is_remote_asset_path(path: &str) -> bool {
+    path.starts_with("db:") || path.starts_with("http://") || path.starts_with("https://")
+}
+
+/// Read a window sub-schematic's KDL. `db:`/HTTP references are fetched from the
+/// DB Asset Server (RFD #724); everything else is read from the local filesystem
+/// (offline `--kdl` dev). The fetch is bounded so an unreachable DB cannot hang
+/// the load.
+fn read_window_schematic_kdl(
+    path: &Path,
+    connection_addr: Option<std::net::SocketAddr>,
+) -> Result<String, String> {
+    let path_str = path
+        .to_str()
+        .ok_or_else(|| "non-utf8 window path".to_string())?;
+    if !is_remote_asset_path(path_str) {
+        return std::fs::read_to_string(path).map_err(|err| err.to_string());
+    }
+
+    let url = crate::object_3d::resolve_db_asset_url(path_str, connection_addr);
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .map_err(|err| format!("{url}: {err}"))?;
+    let response = client
+        .get(&url)
+        .send()
+        .map_err(|err| format!("{url}: {err}"))?;
+    if !response.status().is_success() {
+        return Err(format!("{url}: HTTP {}", response.status()));
+    }
+    response.text().map_err(|err| format!("{url}: {err}"))
+}
+
 fn resolve_window_descriptor(
     window: &WindowSchematic,
     base_dir: Option<&Path>,
     theme_mode: Option<&str>,
 ) -> Option<WindowDescriptor> {
     let path_str = window.path.as_ref()?;
-    let mut resolved = PathBuf::from(path_str);
-
-    if resolved.is_relative() {
-        if let Some(base) = base_dir {
-            resolved = base.join(resolved);
-        } else if let Ok(cwd) = std::env::current_dir() {
-            resolved = cwd.join(resolved);
+    // Keep `db:`/HTTP references verbatim; only local paths are anchored to the
+    // schematic's directory. The remote ones are fetched over HTTP at spawn time.
+    let resolved = if is_remote_asset_path(path_str) {
+        PathBuf::from(path_str)
+    } else {
+        let mut resolved = PathBuf::from(path_str);
+        if resolved.is_relative() {
+            if let Some(base) = base_dir {
+                resolved = base.join(resolved);
+            } else if let Ok(cwd) = std::env::current_dir() {
+                resolved = cwd.join(resolved);
+            }
         }
-    }
+        resolved
+    };
 
     Some(WindowDescriptor {
         path: Some(resolved),
@@ -419,7 +461,8 @@ impl LoadSchematicParams<'_, '_> {
             }
 
             if let Some(path) = descriptor.path.clone() {
-                match std::fs::read_to_string(&path) {
+                let connection_addr = self.connection_addr.as_ref().map(|addr| addr.0);
+                match read_window_schematic_kdl(&path, connection_addr) {
                     Ok(kdl) => match impeller2_wkt::Schematic::from_kdl(&kdl) {
                         Ok(window_schematic) => {
                             self.spawn_window(
@@ -442,7 +485,7 @@ impl LoadSchematicParams<'_, '_> {
                     },
                     Err(err) => {
                         warn!(
-                            ?err,
+                            %err,
                             path = ?descriptor.path,
                             "Failed to read window schematic"
                         );
@@ -1520,6 +1563,37 @@ mod tests {
         );
 
         loaded
+    }
+
+    #[test]
+    fn remote_asset_paths_are_detected() {
+        use super::is_remote_asset_path;
+        assert!(is_remote_asset_path("db:schematics/window.kdl"));
+        assert!(is_remote_asset_path(
+            "http://127.0.0.1:2241/schematics/w.kdl"
+        ));
+        assert!(is_remote_asset_path("https://example.com/w.kdl"));
+        assert!(!is_remote_asset_path("schematics/window.kdl"));
+        assert!(!is_remote_asset_path("/abs/path/window.kdl"));
+    }
+
+    #[test]
+    fn read_window_schematic_kdl_reads_local_file() {
+        use super::read_window_schematic_kdl;
+        let dir = std::env::temp_dir().join(format!(
+            "elodin-window-kdl-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("window.kdl");
+        std::fs::write(&path, "viewport name=\"W\"\n").unwrap();
+
+        let kdl = read_window_schematic_kdl(&path, None).expect("read local window kdl");
+        assert!(kdl.contains("viewport"));
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -27,8 +27,7 @@ use crate::{
     plugins::{
         kdl_document::{
             CurrentDocument, DocumentCleared, DocumentCommandFailed, DocumentLoadFailed,
-            DocumentLoaded, DocumentReloaded, DocumentSaved, SchematicDocumentAsset,
-            SchematicWindow,
+            DocumentLoaded, DocumentReloaded, SchematicDocumentAsset, SchematicWindow,
         },
         render_layer_alloc::RenderLayerAllocator,
     },
@@ -1321,25 +1320,6 @@ pub fn apply_document_cleared(
         return;
     }
     params.load_default_data_overview();
-}
-
-pub fn apply_document_saved(
-    mut events: MessageReader<DocumentSaved>,
-    mut windows_state: Query<(&WindowId, &mut WindowState)>,
-) {
-    for event in events.read() {
-        info!(path = %event.save_path.display(), "Saved schematic");
-        let base_dir = event.save_path.parent().unwrap_or_else(|| Path::new("."));
-        for (id, mut state) in &mut windows_state {
-            if id.is_primary() {
-                state.descriptor.path = Some(event.save_path.clone());
-                continue;
-            }
-            if let Some(info) = event.windows.iter().find(|w| w.window_id == *id) {
-                state.descriptor.path = Some(base_dir.join(&info.file_name));
-            }
-        }
-    }
 }
 
 pub fn show_document_command_failures(

--- a/libs/elodin-editor/src/ui/schematic/mod.rs
+++ b/libs/elodin-editor/src/ui/schematic/mod.rs
@@ -29,9 +29,9 @@ pub use tree::*;
 mod load;
 pub use crate::plugins::kdl_document::{
     CurrentDocument, DocumentCleared, DocumentLoadFailed, DocumentLoaded, DocumentReloaded,
-    DocumentSaved, InitialKdlPath, KdlDocumentSet, OpenDocumentFromContentRequest,
-    OpenDocumentRequest, SaveCurrentDocumentRequest, SavedWindowInfo, SchematicDocumentAsset,
-    SchematicWindow, WindowDocumentSave, apply_initial_kdl_path, sync_document_from_config,
+    InitialKdlPath, KdlDocumentSet, OpenDocumentFromContentRequest, OpenDocumentRequest,
+    SchematicDocumentAsset, SchematicWindow, WindowDocumentSave, apply_initial_kdl_path,
+    sync_document_from_config,
 };
 pub use load::*;
 
@@ -558,7 +558,6 @@ impl Plugin for SchematicPlugin {
                 (
                     load::apply_document_cleared,
                     load::apply_document_loaded.before(crate::ui::sync_windows),
-                    load::apply_document_saved,
                     load::apply_document_reloaded.before(crate::ui::sync_windows),
                     load::show_document_command_failures,
                     load::show_document_load_failures,

--- a/libs/impeller2/kdl/src/rewrite.rs
+++ b/libs/impeller2/kdl/src/rewrite.rs
@@ -140,6 +140,13 @@ where
             rewrite_icon_path(&mut obj.icon, map);
         }
         SchematicElem::Panel(panel) => rewrite_panel(panel, map),
+        SchematicElem::Window(window) => {
+            if let Some(path) = &mut window.path
+                && let Some(new_path) = map(path)
+            {
+                *path = new_path;
+            }
+        }
         _ => {}
     }
 }
@@ -239,6 +246,13 @@ fn collect_elem_db_asset_names(elem: &SchematicElem, names: &mut Vec<String>) {
             }
         }
         SchematicElem::Panel(panel) => collect_panel_db_asset_names(panel, names),
+        SchematicElem::Window(window) => {
+            if let Some(path) = &window.path
+                && let Some(name) = db_asset_name(path)
+            {
+                names.push(name);
+            }
+        }
         _ => {}
     }
 }
@@ -276,6 +290,13 @@ fn collect_elem_paths(elem: &SchematicElem, paths: &mut Vec<String>) {
             }
         }
         SchematicElem::Panel(panel) => collect_panel_paths(panel, paths),
+        SchematicElem::Window(window) => {
+            if let Some(path) = &window.path
+                && is_local_asset_path(path)
+            {
+                paths.push(path.clone());
+            }
+        }
         _ => {}
     }
 }
@@ -735,6 +756,54 @@ mod tests {
             skybox_manifest_cubemap_asset_name(manifest, "desert_night").unwrap(),
             Some("skyboxes/desert_night.cubemap.ktx2".to_string())
         );
+    }
+
+    #[test]
+    fn rewrite_and_collect_window_schematic_path() {
+        use impeller2_wkt::WindowSchematic;
+
+        let mut schematic = Schematic {
+            elems: vec![SchematicElem::Window(WindowSchematic {
+                title: Some("detail".into()),
+                path: Some("schematics/window-detail.kdl".into()),
+                screen: None,
+                screen_rect: None,
+            })],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            collect_local_asset_paths(&schematic),
+            vec!["schematics/window-detail.kdl".to_string()]
+        );
+
+        rewrite_asset_paths(&mut schematic, |path| {
+            local_asset_name(path).map(|name| format!("db:{name}"))
+        });
+
+        let SchematicElem::Window(window) = &schematic.elems[0] else {
+            panic!("expected window");
+        };
+        assert_eq!(
+            window.path.as_deref(),
+            Some("db:schematics/window-detail.kdl")
+        );
+        assert_eq!(
+            collect_db_asset_names(&schematic),
+            vec!["schematics/window-detail.kdl".to_string()]
+        );
+    }
+
+    #[test]
+    fn collect_window_without_path_is_empty() {
+        use impeller2_wkt::WindowSchematic;
+
+        let schematic = Schematic {
+            elems: vec![SchematicElem::Window(WindowSchematic::default())],
+            ..Default::default()
+        };
+        assert!(collect_local_asset_paths(&schematic).is_empty());
+        assert!(collect_db_asset_names(&schematic).is_empty());
     }
 
     #[test]

--- a/libs/impeller2/wkt/src/msgs.rs
+++ b/libs/impeller2/wkt/src/msgs.rs
@@ -341,6 +341,21 @@ impl DbConfig {
         self.metadata.get("schematic.content").map(String::as_str)
     }
 
+    /// Asset key of the active schematic under `{db}/assets/`
+    /// (e.g. `schematics/main.kdl`). Consumers fetch it over the Asset Server
+    /// HTTP rather than reading inline `schematic.content` (RFD #724).
+    pub fn set_schematic_active(&mut self, key: impl Into<String>) {
+        self.metadata
+            .insert("schematic.active".to_string(), key.into());
+    }
+
+    pub fn schematic_active(&self) -> Option<&str> {
+        self.metadata
+            .get("schematic.active")
+            .filter(|key| !key.is_empty())
+            .map(String::as_str)
+    }
+
     pub fn set_skybox_active(&mut self, name: Option<&str>) {
         match name {
             Some(name) => {

--- a/libs/nox-py/src/impeller2_server.rs
+++ b/libs/nox-py/src/impeller2_server.rs
@@ -2,10 +2,9 @@ use crate::Error;
 use bytemuck;
 use elodin_db::{AtomicTimestampExt, DB, State, handle_conn};
 use impeller2::types::{ComponentId, Timestamp};
-use impeller2_wkt::{ComponentMetadata, EntityMetadata, Schematic};
+use impeller2_wkt::{ComponentMetadata, EntityMetadata};
 use std::{
     collections::HashSet,
-    io,
     path::{Path, PathBuf},
     sync::{
         Arc,
@@ -88,28 +87,60 @@ impl Server {
     }
 }
 
-/// Copy schematic-referenced files into `{db}/assets/` and rewrite KDL paths to `db:…`.
+/// Asset key under `{db}/assets/` for the active schematic the editor loads.
+const ACTIVE_SCHEMATIC_KEY: &str = "schematics/main.kdl";
+
+/// Ingest the source `assets/` tree into `{db}/assets/` once and register the
+/// generated schematic as a stored asset (RFD #724).
 ///
-/// Call once before starting the DB Asset Server so early HTTP requests do not 404.
-/// `init_db` does not call this — `world.run` primes before `spawn_assets_http`.
-pub fn prime_schematic_assets(
-    db: &elodin_db::DB,
-    world: &mut World,
-) -> Result<(), elodin_db::Error> {
-    let Some(content) = world.metadata.schematic.clone() else {
+/// The DB owns all KDL handling: `ingest_asset_dir` copies the whole tree and
+/// rewrites local asset paths to `db:`, and `store_asset` rewrites the active
+/// schematic the same way. This producer does no KDL parsing or rewriting and
+/// never mutates `world.metadata.schematic`. Call once before starting the DB
+/// Asset Server so early HTTP requests do not 404.
+pub fn prime_schematic_assets(db: &elodin_db::DB, world: &World) -> Result<(), elodin_db::Error> {
+    if let Some(source) = resolve_source_assets_root(world.metadata.schematic_path.as_deref()) {
+        match elodin_db::assets::ingest_asset_dir(&db.path, &source) {
+            Ok(report) if report.skipped => {
+                tracing::info!(source = %source.display(), "assets already ingested; skipping")
+            }
+            Ok(report) => tracing::info!(
+                source = %source.display(),
+                files = report.file_count,
+                bytes = report.byte_count,
+                "ingested assets into db"
+            ),
+            Err(err) => {
+                tracing::warn!(?err, source = %source.display(), "failed to ingest assets into db")
+            }
+        }
+    }
+
+    // Register the generated schematic as a stored asset. `store_asset` rewrites
+    // its asset paths to `db:` (unparsable KDL is stored verbatim), then
+    // `set_active_schematic` points `schematic.active` at it. Failures are
+    // logged, not fatal: a missing schematic asset must not abort the sim.
+    let Some(content) = world.metadata.schematic.as_deref() else {
         return Ok(());
     };
-    match impeller2_kdl::parse_schematic(&content) {
-        Ok(mut schematic) => {
-            persist_schematic_assets(db, &mut schematic, world.metadata.schematic_path.as_deref());
-            world.metadata.schematic = Some(impeller2_kdl::serialize_schematic(&schematic));
-        }
+    // Store the schematic as the active asset and point at it. If either step
+    // fails, fall back to inline `schematic.content` so consumers still receive
+    // the generated schematic instead of empty metadata.
+    let active_set = match db.store_asset(ACTIVE_SCHEMATIC_KEY, content.as_bytes()) {
+        Ok(()) => match db.set_active_schematic(ACTIVE_SCHEMATIC_KEY) {
+            Ok(()) => true,
+            Err(err) => {
+                tracing::warn!(?err, "failed to set active schematic pointer");
+                false
+            }
+        },
         Err(err) => {
-            return Err(elodin_db::Error::Io(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("failed to parse schematic KDL for DB asset upload: {err}"),
-            )));
+            tracing::warn!(?err, "failed to store active schematic into db assets");
+            false
         }
+    };
+    if !active_set && let Err(err) = db.set_schematic_content(content) {
+        tracing::warn!(?err, "failed to set fallback schematic content");
     }
     Ok(())
 }
@@ -121,7 +152,6 @@ pub fn init_db(
 ) -> Result<(), elodin_db::Error> {
     tracing::info!("initializing db");
     db.set_earliest_timestamp(start_timestamp)?;
-    let schematic_content = world.metadata.schematic.clone();
 
     db.with_state_mut(|state| {
         for (component_id, (schema, component_metadata)) in world.metadata.component_map.iter() {
@@ -162,9 +192,6 @@ pub fn init_db(
             state
                 .db_config
                 .set_schematic_path(path.to_string_lossy().to_string());
-        }
-        if let Some(content) = &schematic_content {
-            state.db_config.set_schematic_content(content.clone());
         }
         if !world.metadata.sensor_cameras.is_empty() {
             match serde_json::to_string(&world.metadata.sensor_cameras) {
@@ -207,231 +234,32 @@ pub fn init_db(
     Ok(())
 }
 
-const DEFAULT_ASSETS_DIR: &str = "assets";
-
-fn elodin_assets_root() -> PathBuf {
-    let dir_name = std::env::var_os("ELODIN_ASSETS_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from(DEFAULT_ASSETS_DIR));
-    if dir_name.is_absolute() {
-        dir_name
+/// Resolve the source `assets/` tree to ingest. Defers to the shared
+/// [`elodin_db::assets::resolve_assets_root`] (which honors `$ELODIN_ASSETS`,
+/// the entry directory, cwd, and ancestors), then falls back to the legacy
+/// `$ELODIN_ASSETS_DIR` so existing projects keep working until it is removed
+/// (RFD #724, Phase 4).
+fn resolve_source_assets_root(schematic_path: Option<&Path>) -> Option<PathBuf> {
+    if let Some(root) = elodin_db::assets::resolve_assets_root(schematic_path) {
+        return Some(root);
+    }
+    let legacy = std::env::var_os("ELODIN_ASSETS_DIR").map(PathBuf::from)?;
+    let legacy = if legacy.is_absolute() {
+        legacy
     } else {
-        std::env::current_dir()
-            .unwrap_or_else(|_| PathBuf::from("."))
-            .join(dir_name)
-    }
-}
-
-fn local_asset_path_candidates(local_path: &str, schematic_path: Option<&Path>) -> Vec<PathBuf> {
-    let path = PathBuf::from(local_path);
-    if path.is_absolute() {
-        return vec![path];
-    }
-
-    let mut candidates = Vec::new();
-    if let Some(schematic_path) = schematic_path
-        && let Some(base) = schematic_path
-            .parent()
-            .filter(|p| !p.as_os_str().is_empty())
-    {
-        candidates.push(base.join(&path));
-    }
-    candidates.push(elodin_assets_root().join(&path));
-    if let Ok(cwd) = std::env::current_dir() {
-        let cwd_path = cwd.join(&path);
-        if !candidates.contains(&cwd_path) {
-            candidates.push(cwd_path);
-        }
-    }
-    candidates
-}
-
-fn read_local_asset_file(
-    local_path: &str,
-    schematic_path: Option<&Path>,
-) -> Result<Vec<u8>, (PathBuf, io::Error)> {
-    let candidates = local_asset_path_candidates(local_path, schematic_path);
-    let mut last_err = None;
-    for candidate in &candidates {
-        match std::fs::read(candidate) {
-            Ok(data) => return Ok(data),
-            Err(err) => last_err = Some((candidate.clone(), err)),
-        }
-    }
-    Err(last_err.unwrap_or_else(|| {
-        (
-            PathBuf::from(local_path),
-            io::Error::new(io::ErrorKind::NotFound, "asset not found"),
-        )
-    }))
-}
-
-/// Best-effort: append the active skybox's `manifest.ron` and cubemap to
-/// `local_paths`. A missing/unreadable manifest or an absent skybox entry is
-/// logged and skipped so it never blocks the mandatory meshes/icons.
-fn add_local_skybox_cubemap_path(
-    local_paths: &mut Vec<String>,
-    schematic: &Schematic,
-    schematic_path: Option<&Path>,
-    active_skybox_name: Option<&str>,
-) {
-    let skybox_name =
-        active_skybox_name.or_else(|| schematic.skybox.as_ref().map(|skybox| skybox.name.as_str()));
-    let Some(skybox_name) = skybox_name else {
-        return;
+        std::env::current_dir().unwrap_or_default().join(legacy)
     };
-    local_paths.push(impeller2_kdl::SKYBOX_MANIFEST_ASSET_NAME.to_string());
-    let manifest_data =
-        match read_local_asset_file(impeller2_kdl::SKYBOX_MANIFEST_ASSET_NAME, schematic_path) {
-            Ok(data) => data,
-            Err((path, err)) => {
-                tracing::warn!(
-                    ?err,
-                    path = %path.display(),
-                    skybox = %skybox_name,
-                    "skipping skybox cubemap: local manifest unreadable for db upload"
-                );
-                return;
-            }
-        };
-    let manifest = match std::str::from_utf8(&manifest_data) {
-        Ok(manifest) => manifest,
-        Err(err) => {
-            tracing::warn!(%err, skybox = %skybox_name, "skipping skybox cubemap: manifest is not utf-8");
-            return;
-        }
-    };
-    match impeller2_kdl::skybox_manifest_cubemap_asset_name(manifest, skybox_name) {
-        Ok(Some(cubemap_path)) => local_paths.push(cubemap_path),
-        Ok(None) => tracing::warn!(
-            skybox = %skybox_name,
-            "skipping skybox cubemap: skybox not present in {}",
-            impeller2_kdl::SKYBOX_MANIFEST_ASSET_NAME
-        ),
-        Err(err) => tracing::warn!(
-            %err,
-            skybox = %skybox_name,
-            "skipping skybox cubemap: failed to resolve from local manifest"
-        ),
-    }
-}
-
-/// Copy schematic-referenced files into `{db}/assets/`, rewriting only the
-/// successfully stored ones to `db:`. Per-asset read/write failures are
-/// non-fatal (logged and skipped) so one bad file cannot block the rest; a
-/// skipped asset keeps its original local path rather than gaining a dangling
-/// `db:` reference.
-fn persist_schematic_assets(db: &DB, schematic: &mut Schematic, schematic_path: Option<&Path>) {
-    let assets_dir = elodin_db::assets_http::assets_dir(&db.path);
-    let active_skybox = db.with_state(|state| state.db_config.skybox_active_desired());
-    let mut local_paths = impeller2_kdl::collect_local_asset_paths(schematic);
-    add_local_skybox_cubemap_path(
-        &mut local_paths,
-        schematic,
-        schematic_path,
-        active_skybox.as_ref().and_then(|name| name.as_deref()),
-    );
-    local_paths.sort();
-    local_paths.dedup();
-
-    let mut stored: HashSet<String> = HashSet::new();
-    for local_path in &local_paths {
-        let Some(name) = impeller2_kdl::local_asset_name(local_path) else {
-            continue;
-        };
-        let data = match read_local_asset_file(local_path, schematic_path) {
-            Ok(data) => data,
-            Err((path, err)) => {
-                tracing::warn!(
-                    ?err,
-                    path = %path.display(),
-                    asset = %name,
-                    "skipping unreadable local asset for db upload"
-                );
-                continue;
-            }
-        };
-        if let Err(err) = elodin_db::assets_http::write_asset_file(&assets_dir, &name, &data) {
-            tracing::warn!(
-                ?err,
-                asset = %name,
-                "skipping asset that failed to write into database assets folder"
-            );
-            continue;
-        }
-        tracing::info!(asset = %name, "stored schematic asset in database");
-        stored.insert(name);
-    }
-
-    impeller2_kdl::rewrite_asset_paths(schematic, |path| {
-        impeller2_kdl::local_asset_name(path)
-            .filter(|name| stored.contains(name))
-            .map(|name| format!("db:{name}"))
-    });
+    legacy.is_dir().then_some(legacy)
 }
 
 #[cfg(test)]
 mod asset_tests {
     use super::*;
-    use impeller2_wkt::{
-        Object3D, Object3DIcon, Object3DIconSource, Object3DMesh, SchematicElem, SkyboxConfig,
-        default_icon_color, default_icon_size,
-    };
+    use std::sync::Mutex;
     use tempfile::tempdir;
 
-    fn glb_object(path: &str) -> SchematicElem {
-        SchematicElem::Object3d(Object3D {
-            eql: "e.world_pos".into(),
-            mesh: Object3DMesh::glb(path),
-            frame: None,
-            icon: None,
-            thrusters: Vec::new(),
-            mesh_visibility_range: None,
-            node_id: Default::default(),
-        })
-    }
-
-    fn resolve_local_asset_path(local_path: &str, schematic_path: Option<&Path>) -> PathBuf {
-        local_asset_path_candidates(local_path, schematic_path)
-            .into_iter()
-            .find(|candidate| candidate.exists())
-            .unwrap_or_else(|| {
-                local_asset_path_candidates(local_path, schematic_path)
-                    .into_iter()
-                    .next()
-                    .unwrap_or_else(|| PathBuf::from(local_path))
-            })
-    }
-
-    #[test]
-    fn resolve_local_asset_path_relative_to_schematic_parent() {
-        let schematic = PathBuf::from("/sim/layout/schematic.kdl");
-        assert_eq!(
-            resolve_local_asset_path("models/rocket.glb", Some(schematic.as_path())),
-            PathBuf::from("/sim/layout/models/rocket.glb")
-        );
-    }
-
-    #[test]
-    fn resolve_local_asset_path_honors_absolute_paths() {
-        assert_eq!(
-            resolve_local_asset_path("/abs/rocket.glb", Some(Path::new("/sim/schematic.kdl"))),
-            PathBuf::from("/abs/rocket.glb")
-        );
-    }
-
-    #[test]
-    fn prime_schematic_assets_rejects_invalid_kdl() {
-        let dir = tempdir().unwrap();
-        let db = elodin_db::DB::create(dir.path().join("db")).unwrap();
-        let mut world = World::default();
-        world.metadata.schematic = Some("object_3d {\n".to_string());
-
-        let err = prime_schematic_assets(&db, &mut world).unwrap_err();
-        assert!(
-            matches!(err, elodin_db::Error::Io(ref io) if io.kind() == io::ErrorKind::InvalidData)
-        );
-    }
+    /// Serializes tests that mutate `ELODIN_ASSETS*` env vars (process-global).
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     struct EnvVarGuard {
         key: &'static str,
@@ -441,9 +269,18 @@ mod asset_tests {
     impl EnvVarGuard {
         fn set(key: &'static str, value: &str) -> Self {
             let previous = std::env::var_os(key);
-            // SAFETY: env mutations are scoped to this test via `_guard`.
+            // SAFETY: env mutations are serialized by `ENV_LOCK` and restored on drop.
             unsafe {
                 std::env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+
+        fn unset(key: &'static str) -> Self {
+            let previous = std::env::var_os(key);
+            // SAFETY: env mutations are serialized by `ENV_LOCK` and restored on drop.
+            unsafe {
+                std::env::remove_var(key);
             }
             Self { key, previous }
         }
@@ -462,489 +299,109 @@ mod asset_tests {
     }
 
     #[test]
-    fn resolve_local_asset_path_falls_back_to_elodin_assets_dir() {
+    fn prime_stores_active_schematic_and_sets_pointer() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = tempdir().unwrap();
-        let assets_dir = dir.path().join("assets");
-        std::fs::create_dir_all(&assets_dir).unwrap();
-        std::fs::write(assets_dir.join("f22.glb"), b"jet").unwrap();
+        let assets = dir.path().join("assets");
+        std::fs::create_dir_all(assets.join("meshes")).unwrap();
+        std::fs::write(assets.join("meshes/rocket.glb"), b"glb-bytes").unwrap();
 
-        let _guard = EnvVarGuard::set("ELODIN_ASSETS_DIR", assets_dir.to_str().unwrap());
+        let db = elodin_db::DB::create(dir.path().join("db")).unwrap();
+        let mut world = World::default();
+        world.metadata.schematic = Some(
+            "object_3d \"rocket.world_pos\" {\n    glb path=\"meshes/rocket.glb\"\n}\n".to_string(),
+        );
+
+        let _guard = EnvVarGuard::set("ELODIN_ASSETS", assets.to_str().unwrap());
+        prime_schematic_assets(&db, &world).unwrap();
+
+        // The whole source tree is copied into the DB once.
+        let stored = elodin_db::assets_http::assets_dir(&db.path);
         assert_eq!(
-            resolve_local_asset_path("f22.glb", Some(Path::new("bdx.kdl"))),
-            assets_dir.join("f22.glb")
+            std::fs::read(stored.join("meshes/rocket.glb")).unwrap(),
+            b"glb-bytes".to_vec()
         );
-    }
+        assert!(elodin_db::assets::assets_ingested(&db.path));
 
-    #[test]
-    fn persist_rc_jet_like_flat_glb_names_via_elodin_assets_dir() {
-        let dir = tempdir().unwrap();
-        let assets_dir = dir.path().join("assets");
-        std::fs::create_dir_all(&assets_dir).unwrap();
-        std::fs::write(assets_dir.join("f22.glb"), b"f22").unwrap();
-        std::fs::write(assets_dir.join("edu-450-v2-drone.glb"), b"drone").unwrap();
-
-        let db = DB::create(dir.path().join("db")).unwrap();
-        let mut schematic = Schematic {
-            elems: vec![glb_object("f22.glb"), glb_object("edu-450-v2-drone.glb")],
-            ..Default::default()
-        };
-
-        let _guard = EnvVarGuard::set("ELODIN_ASSETS_DIR", assets_dir.to_str().unwrap());
-        persist_schematic_assets(&db, &mut schematic, Some(Path::new("bdx.kdl")));
-
-        let stored_assets = elodin_db::assets_http::assets_dir(&db.path);
-        assert_eq!(
-            std::fs::read(stored_assets.join("f22.glb")).unwrap(),
-            b"f22".to_vec()
-        );
-        assert_eq!(
-            std::fs::read(stored_assets.join("edu-450-v2-drone.glb")).unwrap(),
-            b"drone".to_vec()
-        );
-
-        let paths: Vec<_> = schematic
-            .elems
-            .iter()
-            .map(|elem| {
-                let SchematicElem::Object3d(obj) = elem else {
-                    panic!("expected object_3d");
-                };
-                let Object3DMesh::Glb { path, .. } = &obj.mesh else {
-                    panic!("expected glb");
-                };
-                path.clone()
-            })
-            .collect();
-        assert_eq!(paths, vec!["db:f22.glb", "db:edu-450-v2-drone.glb"]);
-    }
-
-    #[test]
-    fn persist_flat_glb_next_to_schematic_kdl() {
-        let dir = tempdir().unwrap();
-        let db = DB::create(dir.path().join("db")).unwrap();
-        std::fs::write(dir.path().join("rocket.glb"), b"glb-data").unwrap();
-
-        let mut schematic = Schematic {
-            elems: vec![glb_object("rocket.glb")],
-            ..Default::default()
-        };
-
-        persist_schematic_assets(
-            &db,
-            &mut schematic,
-            Some(dir.path().join("schematic.kdl").as_path()),
-        );
-
-        let assets_dir = elodin_db::assets_http::assets_dir(&db.path);
-        assert_eq!(
-            std::fs::read(assets_dir.join("rocket.glb")).unwrap(),
-            b"glb-data".to_vec()
-        );
-        let SchematicElem::Object3d(obj) = &schematic.elems[0] else {
-            panic!("expected object_3d");
-        };
-        let Object3DMesh::Glb { path, .. } = &obj.mesh else {
-            panic!("expected glb");
-        };
-        assert_eq!(path, "db:rocket.glb");
-    }
-
-    #[test]
-    fn persist_nested_glb_path_preserves_relative_path_on_disk() {
-        let dir = tempdir().unwrap();
-        let db = DB::create(dir.path().join("db")).unwrap();
-        std::fs::create_dir_all(dir.path().join("models")).unwrap();
-        std::fs::write(dir.path().join("models/rocket.glb"), b"nested-glb").unwrap();
-
-        let mut schematic = Schematic {
-            elems: vec![glb_object("models/rocket.glb")],
-            ..Default::default()
-        };
-
-        persist_schematic_assets(
-            &db,
-            &mut schematic,
-            Some(dir.path().join("schematic.kdl").as_path()),
-        );
-
-        let assets_dir = elodin_db::assets_http::assets_dir(&db.path);
-        assert_eq!(
-            std::fs::read(assets_dir.join("models/rocket.glb")).unwrap(),
-            b"nested-glb".to_vec()
-        );
-        let SchematicElem::Object3d(obj) = &schematic.elems[0] else {
-            panic!("expected object_3d");
-        };
-        let Object3DMesh::Glb { path, .. } = &obj.mesh else {
-            panic!("expected glb");
-        };
-        assert_eq!(path, "db:models/rocket.glb");
-    }
-
-    #[test]
-    fn persist_missing_glb_is_skipped_without_error() {
-        let dir = tempdir().unwrap();
-        let db = DB::create(dir.path().join("db")).unwrap();
-        let mut schematic = Schematic {
-            elems: vec![glb_object("missing.glb")],
-            ..Default::default()
-        };
-
-        persist_schematic_assets(
-            &db,
-            &mut schematic,
-            Some(dir.path().join("schematic.kdl").as_path()),
-        );
-        let SchematicElem::Object3d(obj) = &schematic.elems[0] else {
-            panic!("expected object_3d");
-        };
-        let Object3DMesh::Glb { path, .. } = &obj.mesh else {
-            panic!("expected glb");
-        };
-        // A missing asset is skipped (non-fatal) and keeps its local path so it
-        // never gains a dangling `db:` reference.
-        assert_eq!(path, "missing.glb");
+        // The DB stores the active schematic with its path rewritten to db: and
+        // points schematic.active at it. The producer never touches
+        // world.metadata.schematic.
+        let active_kdl = std::fs::read_to_string(stored.join("schematics/main.kdl")).unwrap();
         assert!(
-            !elodin_db::assets_http::assets_dir(&db.path)
-                .join("missing.glb")
-                .exists()
+            active_kdl.contains("path=\"db:meshes/rocket.glb\""),
+            "expected db: path in stored schematic, got:\n{active_kdl}"
+        );
+        let active = db.with_state(|state| state.db_config.schematic_active().map(str::to_owned));
+        assert_eq!(active.as_deref(), Some("schematics/main.kdl"));
+
+        // Transition shim: schematic.content mirrors the rewritten active asset.
+        let content = db.with_state(|s| s.db_config.schematic_content().map(str::to_owned));
+        assert_eq!(content.as_deref(), Some(active_kdl.as_str()));
+    }
+
+    #[test]
+    fn prime_ingest_is_copy_once() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempdir().unwrap();
+        let assets = dir.path().join("assets");
+        std::fs::create_dir_all(&assets).unwrap();
+        std::fs::write(assets.join("rocket.glb"), b"v1").unwrap();
+
+        let db = elodin_db::DB::create(dir.path().join("db")).unwrap();
+        let world = World::default();
+
+        let _guard = EnvVarGuard::set("ELODIN_ASSETS", assets.to_str().unwrap());
+        prime_schematic_assets(&db, &world).unwrap();
+
+        // A source change after ingest must not leak into the frozen DB record.
+        std::fs::write(assets.join("rocket.glb"), b"v2").unwrap();
+        prime_schematic_assets(&db, &world).unwrap();
+
+        let stored = elodin_db::assets_http::assets_dir(&db.path);
+        assert_eq!(
+            std::fs::read(stored.join("rocket.glb")).unwrap(),
+            b"v1".to_vec()
         );
     }
 
     #[test]
-    fn persist_continues_after_missing_local_file() {
+    fn prime_keeps_active_local_when_asset_absent() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = tempdir().unwrap();
-        let db = DB::create(dir.path().join("db")).unwrap();
-        std::fs::write(dir.path().join("first.glb"), b"first").unwrap();
+        // No source assets resolved, so nothing is ingested into the DB.
+        let _no_assets =
+            EnvVarGuard::set("ELODIN_ASSETS", dir.path().join("nope").to_str().unwrap());
+        let _no_legacy = EnvVarGuard::unset("ELODIN_ASSETS_DIR");
 
-        let mut schematic = Schematic {
-            elems: vec![glb_object("first.glb"), glb_object("missing.glb")],
-            ..Default::default()
-        };
-
-        persist_schematic_assets(
-            &db,
-            &mut schematic,
-            Some(dir.path().join("schematic.kdl").as_path()),
+        let db = elodin_db::DB::create(dir.path().join("db")).unwrap();
+        let mut world = World::default();
+        world.metadata.schematic = Some(
+            "object_3d \"rocket.world_pos\" {\n    glb path=\"meshes/rocket.glb\"\n}\n".to_string(),
         );
 
-        // The readable asset is persisted; the missing one is skipped without
-        // aborting or rolling back the rest.
-        let assets_dir = elodin_db::assets_http::assets_dir(&db.path);
-        assert_eq!(
-            std::fs::read(assets_dir.join("first.glb")).unwrap(),
-            b"first".to_vec()
-        );
-        assert!(!assets_dir.join("missing.glb").exists());
+        prime_schematic_assets(&db, &world).unwrap();
 
-        let paths: Vec<_> = schematic
-            .elems
-            .iter()
-            .map(|elem| {
-                let SchematicElem::Object3d(obj) = elem else {
-                    panic!("expected object_3d");
-                };
-                let Object3DMesh::Glb { path, .. } = &obj.mesh else {
-                    panic!("expected glb");
-                };
-                path.clone()
-            })
-            .collect();
-        // Only the stored asset is rewritten to `db:`; the skipped one stays local.
-        assert_eq!(
-            paths,
-            vec!["db:first.glb".to_string(), "missing.glb".to_string()]
-        );
+        // The glb never reached the DB, so store_asset must NOT rewrite the path
+        // to db: (which would make the editor chase a 404). The active pointer is
+        // still set so the editor can load the (local-path) schematic.
+        let stored = elodin_db::assets_http::assets_dir(&db.path);
+        let active_kdl = std::fs::read_to_string(stored.join("schematics/main.kdl")).unwrap();
+        assert!(active_kdl.contains("path=\"meshes/rocket.glb\""));
+        assert!(!active_kdl.contains("db:meshes/rocket.glb"));
+        let active = db.with_state(|state| state.db_config.schematic_active().map(str::to_owned));
+        assert_eq!(active.as_deref(), Some("schematics/main.kdl"));
     }
 
     #[test]
-    fn persist_kdl_round_trip_rewrites_glb_to_db_scheme() {
+    fn resolve_source_assets_root_falls_back_to_legacy_env() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = tempdir().unwrap();
-        let db = DB::create(dir.path().join("db")).unwrap();
-        std::fs::create_dir_all(dir.path().join("models")).unwrap();
-        std::fs::write(dir.path().join("models/rocket.glb"), b"payload").unwrap();
+        let legacy = dir.path().join("legacy_assets");
+        std::fs::create_dir_all(&legacy).unwrap();
 
-        let kdl = r#"
-object_3d "rocket.world_pos" {
-    glb path="models/rocket.glb"
-}
-"#;
-        let mut schematic = impeller2_kdl::parse_schematic(kdl).unwrap();
-        persist_schematic_assets(
-            &db,
-            &mut schematic,
-            Some(dir.path().join("schematic.kdl").as_path()),
-        );
-
-        let serialized = impeller2_kdl::serialize_schematic(&schematic);
-        assert!(
-            serialized.contains("path=\"db:models/rocket.glb\""),
-            "expected db: path in serialized KDL:\n{serialized}"
-        );
-
-        let reparsed = impeller2_kdl::parse_schematic(&serialized).unwrap();
-        let SchematicElem::Object3d(obj) = &reparsed.elems[0] else {
-            panic!("expected object_3d");
-        };
-        let Object3DMesh::Glb { path, .. } = &obj.mesh else {
-            panic!("expected glb");
-        };
-        assert_eq!(path, "db:models/rocket.glb");
-    }
-
-    #[test]
-    fn persist_basename_collision_keeps_distinct_relative_paths() {
-        let dir = tempdir().unwrap();
-        let db = DB::create(dir.path().join("db")).unwrap();
-        std::fs::create_dir_all(dir.path().join("a")).unwrap();
-        std::fs::create_dir_all(dir.path().join("b")).unwrap();
-        std::fs::write(dir.path().join("a/rocket.glb"), b"from-a").unwrap();
-        std::fs::write(dir.path().join("b/rocket.glb"), b"from-b").unwrap();
-
-        let mut schematic = Schematic {
-            elems: vec![glb_object("a/rocket.glb"), glb_object("b/rocket.glb")],
-            ..Default::default()
-        };
-
-        persist_schematic_assets(
-            &db,
-            &mut schematic,
-            Some(dir.path().join("schematic.kdl").as_path()),
-        );
-
-        let assets_dir = elodin_db::assets_http::assets_dir(&db.path);
-        assert_eq!(
-            std::fs::read(assets_dir.join("a/rocket.glb")).unwrap(),
-            b"from-a".to_vec()
-        );
-        assert_eq!(
-            std::fs::read(assets_dir.join("b/rocket.glb")).unwrap(),
-            b"from-b".to_vec()
-        );
-
-        let paths: Vec<_> = schematic
-            .elems
-            .iter()
-            .map(|elem| {
-                let SchematicElem::Object3d(obj) = elem else {
-                    panic!("expected object_3d");
-                };
-                let Object3DMesh::Glb { path, .. } = &obj.mesh else {
-                    panic!("expected glb");
-                };
-                path.clone()
-            })
-            .collect();
-        assert_eq!(paths, vec!["db:a/rocket.glb", "db:b/rocket.glb"]);
-    }
-
-    #[test]
-    fn persist_icon_png_path() {
-        let dir = tempdir().unwrap();
-        let db = DB::create(dir.path().join("db")).unwrap();
-        std::fs::create_dir_all(dir.path().join("icons")).unwrap();
-        std::fs::write(dir.path().join("icons/marker.png"), b"png-bytes").unwrap();
-
-        let mut schematic = Schematic {
-            elems: vec![SchematicElem::Object3d(Object3D {
-                eql: "e.world_pos".into(),
-                mesh: Object3DMesh::glb("model.glb"),
-                frame: None,
-                icon: Some(Object3DIcon {
-                    source: Object3DIconSource::Path("icons/marker.png".into()),
-                    color: default_icon_color(),
-                    size: default_icon_size(),
-                    visibility_range: None,
-                }),
-                thrusters: Vec::new(),
-                mesh_visibility_range: None,
-                node_id: Default::default(),
-            })],
-            ..Default::default()
-        };
-        std::fs::write(dir.path().join("model.glb"), b"glb").unwrap();
-
-        persist_schematic_assets(
-            &db,
-            &mut schematic,
-            Some(dir.path().join("schematic.kdl").as_path()),
-        );
-
-        let assets_dir = elodin_db::assets_http::assets_dir(&db.path);
-        assert_eq!(
-            std::fs::read(assets_dir.join("icons/marker.png")).unwrap(),
-            b"png-bytes".to_vec()
-        );
-        let SchematicElem::Object3d(obj) = &schematic.elems[0] else {
-            panic!("expected object_3d");
-        };
-        let Object3DIconSource::Path(icon_path) = &obj.icon.as_ref().unwrap().source else {
-            panic!("expected icon path");
-        };
-        assert_eq!(icon_path, "db:icons/marker.png");
-    }
-
-    #[test]
-    fn persist_skybox_manifest_and_ktx2() {
-        let dir = tempdir().unwrap();
-        let db = DB::create(dir.path().join("db")).unwrap();
-        std::fs::create_dir_all(dir.path().join("skyboxes")).unwrap();
-        let manifest = r#"
-(
-    version: 2,
-    entries: [
-        (
-            name: "desert_night",
-            prompt: "mojave",
-            style: M3Photoreal,
-            blockade: None,
-            cubemap_file: "desert_night.cubemap.ktx2",
-            face_size: 2048,
-            created_at: "2026-05-11T05:34:26Z",
-        ),
-    ],
-    default: Some("desert_night"),
-)
-"#;
-        std::fs::write(dir.path().join("skyboxes/manifest.ron"), manifest).unwrap();
-        std::fs::write(
-            dir.path().join("skyboxes/desert_night.cubemap.ktx2"),
-            b"ktx2-bytes",
-        )
-        .unwrap();
-
-        let mut schematic = Schematic {
-            skybox: Some(SkyboxConfig {
-                name: "desert_night".into(),
-            }),
-            ..Default::default()
-        };
-
-        persist_schematic_assets(
-            &db,
-            &mut schematic,
-            Some(dir.path().join("schematic.kdl").as_path()),
-        );
-
-        let assets_dir = elodin_db::assets_http::assets_dir(&db.path);
-        assert_eq!(
-            std::fs::read(assets_dir.join("skyboxes/manifest.ron")).unwrap(),
-            manifest.as_bytes().to_vec()
-        );
-        assert_eq!(
-            std::fs::read(assets_dir.join("skyboxes/desert_night.cubemap.ktx2")).unwrap(),
-            b"ktx2-bytes".to_vec()
-        );
-    }
-
-    #[test]
-    fn persist_skybox_uses_active_metadata_over_kdl_name() {
-        let dir = tempdir().unwrap();
-        let db = DB::create(dir.path().join("db")).unwrap();
-        db.with_state_mut(|state| {
-            state.db_config.set_skybox_active(Some("alpine"));
-            Ok::<_, elodin_db::Error>(())
-        })
-        .unwrap();
-        std::fs::create_dir_all(dir.path().join("skyboxes")).unwrap();
-        let manifest = r#"
-(
-    version: 2,
-    entries: [
-        (
-            name: "desert_night",
-            prompt: "mojave",
-            style: M3Photoreal,
-            blockade: None,
-            cubemap_file: "desert_night.cubemap.ktx2",
-            face_size: 2048,
-            created_at: "2026-05-11T05:34:26Z",
-        ),
-        (
-            name: "alpine",
-            prompt: "alpine",
-            style: M3Photoreal,
-            blockade: None,
-            cubemap_file: "alpine.cubemap.ktx2",
-            face_size: 2048,
-            created_at: "2026-05-11T05:34:26Z",
-        ),
-    ],
-    default: Some("desert_night"),
-)
-"#;
-        std::fs::write(dir.path().join("skyboxes/manifest.ron"), manifest).unwrap();
-        std::fs::write(
-            dir.path().join("skyboxes/desert_night.cubemap.ktx2"),
-            b"mojave",
-        )
-        .unwrap();
-        std::fs::write(dir.path().join("skyboxes/alpine.cubemap.ktx2"), b"alpine").unwrap();
-
-        let mut schematic = Schematic {
-            skybox: Some(SkyboxConfig {
-                name: "desert_night".into(),
-            }),
-            ..Default::default()
-        };
-
-        persist_schematic_assets(
-            &db,
-            &mut schematic,
-            Some(dir.path().join("schematic.kdl").as_path()),
-        );
-
-        let assets_dir = elodin_db::assets_http::assets_dir(&db.path);
-        assert_eq!(
-            std::fs::read(assets_dir.join("skyboxes/manifest.ron")).unwrap(),
-            manifest.as_bytes().to_vec()
-        );
-        assert_eq!(
-            std::fs::read(assets_dir.join("skyboxes/alpine.cubemap.ktx2")).unwrap(),
-            b"alpine".to_vec()
-        );
-        assert!(
-            !assets_dir
-                .join("skyboxes/desert_night.cubemap.ktx2")
-                .exists()
-        );
-    }
-
-    #[test]
-    fn persist_missing_skybox_does_not_block_glb() {
-        let dir = tempdir().unwrap();
-        let db = DB::create(dir.path().join("db")).unwrap();
-        std::fs::write(dir.path().join("rocket.glb"), b"rocket").unwrap();
-        // Note: no skyboxes/manifest.ron on disk.
-
-        let mut schematic = Schematic {
-            skybox: Some(SkyboxConfig {
-                name: "desert_night".into(),
-            }),
-            elems: vec![glb_object("rocket.glb")],
-            ..Default::default()
-        };
-
-        persist_schematic_assets(
-            &db,
-            &mut schematic,
-            Some(dir.path().join("schematic.kdl").as_path()),
-        );
-
-        let assets_dir = elodin_db::assets_http::assets_dir(&db.path);
-        // The mandatory mesh is persisted and rewritten despite the missing skybox.
-        assert_eq!(
-            std::fs::read(assets_dir.join("rocket.glb")).unwrap(),
-            b"rocket".to_vec()
-        );
-        assert!(!assets_dir.join("skyboxes/manifest.ron").exists());
-        let SchematicElem::Object3d(obj) = &schematic.elems[0] else {
-            panic!("expected object_3d");
-        };
-        let Object3DMesh::Glb { path, .. } = &obj.mesh else {
-            panic!("expected glb");
-        };
-        assert_eq!(path, "db:rocket.glb");
+        let _no_assets = EnvVarGuard::unset("ELODIN_ASSETS");
+        let _guard = EnvVarGuard::set("ELODIN_ASSETS_DIR", legacy.to_str().unwrap());
+        assert_eq!(resolve_source_assets_root(None), Some(legacy));
     }
 }
 

--- a/libs/nox-py/src/world_builder.rs
+++ b/libs/nox-py/src/world_builder.rs
@@ -666,7 +666,7 @@ impl WorldBuilder {
                     })?;
                 crate::impeller2_server::prime_schematic_assets(&db_server.db, exec.world_mut())
                     .map_err(crate::Error::DB)?;
-                elodin_db::assets_http::spawn_assets_http(&db_path, addr)?;
+                elodin_db::assets_http::spawn_assets_http(&db_path, addr, true)?;
                 capture_simulation_source(py, &db_path, simulation_source_entrypoint.as_deref())?;
                 let run_result = py.allow_threads(|| {
                     // Run the async executor (and therefore the JIT tick_fn) on a


### PR DESCRIPTION
> See also: https://github.com/elodin-sys/elodin/discussions/724 (RFD) & https://github.com/elodin-sys/elodin/issues/719 (issue)

---


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches schematic load/save paths, follower replication asset sync, and one-time ingest semantics; mistakes could leave stale schematics or divergent follower assets, but path sanitization and copy-once guards limit blast radius.
> 
> **Overview**
> Implements **RFD #724** so assets and schematics live under `{db}/assets/` and are served over the DB Asset Server instead of selective copies and local filesystem saves in `nox-py` and the editor.
> 
> **DB layer:** New `libs/db/src/assets.rs` ingests a whole source `assets/` tree once (copy-once via `.elodin-ingested`, wipe on retry, reserved keys, symlink skip) and rewrites stored `.kdl` paths to `db:` when bytes exist. `elodin-db run` gains `--assets` / `$ELODIN_ASSETS` resolution and ingests on primary startup; followers skip ingest and run the asset HTTP server **read-only** (PUT → 405). The asset server adds **PUT** uploads (256 MB cap), **`GET /__index__`** listing, reserved-key rejection, and follower sync that pulls the **active schematic file** from the source before syncing `db:` dependencies.
> 
> **Schematic metadata:** `schematic.active` points at a stored asset key; `SetDbConfig` can atomically store inline content as that asset, mirror rewritten bytes into legacy `schematic.content`, and `store_asset` rewrites `.kdl` on write. Python `prime_schematic_assets` delegates ingest + active registration to the DB and drops the old per-file KDL rewrite path.
> 
> **Editor:** Loads the main schematic via HTTP from `schematic.active` (with content mirror fallback); saves upload window sub-schematics, local meshes, and `schematics/main.kdl` via PUT then set `schematic.active`. Window sub-schematics and KDL rewrite/collect now include **window paths**. Palette drops separate load/save-to-disk flows in favor of DB-native save.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c94cb4029fd9bb186063fecbf1d293dace6d775. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->