### PR TITLE
fix(editor): Stop line_3d flicker from f32 ECEF precision loss.

### DIFF
--- a/libs/elodin-editor/src/ui/inspector/viewport.rs
+++ b/libs/elodin-editor/src/ui/inspector/viewport.rs
@@ -463,21 +463,30 @@ fn eql_input(ui: &mut egui::Ui, editable_expr: &mut EditableEQL, ctx: &eql::Cont
 
 /// Time constant (seconds) of the follow-camera low-pass. Larger = smoother but
 /// laggier. Telemetry drives the follow pose only at the data rate (~5-10 Hz),
-/// so this must span a few data periods to actually reject the jitter; genuine
-/// fast motion is protected by the snap-to-target path, not by a small tau.
+/// so this must span a few data periods to actually reject the jitter. `pos` and
+/// `look_at` share the filter, so lag stays along-track and the vehicle remains
+/// framed; seeks jump straight via [`follow_should_snap`].
 const FOLLOW_SMOOTHING_TAU: f64 = 0.3;
+
+/// Minimum raw-target jump (metres) treated as a seek/teleport. Continuous
+/// mid-flight motion (Shane ~250 m/s → ~4 m/frame at 60 Hz) stays well below
+/// this; a timeline scrub of a second or more does not.
+const FOLLOW_SEEK_SNAP_MIN_METERS: f64 = 50.0;
 
 /// Per-viewport low-pass state for a following camera. Holds the previous
 /// frame's smoothed position and look-at target (viewport/sim coordinates) so
 /// telemetry noise in a `pos`/`look_at` EQL that tracks a moving entity does not
 /// shake the whole view during playback. Snaps to the raw target on the first
-/// frame and on jumps larger than the framing distance (seek / fast motion), so
-/// genuine motion is never lagged.
+/// frame and when the *raw* telemetry jumps farther than a seek threshold —
+/// not when the smoother merely lags during fast flight (that used to thrash
+/// against the framing distance and re-inject noise).
 #[derive(Component, Default)]
 pub struct ViewportFollowSmoothing {
     initialized: bool,
     pos: DVec3,
     look_at: DVec3,
+    prev_raw_pos: Option<DVec3>,
+    prev_raw_look: Option<DVec3>,
 }
 
 /// Framerate-independent exponential smoothing factor for time step `dt`.
@@ -486,6 +495,17 @@ fn follow_smoothing_alpha(dt: f64) -> f64 {
         return 1.0;
     }
     1.0 - (-dt / FOLLOW_SMOOTHING_TAU).exp()
+}
+
+/// Whether the follow pose should snap to the raw target instead of easing.
+///
+/// `raw_jump` is the max displacement of the raw `pos`/`look_at` since the
+/// previous frame (not the smoother's lag). Comparing lag to the framing
+/// distance (~3 m on Shane's ECEF cam) snapped every few frames at ~250 m/s and
+/// made the trail tremble; seek detection must use the raw step.
+fn follow_should_snap(initialized: bool, framing: f64, raw_jump: f64) -> bool {
+    let seek_thresh = (framing * 10.0).max(FOLLOW_SEEK_SNAP_MIN_METERS);
+    !initialized || !framing.is_finite() || raw_jump > seek_thresh
 }
 
 pub fn set_viewport_pos(
@@ -537,21 +557,22 @@ pub fn set_viewport_pos(
         // following cameras (look_at present) that carry a smoothing state: `pos`
         // and `look_at` share the same noise, so filtering both with one alpha
         // cancels it from the view direction. Snap on the first frame and on
-        // jumps larger than the framing distance (seek / fast flight) so genuine
-        // motion is never lagged. Without a look_at we keep the raw pose.
+        // raw teleports/seeks — not on smoother lag during fast flight (see
+        // [`follow_should_snap`]). Without a look_at we keep the raw pose.
         let (eff_pos, eff_look_at) =
             if let (Some(look_at), Some(sm)) = (look_at_target, smoothing.as_deref_mut()) {
                 let raw_look = look_at.pos();
-                let snap_dist = (raw_look - raw_pos).length();
+                let framing = (raw_look - raw_pos).length();
                 let alpha = follow_smoothing_alpha(time.delta_secs_f64());
-                // Snap if *either* endpoint jumps farther than the framing distance,
-                // so a seek is followed instantly even when only the look_at target
-                // moves (fixed-vantage camera) and the pos stays put.
-                let snap = !sm.initialized
-                    || !snap_dist.is_finite()
-                    || sm.pos.distance(raw_pos) > snap_dist
-                    || sm.look_at.distance(raw_look) > snap_dist;
-                if snap {
+                let raw_jump = match (sm.prev_raw_pos, sm.prev_raw_look) {
+                    (Some(prev_pos), Some(prev_look)) => {
+                        prev_pos.distance(raw_pos).max(prev_look.distance(raw_look))
+                    }
+                    _ => 0.0,
+                };
+                sm.prev_raw_pos = Some(raw_pos);
+                sm.prev_raw_look = Some(raw_look);
+                if follow_should_snap(sm.initialized, framing, raw_jump) {
                     sm.pos = raw_pos;
                     sm.look_at = raw_look;
                 } else {
@@ -704,6 +725,21 @@ mod tests {
         let one = 1.0 - follow_smoothing_alpha(dt);
         let two = (1.0 - follow_smoothing_alpha(dt / 2.0)).powi(2);
         assert!((one - two).abs() < 1e-12, "one={one} two={two}");
+    }
+
+    #[test]
+    fn follow_snap_ignores_fast_flight_lag_but_catches_seeks() {
+        // Shane ECEF cam framing ≈ 3.5 m; mid-flight ~4 m/frame must NOT snap
+        // (that thrash was the residual trajectory tremble).
+        let framing = 3.464;
+        assert!(follow_should_snap(false, framing, 0.0), "first frame");
+        assert!(!follow_should_snap(true, framing, 4.0), "60 Hz @ 250 m/s");
+        assert!(!follow_should_snap(true, framing, 25.0), "10 Hz @ 250 m/s");
+        assert!(
+            follow_should_snap(true, framing, 80.0),
+            "seek / long hitch"
+        );
+        assert!(follow_should_snap(true, f64::NAN, 0.0), "invalid framing");
     }
 
     #[test]

--- a/libs/elodin-editor/src/ui/inspector/viewport.rs
+++ b/libs/elodin-editor/src/ui/inspector/viewport.rs
@@ -735,10 +735,7 @@ mod tests {
         assert!(follow_should_snap(false, framing, 0.0), "first frame");
         assert!(!follow_should_snap(true, framing, 4.0), "60 Hz @ 250 m/s");
         assert!(!follow_should_snap(true, framing, 25.0), "10 Hz @ 250 m/s");
-        assert!(
-            follow_should_snap(true, framing, 80.0),
-            "seek / long hitch"
-        );
+        assert!(follow_should_snap(true, framing, 80.0), "seek / long hitch");
         assert!(follow_should_snap(true, f64::NAN, 0.0), "invalid framing");
     }
 

--- a/libs/elodin-editor/src/ui/inspector/viewport.rs
+++ b/libs/elodin-editor/src/ui/inspector/viewport.rs
@@ -461,55 +461,131 @@ fn eql_input(ui: &mut egui::Ui, editable_expr: &mut EditableEQL, ctx: &eql::Cont
     });
 }
 
+/// Time constant (seconds) of the follow-camera low-pass. Larger = smoother but
+/// laggier. Telemetry drives the follow pose only at the data rate (~5-10 Hz),
+/// so this must span a few data periods to actually reject the jitter; genuine
+/// fast motion is protected by the snap-to-target path, not by a small tau.
+const FOLLOW_SMOOTHING_TAU: f64 = 0.3;
+
+/// Per-viewport low-pass state for a following camera. Holds the previous
+/// frame's smoothed position and look-at target (viewport/sim coordinates) so
+/// telemetry noise in a `pos`/`look_at` EQL that tracks a moving entity does not
+/// shake the whole view during playback. Snaps to the raw target on the first
+/// frame and on jumps larger than the framing distance (seek / fast motion), so
+/// genuine motion is never lagged.
+#[derive(Component, Default)]
+pub struct ViewportFollowSmoothing {
+    initialized: bool,
+    pos: DVec3,
+    look_at: DVec3,
+}
+
+/// Framerate-independent exponential smoothing factor for time step `dt`.
+fn follow_smoothing_alpha(dt: f64) -> f64 {
+    if dt <= 0.0 {
+        return 1.0;
+    }
+    1.0 - (-dt / FOLLOW_SMOOTHING_TAU).exp()
+}
+
 pub fn set_viewport_pos(
-    mut viewports: Query<(&Viewport, &mut EditorCam)>,
+    mut viewports: Query<(
+        &Viewport,
+        &mut EditorCam,
+        Option<&mut ViewportFollowSmoothing>,
+    )>,
     mut pos: Query<&mut WorldPos>,
     entity_map: Res<EntityMap>,
     values: Query<&'static ComponentValue>,
     geo_context: Res<GeoContext>,
+    time: Res<Time>,
 ) {
-    for (viewport, mut editor_cam) in viewports.iter_mut() {
+    for (viewport, mut editor_cam, mut smoothing) in viewports.iter_mut() {
         let Ok(mut pos) = pos.get_mut(viewport.parent_entity) else {
             continue;
         };
-        if let Some(compiled_expr) = &viewport.pos.compiled_expr {
-            match compiled_expr.execute(&entity_map, &values) {
-                Ok(val) => {
-                    if let Some(world_pos) = val.as_world_pos() {
-                        *pos = world_pos;
-                    } else {
-                        bevy::log::warn!("viewport pos expression didn't produce a WorldPos");
-                    }
-                }
-                Err(e) => {
-                    bevy::log::error_once!("viewport pos formula execution error: {}", e);
-                }
-            }
-            if let Some(compiled_expr) = &viewport.look_at.compiled_expr
-                && let Ok(val) = compiled_expr.execute(&entity_map, &values)
-                && let Some(look_at) = val.as_world_pos()
-            {
-                let frame = viewport.frame.or_default().unwrap_or(GeoFrame::ENU);
-                // Everything stays in the viewport's frame: direction and up
-                // are frame coordinates, and `GeoRotation::look_at` yields the
-                // attitude expressed in that frame. `sync_pos` carries it into
-                // the entity's `GeoRotation` unchanged.
-                let dir = look_at.pos() - pos.pos();
-                let target_distance = dir.length();
-
-                if !is_valid_viewport_target_distance(target_distance) {
+        let Some(pos_expr) = &viewport.pos.compiled_expr else {
+            continue;
+        };
+        let target = match pos_expr.execute(&entity_map, &values) {
+            Ok(val) => match val.as_world_pos() {
+                Some(world_pos) => world_pos,
+                None => {
+                    bevy::log::warn!("viewport pos expression didn't produce a WorldPos");
                     continue;
                 }
-                refresh_default_anchor_depth(&mut editor_cam, target_distance);
-                let up = viewport
-                    .up
-                    .compiled_expr
-                    .as_ref()
-                    .and_then(|up_expr| up_expr.execute(&entity_map, &values).ok())
-                    .and_then(|v| extract_vec3(&v))
-                    .filter(|v| v.length_squared() > 1e-20);
-                pos.att = GeoRotation::look_at(frame, dir, up, &geo_context).1.into();
+            },
+            Err(e) => {
+                bevy::log::error_once!("viewport pos formula execution error: {}", e);
+                continue;
             }
+        };
+
+        // Optional look-at target: a following camera derives its framing from
+        // it. Without one the position EQL stands alone (e.g. a static camera).
+        let look_at_target = viewport
+            .look_at
+            .compiled_expr
+            .as_ref()
+            .and_then(|expr| expr.execute(&entity_map, &values).ok())
+            .and_then(|val| val.as_world_pos());
+
+        let raw_pos = target.pos();
+
+        // Temporally low-pass the follow pose so telemetry noise in the EQL does
+        // not shake the whole view (see #735 residual playback flicker). Only for
+        // following cameras (look_at present) that carry a smoothing state: `pos`
+        // and `look_at` share the same noise, so filtering both with one alpha
+        // cancels it from the view direction. Snap on the first frame and on
+        // jumps larger than the framing distance (seek / fast flight) so genuine
+        // motion is never lagged. Without a look_at we keep the raw pose.
+        let (eff_pos, eff_look_at) = if let (Some(look_at), Some(sm)) =
+            (look_at_target, smoothing.as_deref_mut())
+        {
+            let raw_look = look_at.pos();
+            let snap_dist = (raw_look - raw_pos).length();
+            let alpha = follow_smoothing_alpha(time.delta_secs_f64());
+            let snap =
+                !sm.initialized || !snap_dist.is_finite() || sm.pos.distance(raw_pos) > snap_dist;
+            if snap {
+                sm.pos = raw_pos;
+                sm.look_at = raw_look;
+            } else {
+                sm.pos = sm.pos.lerp(raw_pos, alpha);
+                sm.look_at = sm.look_at.lerp(raw_look, alpha);
+            }
+            sm.initialized = true;
+            (sm.pos, Some(sm.look_at))
+        } else {
+            (raw_pos, look_at_target.map(|l| l.pos()))
+        };
+
+        // Keep the pos EQL's attitude (used when there is no look_at) and replace
+        // the translation with the smoothed one.
+        *pos = target;
+        pos.pos = nox::Vector3::new(eff_pos.x, eff_pos.y, eff_pos.z);
+
+        if let Some(look_at_pos) = eff_look_at {
+            let frame = viewport.frame.or_default().unwrap_or(GeoFrame::ENU);
+            // Everything stays in the viewport's frame: direction and up are
+            // frame coordinates, and `GeoRotation::look_at` yields the attitude
+            // expressed in that frame. `sync_pos` carries it into the entity's
+            // `GeoRotation` unchanged.
+            let dir = look_at_pos - eff_pos;
+            let target_distance = dir.length();
+
+            if !is_valid_viewport_target_distance(target_distance) {
+                continue;
+            }
+            refresh_default_anchor_depth(&mut editor_cam, target_distance);
+            let up = viewport
+                .up
+                .compiled_expr
+                .as_ref()
+                .and_then(|up_expr| up_expr.execute(&entity_map, &values).ok())
+                .and_then(|v| extract_vec3(&v))
+                .filter(|v| v.length_squared() > 1e-20);
+            pos.att = GeoRotation::look_at(frame, dir, up, &geo_context).1.into();
         }
     }
 }
@@ -612,6 +688,21 @@ mod tests {
     }
 
     #[test]
+    fn follow_smoothing_alpha_is_bounded_and_framerate_consistent() {
+        // Non-positive dt (e.g. paused / first tick) snaps fully to the target.
+        assert_eq!(follow_smoothing_alpha(0.0), 1.0);
+        // A single big step approaches (but never exceeds) 1.
+        let big = follow_smoothing_alpha(10.0);
+        assert!(big > 0.99 && big < 1.0, "alpha={big}");
+        // Two half-steps must leave the same residual as one full step, so the
+        // filter behaves identically regardless of framerate.
+        let dt = 0.1;
+        let one = 1.0 - follow_smoothing_alpha(dt);
+        let two = (1.0 - follow_smoothing_alpha(dt / 2.0)).powi(2);
+        assert!((one - two).abs() < 1e-12, "one={one} two={two}");
+    }
+
+    #[test]
     fn refresh_default_anchor_depth_keeps_user_adjusted_depth() {
         let mut editor_cam = EditorCam {
             last_anchor_depth: -8.0,
@@ -666,6 +757,7 @@ mod tests {
             let mut app = bevy::app::App::new();
             app.insert_resource(GeoContext::default());
             app.init_resource::<super::EntityMap>();
+            app.init_resource::<bevy::time::Time>();
             crate::register_world_pos_components(&mut app);
             app.add_systems(
                 bevy::app::Update,

--- a/libs/elodin-editor/src/ui/inspector/viewport.rs
+++ b/libs/elodin-editor/src/ui/inspector/viewport.rs
@@ -539,26 +539,30 @@ pub fn set_viewport_pos(
         // cancels it from the view direction. Snap on the first frame and on
         // jumps larger than the framing distance (seek / fast flight) so genuine
         // motion is never lagged. Without a look_at we keep the raw pose.
-        let (eff_pos, eff_look_at) = if let (Some(look_at), Some(sm)) =
-            (look_at_target, smoothing.as_deref_mut())
-        {
-            let raw_look = look_at.pos();
-            let snap_dist = (raw_look - raw_pos).length();
-            let alpha = follow_smoothing_alpha(time.delta_secs_f64());
-            let snap =
-                !sm.initialized || !snap_dist.is_finite() || sm.pos.distance(raw_pos) > snap_dist;
-            if snap {
-                sm.pos = raw_pos;
-                sm.look_at = raw_look;
+        let (eff_pos, eff_look_at) =
+            if let (Some(look_at), Some(sm)) = (look_at_target, smoothing.as_deref_mut()) {
+                let raw_look = look_at.pos();
+                let snap_dist = (raw_look - raw_pos).length();
+                let alpha = follow_smoothing_alpha(time.delta_secs_f64());
+                // Snap if *either* endpoint jumps farther than the framing distance,
+                // so a seek is followed instantly even when only the look_at target
+                // moves (fixed-vantage camera) and the pos stays put.
+                let snap = !sm.initialized
+                    || !snap_dist.is_finite()
+                    || sm.pos.distance(raw_pos) > snap_dist
+                    || sm.look_at.distance(raw_look) > snap_dist;
+                if snap {
+                    sm.pos = raw_pos;
+                    sm.look_at = raw_look;
+                } else {
+                    sm.pos = sm.pos.lerp(raw_pos, alpha);
+                    sm.look_at = sm.look_at.lerp(raw_look, alpha);
+                }
+                sm.initialized = true;
+                (sm.pos, Some(sm.look_at))
             } else {
-                sm.pos = sm.pos.lerp(raw_pos, alpha);
-                sm.look_at = sm.look_at.lerp(raw_look, alpha);
-            }
-            sm.initialized = true;
-            (sm.pos, Some(sm.look_at))
-        } else {
-            (raw_pos, look_at_target.map(|l| l.pos()))
-        };
+                (raw_pos, look_at_target.map(|l| l.pos()))
+            };
 
         // Keep the pos EQL's attitude (used when there is no look_at) and replace
         // the translation with the smoothed one.

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -104,6 +104,13 @@ pub struct PlotDataComponent {
     pub label: String,
     pub element_names: Vec<String>,
     pub lines: BTreeMap<usize, Handle<Line>>,
+    /// Optional per-element `f64` offset subtracted from each incoming sample
+    /// **before** the `f32` cast, indexed by element. Used by `line_3d` for
+    /// large ECEF coordinates: the raw value (~6.4e6) loses ~0.5 m to `f32`
+    /// rounding, so we rebase against the frame origin here (in `f64`) to keep
+    /// millimetre precision in the stored vertices. `None` = no rebase (the
+    /// default for every 2D-graph component, so their values are untouched).
+    pub value_offset: Option<Vec<f64>>,
     request_states: HashMap<Timestamp, RequestState>,
     /// Whether the overview data has been requested for each line element
     overview_requested: HashMap<usize, bool>,
@@ -124,9 +131,21 @@ impl PlotDataComponent {
             label: component_label.to_string(),
             element_names,
             lines: BTreeMap::new(),
+            value_offset: None,
             request_states: HashMap::new(),
             overview_requested: HashMap::new(),
         }
+    }
+
+    /// `f64` offset subtracted from element `index` before the `f32` cast, or
+    /// `0.0` when no rebase is configured. See [`Self::value_offset`].
+    #[inline]
+    pub fn axis_offset(&self, index: usize) -> f64 {
+        self.value_offset
+            .as_ref()
+            .and_then(|o| o.get(index))
+            .copied()
+            .unwrap_or(0.0)
     }
 
     pub fn push_value(
@@ -144,7 +163,9 @@ impl PlotDataComponent {
             .map(|s| Some(s.as_str()))
             .chain(std::iter::repeat(None));
         for (i, (new_value, name)) in component_view.iter().zip(element_names).enumerate() {
-            let new_value = new_value.as_f32();
+            // Rebase against the frame origin in f64 before the f32 cast so
+            // large ECEF vertices keep mm precision (no-op when offset is None).
+            let new_value = (new_value.as_f64() - self.axis_offset(i)) as f32;
             let line = self.lines.entry(i).or_insert_with(|| {
                 let label = name.map(str::to_string).unwrap_or_else(|| format!("[{i}]"));
                 assets.add(Line {
@@ -439,6 +460,9 @@ fn process_time_series<T>(
         return;
     };
     for i in 0..len {
+        // Rebase in f64 before the f32 cast (no-op when offset is None); keeps
+        // large ECEF vertices from losing ~0.5 m to f32 rounding at storage.
+        let off = plot_data.axis_offset(i);
         let line = plot_data.lines.entry(i).or_insert_with(|| {
             let label = plot_data
                 .element_names
@@ -451,7 +475,11 @@ fn process_time_series<T>(
                 ..Default::default()
             })
         });
-        let values = data.iter().skip(i).step_by(len).map(|v| v.as_f32());
+        let values = data
+            .iter()
+            .skip(i)
+            .step_by(len)
+            .map(move |v| (v.as_f64() - off) as f32);
         let Some(line) = lines.get_mut(line) else {
             continue;
         };
@@ -894,6 +922,11 @@ fn handle_overview_response(
         return;
     };
 
+    // Keep overview points in the same rebased space as the full-resolution
+    // series (no-op when offset is None). Overview values are already f32 from
+    // the DB, so this only aligns placement, not precision.
+    let off = plot_data.axis_offset(element_index);
+
     // Get or create the line for this element
     let line = plot_data.lines.entry(element_index).or_insert_with(|| {
         let label = plot_data
@@ -918,7 +951,11 @@ fn handle_overview_response(
     };
 
     // Create a chunk with the overview data
-    if let Some(chunk) = Chunk::from_iter(timestamps, earliest_timestamp, values.iter().copied()) {
+    if let Some(chunk) = Chunk::from_iter(
+        timestamps,
+        earliest_timestamp,
+        values.iter().map(|v| (*v as f64 - off) as f32),
+    ) {
         line.data.insert(chunk);
     }
 }
@@ -1078,12 +1115,16 @@ impl XYLine {
 
 pub trait AsF32 {
     fn as_f32(&self) -> f32;
+    /// `f64` view of the sample, used to subtract a large frame origin in full
+    /// precision before the lossy `f32` cast (see [`PlotDataComponent::value_offset`]).
+    fn as_f64(&self) -> f64;
 }
 macro_rules! impl_as_f32 {
     ($($t:ty),*) => {
         $(
             impl AsF32 for $t {
                 fn as_f32(&self) -> f32 { *self as f32 }
+                fn as_f64(&self) -> f64 { *self as f64 }
             }
         )*
     }
@@ -1095,10 +1136,16 @@ impl AsF32 for f32 {
     fn as_f32(&self) -> f32 {
         *self
     }
+    fn as_f64(&self) -> f64 {
+        *self as f64
+    }
 }
 
 impl AsF32 for bool {
     fn as_f32(&self) -> f32 {
+        if *self { 1.0 } else { 0.0 }
+    }
+    fn as_f64(&self) -> f64 {
         if *self { 1.0 } else { 0.0 }
     }
 }

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -814,6 +814,11 @@ pub fn queue_timestamp_read(
     // This covers two use cases:
     // 1. Live telemetry: data span is small (< 10 minutes) -> direct chunked loading
     // 2. Historical datasets: data span is large (> 10 minutes) -> use LTTB overview first
+    //
+    // Framed `line_3d` components (`value_offset` set) always skip overview: the
+    // DB overview reply is already f32, so rebasing it cannot recover the mm
+    // precision that live / GetTimeSeries paths get via f64-before-cast. Mixing
+    // those coarse overview vertices with precise live points jumps/shimmers.
     const TEN_MINUTES_MICROS: i64 = 600_000_000; // 10 minutes in microseconds
     let range_duration = query_range.end.0.saturating_sub(query_range.start.0);
     let use_overview = range_duration > TEN_MINUTES_MICROS;
@@ -830,7 +835,7 @@ pub fn queue_timestamp_read(
             continue;
         }
 
-        if use_overview {
+        if use_overview && component.value_offset.is_none() {
             // Request overview for each element that hasn't been requested yet
             let num_elements = component.element_names.len().max(1);
 
@@ -1025,10 +1030,12 @@ fn handle_overview_response(
         .map(|s| s.to_string())
         .unwrap_or_else(|| format!("[{element_index}]"));
 
-    // Raw overview for 2D graphs.
+    // Overview is f32 from the DB — fine for 2D graphs. Never mirror into
+    // `rebased_lines`: those require f64-before-cast rebase (see queue path
+    // skipping overview when `value_offset` is set).
     let line = plot_data.lines.entry(element_index).or_insert_with(|| {
         lines.add(Line {
-            label: label.clone(),
+            label,
             ..Default::default()
         })
     });
@@ -1037,30 +1044,6 @@ fn handle_overview_response(
             Chunk::from_iter(timestamps, earliest_timestamp, values.iter().copied())
     {
         line.data.insert(chunk);
-    }
-
-    // Rebased overview mirror for line_3d. Overview values are already f32 from
-    // the DB, so this only aligns placement with the rebased full-res series.
-    if plot_data.value_offset.is_some() {
-        let off = plot_data.axis_offset(element_index);
-        let rebased = plot_data
-            .rebased_lines
-            .entry(element_index)
-            .or_insert_with(|| {
-                lines.add(Line {
-                    label,
-                    ..Default::default()
-                })
-            });
-        if let Some(rebased) = lines.get_mut(rebased)
-            && let Some(chunk) = Chunk::from_iter(
-                timestamps,
-                earliest_timestamp,
-                values.iter().map(|v| (*v as f64 - off) as f32),
-            )
-        {
-            rebased.data.insert(chunk);
-        }
     }
 }
 
@@ -2388,6 +2371,25 @@ mod tests {
             Timestamp(0),
         );
         assert!(plain.rebased_lines.is_empty());
+    }
+
+    /// Bugbot #736 "Overview degrades rebased trail": rebasing after an f32
+    /// cast (what PlotOverviewQuery sends) cannot recover ECEF millimetres.
+    /// Framed line_3d must ingest via f64-before-cast (GetTimeSeries / live).
+    #[test]
+    fn ecef_rebase_must_precede_f32_cast() {
+        let origin = 2_551_234.567_890_123_f64;
+        let raw = origin + 0.001;
+        let precise = (raw - origin) as f32;
+        let via_overview_wire = (raw as f32 as f64 - origin) as f32;
+        assert!(
+            (precise - 0.001).abs() < 1e-6,
+            "f64-before-cast keeps mm: {precise}"
+        );
+        assert!(
+            (precise - via_overview_wire).abs() > 1e-4,
+            "f32-then-rebase loses precision: precise={precise} overview={via_overview_wire}"
+        );
     }
 
     #[test]

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -2153,8 +2153,12 @@ mod tests {
 
         // Two samples, three elements, laid out sample-major: [s0xyz, s1xyz].
         let samples: Vec<f64> = vec![
-            1_000_010.5, 2_000_020.5, 3_000_030.5, // sample 0
-            1_000_011.5, 2_000_021.5, 3_000_031.5, // sample 1
+            1_000_010.5,
+            2_000_020.5,
+            3_000_030.5, // sample 0
+            1_000_011.5,
+            2_000_021.5,
+            3_000_031.5, // sample 1
         ];
         let timestamps = [Timestamp(10), Timestamp(20)];
         process_time_series::<f64>(

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -1940,9 +1940,9 @@ pub const LINE_3D_MIN_SEGMENT_METERS: f32 = 0.1;
 /// Write synchronized XYZ strip indices for a `line_3d`, dropping samples that
 /// stay within `min_dist` metres of the last kept vertex.
 ///
-/// Collapses the pre-launch / EKF-converge scribble (cm-scale wander in a ~1 m
-/// ball) while preserving flight geometry. The three trees must share
-/// timestamps (same component axes); mismatched samples are skipped.
+/// Walks the three trees in lockstep (same chunk / local index). If their
+/// layouts diverge, falls back to per-axis writes without dedupe so the trail
+/// is never truncated by a failed cross-axis timestamp lookup.
 pub fn write_joint_xyz_index_buffers_with_step(
     xyz: [&LineTree<f32>; 3],
     index_buffers: [&Buffer; 3],
@@ -1954,42 +1954,82 @@ pub fn write_joint_xyz_index_buffers_with_step(
     let step = step.max(1);
     let min_d2 = min_dist * min_dist;
 
+    let chunks_x: Vec<_> = xyz[0].range_iter(line_visible_range.clone()).collect();
+    let chunks_y: Vec<_> = xyz[1].range_iter(line_visible_range.clone()).collect();
+    let chunks_z: Vec<_> = xyz[2].range_iter(line_visible_range.clone()).collect();
+    if chunks_x.len() != chunks_y.len() || chunks_x.len() != chunks_z.len() || chunks_x.is_empty() {
+        return write_xyz_independent(xyz, index_buffers, render_queue, line_visible_range, step);
+    }
+
     let mut idx_x: Vec<u32> = Vec::new();
     let mut idx_y: Vec<u32> = Vec::new();
     let mut idx_z: Vec<u32> = Vec::new();
     let mut last_kept: Option<[f32; 3]> = None;
     let mut pending_tip: Option<[u32; 3]> = None;
 
-    let push_triple = |ix: &mut Vec<u32>, iy: &mut Vec<u32>, iz: &mut Vec<u32>, idx: [u32; 3]| {
-        if ix.len() >= INDEX_BUFFER_LEN {
+    let push_triple = |xs: &mut Vec<u32>, ys: &mut Vec<u32>, zs: &mut Vec<u32>, idx: [u32; 3]| {
+        if xs.len() >= INDEX_BUFFER_LEN {
             return false;
         }
-        ix.push(idx[0]);
-        iy.push(idx[1]);
-        iz.push(idx[2]);
+        xs.push(idx[0]);
+        ys.push(idx[1]);
+        zs.push(idx[2]);
         true
     };
 
-    'chunks: for chunk in xyz[0].range_iter(line_visible_range.clone()) {
+    for ((cx, cy), cz) in chunks_x.iter().zip(chunks_y.iter()).zip(chunks_z.iter()) {
+        if cx.summary.len != cy.summary.len || cx.summary.len != cz.summary.len {
+            return write_xyz_independent(
+                xyz,
+                index_buffers,
+                render_queue,
+                line_visible_range,
+                step,
+            );
+        }
         let Some((start_offset, end_offset)) =
-            chunk_visible_offsets(&chunk.timestamps, &line_visible_range)
+            chunk_visible_offsets(&cx.timestamps, &line_visible_range)
         else {
             continue;
         };
         if end_offset <= start_offset {
             continue;
         }
-        let base = {
-            let gpu = chunk.data.gpu.lock();
-            let Some(gpu) = gpu.as_ref() else {
-                continue;
-            };
-            gpu.as_index_chunk::<f32>(chunk.summary.len).range.start
+
+        let bases = {
+            let gx = cx.data.gpu.lock();
+            let gy = cy.data.gpu.lock();
+            let gz = cz.data.gpu.lock();
+            match (gx.as_ref(), gy.as_ref(), gz.as_ref()) {
+                (Some(gx), Some(gy), Some(gz)) => [
+                    gx.as_index_chunk::<f32>(cx.summary.len).range.start,
+                    gy.as_index_chunk::<f32>(cy.summary.len).range.start,
+                    gz.as_index_chunk::<f32>(cz.summary.len).range.start,
+                ],
+                _ => continue,
+            }
         };
-        let cpu = chunk.data.cpu();
+        let cpu_x = cx.data.cpu();
+        let cpu_y = cy.data.cpu();
+        let cpu_z = cz.data.cpu();
+        if cpu_x.len() < end_offset || cpu_y.len() < end_offset || cpu_z.len() < end_offset {
+            return write_xyz_independent(
+                xyz,
+                index_buffers,
+                render_queue,
+                line_visible_range,
+                step,
+            );
+        }
 
         if !push_triple(&mut idx_x, &mut idx_y, &mut idx_z, [0, 0, 0]) {
-            break 'chunks;
+            return write_xyz_independent(
+                xyz,
+                index_buffers,
+                render_queue,
+                line_visible_range,
+                step,
+            );
         }
 
         let last_local = end_offset - 1;
@@ -2007,17 +2047,12 @@ pub fn write_joint_xyz_index_buffers_with_step(
         }
 
         for local in locals {
-            let t = chunk.timestamps[local];
-            let x = cpu[local];
-            let gx = base.saturating_add(local as u32);
-            let Some((y, gy)) = xyz[1].gpu_sample_at_exact(t) else {
-                continue;
-            };
-            let Some((z, gz)) = xyz[2].gpu_sample_at_exact(t) else {
-                continue;
-            };
-            let p = [x, y, z];
-            let idx = [gx, gy, gz];
+            let p = [cpu_x[local], cpu_y[local], cpu_z[local]];
+            let idx = [
+                bases[0].saturating_add(local as u32),
+                bases[1].saturating_add(local as u32),
+                bases[2].saturating_add(local as u32),
+            ];
             pending_tip = Some(idx);
             let keep = match last_kept {
                 None => true,
@@ -2030,7 +2065,16 @@ pub fn write_joint_xyz_index_buffers_with_step(
             };
             if keep {
                 if !push_triple(&mut idx_x, &mut idx_y, &mut idx_z, idx) {
-                    break 'chunks;
+                    // Buffer full: rather than truncate the trail to the pad
+                    // scribble, fall back to undecimated independent writes
+                    // (already stride-fitted to INDEX_BUFFER_LEN).
+                    return write_xyz_independent(
+                        xyz,
+                        index_buffers,
+                        render_queue,
+                        line_visible_range,
+                        step,
+                    );
                 }
                 last_kept = Some(p);
                 pending_tip = None;
@@ -2038,7 +2082,13 @@ pub fn write_joint_xyz_index_buffers_with_step(
         }
 
         if !push_triple(&mut idx_x, &mut idx_y, &mut idx_z, [0, 0, 0]) {
-            break 'chunks;
+            return write_xyz_independent(
+                xyz,
+                index_buffers,
+                render_queue,
+                line_visible_range,
+                step,
+            );
         }
     }
 
@@ -2060,6 +2110,24 @@ pub fn write_joint_xyz_index_buffers_with_step(
         render_queue.write_buffer(buf, 0, bytes);
     }
     written
+}
+
+fn write_xyz_independent(
+    xyz: [&LineTree<f32>; 3],
+    index_buffers: [&Buffer; 3],
+    render_queue: &RenderQueue,
+    line_visible_range: Range<Timestamp>,
+    step: usize,
+) -> u32 {
+    let counts = [0, 1, 2].map(|i| {
+        xyz[i].write_to_index_buffer_with_step(
+            index_buffers[i],
+            render_queue,
+            line_visible_range.clone(),
+            step,
+        )
+    });
+    counts.into_iter().min().unwrap_or_default()
 }
 
 fn release_line_chunk_gpu(
@@ -2085,17 +2153,6 @@ fn release_line_chunk_gpu(
 }
 
 impl LineTree<f32> {
-    /// GPU index + CPU value for an exact timestamp, when the chunk is GPU-resident.
-    fn gpu_sample_at_exact(&self, timestamp: Timestamp) -> Option<(f32, u32)> {
-        let (_, chunk) = self.tree.overlapping(ii(timestamp.0, timestamp.0)).next()?;
-        let index = chunk.timestamps.binary_search(&timestamp).ok()?;
-        let value = *chunk.data.cpu().get(index)?;
-        let gpu = chunk.data.gpu.lock();
-        let gpu = gpu.as_ref()?;
-        let base = gpu.as_index_chunk::<f32>(chunk.summary.len).range.start;
-        Some((value, base.saturating_add(index as u32)))
-    }
-
     pub fn flattened_time_series(&self) -> (Vec<Timestamp>, Vec<f32>) {
         let mut ts = Vec::new();
         let mut vs = Vec::new();

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -103,13 +103,19 @@ impl Default for CurveCompressSettings {
 pub struct PlotDataComponent {
     pub label: String,
     pub element_names: Vec<String>,
+    /// Raw telemetry, one line per element, in the component's native units.
+    /// 2D graphs read these, so the values stay exactly as received.
     pub lines: BTreeMap<usize, Handle<Line>>,
-    /// Optional per-element `f64` offset subtracted from each incoming sample
-    /// **before** the `f32` cast, indexed by element. Used by `line_3d` for
-    /// large ECEF coordinates: the raw value (~6.4e6) loses ~0.5 m to `f32`
-    /// rounding, so we rebase against the frame origin here (in `f64`) to keep
-    /// millimetre precision in the stored vertices. `None` = no rebase (the
-    /// default for every 2D-graph component, so their values are untouched).
+    /// Origin-rebased mirror of [`Self::lines`], populated only when
+    /// [`Self::value_offset`] is set (i.e. for a framed `line_3d`). Each sample
+    /// is `raw - offset[element]` computed in `f64` before the `f32` cast, so
+    /// large ECEF vertices keep millimetre precision instead of snapping to the
+    /// ~0.5 m `f32` grid. `line_3d` renders from these; graphs never touch them,
+    /// so raw telemetry is never shown rebased.
+    pub rebased_lines: BTreeMap<usize, Handle<Line>>,
+    /// Optional per-element `f64` offset used to build [`Self::rebased_lines`].
+    /// `None` (the default, and every 2D-graph component) means no rebased
+    /// mirror is kept and rendering falls back to the raw lines.
     pub value_offset: Option<Vec<f64>>,
     request_states: HashMap<Timestamp, RequestState>,
     /// Whether the overview data has been requested for each line element
@@ -131,6 +137,7 @@ impl PlotDataComponent {
             label: component_label.to_string(),
             element_names,
             lines: BTreeMap::new(),
+            rebased_lines: BTreeMap::new(),
             value_offset: None,
             request_states: HashMap::new(),
             overview_requested: HashMap::new(),
@@ -148,6 +155,18 @@ impl PlotDataComponent {
             .unwrap_or(0.0)
     }
 
+    /// Handle a `line_3d` should render for `index`: the rebased mirror when a
+    /// rebase is configured (mm precision at ECEF scale), else the raw line.
+    /// Returns `None` while the chosen line has not been created yet.
+    #[inline]
+    pub fn render_line(&self, index: usize) -> Option<&Handle<Line>> {
+        if self.value_offset.is_some() {
+            self.rebased_lines.get(&index)
+        } else {
+            self.lines.get(&index)
+        }
+    }
+
     pub fn push_value(
         &mut self,
         component_view: ComponentView<'_>,
@@ -163,9 +182,7 @@ impl PlotDataComponent {
             .map(|s| Some(s.as_str()))
             .chain(std::iter::repeat(None));
         for (i, (new_value, name)) in component_view.iter().zip(element_names).enumerate() {
-            // Rebase against the frame origin in f64 before the f32 cast so
-            // large ECEF vertices keep mm precision (no-op when offset is None).
-            let new_value = (new_value.as_f64() - self.axis_offset(i)) as f32;
+            let raw = new_value.as_f32();
             let line = self.lines.entry(i).or_insert_with(|| {
                 let label = name.map(str::to_string).unwrap_or_else(|| format!("[{i}]"));
                 assets.add(Line {
@@ -178,28 +195,66 @@ impl PlotDataComponent {
             // line.  The FixedRate stream sends a snapshot at the current
             // playback position each frame; skipping timestamps already covered
             // prevents corrupting historical data loaded by GetTimeSeries.
-            let mut accepted = false;
-            if let Some(last) = line.data.last() {
-                if timestamp <= last.summary.end_timestamp {
-                    continue;
-                }
-                if last.timestamps.len() < CHUNK_LEN {
-                    line.data.update_last(|c| {
-                        c.push(timestamp, earliest_timestamp, new_value);
-                    });
-                    accepted = true;
-                }
+            if let Some(last) = line.data.last()
+                && timestamp <= last.summary.end_timestamp
+            {
+                continue;
             }
-            if !accepted {
-                let new_chunk = Chunk::from_initial_value(timestamp, earliest_timestamp, new_value);
-                line.data.insert(new_chunk);
+            push_sample(line, timestamp, earliest_timestamp, raw, archive_enabled);
+
+            // Mirror the same sample, rebased in f64 before the f32 cast, into
+            // the rebased line line_3d renders from (kept only when configured).
+            if self.value_offset.is_some() {
+                let rebased = (new_value.as_f64() - self.axis_offset(i)) as f32;
+                let rebased_handle = self.rebased_lines.entry(i).or_insert_with(|| {
+                    let label = name.map(str::to_string).unwrap_or_else(|| format!("[{i}]"));
+                    assets.add(Line {
+                        label,
+                        ..Default::default()
+                    })
+                });
+                let rebased_line = assets
+                    .get_mut(rebased_handle.id())
+                    .expect("missing rebased line asset");
+                push_sample(
+                    rebased_line,
+                    timestamp,
+                    earliest_timestamp,
+                    rebased,
+                    archive_enabled,
+                );
             }
-            // Archive mirrors exactly the sequence accepted by the view. Monotonicity of raw is
-            // enforced by `push_raw` itself, so re-ingestion of historical timestamps (already
-            // rejected above) is doubly safe.
-            line.data.push_raw(archive_enabled, timestamp, new_value);
         }
     }
+}
+
+/// Append one already-cast `value` to a line's view (extending the last chunk
+/// or starting a new one) and to its raw archive. The caller is responsible for
+/// the monotonic-timestamp gate; `push_raw` enforces archive monotonicity too.
+fn push_sample(
+    line: &mut Line,
+    timestamp: Timestamp,
+    earliest_timestamp: Timestamp,
+    value: f32,
+    archive_enabled: bool,
+) {
+    let mut accepted = false;
+    if let Some(last) = line.data.last()
+        && last.timestamps.len() < CHUNK_LEN
+    {
+        line.data.update_last(|c| {
+            c.push(timestamp, earliest_timestamp, value);
+        });
+        accepted = true;
+    }
+    if !accepted {
+        line.data.insert(Chunk::from_initial_value(
+            timestamp,
+            earliest_timestamp,
+            value,
+        ));
+    }
+    line.data.push_raw(archive_enabled, timestamp, value);
 }
 
 #[derive(Resource, Clone, Default)]
@@ -284,16 +339,16 @@ pub fn maybe_compress_all_graph_lines(
         return;
     }
     for component in graph_data.components.values_mut() {
-        let handles: Vec<Handle<Line>> = component.lines.values().cloned().collect();
-        if handles.len() == 3 && try_joint_triline_compress(lines, &handles, earliest, settings) {
-            continue;
-        }
-        for line_handle in &handles {
-            let Some(line) = lines.get_mut(line_handle) else {
-                continue;
-            };
-            line.maybe_compress_live(earliest, settings);
-        }
+        // Compress the raw lines (2D graphs) and their rebased mirror (line_3d)
+        // identically, so both stay within GPU buffer limits and, for 3-vector
+        // components, keep coherent joint (triline) decimation.
+        compress_line_set(lines, component.lines.values().cloned(), earliest, settings);
+        compress_line_set(
+            lines,
+            component.rebased_lines.values().cloned(),
+            earliest,
+            settings,
+        );
     }
     if settings.archive_enabled {
         // Safety net: flag outsized archives so multi-hour aerospace runs don't silently blow up
@@ -314,6 +369,26 @@ pub fn maybe_compress_all_graph_lines(
                 }
             }
         }
+    }
+}
+
+/// Compress one set of lines: joint (triline) decimation when there are exactly
+/// three (keeps 3D curvature coherent), else per-line live compression.
+fn compress_line_set(
+    lines: &mut Assets<Line>,
+    handles: impl IntoIterator<Item = Handle<Line>>,
+    earliest: Timestamp,
+    settings: &CurveCompressSettings,
+) {
+    let handles: Vec<Handle<Line>> = handles.into_iter().collect();
+    if handles.len() == 3 && try_joint_triline_compress(lines, &handles, earliest, settings) {
+        return;
+    }
+    for line_handle in &handles {
+        let Some(line) = lines.get_mut(line_handle) else {
+            continue;
+        };
+        line.maybe_compress_live(earliest, settings);
     }
 }
 
@@ -459,34 +534,50 @@ fn process_time_series<T>(
     let Ok(data) = <[T]>::try_ref_from_bytes(time_series_buf) else {
         return;
     };
+    let rebase = plot_data.value_offset.is_some();
     for i in 0..len {
-        // Rebase in f64 before the f32 cast (no-op when offset is None); keeps
-        // large ECEF vertices from losing ~0.5 m to f32 rounding at storage.
-        let off = plot_data.axis_offset(i);
+        let label = plot_data
+            .element_names
+            .get(i)
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| format!("[{i}]"));
+
+        // Raw line for 2D graphs: values exactly as received.
         let line = plot_data.lines.entry(i).or_insert_with(|| {
-            let label = plot_data
-                .element_names
-                .get(i)
-                .filter(|s| !s.is_empty())
-                .map(|s| s.to_string())
-                .unwrap_or_else(|| format!("[{i}]"));
             lines.add(Line {
-                label,
+                label: label.clone(),
                 ..Default::default()
             })
         });
-        let values = data
-            .iter()
-            .skip(i)
-            .step_by(len)
-            .map(move |v| (v.as_f64() - off) as f32);
-        let Some(line) = lines.get_mut(line) else {
-            continue;
-        };
-        let Some(chunk) = Chunk::from_iter(timestamps, earliest_timestamp, values) else {
-            continue;
-        };
-        line.data.insert(chunk);
+        if let Some(line) = lines.get_mut(line) {
+            let values = data.iter().skip(i).step_by(len).map(|v| v.as_f32());
+            if let Some(chunk) = Chunk::from_iter(timestamps, earliest_timestamp, values) {
+                line.data.insert(chunk);
+            }
+        }
+
+        // Rebased mirror for line_3d: subtract the frame origin in f64 before
+        // the f32 cast so large ECEF vertices keep mm precision.
+        if rebase {
+            let off = plot_data.axis_offset(i);
+            let rebased = plot_data.rebased_lines.entry(i).or_insert_with(|| {
+                lines.add(Line {
+                    label,
+                    ..Default::default()
+                })
+            });
+            if let Some(rebased) = lines.get_mut(rebased) {
+                let values = data
+                    .iter()
+                    .skip(i)
+                    .step_by(len)
+                    .map(move |v| (v.as_f64() - off) as f32);
+                if let Some(chunk) = Chunk::from_iter(timestamps, earliest_timestamp, values) {
+                    rebased.data.insert(chunk);
+                }
+            }
+        }
     }
 }
 
@@ -922,41 +1013,54 @@ fn handle_overview_response(
         return;
     };
 
-    // Keep overview points in the same rebased space as the full-resolution
-    // series (no-op when offset is None). Overview values are already f32 from
-    // the DB, so this only aligns placement, not precision.
-    let off = plot_data.axis_offset(element_index);
-
-    // Get or create the line for this element
-    let line = plot_data.lines.entry(element_index).or_insert_with(|| {
-        let label = plot_data
-            .element_names
-            .get(element_index)
-            .filter(|s| !s.is_empty())
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| format!("[{element_index}]"));
-        lines.add(Line {
-            label,
-            ..Default::default()
-        })
-    });
-
-    let Some(line) = lines.get_mut(line) else {
-        return;
-    };
-
     // The response contains f32 values
     let Ok(values) = <[f32]>::try_ref_from_bytes(buf) else {
         return;
     };
 
-    // Create a chunk with the overview data
-    if let Some(chunk) = Chunk::from_iter(
-        timestamps,
-        earliest_timestamp,
-        values.iter().map(|v| (*v as f64 - off) as f32),
-    ) {
+    let label = plot_data
+        .element_names
+        .get(element_index)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| format!("[{element_index}]"));
+
+    // Raw overview for 2D graphs.
+    let line = plot_data.lines.entry(element_index).or_insert_with(|| {
+        lines.add(Line {
+            label: label.clone(),
+            ..Default::default()
+        })
+    });
+    if let Some(line) = lines.get_mut(line)
+        && let Some(chunk) =
+            Chunk::from_iter(timestamps, earliest_timestamp, values.iter().copied())
+    {
         line.data.insert(chunk);
+    }
+
+    // Rebased overview mirror for line_3d. Overview values are already f32 from
+    // the DB, so this only aligns placement with the rebased full-res series.
+    if plot_data.value_offset.is_some() {
+        let off = plot_data.axis_offset(element_index);
+        let rebased = plot_data
+            .rebased_lines
+            .entry(element_index)
+            .or_insert_with(|| {
+                lines.add(Line {
+                    label,
+                    ..Default::default()
+                })
+            });
+        if let Some(rebased) = lines.get_mut(rebased)
+            && let Some(chunk) = Chunk::from_iter(
+                timestamps,
+                earliest_timestamp,
+                values.iter().map(|v| (*v as f64 - off) as f32),
+            )
+        {
+            rebased.data.insert(chunk);
+        }
     }
 }
 
@@ -2037,6 +2141,54 @@ mod tests {
         assert_eq!(next_timestamp(Timestamp(41)), Timestamp(42));
     }
 
+    /// A rebased component (line_3d) must keep raw telemetry untouched in
+    /// `lines` (what 2D graphs read) while `rebased_lines` holds the f64-rebased
+    /// mirror. This is the Bugbot #736 "2D graphs show rebased values" guard.
+    #[test]
+    fn rebase_leaves_raw_lines_untouched() {
+        let mut lines = Assets::<Line>::default();
+        let mut component =
+            PlotDataComponent::new("POS_ECEF", vec!["X".into(), "Y".into(), "Z".into()]);
+        component.value_offset = Some(vec![1_000_000.0, 2_000_000.0, 3_000_000.0]);
+
+        // Two samples, three elements, laid out sample-major: [s0xyz, s1xyz].
+        let samples: Vec<f64> = vec![
+            1_000_010.5, 2_000_020.5, 3_000_030.5, // sample 0
+            1_000_011.5, 2_000_021.5, 3_000_031.5, // sample 1
+        ];
+        let timestamps = [Timestamp(10), Timestamp(20)];
+        process_time_series::<f64>(
+            samples.as_bytes(),
+            &timestamps,
+            3,
+            &mut component,
+            &mut lines,
+            Timestamp(0),
+        );
+
+        // Raw line X keeps the native ECEF values (for 2D graphs).
+        let raw_x = lines.get(&component.lines[&0]).unwrap();
+        let (_, raw_vals) = raw_x.data.flattened_time_series();
+        assert_eq!(raw_vals, vec![1_000_010.5, 1_000_011.5]);
+
+        // Rebased line X subtracts the frame origin in f64: small, precise.
+        let reb_x = lines.get(&component.rebased_lines[&0]).unwrap();
+        let (_, reb_vals) = reb_x.data.flattened_time_series();
+        assert_eq!(reb_vals, vec![10.5, 11.5]);
+
+        // A component without an offset keeps no rebased mirror at all.
+        let mut plain = PlotDataComponent::new("V", vec!["X".into()]);
+        process_time_series::<f64>(
+            [7.0f64, 8.0].as_bytes(),
+            &timestamps,
+            1,
+            &mut plain,
+            &mut lines,
+            Timestamp(0),
+        );
+        assert!(plain.rebased_lines.is_empty());
+    }
+
     #[test]
     fn next_timestamp_saturates_at_i64_max() {
         assert_eq!(next_timestamp(Timestamp(i64::MAX)), Timestamp(i64::MAX));
@@ -2380,7 +2532,11 @@ pub fn collect_garbage(
         return;
     }
     for component in graph_data.components.values() {
-        for line in component.lines.values() {
+        for line in component
+            .lines
+            .values()
+            .chain(component.rebased_lines.values())
+        {
             let Some(line) = lines.get_mut(line) else {
                 continue;
             };

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -1933,6 +1933,135 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
     }
 }
 
+/// Minimum world-space spacing (metres) between consecutive `line_3d` vertices.
+/// Collapses the pre-launch / EKF-converge scribble under a close follow camera.
+pub const LINE_3D_MIN_SEGMENT_METERS: f32 = 0.1;
+
+/// Write synchronized XYZ strip indices for a `line_3d`, dropping samples that
+/// stay within `min_dist` metres of the last kept vertex.
+///
+/// Collapses the pre-launch / EKF-converge scribble (cm-scale wander in a ~1 m
+/// ball) while preserving flight geometry. The three trees must share
+/// timestamps (same component axes); mismatched samples are skipped.
+pub fn write_joint_xyz_index_buffers_with_step(
+    xyz: [&LineTree<f32>; 3],
+    index_buffers: [&Buffer; 3],
+    render_queue: &RenderQueue,
+    line_visible_range: Range<Timestamp>,
+    step: usize,
+    min_dist: f32,
+) -> u32 {
+    let step = step.max(1);
+    let min_d2 = min_dist * min_dist;
+
+    let mut idx_x: Vec<u32> = Vec::new();
+    let mut idx_y: Vec<u32> = Vec::new();
+    let mut idx_z: Vec<u32> = Vec::new();
+    let mut last_kept: Option<[f32; 3]> = None;
+    let mut pending_tip: Option<[u32; 3]> = None;
+
+    let push_triple = |ix: &mut Vec<u32>, iy: &mut Vec<u32>, iz: &mut Vec<u32>, idx: [u32; 3]| {
+        if ix.len() >= INDEX_BUFFER_LEN {
+            return false;
+        }
+        ix.push(idx[0]);
+        iy.push(idx[1]);
+        iz.push(idx[2]);
+        true
+    };
+
+    'chunks: for chunk in xyz[0].range_iter(line_visible_range.clone()) {
+        let Some((start_offset, end_offset)) =
+            chunk_visible_offsets(&chunk.timestamps, &line_visible_range)
+        else {
+            continue;
+        };
+        if end_offset <= start_offset {
+            continue;
+        }
+        let base = {
+            let gpu = chunk.data.gpu.lock();
+            let Some(gpu) = gpu.as_ref() else {
+                continue;
+            };
+            gpu.as_index_chunk::<f32>(chunk.summary.len).range.start
+        };
+        let cpu = chunk.data.cpu();
+
+        if !push_triple(&mut idx_x, &mut idx_y, &mut idx_z, [0, 0, 0]) {
+            break 'chunks;
+        }
+
+        let last_local = end_offset - 1;
+        let mut locals = Vec::with_capacity(
+            2 + end_offset.saturating_sub(start_offset).saturating_sub(1) / step,
+        );
+        locals.push(start_offset);
+        let mut local = start_offset.saturating_add(step);
+        while local < end_offset {
+            locals.push(local);
+            local = local.saturating_add(step);
+        }
+        if *locals.last().unwrap_or(&start_offset) != last_local {
+            locals.push(last_local);
+        }
+
+        for local in locals {
+            let t = chunk.timestamps[local];
+            let x = cpu[local];
+            let gx = base.saturating_add(local as u32);
+            let Some((y, gy)) = xyz[1].gpu_sample_at_exact(t) else {
+                continue;
+            };
+            let Some((z, gz)) = xyz[2].gpu_sample_at_exact(t) else {
+                continue;
+            };
+            let p = [x, y, z];
+            let idx = [gx, gy, gz];
+            pending_tip = Some(idx);
+            let keep = match last_kept {
+                None => true,
+                Some(prev) => {
+                    let dx = p[0] - prev[0];
+                    let dy = p[1] - prev[1];
+                    let dz = p[2] - prev[2];
+                    dx * dx + dy * dy + dz * dz >= min_d2
+                }
+            };
+            if keep {
+                if !push_triple(&mut idx_x, &mut idx_y, &mut idx_z, idx) {
+                    break 'chunks;
+                }
+                last_kept = Some(p);
+                pending_tip = None;
+            }
+        }
+
+        if !push_triple(&mut idx_x, &mut idx_y, &mut idx_z, [0, 0, 0]) {
+            break 'chunks;
+        }
+    }
+
+    if let Some(idx) = pending_tip
+        && push_triple(&mut idx_x, &mut idx_y, &mut idx_z, [0, 0, 0])
+        && push_triple(&mut idx_x, &mut idx_y, &mut idx_z, idx)
+        && push_triple(&mut idx_x, &mut idx_y, &mut idx_z, idx)
+    {
+        let _ = push_triple(&mut idx_x, &mut idx_y, &mut idx_z, [0, 0, 0]);
+    }
+
+    let written = idx_x.len().min(INDEX_BUFFER_LEN) as u32;
+    for (buf, indices) in [
+        (index_buffers[0], &idx_x),
+        (index_buffers[1], &idx_y),
+        (index_buffers[2], &idx_z),
+    ] {
+        let bytes = indices[..written as usize].as_bytes();
+        render_queue.write_buffer(buf, 0, bytes);
+    }
+    written
+}
+
 fn release_line_chunk_gpu(
     chunk: &mut Chunk<f32>,
     data_alloc: &mut Option<BufferShardAlloc>,
@@ -1956,6 +2085,17 @@ fn release_line_chunk_gpu(
 }
 
 impl LineTree<f32> {
+    /// GPU index + CPU value for an exact timestamp, when the chunk is GPU-resident.
+    fn gpu_sample_at_exact(&self, timestamp: Timestamp) -> Option<(f32, u32)> {
+        let (_, chunk) = self.tree.overlapping(ii(timestamp.0, timestamp.0)).next()?;
+        let index = chunk.timestamps.binary_search(&timestamp).ok()?;
+        let value = *chunk.data.cpu().get(index)?;
+        let gpu = chunk.data.gpu.lock();
+        let gpu = gpu.as_ref()?;
+        let base = gpu.as_index_chunk::<f32>(chunk.summary.len).range.start;
+        Some((value, base.saturating_add(index as u32)))
+    }
+
     pub fn flattened_time_series(&self) -> (Vec<Timestamp>, Vec<f32>) {
         let mut ts = Vec::new();
         let mut vs = Vec::new();

--- a/libs/elodin-editor/src/ui/plot_3d/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/gpu.rs
@@ -225,16 +225,11 @@ pub struct LineUniform {
     pub color: Vec4,
     pub depth_bias: f32,
     pub model: Mat4,
-    /// Reference point (in the line's raw frame coordinates, e.g. ECEF) that the
-    /// shader subtracts from every vertex before the f32 `model` multiply.
-    ///
-    /// At ECEF magnitudes (~6.4e6 m) both the vertex and the model translation
-    /// are large and opposite, so `model * point` loses ~1 m of precision to
-    /// catastrophic cancellation; a sub-meter per-frame wobble of the floating
-    /// origin then flips low bits and the trail flickers even while paused.
-    /// Subtracting this reference keeps the shader operands small. It must match
-    /// the entity's `GeoPosition` reference so the model still supplies the
-    /// (reference -> floating origin) offset, computed by big_space in f64.
+    /// Reference point (raw frame coords) the shader subtracts from every vertex
+    /// before the f32 `model` multiply. Kept at zero now that the rebase happens
+    /// in f64 at ingestion (`PlotDataComponent::value_offset`), which also
+    /// recovers the ~0.5 m the vertices used to lose to the `f32` cast at ECEF
+    /// magnitudes. Retained (subtracting zero) so the uniform layout is stable.
     /// `w` is unused. See [`LineFrameOrigin`].
     pub world_origin: Vec4,
     pub perspective: u32,
@@ -257,17 +252,18 @@ impl LineUniform {
     }
 }
 
-/// Per-`line_3d` reference point, in the line's frame coordinates, subtracted
-/// from the raw vertices before the f32 `model` transform (see
-/// [`LineUniform::world_origin`]).
+/// Per-`line_3d` reference point, in the line's frame coordinates, used to
+/// rebase the raw vertices in f64 at ingestion (`PlotDataComponent::value_offset`)
+/// so ECEF trails keep mm precision instead of the ~0.5 m lost to the `f32` cast.
 ///
 /// Set at spawn from the schematic's `GeoContext` origin so it equals the
 /// entity's `GeoPosition` reference: for an ECEF line this is the geo origin in
 /// ECEF (~6.4e6 m), for ENU/NED it is zero (those vertices are already
 /// launch-relative). Mirroring the `GeoPosition` reference is what keeps the
-/// rendered coordinates small without shifting the line.
+/// rendered coordinates small without shifting the line. Kept as `f64` so the
+/// rebase offset itself is exact.
 #[derive(Component, Debug, Clone, Copy, Default)]
-pub struct LineFrameOrigin(pub bevy::math::Vec3);
+pub struct LineFrameOrigin(pub bevy::math::DVec3);
 
 #[derive(Resource)]
 struct LineValuesLayout {
@@ -906,16 +902,21 @@ mod tests {
     /// drifts a few cm per frame (as it does when the camera settles even while
     /// playback is paused). It asserts the *temporal variation* of the render
     /// error — i.e. the visible flicker — collapses once the operands are small.
+    /// The trail's paused shimmer was the ~0.5 m the ECEF vertices lose when a
+    /// ~6.4e6 m `f64` position is cast straight to `f32` at ingestion: adjacent
+    /// samples snap to the same 0.5 m grid, so the polyline is permanently
+    /// jagged and shimmers under any camera motion. Rebasing against the frame
+    /// origin **in f64 before the cast** (what `value_offset` now does) stores
+    /// small launch-relative values that keep millimetre precision.
     #[test]
-    fn ecef_world_origin_rebase_removes_paused_flicker() {
-        use bevy::math::{DQuat, DVec3, Mat4};
-        use bevy_geo_frames::{GeoContext, GeoFrame, GeoOrigin, GeoPosition, GeoRotation};
+    fn ecef_ingest_rebase_preserves_precision() {
+        use bevy::math::{DVec3, Vec3};
+        use bevy_geo_frames::{GeoContext, GeoFrame, GeoOrigin, GeoPosition};
 
         // Mojave launch site, matching shane/line_3d.shane.kdl.
         let ctx: GeoContext = GeoOrigin::new_from_degrees(35.3506640, -117.80902, 589.2740).into();
 
-        // ECEF reference the shader subtracts (and the entity's GeoPosition):
-        // the geo origin expressed in ECEF (~6.4e6 m).
+        // ECEF reference used as the per-element rebase offset (~6.4e6 m).
         let reference = GeoPosition::from_bevy(GeoFrame::ECEF, DVec3::ZERO, &ctx).1;
         assert!(
             reference.length() > 6.0e6,
@@ -923,61 +924,44 @@ mod tests {
             reference.length()
         );
 
-        // Entity rotation (ECEF -> Bevy basis) and absolute Bevy positions.
-        let rot = GeoRotation::absolute(GeoFrame::ECEF, DQuat::IDENTITY).to_bevy(&ctx);
-        let rot_f32 = rot.as_quat();
-        let entity_abs_old = GeoPosition(GeoFrame::ECEF, DVec3::ZERO).to_bevy(&ctx); // ~ -R*ref
-        let entity_abs_new = GeoPosition(GeoFrame::ECEF, reference).to_bevy(&ctx); // ~ 0
+        // Walk a few hundred trail samples out from the launch site and track
+        // the worst-case error of each stored vertex against the f64 truth.
+        let mut old_err = 0.0f32;
+        let mut new_err = 0.0f32;
+        for k in 0..400i32 {
+            let d = k as f64 * 7.31; // irregular metre-scale spacing along the trail
+            let vertex = reference + DVec3::new(d, -0.5 * d, 0.25 * d);
+            // Ground truth (full f64 subtraction, then cast).
+            let truth = (vertex - reference).as_vec3();
+
+            // OLD: cast each f64 element straight to f32, then subtract (what the
+            // shader used to do) — both operands are quantised to the ~0.5 m f32
+            // grid at ECEF scale, so the difference carries that grid noise.
+            let old_stored = vertex.as_vec3() - reference.as_vec3();
+            // NEW: subtract the reference in f64, then cast — small values, so
+            // the f32 grid is millimetric.
+            let new_stored = Vec3::new(
+                (vertex.x - reference.x) as f32,
+                (vertex.y - reference.y) as f32,
+                (vertex.z - reference.z) as f32,
+            );
+
+            old_err = old_err.max((old_stored - truth).length());
+            new_err = new_err.max((new_stored - truth).length());
+        }
+
+        // The straight cast loses decimetres; the f64 rebase is sub-millimetre.
         assert!(
-            entity_abs_new.length() < 1.0,
-            "rebased entity should sit at the launch site (~0), got {}",
-            entity_abs_new.length()
-        );
-
-        // A vehicle vertex a couple of km from the launch site (still ECEF-scale
-        // in absolute terms — this is exactly what is stored for the trail).
-        let vertex_ecef = reference + DVec3::new(2100.0, -1300.0, 900.0);
-        let vehicle_bevy = GeoPosition(GeoFrame::ECEF, vertex_ecef).to_bevy(&ctx);
-
-        // f32 vertex data as uploaded to the value buffer.
-        let raw_f32 = vertex_ecef.as_vec3();
-        let origin_f32 = reference.as_vec3();
-
-        // Emulate the floating origin drifting ~3 cm/frame near the vehicle,
-        // plus a sub-mm asymptotic settle (camera damping never fully stops).
-        let spread = |entity_abs: DVec3, point: bevy::math::Vec3| -> f32 {
-            let mut min_err = f32::INFINITY;
-            let mut max_err = f32::NEG_INFINITY;
-            for i in 0..240i32 {
-                let t = i as f64;
-                let fo = vehicle_bevy
-                    + DVec3::new(0.03 * t, -0.02 * t, 0.015 * t)
-                    + DVec3::new(0.4 * (t * 0.3).sin(), 0.0, 0.0) * 0.001;
-                // model = entity GlobalTransform relative to the floating origin.
-                let model = Mat4::from_rotation_translation(rot_f32, (entity_abs - fo).as_vec3());
-                let rendered = model.transform_point3(point); // f32, like the shader
-                let truth = (vehicle_bevy - fo).as_vec3(); // f64 -> f32, no cancellation
-                let err = (rendered - truth).length();
-                min_err = min_err.min(err);
-                max_err = max_err.max(err);
-            }
-            max_err - min_err
-        };
-
-        // OLD: raw ECEF vertex, entity at ~ -R*ref -> model.translation ~ -6.4e6.
-        let old_spread = spread(entity_abs_old, raw_f32);
-        // NEW: vertex rebased by world_origin, entity at ~0 -> operands small.
-        let new_spread = spread(entity_abs_new, raw_f32 - origin_f32);
-
-        // The old path jitters on the order of decimetres frame-to-frame (the
-        // visible flicker); the rebase must cut that by orders of magnitude.
-        assert!(
-            old_spread > 0.1,
-            "expected the un-rebased ECEF path to flicker (>0.1 m), got {old_spread}"
+            old_err > 0.05,
+            "expected the straight f32 cast to lose >5 cm, got {old_err}"
         );
         assert!(
-            new_spread < old_spread / 50.0,
-            "rebase should remove the flicker: old={old_spread} new={new_spread}"
+            new_err < 1.0e-3,
+            "f64 rebase should keep mm precision, got {new_err}"
+        );
+        assert!(
+            new_err < old_err / 50.0,
+            "f64 rebase should be orders of magnitude tighter: old={old_err} new={new_err}"
         );
     }
 }

--- a/libs/elodin-editor/src/ui/plot_3d/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/gpu.rs
@@ -161,6 +161,7 @@ fn update_uniform_model(mut query: Query<(&mut LineUniform, &GlobalTransform)>) 
         uniform.model = transform.to_matrix();
     }
 }
+
 #[derive(Component, Debug, Clone, ExtractComponent)]
 #[require(SyncToRenderWorld)]
 pub struct LineHandles(pub [Handle<Line>; 3]);
@@ -224,6 +225,18 @@ pub struct LineUniform {
     pub color: Vec4,
     pub depth_bias: f32,
     pub model: Mat4,
+    /// Reference point (in the line's raw frame coordinates, e.g. ECEF) that the
+    /// shader subtracts from every vertex before the f32 `model` multiply.
+    ///
+    /// At ECEF magnitudes (~6.4e6 m) both the vertex and the model translation
+    /// are large and opposite, so `model * point` loses ~1 m of precision to
+    /// catastrophic cancellation; a sub-meter per-frame wobble of the floating
+    /// origin then flips low bits and the trail flickers even while paused.
+    /// Subtracting this reference keeps the shader operands small. It must match
+    /// the entity's `GeoPosition` reference so the model still supplies the
+    /// (reference -> floating origin) offset, computed by big_space in f64.
+    /// `w` is unused. See [`LineFrameOrigin`].
+    pub world_origin: Vec4,
     pub perspective: u32,
     #[cfg(target_arch = "wasm32")]
     pub _padding: f32,
@@ -236,12 +249,25 @@ impl LineUniform {
             color: Vec4::from_array(color.to_linear().to_f32_array()),
             depth_bias: 0.0,
             model: Mat4::IDENTITY,
+            world_origin: Vec4::ZERO,
             perspective: 0,
             #[cfg(target_arch = "wasm32")]
             _padding: Default::default(),
         }
     }
 }
+
+/// Per-`line_3d` reference point, in the line's frame coordinates, subtracted
+/// from the raw vertices before the f32 `model` transform (see
+/// [`LineUniform::world_origin`]).
+///
+/// Set at spawn from the schematic's `GeoContext` origin so it equals the
+/// entity's `GeoPosition` reference: for an ECEF line this is the geo origin in
+/// ECEF (~6.4e6 m), for ENU/NED it is zero (those vertices are already
+/// launch-relative). Mirroring the `GeoPosition` reference is what keeps the
+/// rendered coordinates small without shifting the line.
+#[derive(Component, Debug, Clone, Copy, Default)]
+pub struct LineFrameOrigin(pub bevy::math::Vec3);
 
 #[derive(Resource)]
 struct LineValuesLayout {
@@ -871,5 +897,87 @@ mod tests {
             future: Some(half),
         });
         assert_eq!(future, half);
+    }
+
+    /// Reproduces issue #735 numerically: the line_3d vertex pipeline is
+    /// `clip = clip_from_world · model · point`. The `model · point` product is
+    /// evaluated in f32. This emulates that product for an ECEF vertex, before
+    /// and after the `world_origin` rebase, while the big_space floating origin
+    /// drifts a few cm per frame (as it does when the camera settles even while
+    /// playback is paused). It asserts the *temporal variation* of the render
+    /// error — i.e. the visible flicker — collapses once the operands are small.
+    #[test]
+    fn ecef_world_origin_rebase_removes_paused_flicker() {
+        use bevy::math::{DQuat, DVec3, Mat4};
+        use bevy_geo_frames::{GeoContext, GeoFrame, GeoOrigin, GeoPosition, GeoRotation};
+
+        // Mojave launch site, matching shane/line_3d.shane.kdl.
+        let ctx: GeoContext = GeoOrigin::new_from_degrees(35.3506640, -117.80902, 589.2740).into();
+
+        // ECEF reference the shader subtracts (and the entity's GeoPosition):
+        // the geo origin expressed in ECEF (~6.4e6 m).
+        let reference = GeoPosition::from_bevy(GeoFrame::ECEF, DVec3::ZERO, &ctx).1;
+        assert!(
+            reference.length() > 6.0e6,
+            "ECEF reference should be Earth-radius scale, got {}",
+            reference.length()
+        );
+
+        // Entity rotation (ECEF -> Bevy basis) and absolute Bevy positions.
+        let rot = GeoRotation::absolute(GeoFrame::ECEF, DQuat::IDENTITY).to_bevy(&ctx);
+        let rot_f32 = rot.as_quat();
+        let entity_abs_old = GeoPosition(GeoFrame::ECEF, DVec3::ZERO).to_bevy(&ctx); // ~ -R*ref
+        let entity_abs_new = GeoPosition(GeoFrame::ECEF, reference).to_bevy(&ctx); // ~ 0
+        assert!(
+            entity_abs_new.length() < 1.0,
+            "rebased entity should sit at the launch site (~0), got {}",
+            entity_abs_new.length()
+        );
+
+        // A vehicle vertex a couple of km from the launch site (still ECEF-scale
+        // in absolute terms — this is exactly what is stored for the trail).
+        let vertex_ecef = reference + DVec3::new(2100.0, -1300.0, 900.0);
+        let vehicle_bevy = GeoPosition(GeoFrame::ECEF, vertex_ecef).to_bevy(&ctx);
+
+        // f32 vertex data as uploaded to the value buffer.
+        let raw_f32 = vertex_ecef.as_vec3();
+        let origin_f32 = reference.as_vec3();
+
+        // Emulate the floating origin drifting ~3 cm/frame near the vehicle,
+        // plus a sub-mm asymptotic settle (camera damping never fully stops).
+        let spread = |entity_abs: DVec3, point: bevy::math::Vec3| -> f32 {
+            let mut min_err = f32::INFINITY;
+            let mut max_err = f32::NEG_INFINITY;
+            for i in 0..240i32 {
+                let t = i as f64;
+                let fo = vehicle_bevy
+                    + DVec3::new(0.03 * t, -0.02 * t, 0.015 * t)
+                    + DVec3::new(0.4 * (t * 0.3).sin(), 0.0, 0.0) * 0.001;
+                // model = entity GlobalTransform relative to the floating origin.
+                let model = Mat4::from_rotation_translation(rot_f32, (entity_abs - fo).as_vec3());
+                let rendered = model.transform_point3(point); // f32, like the shader
+                let truth = (vehicle_bevy - fo).as_vec3(); // f64 -> f32, no cancellation
+                let err = (rendered - truth).length();
+                min_err = min_err.min(err);
+                max_err = max_err.max(err);
+            }
+            max_err - min_err
+        };
+
+        // OLD: raw ECEF vertex, entity at ~ -R*ref -> model.translation ~ -6.4e6.
+        let old_spread = spread(entity_abs_old, raw_f32);
+        // NEW: vertex rebased by world_origin, entity at ~0 -> operands small.
+        let new_spread = spread(entity_abs_new, raw_f32 - origin_f32);
+
+        // The old path jitters on the order of decimetres frame-to-frame (the
+        // visible flicker); the rebase must cut that by orders of magnitude.
+        assert!(
+            old_spread > 0.1,
+            "expected the un-rebased ECEF path to flicker (>0.1 m), got {old_spread}"
+        );
+        assert!(
+            new_spread < old_spread / 50.0,
+            "rebase should remove the flicker: old={old_spread} new={new_spread}"
+        );
     }
 }

--- a/libs/elodin-editor/src/ui/plot_3d/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/gpu.rs
@@ -672,17 +672,21 @@ fn extract_lines(
                 });
                 let index_bind_group =
                     render_device.create_bind_group("line indexes", &index_layout.layout, &entries);
-                let counts = [0, 1, 2].map(|i| {
+                // Joint XYZ write with a world-space min spacing so the
+                // pre-launch / EKF-converge scribble collapses under a close
+                // follow camera, instead of three independent strides.
+                let xyz = [0, 1, 2].map(|i| {
                     let line = &line_handles.0[i];
-                    let line = line_assets.get(line).expect("line missing");
-                    line.data.write_to_index_buffer_with_step(
-                        &index_buffers[i],
-                        &render_queue,
-                        range.clone(),
-                        step,
-                    )
+                    &line_assets.get(line).expect("line missing").data
                 });
-                let count = counts.into_iter().min().unwrap_or_default();
+                let count = crate::ui::plot::data::write_joint_xyz_index_buffers_with_step(
+                    xyz,
+                    [&index_buffers[0], &index_buffers[1], &index_buffers[2]],
+                    &render_queue,
+                    range.clone(),
+                    step,
+                    crate::ui::plot::data::LINE_3D_MIN_SEGMENT_METERS,
+                );
                 if count < 2 {
                     return None;
                 }

--- a/libs/elodin-editor/src/ui/plot_3d/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/gpu.rs
@@ -225,12 +225,12 @@ pub struct LineUniform {
     pub color: Vec4,
     pub depth_bias: f32,
     pub model: Mat4,
-    /// Reference point (raw frame coords) the shader subtracts from every vertex
-    /// before the f32 `model` multiply. Kept at zero now that the rebase happens
-    /// in f64 at ingestion (`PlotDataComponent::value_offset`), which also
-    /// recovers the ~0.5 m the vertices used to lose to the `f32` cast at ECEF
-    /// magnitudes. Retained (subtracting zero) so the uniform layout is stable.
-    /// `w` is unused. See [`LineFrameOrigin`].
+    /// Residual reference (raw frame coords) the shader subtracts from every
+    /// vertex before the f32 `model` multiply. Zero for axes rebased in f64 at
+    /// ingestion (`PlotDataComponent::value_offset`, the precise path); the
+    /// frame origin for axes whose component pre-existed with raw values (e.g.
+    /// first collected by a 2D graph), so they still render in place, at
+    /// pre-rebase precision. `w` is unused. See [`LineFrameOrigin`].
     pub world_origin: Vec4,
     pub perspective: u32,
     #[cfg(target_arch = "wasm32")]
@@ -895,19 +895,13 @@ mod tests {
         assert_eq!(future, half);
     }
 
-    /// Reproduces issue #735 numerically: the line_3d vertex pipeline is
-    /// `clip = clip_from_world · model · point`. The `model · point` product is
-    /// evaluated in f32. This emulates that product for an ECEF vertex, before
-    /// and after the `world_origin` rebase, while the big_space floating origin
-    /// drifts a few cm per frame (as it does when the camera settles even while
-    /// playback is paused). It asserts the *temporal variation* of the render
-    /// error — i.e. the visible flicker — collapses once the operands are small.
-    /// The trail's paused shimmer was the ~0.5 m the ECEF vertices lose when a
-    /// ~6.4e6 m `f64` position is cast straight to `f32` at ingestion: adjacent
-    /// samples snap to the same 0.5 m grid, so the polyline is permanently
-    /// jagged and shimmers under any camera motion. Rebasing against the frame
-    /// origin **in f64 before the cast** (what `value_offset` now does) stores
-    /// small launch-relative values that keep millimetre precision.
+    /// Reproduces issue #735 numerically. The trail's paused shimmer was the
+    /// ~0.5 m each ECEF vertex loses when its ~6.4e6 m `f64` position is cast
+    /// straight to `f32` at ingestion: adjacent samples snap to the same 0.5 m
+    /// grid, so the polyline is permanently jagged and shimmers under any
+    /// camera motion. Rebasing against the frame origin **in f64 before the
+    /// cast** (what `PlotDataComponent::value_offset` now does) stores small
+    /// launch-relative values that keep millimetre precision.
     #[test]
     fn ecef_ingest_rebase_preserves_precision() {
         use bevy::math::{DVec3, Vec3};

--- a/libs/elodin-editor/src/ui/plot_3d/line.wgsl
+++ b/libs/elodin-editor/src/ui/plot_3d/line.wgsl
@@ -80,11 +80,20 @@ fn vertex(vertex: Vertex) -> VertexOutput {
     let screen0 = resolution * (0.5 * clip0.xy / clip0.w + 0.5);
     let screen1 = resolution * (0.5 * clip1.xy / clip1.w + 0.5);
 
-    let x_basis = normalize(screen1 - screen0);
+    // Stationary / near-duplicate samples (e.g. pre-launch ECEF pad) project to
+    // sub-pixel segments. `normalize(0)` is undefined and the expanded quad
+    // flickers as a scribble; collapse those instances instead.
+    let screen_delta = screen1 - screen0;
+    let screen_len = length(screen_delta);
+    let x_basis = select(vec2(1.0, 0.0), screen_delta / screen_len, screen_len >= 0.5);
     let y_basis = vec2(-x_basis.y, x_basis.x);
 
     var line_width = line_uniform.line_width;
     var color = line_uniform.color;
+    if (screen_len < 0.5) {
+        line_width = 0.0;
+        color.a = 0.0;
+    }
 
     if (line_uniform.perspective == 1) {
         line_width /= clip.w;

--- a/libs/elodin-editor/src/ui/plot_3d/line.wgsl
+++ b/libs/elodin-editor/src/ui/plot_3d/line.wgsl
@@ -83,17 +83,22 @@ fn vertex(vertex: Vertex) -> VertexOutput {
     // Stationary / near-duplicate samples (e.g. pre-launch ECEF pad) project to
     // sub-pixel segments. `normalize(0)` is undefined and the expanded quad
     // flickers as a scribble; collapse those instances instead.
+    //
+    // Use a soft fade band rather than a hard pixel cutoff: a binary
+    // `screen_len < 0.5` gate shimmered when follow-camera jitter pushed the
+    // same segment above/below the threshold each frame. `smoothstep` keeps
+    // near-threshold segments partially visible so small moves don't flip
+    // width/alpha on and off.
     let screen_delta = screen1 - screen0;
     let screen_len = length(screen_delta);
-    let x_basis = select(vec2(1.0, 0.0), screen_delta / screen_len, screen_len >= 0.5);
+    let x_basis = select(vec2(1.0, 0.0), screen_delta / max(screen_len, 1e-4), screen_len >= 1e-4);
     let y_basis = vec2(-x_basis.y, x_basis.x);
 
-    var line_width = line_uniform.line_width;
+    // Invisible below ~0.25 px, fully opaque by ~1.0 px.
+    let visibility = smoothstep(0.25, 1.0, screen_len);
+    var line_width = line_uniform.line_width * visibility;
     var color = line_uniform.color;
-    if (screen_len < 0.5) {
-        line_width = 0.0;
-        color.a = 0.0;
-    }
+    color.a *= visibility;
 
     if (line_uniform.perspective == 1) {
         line_width /= clip.w;

--- a/libs/elodin-editor/src/ui/plot_3d/line.wgsl
+++ b/libs/elodin-editor/src/ui/plot_3d/line.wgsl
@@ -9,6 +9,9 @@ struct LineUniform {
     color: vec4<f32>,
     depth_bias: f32,
     model: mat4x4<f32>,
+    // Reference point (raw frame coords) subtracted from each vertex before the
+    // model transform to avoid f32 cancellation at ECEF magnitudes. `w` unused.
+    world_origin: vec4<f32>,
     perspective: u32,
 #ifdef SIXTEEN_BYTE_ALIGNMENT
     // WebGL2 structs must be 16 byte aligned.
@@ -56,9 +59,12 @@ fn vertex(vertex: Vertex) -> VertexOutput {
     let index_x_b = index_x_buffer[vertex.instance_index + 1];
     let index_y_b = index_y_buffer[vertex.instance_index + 1];
     let index_z_b = index_z_buffer[vertex.instance_index + 1];
-    // Let's not assume ENU here.
-    let point_a = vec3(x_values[index_x_a], y_values[index_y_a], z_values[index_z_a]);
-    let point_b = vec3(x_values[index_x_b], y_values[index_y_b], z_values[index_z_b]);
+    // Let's not assume ENU here. Rebase onto `world_origin` (in the same raw
+    // frame coords as the vertices) so the f32 `model` multiply operates on
+    // small values instead of subtracting two ~6.4e6 ECEF magnitudes.
+    let origin = line_uniform.world_origin.xyz;
+    let point_a = vec3(x_values[index_x_a], y_values[index_y_a], z_values[index_z_a]) - origin;
+    let point_b = vec3(x_values[index_x_b], y_values[index_y_b], z_values[index_z_b]) - origin;
 
     // algorithm based on https://wwwtyro.net/2019/11/18/instanced-lines.html
     var clip0 = view.clip_from_world * line_uniform.model * vec4(point_a, 1.0);

--- a/libs/elodin-editor/src/ui/plot_3d/mod.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/mod.rs
@@ -85,7 +85,7 @@ pub fn sync_line_plot_3d(
                 .components
                 .entry(c.id)
                 .or_insert_with(|| {
-                    PlotDataComponent::new(
+                    let mut component = PlotDataComponent::new(
                         metadata.name.clone(),
                         metadata
                             .element_names()
@@ -93,7 +93,16 @@ pub fn sync_line_plot_3d(
                             .filter(|s| !s.is_empty())
                             .map(str::to_string)
                             .collect(),
-                    )
+                    );
+                    // Rebase this line's vertices against the frame origin in
+                    // f64 at ingestion so large ECEF coordinates keep mm
+                    // precision (see LineFrameOrigin). Set only at creation, so
+                    // a component already collected for a 2D graph is untouched.
+                    if let Some(frame_origin) = frame_origin {
+                        let r = frame_origin.0;
+                        component.value_offset = Some(vec![r.x, r.y, r.z]);
+                    }
+                    component
                 });
             handles[i] = data.lines.get(index).cloned();
         }
@@ -110,7 +119,9 @@ pub fn sync_line_plot_3d(
                     color: trail.played.unwrap_or(Vec4::ZERO),
                     depth_bias: 0.0,
                     model: Mat4::IDENTITY,
-                    world_origin: frame_origin.map(|o| o.0.extend(0.0)).unwrap_or(Vec4::ZERO),
+                    // Vertices are already rebased at ingestion (value_offset),
+                    // so the shader must not subtract the origin again.
+                    world_origin: Vec4::ZERO,
                     perspective: if line_plot.perspective { 1 } else { 0 },
                     #[cfg(target_arch = "wasm32")]
                     _padding: Default::default(),

--- a/libs/elodin-editor/src/ui/plot_3d/mod.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/mod.rs
@@ -87,7 +87,6 @@ pub fn sync_line_plot_3d(
             };
             // Frame-origin coordinate for this axis (x/y/z of the reference).
             let r_i = frame_origin.map(|o| o.0[i]).unwrap_or(0.0);
-            let created = !collected_graph_data.components.contains_key(&c.id);
             let data = collected_graph_data
                 .components
                 .entry(c.id)
@@ -104,12 +103,15 @@ pub fn sync_line_plot_3d(
                 });
             // Rebase this axis's samples against the frame origin in f64 at
             // ingestion so large ECEF coordinates keep mm precision (see
-            // LineFrameOrigin). Element-indexed so an axis served by its own
-            // scalar component still subtracts its own coordinate. Set only at
-            // creation: a component already collected (e.g. by a 2D graph)
-            // keeps raw values, and the shader subtracts the residual instead
-            // (correct placement, pre-rebase precision).
-            if created && r_i != 0.0 {
+            // LineFrameOrigin). Element-indexed, so both a shared 3-vector
+            // component (X/Y/Z at indices 0/1/2) and per-axis scalar components
+            // subtract the right coordinate. Guarded on "no samples yet" rather
+            // than "just created", so every axis of a shared component is set,
+            // and a component that already holds data (e.g. collected by a 2D
+            // graph) is never mutated mid-stream: it keeps raw values and the
+            // shader subtracts the residual instead (correct placement, at the
+            // pre-rebase precision).
+            if r_i != 0.0 && data.lines.is_empty() {
                 let offsets = data.value_offset.get_or_insert_with(Vec::new);
                 if offsets.len() <= *index {
                     offsets.resize(index + 1, 0.0);

--- a/libs/elodin-editor/src/ui/plot_3d/mod.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/mod.rs
@@ -42,7 +42,10 @@ fn line_trail_colors(line_plot: &Line3d) -> gpu::LineTrailColors {
 }
 
 pub fn sync_line_plot_3d(
-    line_plot_3d_query: Query<(Entity, &Line3d), Without<gpu::LineHandles>>,
+    line_plot_3d_query: Query<
+        (Entity, &Line3d, Option<&gpu::LineFrameOrigin>),
+        Without<gpu::LineHandles>,
+    >,
     mut uniforms: Query<
         (
             Entity,
@@ -57,7 +60,7 @@ pub fn sync_line_plot_3d(
     mut collected_graph_data: ResMut<CollectedGraphData>,
     metadata_store: Res<ComponentMetadataRegistry>,
 ) {
-    for (entity, line_plot) in line_plot_3d_query.iter() {
+    for (entity, line_plot, frame_origin) in line_plot_3d_query.iter() {
         // Parse and compile the EQL expression
         let parsed = match eql_ctx.0.parse_str(&line_plot.eql) {
             Ok(expr) => expr,
@@ -107,6 +110,7 @@ pub fn sync_line_plot_3d(
                     color: trail.played.unwrap_or(Vec4::ZERO),
                     depth_bias: 0.0,
                     model: Mat4::IDENTITY,
+                    world_origin: frame_origin.map(|o| o.0.extend(0.0)).unwrap_or(Vec4::ZERO),
                     perspective: if line_plot.perspective { 1 } else { 0 },
                     #[cfg(target_arch = "wasm32")]
                     _padding: Default::default(),

--- a/libs/elodin-editor/src/ui/plot_3d/mod.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/mod.rs
@@ -101,16 +101,16 @@ pub fn sync_line_plot_3d(
                             .collect(),
                     )
                 });
-            // Rebase this axis's samples against the frame origin in f64 at
-            // ingestion so large ECEF coordinates keep mm precision (see
-            // LineFrameOrigin). Element-indexed, so both a shared 3-vector
-            // component (X/Y/Z at indices 0/1/2) and per-axis scalar components
-            // subtract the right coordinate. Guarded on "no samples yet" rather
-            // than "just created", so every axis of a shared component is set,
-            // and a component that already holds data (e.g. collected by a 2D
-            // graph) is never mutated mid-stream: it keeps raw values and the
-            // shader subtracts the residual instead (correct placement, at the
-            // pre-rebase precision).
+            // Configure the f64 rebase for this axis: ingestion then keeps a
+            // rebased mirror (PlotDataComponent::rebased_lines) that line_3d
+            // renders from, while the raw lines (2D graphs) stay untouched.
+            // Element-indexed, so both a shared 3-vector component (X/Y/Z at
+            // indices 0/1/2) and per-axis scalar components subtract the right
+            // coordinate. Only set before any samples arrive, so the mirror
+            // covers the whole series; a component that already holds data
+            // (e.g. a 2D graph fetched it first) keeps no mirror and line_3d
+            // falls back to the raw lines with the shader world_origin residual
+            // (correct placement, at the pre-rebase precision).
             if r_i != 0.0 && data.lines.is_empty() {
                 let offsets = data.value_offset.get_or_insert_with(Vec::new);
                 if offsets.len() <= *index {
@@ -119,7 +119,7 @@ pub fn sync_line_plot_3d(
                 offsets[*index] = r_i;
             }
             world_origin[i] = (r_i - data.axis_offset(*index)) as f32;
-            handles[i] = data.lines.get(index).cloned();
+            handles[i] = data.render_line(*index).cloned();
         }
         let [Some(x), Some(y), Some(z)] = handles else {
             continue;

--- a/libs/elodin-editor/src/ui/plot_3d/mod.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/mod.rs
@@ -77,15 +77,22 @@ pub fn sync_line_plot_3d(
         let graph_components = parsed.to_graph_components();
         let skip = if graph_components.len() == 7 { 4 } else { 0 };
         let mut handles: [Option<Handle<Line>>; 3] = [None, None, None];
+        // Residual origin the shader must still subtract, per axis. Zero when
+        // the axis data is rebased at ingestion; the full frame origin when the
+        // component pre-existed without a rebase (see below).
+        let mut world_origin = Vec4::ZERO;
         for (i, (c, index)) in graph_components.iter().skip(skip).take(3).enumerate() {
             let Some(metadata) = metadata_store.get_metadata(&c.id) else {
                 continue;
             };
+            // Frame-origin coordinate for this axis (x/y/z of the reference).
+            let r_i = frame_origin.map(|o| o.0[i]).unwrap_or(0.0);
+            let created = !collected_graph_data.components.contains_key(&c.id);
             let data = collected_graph_data
                 .components
                 .entry(c.id)
                 .or_insert_with(|| {
-                    let mut component = PlotDataComponent::new(
+                    PlotDataComponent::new(
                         metadata.name.clone(),
                         metadata
                             .element_names()
@@ -93,17 +100,23 @@ pub fn sync_line_plot_3d(
                             .filter(|s| !s.is_empty())
                             .map(str::to_string)
                             .collect(),
-                    );
-                    // Rebase this line's vertices against the frame origin in
-                    // f64 at ingestion so large ECEF coordinates keep mm
-                    // precision (see LineFrameOrigin). Set only at creation, so
-                    // a component already collected for a 2D graph is untouched.
-                    if let Some(frame_origin) = frame_origin {
-                        let r = frame_origin.0;
-                        component.value_offset = Some(vec![r.x, r.y, r.z]);
-                    }
-                    component
+                    )
                 });
+            // Rebase this axis's samples against the frame origin in f64 at
+            // ingestion so large ECEF coordinates keep mm precision (see
+            // LineFrameOrigin). Element-indexed so an axis served by its own
+            // scalar component still subtracts its own coordinate. Set only at
+            // creation: a component already collected (e.g. by a 2D graph)
+            // keeps raw values, and the shader subtracts the residual instead
+            // (correct placement, pre-rebase precision).
+            if created && r_i != 0.0 {
+                let offsets = data.value_offset.get_or_insert_with(Vec::new);
+                if offsets.len() <= *index {
+                    offsets.resize(index + 1, 0.0);
+                }
+                offsets[*index] = r_i;
+            }
+            world_origin[i] = (r_i - data.axis_offset(*index)) as f32;
             handles[i] = data.lines.get(index).cloned();
         }
         let [Some(x), Some(y), Some(z)] = handles else {
@@ -119,9 +132,10 @@ pub fn sync_line_plot_3d(
                     color: trail.played.unwrap_or(Vec4::ZERO),
                     depth_bias: 0.0,
                     model: Mat4::IDENTITY,
-                    // Vertices are already rebased at ingestion (value_offset),
-                    // so the shader must not subtract the origin again.
-                    world_origin: Vec4::ZERO,
+                    // Zero for axes rebased at ingestion (value_offset); the
+                    // frame origin for axes whose component pre-existed with
+                    // raw values, so the shader re-centers them itself.
+                    world_origin,
                     perspective: if line_plot.perspective { 1 } else { 0 },
                     #[cfg(target_arch = "wasm32")]
                     _padding: Default::default(),

--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -927,7 +927,21 @@ impl LoadSchematicParams<'_, '_> {
     }
 
     pub fn spawn_line_3d(&mut self, line_3d: Line3d) {
-        let frame = line_3d.frame;
+        // Reference point (in frame coords) the shader subtracts from each raw
+        // vertex, and the entity's GeoPosition, so both stay small at ECEF
+        // magnitudes (avoids the paused-trail flicker from f32 cancellation).
+        // It is the geo origin expressed in the line's frame: the ECEF geo
+        // origin for an ECEF line, zero for ENU/NED (already launch-relative).
+        let geo = line_3d.frame.or_default().map(|frame| {
+            let reference = bevy_geo_frames::GeoPosition::from_bevy(
+                frame,
+                bevy::math::DVec3::ZERO,
+                &self.geo_context,
+            )
+            .1;
+            (frame, reference)
+        });
+
         let mut spawn = self.commands.spawn(line_3d);
         spawn.insert((
             Name::new("line_3d"),
@@ -939,11 +953,15 @@ impl LoadSchematicParams<'_, '_> {
 
         // Add GeoPosition and GeoRotation; use ENU if no frame is specified.
         // The rotation is Absolute: the line's vertex data is raw frame
-        // coordinates, so its transform must carry the frame -> Bevy basis change.
-        if let Some(frame) = frame.or_default() {
+        // coordinates, so its transform must carry the frame -> Bevy basis
+        // change. Placing GeoPosition at `reference` (not zero) lets big_space
+        // compute the (reference -> floating origin) offset in f64 while the
+        // shader subtracts the same `reference` from the vertices.
+        if let Some((frame, reference)) = geo {
             spawn.insert((
-                bevy_geo_frames::GeoPosition(frame, bevy::math::DVec3::ZERO),
+                bevy_geo_frames::GeoPosition(frame, reference),
                 bevy_geo_frames::GeoRotation::absolute(frame, bevy::math::DQuat::IDENTITY),
+                crate::ui::plot_3d::gpu::LineFrameOrigin(reference.as_vec3()),
             ));
         }
         spawn.insert(SchematicSpawned);

--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -927,9 +927,10 @@ impl LoadSchematicParams<'_, '_> {
     }
 
     pub fn spawn_line_3d(&mut self, line_3d: Line3d) {
-        // Reference point (in frame coords) the shader subtracts from each raw
-        // vertex, and the entity's GeoPosition, so both stay small at ECEF
-        // magnitudes (avoids the paused-trail flicker from f32 cancellation).
+        // Reference point (in frame coords) subtracted from each raw vertex at
+        // ingestion (in f64), and used as the entity's GeoPosition, so the
+        // stored vertices stay small at ECEF magnitudes and keep mm precision
+        // (avoids the paused-trail flicker from the f32 cast).
         // It is the geo origin expressed in the line's frame: the ECEF geo
         // origin for an ECEF line, zero for ENU/NED (already launch-relative).
         let geo = line_3d.frame.or_default().map(|frame| {
@@ -956,12 +957,12 @@ impl LoadSchematicParams<'_, '_> {
         // coordinates, so its transform must carry the frame -> Bevy basis
         // change. Placing GeoPosition at `reference` (not zero) lets big_space
         // compute the (reference -> floating origin) offset in f64 while the
-        // shader subtracts the same `reference` from the vertices.
+        // same `reference` is subtracted from the vertices at ingestion.
         if let Some((frame, reference)) = geo {
             spawn.insert((
                 bevy_geo_frames::GeoPosition(frame, reference),
                 bevy_geo_frames::GeoRotation::absolute(frame, bevy::math::DQuat::IDENTITY),
-                crate::ui::plot_3d::gpu::LineFrameOrigin(reference.as_vec3()),
+                crate::ui::plot_3d::gpu::LineFrameOrigin(reference),
             ));
         }
         spawn.insert(SchematicSpawned);

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -1714,6 +1714,8 @@ impl ViewportPane {
             Name::new("viewport camera3d"),
         ));
 
+        camera.insert(crate::ui::inspector::viewport::ViewportFollowSmoothing::default());
+
         camera.insert(MeshPickingCamera);
         camera.insert(bloom_from_config(viewport.bloom.as_ref()));
         camera.insert(PrimarySkybox);


### PR DESCRIPTION
## Causes

The flicker came from two independent problems:

1. **Precision — the line flickered even when paused.** A framed `line_3d` such as `NAVEKFSTATE.POS_ECEF` uses Earth-scale coordinates (~6.4 million metres). Storing each point as `f32` snapped it to the nearest ~0.5 m, so the whole trajectory sat on a coarse grid and shimmered at the slightest camera move.

2. **Camera — the scene trembled (a bit) only while playing.** The viewport camera follows the vehicle every frame straight from the raw telemetry (`pos = vehicle + offset`, `look_at = vehicle`). Real telemetry is slightly noisy, so that noise was copied 1:1 onto the camera and the entire view (grid plus the otherwise-stable trajectory) appeared to shake during playback.

---




<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches viewport camera pose, plot ingest/query paths, and GPU line rendering for ECEF-scale data; behavior is well-tested but spans playback, historical load, and 3D/2D graph split.
> 
> **Overview**
> Fixes **line_3d** shimmer and playback view shake by addressing ECEF **`f32`** precision and follow-camera noise.
> 
> **ECEF trails:** Framed **`line_3d`** components now keep **raw** telemetry in **`lines`** for 2D graphs and a **`rebased_lines`** mirror with per-axis **`value_offset`** (`raw − origin` in **`f64`** before cast). Spawn sets **`LineFrameOrigin`**, **`GeoPosition`** at the frame reference, and ingestion via **`GetTimeSeries`** / live stream; **overview** is skipped when rebasing is configured (overview is already **`f32`**). The line shader subtracts **`world_origin`**; GPU index building uses joint XYZ writes with a **0.1 m** minimum segment spacing to collapse pad scribble.
> 
> **Follow camera:** Viewports with **`look_at`** get **`ViewportFollowSmoothing`** — shared exponential smoothing on **`pos`** / **`look_at`**, snapping only on first frame or large **raw** jumps (seeks), not smoother lag during fast flight.
> 
> **Rendering:** Sub-pixel line segments fade via **`smoothstep`** in **`line.wgsl`** to avoid **`normalize(0)`** flicker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 121dc51448a945ca80353dbde40ee49a0bc645e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->