### PR TITLE
os: add kernel modules to initrd for sdimage

### DIFF
--- a/aleph/modules/hardware.nix
+++ b/aleph/modules/hardware.nix
@@ -42,6 +42,19 @@
     "pcie_tegra194"
     # Tegra-specific modules required for usb/sdimage boot
     "xhci-tegra"
+    # USB mass-storage boot path
+    "xhci-hcd"
+    "usb_storage"
+    "uas"
+    "sd_mod"
+    "scsi_mod"
+    "ext4"
+  ];
+  boot.initrd.kernelModules = [
+    "xhci-tegra"
+    "usb_storage"
+    "uas"
+    "sd_mod"
   ];
 
   # Avoids a bunch of extra modules we don't have in the tegra_defconfig, like "ata_piix",


### PR DESCRIPTION
fix(os): add kernel modules so that sdimage boot environment recognizes the usb volume that it was already booted from

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Boot-time initrd module configuration only; no application logic, security, or data-path changes beyond enabling USB root discovery on sdimage boot.
> 
> **Overview**
> Extends the Jetson **initramfs** module set so early boot can see the **USB mass-storage** device used for **sdimage** installs.
> 
> `boot.initrd.availableKernelModules` now includes the USB/SCSI/block stack (`xhci-hcd`, `usb_storage`, `uas`, `sd_mod`, `scsi_mod`, `ext4`) alongside the existing Tegra NVMe/USB entries. A new `boot.initrd.kernelModules` list **preloads** `xhci-tegra`, `usb_storage`, `uas`, and `sd_mod` so the initrd can mount the boot USB volume as root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1435483a424a41682b410ca51ef74d9ccf80522d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->