### PR TITLE
Aleph elodin-db default asset path unset

### DIFF
--- a/aleph/modules/elodin-db.nix
+++ b/aleph/modules/elodin-db.nix
@@ -60,18 +60,20 @@ in {
     };
     assetsDir = lib.mkOption {
       type = lib.types.nullOr lib.types.str;
-      default = "/var/lib/elodin/assets";
+      default = null;
       description = ''
         Source assets/ tree ingested into each fresh database on creation
-        (passed to `elodin-db run --assets`). Defaults to the shared asset
-        root seeded by the elodin module, so every recorded database carries
-        its schematic assets and is a complete, portable record. Set to null
-        to disable ingest.
+        (passed to `elodin-db run --assets`). Defaults to null for DB-only
+        deployments; when services.elodin.examples is enabled, this defaults to
+        the shared asset root seeded by the elodin module. Set an explicit path
+        to ingest your own assets.
       '';
     };
   };
 
   config = lib.mkIf cfg.enable {
+    services.elodin-db.assetsDir = lib.mkIf elodinSeeds (lib.mkDefault "/var/lib/elodin/assets");
+
     systemd.services."elodin-db@" = {
       # Order after the asset seed (from the elodin module, when present) so a
       # fresh boot ingests a fully populated tree, not a partial one.

--- a/aleph/template/flake.nix
+++ b/aleph/template/flake.nix
@@ -82,13 +82,13 @@
       #   autostart = true;                 # Set to false to configure but not auto-start
       #   dbUniqueOnBoot = true;            # Create unique db folder on each boot
       #   openFirewall = true;              # Open TCP & UDP ports for external access
-      #   assetsDir = "/var/lib/elodin/assets"; # Assets ingested into each fresh db (null to disable)
+      #   assetsDir = null;                 # DB-only default; examples below set /var/lib/elodin/assets
       # };
 
       # Elodin simulation CLI, examples, and assets
       # services.elodin = {
       #   enable = true;                    # Install the elodin CLI (default: true)
-      #   examples = true;                  # Seed packaged examples + default assets (default: true)
+      #   examples = true;                  # Seed packaged examples + default assets, and feed them to elodin-db
       #   enableRenderer = true;            # Enable headless sensor-camera renderer support
       # };
       #
@@ -97,6 +97,9 @@
       # Packaged examples: /var/lib/elodin/examples
       # To deploy your own assets/sims declaratively, override
       #   services.elodin.assetsPackage / services.elodin.examplesPackage
+      # or, without packaged examples, point elodin-db at your own assets:
+      #   services.elodin.examples = false;
+      #   services.elodin-db.assetsDir = "/var/lib/my-sim/assets";
 
       # GPS module (optional, connected on J7)
       # Uncomment ONE line to enable GPS-disciplined timestamping:

--- a/libs/db/src/main.rs
+++ b/libs/db/src/main.rs
@@ -457,18 +457,25 @@ async fn main() -> miette::Result<()> {
                     .clone()
                     .or_else(|| elodin_db::assets::resolve_assets_root(None));
                 if let Some(source) = source {
-                    match elodin_db::assets::ingest_asset_dir(&path, &source) {
-                        Ok(report) if report.skipped => {
-                            info!(source = %source.display(), "assets already ingested; skipping")
-                        }
-                        Ok(report) => info!(
+                    if !source.is_dir() {
+                        tracing::warn!(
                             source = %source.display(),
-                            files = report.file_count,
-                            bytes = report.byte_count,
-                            "ingested assets into db"
-                        ),
-                        Err(err) => {
-                            tracing::warn!(?err, source = %source.display(), "failed to ingest assets")
+                            "asset source path does not exist; starting without asset ingest"
+                        );
+                    } else {
+                        match elodin_db::assets::ingest_asset_dir(&path, &source) {
+                            Ok(report) if report.skipped => {
+                                info!(source = %source.display(), "assets already ingested; skipping")
+                            }
+                            Ok(report) => info!(
+                                source = %source.display(),
+                                files = report.file_count,
+                                bytes = report.byte_count,
+                                "ingested assets into db"
+                            ),
+                            Err(err) => {
+                                tracing::warn!(?err, source = %source.display(), "failed to ingest assets")
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Fixes a problem where a downstream project deploys Aleph with the elodin-db, which sets the default asset folder, but doesn't actually populate the asset location, will crash the database. This change:
- unsets the default asset path
- allows the database to be tolerant of a missing folder, skipping asset load with a warning but otherwise continuing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to default Nix asset wiring and softer handling of missing asset directories at startup; no auth, data migration, or API contract changes.
> 
> **Overview**
> **Aleph/NixOS** changes `services.elodin-db.assetsDir` so the default is **`null`** (no `--assets` on `elodin-db run`) instead of always pointing at `/var/lib/elodin/assets`. When **`services.elodin.examples`** is enabled, the module still **`mkDefault`s** that shared path so seeded examples continue to feed the DB. Template **`flake.nix`** comments document DB-only vs examples-enabled setups and how to set a custom assets path.
> 
> **`elodin-db run`** now checks that the resolved asset source is an existing directory before calling ingest; if not, it logs a warning and **starts without asset ingest** rather than treating a missing path like a hard failure path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba86173f01c6bd4a1e53a71dc645653c2183de05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->