### PR TITLE
Add local nix develop caching with nix-direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,11 @@
+if ! has nix_direnv_version || ! nix_direnv_version 3.1.0; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.1.0/direnvrc" "sha256-yMJ2OVMzrFaDPn7q8nCBZFRYpL/f0RcHzhmw/i6btJM="
+fi
+
+use flake
+
+# Auto-activate the uv-managed venv (created by `just install`) when present.
+if [[ -e .venv/bin/python ]]; then
+  export VIRTUAL_ENV="$PWD/.venv"
+  PATH_add .venv/bin
+fi

--- a/.envrc
+++ b/.envrc
@@ -4,6 +4,8 @@ fi
 
 use flake
 
+watch_file .venv/bin/python
+
 # Auto-activate the uv-managed venv (created by `just install`) when present.
 if [[ -e .venv/bin/python ]]; then
   export VIRTUAL_ENV="$PWD/.venv"

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ result-bin
 .vscode
 node_modules
 profile_output
+.direnv/
 
 # ai
 ai-context


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Local developer-environment wiring only; no application, auth, or deployment behavior changes.
> 
> **Overview**
> Adds a root **`.envrc`** so entering the repo can load the Nix flake through **nix-direnv** (pinned **3.1.0**) for faster repeated `nix develop` / `use flake` loads, and ignores **`.direnv/`** in git.
> 
> When **`.venv/bin/python`** exists (from `just install`), direnv also sets **`VIRTUAL_ENV`** and prepends **`.venv/bin`** to **`PATH`** so the uv-managed venv is active alongside the flake shell.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c22ad8dcd7965c69ccb1db0e924882e26421de89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->