### PR TITLE
Fix: Line 3d jitter

### DIFF
--- a/.cursor/skills/bevy/SKILL.md
+++ b/.cursor/skills/bevy/SKILL.md
@@ -594,6 +594,24 @@ Use `bevy_defer` if you have an operation that runs asynchronously over multiple
 
 # Bevy Ergonomics
 
+## Prefer spawn-time correctness over per-frame fix-up systems
+
+Do not add systems that scan every frame to repair entities that were spawned
+incorrectly (wrong parent, missing required components, invalid hierarchy).
+Those janitors hide the root cause, burn frame time even when nothing is wrong,
+and can fight the systems that keep rewriting the bad state.
+
+Instead:
+
+- Spawn entities with the correct components and parents up front.
+- Use required components (`register_required_components`) so dependents appear
+  with the owner.
+- Use `OnAdd` / `OnInsert` observers (or component hooks) for cross-cutting
+  invariants that many spawn sites share — they run at insert time, not every
+  frame.
+- If a producer re-applies a bad relationship every packet (e.g. `ChildOf`), fix
+  that producer so it wires hierarchy once; do not paper over it with a janitor.
+
 ## Avoid type names that contain "Secondary" or "Primary".
 
 We had two distinct code paths: one for the primary window, and another for secondary windows. This was codified in the type names that would sometimes impede them from code reuse. I have tried to unify these things where appropriate. 

--- a/libs/elodin-editor/src/plugins/gizmos/mod.rs
+++ b/libs/elodin-editor/src/plugins/gizmos/mod.rs
@@ -248,6 +248,7 @@ fn spawn_arrow_endpoint(
     world_pos: WorldPos,
     frame: Option<GeoFrame>,
     name: &'static str,
+    #[cfg(feature = "big_space")] root: Option<&crate::spatial::BigSpaceRootEntity>,
 ) -> Entity {
     let mut endpoint = commands.spawn((
         world_pos,
@@ -263,6 +264,8 @@ fn spawn_arrow_endpoint(
             GeoRotation::relative(frame, bevy::math::DQuat::IDENTITY),
         ));
     }
+    #[cfg(feature = "big_space")]
+    crate::spatial::parent_under_big_space(&mut endpoint, root);
     endpoint.id()
 }
 
@@ -282,6 +285,7 @@ pub fn evaluate_vector_arrows(
     )>,
     mut world_pos: Query<&mut WorldPos>,
     mut logged_missing: Local<HashSet<Entity>>,
+    #[cfg(feature = "big_space")] root: Option<Res<crate::spatial::BigSpaceRootEntity>>,
 ) {
     for (entity, arrow, mut state, endpoints) in arrows.iter_mut() {
         let Some((start, end)) =
@@ -309,8 +313,24 @@ pub fn evaluate_vector_arrows(
         } else {
             // Use ENU if no frame is specified.
             let frame = arrow.frame.or_default();
-            let start = spawn_arrow_endpoint(&mut commands, entity, start, frame, "arrow_start");
-            let end = spawn_arrow_endpoint(&mut commands, entity, end, frame, "arrow_end");
+            let start = spawn_arrow_endpoint(
+                &mut commands,
+                entity,
+                start,
+                frame,
+                "arrow_start",
+                #[cfg(feature = "big_space")]
+                root.as_deref(),
+            );
+            let end = spawn_arrow_endpoint(
+                &mut commands,
+                entity,
+                end,
+                frame,
+                "arrow_end",
+                #[cfg(feature = "big_space")]
+                root.as_deref(),
+            );
             commands
                 .entity(entity)
                 .insert(ArrowEndpoints { start, end });

--- a/libs/elodin-editor/src/sensor_camera.rs
+++ b/libs/elodin-editor/src/sensor_camera.rs
@@ -362,6 +362,7 @@ pub fn spawn_sensor_camera_frustum_sources(
     mut commands: Commands,
     configs: Res<SensorCameraConfigs>,
     mut spawned: ResMut<SensorCameraFrustumSourcesSpawned>,
+    #[cfg(feature = "big_space")] root: Option<Res<crate::spatial::BigSpaceRootEntity>>,
 ) {
     for (i, config) in configs.0.iter().enumerate() {
         let mut perspective = PerspectiveProjection {
@@ -375,7 +376,7 @@ pub fn spawn_sensor_camera_frustum_sources(
             perspective.aspect_ratio = config.width as f32 / config.height as f32;
         }
 
-        commands.spawn((
+        let mut entity = commands.spawn((
             Transform::default(),
             GlobalTransform::default(),
             Projection::Perspective(perspective),
@@ -384,6 +385,8 @@ pub fn spawn_sensor_camera_frustum_sources(
             SensorCameraFrustumSource { config_index: i },
             Name::new(format!("sensor_camera_frustum_{}", config.camera_name)),
         ));
+        #[cfg(feature = "big_space")]
+        crate::spatial::parent_under_big_space(&mut entity, root.as_deref());
     }
 
     spawned.0 = true;
@@ -395,6 +398,7 @@ fn spawn_sensor_cameras(
     mut images: ResMut<Assets<Image>>,
     render_device: Res<RenderDevice>,
     mut spawned: ResMut<SensorCamerasSpawned>,
+    #[cfg(feature = "big_space")] root: Option<Res<crate::spatial::BigSpaceRootEntity>>,
 ) {
     for (i, config) in configs.0.iter().enumerate() {
         let size = Extent3d {
@@ -456,7 +460,7 @@ fn spawn_sensor_cameras(
             _ => (0u32, 0.0, 0.0),
         };
 
-        commands.spawn((
+        let mut entity = commands.spawn((
             (
                 Camera3d::default(),
                 Camera {
@@ -486,6 +490,8 @@ fn spawn_sensor_cameras(
             sensor_camera_render_layers(config),
             Name::new(format!("sensor_camera_{}", config.camera_name)),
         ));
+        #[cfg(feature = "big_space")]
+        crate::spatial::parent_under_big_space(&mut entity, root.as_deref());
 
         bevy::log::debug!(
             "Spawned sensor camera '{}' ({}x{}, effect={})",

--- a/libs/elodin-editor/src/spatial.rs
+++ b/libs/elodin-editor/src/spatial.rs
@@ -17,11 +17,10 @@
 //!   development ergonomics during the Bevy migration; it is **not
 //!   intended to be shipped**.
 //!
-//! Note: spawning the editor's `FloatingOriginPlugin` registers a
-//! [`attach_parentless_grid_cells`] system. Any entity that holds a
-//! [`GridCell`] and no [`ChildOf`] will be reparented to the
-//! [`BigSpaceRoot`] automatically. Call sites can therefore spawn
-//! grid-aware entities without explicitly setting their parent.
+//! Note: spawning the editor's `FloatingOriginPlugin` registers systems that
+//! keep `GridCell` entities under a valid big_space parent: parentless cells
+//! are adopted by [`BigSpaceRoot`], and cells parented under non-spatial
+//! impeller path segments (e.g. `vehicle.world_pos`) are reparented there too.
 
 use bevy::{math::DVec3, prelude::*, transform::TransformSystems};
 
@@ -99,14 +98,26 @@ impl Plugin for FloatingOriginPlugin {
         app.insert_resource(self.settings.clone())
             .add_plugins(big_space::prelude::BigSpaceDefaultPlugins)
             .add_systems(Startup, setup_floating_origin)
-            .add_systems(PreUpdate, attach_parentless_grid_cells)
+            .add_systems(
+                PreUpdate,
+                (
+                    attach_parentless_grid_cells,
+                    reparent_misparented_grid_cells,
+                )
+                    .chain(),
+            )
             // Also adopt right before transform propagation (and big_space's
             // PostUpdate hierarchy validation) so entities that gained a
             // `GridCell` during this frame never cross a validation pass
-            // parentless.
+            // parentless / under a non-spatial path parent.
             .add_systems(
                 PostUpdate,
-                attach_parentless_grid_cells.before(TransformSystems::Propagate),
+                (
+                    attach_parentless_grid_cells,
+                    reparent_misparented_grid_cells,
+                )
+                    .chain()
+                    .before(TransformSystems::Propagate),
             );
     }
 }
@@ -145,6 +156,34 @@ fn attach_parentless_grid_cells(
     };
 
     for entity in &entities {
+        commands.entity(entity).insert(ChildOf(root));
+    }
+}
+
+/// Impeller path hierarchy (`vehicle.world_pos`) parents spatial leaves under
+/// non-spatial path segments. big_space rejects `GridCell` children of
+/// non-spatial entities and skips their `GlobalTransform` propagation — which
+/// leaves meshes at the wrong place while `line_3d` (telemetry-driven) looks
+/// correct, so the trail appears to drift relative to the vehicle.
+///
+/// Reparent any `GridCell` whose parent is not a `Grid` / `GridCell` /
+/// `BigSpace` onto the [`BigSpaceRoot`].
+#[allow(clippy::type_complexity)]
+fn reparent_misparented_grid_cells(
+    mut commands: Commands,
+    roots: Query<Entity, With<BigSpaceRoot>>,
+    cells: Query<(Entity, &ChildOf), (With<GridCell>, Without<BigSpaceRoot>)>,
+    spatial_parents: Query<Entity, Or<(With<Grid>, With<GridCell>, With<BigSpace>)>>,
+) {
+    let Some(root) = roots.iter().next() else {
+        return;
+    };
+
+    for (entity, child_of) in &cells {
+        let parent = child_of.parent();
+        if parent == root || spatial_parents.contains(parent) {
+            continue;
+        }
         commands.entity(entity).insert(ChildOf(root));
     }
 }

--- a/libs/elodin-editor/src/spatial.rs
+++ b/libs/elodin-editor/src/spatial.rs
@@ -17,12 +17,16 @@
 //!   development ergonomics during the Bevy migration; it is **not
 //!   intended to be shipped**.
 //!
-//! Note: spawning the editor's `FloatingOriginPlugin` registers systems that
-//! keep `GridCell` entities under a valid big_space parent: parentless cells
-//! are adopted by [`BigSpaceRoot`], and cells parented under non-spatial
-//! impeller path segments (e.g. `vehicle.world_pos`) are reparented there too.
+//! Prefer parenting `GridCell` entities under [`BigSpaceRoot`] at spawn
+//! (via [`BigSpaceRootEntity`]). Insert-time observers cover impeller path
+//! leaves that become spatial after hierarchy wiring, so we do not need
+//! per-frame janitor systems.
 
-use bevy::{math::DVec3, prelude::*, transform::TransformSystems};
+use bevy::{
+    ecs::lifecycle::{Add, Insert},
+    math::DVec3,
+    prelude::*,
+};
 
 pub use big_space::prelude::{BigSpace, CellCoord as GridCell, FloatingOrigin, Grid};
 
@@ -71,12 +75,14 @@ impl FloatingOriginSettings {
 }
 
 /// Marker for the unique `BigSpace` root entity spawned by
-/// [`FloatingOriginPlugin`]. Lets [`attach_parentless_grid_cells`] adopt
-/// any new grid-bearing entity without having to look up the root by name.
+/// [`FloatingOriginPlugin`].
 #[derive(Component)]
 pub struct BigSpaceRoot;
 
-type ParentlessGridCellFilter = (With<GridCell>, Without<ChildOf>, Without<BigSpaceRoot>);
+/// Handle to the unique [`BigSpaceRoot`] entity. Inserted at startup so
+/// spawn sites can parent grid-bearing entities without a query.
+#[derive(Resource, Clone, Copy, Debug)]
+pub struct BigSpaceRootEntity(pub Entity);
 
 pub struct FloatingOriginPlugin {
     settings: FloatingOriginSettings,
@@ -98,27 +104,8 @@ impl Plugin for FloatingOriginPlugin {
         app.insert_resource(self.settings.clone())
             .add_plugins(big_space::prelude::BigSpaceDefaultPlugins)
             .add_systems(Startup, setup_floating_origin)
-            .add_systems(
-                PreUpdate,
-                (
-                    attach_parentless_grid_cells,
-                    reparent_misparented_grid_cells,
-                )
-                    .chain(),
-            )
-            // Also adopt right before transform propagation (and big_space's
-            // PostUpdate hierarchy validation) so entities that gained a
-            // `GridCell` during this frame never cross a validation pass
-            // parentless / under a non-spatial path parent.
-            .add_systems(
-                PostUpdate,
-                (
-                    attach_parentless_grid_cells,
-                    reparent_misparented_grid_cells,
-                )
-                    .chain()
-                    .before(TransformSystems::Propagate),
-            );
+            .add_observer(on_grid_cell_added)
+            .add_observer(on_child_of_inserted_for_grid_cell);
     }
 }
 
@@ -132,6 +119,8 @@ pub fn setup_floating_origin(mut commands: Commands, settings: Res<FloatingOrigi
         ))
         .id();
 
+    commands.insert_resource(BigSpaceRootEntity(root));
+
     commands.spawn((
         FloatingOrigin,
         GridCell::default(),
@@ -141,49 +130,67 @@ pub fn setup_floating_origin(mut commands: Commands, settings: Res<FloatingOrigi
     ));
 }
 
-/// PreUpdate system that adopts every entity carrying a [`GridCell`] but
-/// no [`ChildOf`] under the unique [`BigSpaceRoot`]. This keeps callers
-/// free from having to know about the root entity when they spawn
-/// grid-aware entities. Runs before transform propagation as well so entities
-/// spawned by schematic reloads do not spend a frame as invalid root nodes.
-fn attach_parentless_grid_cells(
-    mut commands: Commands,
-    roots: Query<Entity, With<BigSpaceRoot>>,
-    entities: Query<Entity, ParentlessGridCellFilter>,
-) {
-    let Some(root) = roots.iter().next() else {
-        return;
-    };
-
-    for entity in &entities {
-        commands.entity(entity).insert(ChildOf(root));
+/// Parent a grid-bearing entity under the BigSpace root when the root is known.
+pub fn parent_under_big_space(entity: &mut EntityCommands, root: Option<&BigSpaceRootEntity>) {
+    if let Some(root) = root {
+        entity.insert(ChildOf(root.0));
     }
 }
 
-/// Impeller path hierarchy (`vehicle.world_pos`) parents spatial leaves under
-/// non-spatial path segments. big_space rejects `GridCell` children of
-/// non-spatial entities and skips their `GlobalTransform` propagation — which
-/// leaves meshes at the wrong place while `line_3d` (telemetry-driven) looks
-/// correct, so the trail appears to drift relative to the vehicle.
-///
-/// Reparent any `GridCell` whose parent is not a `Grid` / `GridCell` /
-/// `BigSpace` onto the [`BigSpaceRoot`].
-#[allow(clippy::type_complexity)]
-fn reparent_misparented_grid_cells(
+type SpatialParentFilter = Or<(With<Grid>, With<GridCell>, With<BigSpace>)>;
+
+fn parent_is_spatial(
+    parent: Entity,
+    root: Entity,
+    spatial_parents: &Query<Entity, SpatialParentFilter>,
+) -> bool {
+    parent == root || spatial_parents.contains(parent)
+}
+
+/// When a [`GridCell`] is added, ensure the entity is under a valid big_space
+/// parent (root if parentless or under a non-spatial impeller path segment).
+fn on_grid_cell_added(
+    add: On<Add, GridCell>,
     mut commands: Commands,
-    roots: Query<Entity, With<BigSpaceRoot>>,
-    cells: Query<(Entity, &ChildOf), (With<GridCell>, Without<BigSpaceRoot>)>,
-    spatial_parents: Query<Entity, Or<(With<Grid>, With<GridCell>, With<BigSpace>)>>,
+    root: Option<Res<BigSpaceRootEntity>>,
+    child_of: Query<&ChildOf>,
+    spatial_parents: Query<Entity, SpatialParentFilter>,
 ) {
-    let Some(root) = roots.iter().next() else {
+    let Some(root) = root else {
         return;
     };
-
-    for (entity, child_of) in &cells {
-        let parent = child_of.parent();
-        if parent == root || spatial_parents.contains(parent) {
-            continue;
-        }
-        commands.entity(entity).insert(ChildOf(root));
+    let entity = add.entity;
+    if entity == root.0 {
+        return;
     }
+    match child_of.get(entity) {
+        Ok(c) if parent_is_spatial(c.parent(), root.0, &spatial_parents) => {}
+        _ => {
+            commands.entity(entity).insert(ChildOf(root.0));
+        }
+    }
+}
+
+/// If a [`GridCell`] entity is (re)parented under a non-spatial entity, move it
+/// to the BigSpace root. Safe against recursion: the second trigger sees
+/// `parent == root` and returns.
+fn on_child_of_inserted_for_grid_cell(
+    insert: On<Insert, ChildOf>,
+    mut commands: Commands,
+    root: Option<Res<BigSpaceRootEntity>>,
+    cells: Query<&ChildOf, With<GridCell>>,
+    spatial_parents: Query<Entity, SpatialParentFilter>,
+) {
+    let Some(root) = root else {
+        return;
+    };
+    let entity = insert.entity;
+    let Ok(child_of) = cells.get(entity) else {
+        return;
+    };
+    let parent = child_of.parent();
+    if parent_is_spatial(parent, root.0, &spatial_parents) {
+        return;
+    }
+    commands.entity(entity).insert(ChildOf(root.0));
 }

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -1503,6 +1503,15 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
         self.content_gen
     }
 
+    /// Earliest sample value in the tree (first point of the first chunk by time).
+    pub fn first_sample(&self) -> Option<D>
+    where
+        D: Copy,
+    {
+        let (_, chunk) = self.tree.first_key_value()?;
+        chunk.data.cpu().first().copied()
+    }
+
     pub fn chunk_count(&self) -> usize {
         self.tree.iter().count()
     }

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -1879,6 +1879,61 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
         written_u32s
     }
 
+    /// Collect CPU sample values for the same visible strip that
+    /// [`Self::write_to_index_buffer_with_step`] would index (same step / clip).
+    ///
+    /// Does not require GPU-resident chunks — used by `line_3d` to build
+    /// floating-origin-local XYZ buffers.
+    pub fn collect_strip_values(&self, line_visible_range: Range<Timestamp>, step: usize) -> Vec<D>
+    where
+        D: Copy,
+    {
+        let step = step.max(1);
+        let mut out = Vec::new();
+        for chunk in self.range_iter(line_visible_range.clone()) {
+            let Some((start_offset, end_offset)) =
+                chunk_visible_offsets(&chunk.timestamps, &line_visible_range)
+            else {
+                continue;
+            };
+            let vis_len = end_offset.saturating_sub(start_offset);
+            if vis_len == 0 {
+                continue;
+            }
+            let values = chunk.data.cpu();
+            let index_chunk = IndexChunk {
+                range: 0..u32::MAX,
+                len: vis_len,
+            };
+            let end = index_chunk.clone().into_index_iter().last();
+            let mut index_iter = index_chunk.into_index_iter();
+            let mut last_written: Option<u32> = None;
+            if let Some(index) = index_iter.next() {
+                let i = start_offset + index as usize;
+                if let Some(&v) = values.get(i) {
+                    out.push(v);
+                }
+                last_written = Some(index);
+            }
+            for index in index_iter.step_by(step) {
+                let i = start_offset + index as usize;
+                if let Some(&v) = values.get(i) {
+                    out.push(v);
+                }
+                last_written = Some(index);
+            }
+            if let Some(end) = end
+                && last_written != Some(end)
+            {
+                let i = start_offset + end as usize;
+                if let Some(&v) = values.get(i) {
+                    out.push(v);
+                }
+            }
+        }
+        out
+    }
+
     pub fn garbage_collect(&mut self, line_visible_range: Range<Timestamp>) {
         let first_half =
             nodit::interval::ii(i64::MIN, line_visible_range.start.0.saturating_sub(1));
@@ -2097,7 +2152,7 @@ fn recent_tail_keep_count(n: usize, keep_recent_fraction: f32) -> usize {
     keep.min(n.saturating_sub(1))
 }
 
-fn chunk_visible_offsets(
+pub(crate) fn chunk_visible_offsets(
     timestamps: &[Timestamp],
     range: &Range<Timestamp>,
 ) -> Option<(usize, usize)> {
@@ -2373,6 +2428,38 @@ mod tests {
     }
 
     #[test]
+    fn short_window_step_one_despite_full_recording_extent() {
+        // Replay: line_3d derives chunk/index stats from the full recording, but
+        // step selection must follow the selected trailing window (last_5s).
+        let full_hour_index_count = 3_600_000;
+        assert_eq!(
+            index_sampling_step_for_selection(
+                5_000_000,
+                500,
+                full_hour_index_count,
+                crate::ui::plot::gpu::INDEX_BUFFER_LEN,
+            ),
+            1
+        );
+    }
+
+    #[test]
+    fn collect_strip_values_matches_step_sampling() {
+        let mut tree = LineTree::<f32>::default();
+        let n = 10;
+        let ts: Vec<Timestamp> = (0..n).map(|i| Timestamp(i as i64 * 1_000)).collect();
+        let vals: Vec<f32> = (0..n).map(|i| i as f32).collect();
+        let chunk = Chunk::from_iter(&ts, Timestamp(0), vals.iter().copied()).expect("chunk");
+        tree.insert(chunk);
+        let range = Timestamp(0)..Timestamp(9_000);
+        let step1 = tree.collect_strip_values(range.clone(), 1);
+        assert_eq!(step1, vals);
+        let step3 = tree.collect_strip_values(range, 3);
+        // first, then step_by(3) on remainder, then last if needed
+        assert_eq!(step3, vec![0.0, 1.0, 4.0, 7.0, 9.0]);
+    }
+
+    #[test]
     fn long_window_sampling_step_uses_visible_clip() {
         let zoomed_step = index_sampling_step(1, 200, 400);
         let long = index_sampling_step_for_selection(60_000_000, 1, 200, 400);
@@ -2415,6 +2502,52 @@ mod tests {
             index_sampling_step_for_selection(5_000_000, 1, 1_000, 400),
             1
         );
+    }
+
+    #[test]
+    fn short_window_over_budget_step_doubles_to_fit() {
+        // Short-window selection still starts at step 1, but when sample count
+        // exceeds INDEX_BUFFER_LEN the extract path must double the step rather
+        // than silently truncating the newest tip (line_3d FO-local path).
+        let mut tree = LineTree::<f32>::default();
+        // INDEX_BUFFER_LEN + 1 samples so step-1 strip indices exceed the budget.
+        let n = INDEX_BUFFER_LEN + 1;
+        let ts: Vec<Timestamp> = (0..n).map(|i| Timestamp(i as i64)).collect();
+        let vals: Vec<f32> = (0..n).map(|i| i as f32).collect();
+        let mut offset = 0;
+        while offset < n {
+            let end = (offset + CHUNK_LEN).min(n);
+            let chunk = Chunk::from_iter(
+                &ts[offset..end],
+                Timestamp(0),
+                vals[offset..end].iter().copied(),
+            )
+            .expect("chunk");
+            tree.insert(chunk);
+            offset = end;
+        }
+        let range = Timestamp(0)..Timestamp(n as i64);
+        assert_eq!(
+            index_sampling_step_for_selection(5_000_000, 1, n, INDEX_BUFFER_LEN),
+            1,
+            "short selection must still request step 1"
+        );
+        let mut step = 1usize;
+        let mut fitted = false;
+        for _ in 0..26 {
+            let needed = tree.count_strip_index_u32s(range.clone(), step);
+            if needed <= INDEX_BUFFER_LEN as u32 {
+                fitted = true;
+                break;
+            }
+            step = step.saturating_mul(2).max(2);
+        }
+        assert!(fitted, "step doubling must fit within INDEX_BUFFER_LEN");
+        assert!(
+            step > 1,
+            "over-budget short window must raise step, got {step}"
+        );
+        assert!(tree.count_strip_index_u32s(range, step) <= INDEX_BUFFER_LEN as u32);
     }
 
     #[test]

--- a/libs/elodin-editor/src/ui/plot_3d/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/gpu.rs
@@ -19,6 +19,7 @@ use bevy::{
     ecs::{
         component::Component,
         entity::Entity,
+        hierarchy::ChildOf,
         query::Has,
         schedule::{IntoScheduleConfigs, SystemSet},
         system::{
@@ -28,10 +29,10 @@ use bevy::{
         world::{FromWorld, Mut, World},
     },
     image::BevyDefault,
-    math::{Mat4, Vec4},
+    math::{DVec3, Mat4, Quat, Vec3, Vec4},
     mesh::VertexBufferLayout,
     pbr::{MeshPipeline, MeshPipelineKey, SetMeshViewBindGroup},
-    prelude::{Color, Reflect, Resource},
+    prelude::{Color, Reflect, Resource, With},
     render::{
         ExtractSchedule, MainWorld, Render, RenderApp, RenderSystems,
         extract_component::{ComponentUniforms, DynamicUniformIndex, UniformComponentPlugin},
@@ -43,17 +44,28 @@ use bevy::{
         renderer::{RenderDevice, RenderQueue},
         view::{ExtractedView, Msaa, ViewTarget},
     },
-    transform::TransformSystems,
-    transform::components::{GlobalTransform, Transform},
+    transform::{
+        TransformSystems,
+        components::{GlobalTransform, Transform},
+    },
 };
+use bevy_geo_frames::{GeoContext, GeoFrame, GeoPosition, Present};
 use bevy_render::{
     extract_component::ExtractComponent,
     sync_world::{MainEntity, SyncToRenderWorld, TemporaryRenderEntity},
 };
 use binding_types::storage_buffer_read_only_sized;
-use impeller2_wkt::{CurrentTimestamp, EarliestTimestamp, LastUpdated};
+use impeller2_wkt::{CurrentTimestamp, EarliestTimestamp, LastUpdated, Line3d};
+use std::num::NonZeroU64;
+use zerocopy::IntoBytes;
 
 const LINE_SHADER_HANDLE: Handle<Shader> = uuid_handle!("bfffa3c4-9401-4b6e-b3ab-3564180352f1");
+
+/// Dense line-local XYZ buffers: one `f32` per strip sample plus a leading NaN sentinel.
+/// Sized to the index budget so a full-fidelity short window still fits.
+const LOCAL_VALUE_BUFFER_LEN: usize = INDEX_BUFFER_LEN;
+const LOCAL_VALUE_BUFFER_SIZE: NonZeroU64 =
+    NonZeroU64::new((LOCAL_VALUE_BUFFER_LEN * size_of::<f32>()) as u64).unwrap();
 
 #[derive(SystemSet, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum PlotSystem {
@@ -69,7 +81,14 @@ impl Plugin for Plot3dGpuPlugin {
             .init_asset::<Line>()
             .add_systems(
                 PostUpdate,
-                update_uniform_model.after(TransformSystems::Propagate),
+                (
+                    // After geo rotation so we own Transform; before propagate
+                    // so big_space sees the first-point GridCell pose.
+                    place_line_3d_at_first_point
+                        .after(bevy_geo_frames::apply_geo_rotation)
+                        .before(TransformSystems::Propagate),
+                    update_uniform_model.after(TransformSystems::Propagate),
+                ),
             );
 
         load_internal_asset!(app, LINE_SHADER_HANDLE, "./line.wgsl", Shader::from_wgsl);
@@ -112,9 +131,9 @@ impl Plugin for Plot3dGpuPlugin {
         let layout_entries = BindGroupLayoutEntries::sequential(
             ShaderStages::VERTEX,
             (
-                storage_buffer_read_only_sized(false, Some(VALUE_BUFFER_SIZE)),
-                storage_buffer_read_only_sized(false, Some(VALUE_BUFFER_SIZE)),
-                storage_buffer_read_only_sized(false, Some(VALUE_BUFFER_SIZE)),
+                storage_buffer_read_only_sized(false, Some(LOCAL_VALUE_BUFFER_SIZE)),
+                storage_buffer_read_only_sized(false, Some(LOCAL_VALUE_BUFFER_SIZE)),
+                storage_buffer_read_only_sized(false, Some(LOCAL_VALUE_BUFFER_SIZE)),
             ),
         );
         let values_descriptor =
@@ -157,6 +176,8 @@ impl Plugin for Plot3dGpuPlugin {
 }
 
 fn update_uniform_model(mut query: Query<(&mut LineUniform, &GlobalTransform)>) {
+    // Entity sits at the line's first sample under BigSpaceRoot; big_space
+    // puts that in FO-local GlobalTransform. Vertices are (p - first).
     for (mut uniform, transform) in query.iter_mut() {
         uniform.model = transform.to_matrix();
     }
@@ -389,19 +410,18 @@ pub struct LineConfig {
 pub struct GpuLine {
     values_bind_group: BindGroup,
     index_bind_group: BindGroup,
-    /// Strip indices (decimated by a uniform sampling step to fit
-    /// `INDEX_BUFFER_LEN`) backing `index_bind_group`. This is the GPU-side
-    /// point reduction, distinct from the upstream Hamann-Chen (1994) in-memory
-    /// simplification done on the `LineTree`. Never read directly, but owned
-    /// here so the buffers outlive the bind group / draw rather than relying on
-    /// wgpu's internal reference counting.
+    /// Dense line-local XYZ value buffers (NaN at index 0, samples at 1..n),
+    /// stored relative to the line's first sample (entity world pose).
+    #[allow(dead_code)]
+    value_buffers: [Buffer; 3],
+    /// Strip indices into `value_buffers` (leading/trailing NaN sentinels).
     #[allow(dead_code)]
     index_buffers: [Buffer; 3],
     count: u32,
-    /// Last range + LineTree `content_gen`s written into `index_buffers`.
-    /// Range alone is not enough: SeriesStore sync can clear/rebuild trees while
-    /// the quantized visible range stays fixed.
-    last_index_key: Option<(i64, i64, u64, u64, u64)>,
+    /// Last range + LineTree `content_gen`s + GeoContext/frame hash written
+    /// into the GPU buffers. Placement comes from the entity GlobalTransform.
+    #[allow(clippy::type_complexity)]
+    last_index_key: Option<(i64, i64, u64, u64, u64, u64)>,
 }
 
 /// Per-entity cache of played/future GPU index state so TemporaryRenderEntity
@@ -503,8 +523,214 @@ type LineQueryMut = (
     &'static LineConfig,
     &'static mut LineUniform,
     Option<&'static LineTrailColors>,
+    Option<&'static GeoPosition>,
+    Option<&'static Line3d>,
     Option<&'static mut GpuLineIndexCache>,
 );
+
+/// Hash of GeoContext fields that affect frame→Bevy conversion, plus the
+/// resolved line frame. Buffers built under a different context (e.g. before
+/// the schematic origin lands) must not be reused.
+fn geo_context_cache_key(ctx: &GeoContext, frame: GeoFrame) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    ctx.origin.latitude.to_bits().hash(&mut hasher);
+    ctx.origin.longitude.to_bits().hash(&mut hasher);
+    ctx.origin.altitude.to_bits().hash(&mut hasher);
+    match ctx.present {
+        Present::Plane => 0u8,
+        Present::Sphere => 1u8,
+    }
+    .hash(&mut hasher);
+    match frame {
+        GeoFrame::ENU => 0u8,
+        GeoFrame::NED => 1u8,
+        GeoFrame::ECEF => 2u8,
+    }
+    .hash(&mut hasher);
+    hasher.finish()
+}
+
+fn resolve_line_frame(geo_pos: Option<&GeoPosition>, line: Option<&Line3d>) -> GeoFrame {
+    if let Some(geo) = geo_pos {
+        return geo.0;
+    }
+    line.and_then(|l| l.frame).unwrap_or_default()
+}
+
+/// Convert a frame-space sample to absolute Bevy coordinates (f64).
+fn frame_point_to_bevy(frame: GeoFrame, x: f32, y: f32, z: f32, geo_ctx: &GeoContext) -> DVec3 {
+    GeoPosition(frame, DVec3::new(x as f64, y as f64, z as f64)).to_bevy(geo_ctx)
+}
+
+/// First sample of the line (full recording), in Bevy space. Stable geographic
+/// anchor for both the entity pose and relative vertex buffers.
+fn line_first_point_bevy(
+    line_assets: &Assets<Line>,
+    handles: &[Handle<Line>; 3],
+    frame: GeoFrame,
+    geo_ctx: &GeoContext,
+) -> Option<DVec3> {
+    let full = impeller2::types::Timestamp(i64::MIN)..impeller2::types::Timestamp(i64::MAX);
+    // Huge step still keeps the first sample (and last); we only need the first.
+    let step = usize::MAX;
+    let xs = line_assets
+        .get(&handles[0])?
+        .data
+        .collect_strip_values(full.clone(), step);
+    let ys = line_assets
+        .get(&handles[1])?
+        .data
+        .collect_strip_values(full.clone(), step);
+    let zs = line_assets
+        .get(&handles[2])?
+        .data
+        .collect_strip_values(full, step);
+    let x = *xs.first()?;
+    let y = *ys.first()?;
+    let z = *zs.first()?;
+    Some(frame_point_to_bevy(frame, x, y, z, geo_ctx))
+}
+
+/// Place each `line_3d` entity at its first sample under [`BigSpaceRoot`] so
+/// big_space owns FO-local `GlobalTransform`. Vertices are stored relative to
+/// that same first point.
+#[allow(clippy::type_complexity)]
+fn place_line_3d_at_first_point(
+    mut commands: Commands,
+    mut lines: Query<(
+        Entity,
+        &LineHandles,
+        Option<&GeoPosition>,
+        Option<&Line3d>,
+        &mut Transform,
+        Option<&ChildOf>,
+    )>,
+    line_assets: Res<Assets<Line>>,
+    geo_ctx: Res<GeoContext>,
+    #[cfg(feature = "big_space")] settings: Res<crate::spatial::FloatingOriginSettings>,
+    #[cfg(feature = "big_space")] roots: Query<Entity, With<crate::spatial::BigSpaceRoot>>,
+) {
+    #[cfg(feature = "big_space")]
+    let Some(root) = roots.iter().next() else {
+        return;
+    };
+
+    for (entity, handles, geo_pos, line_3d, mut transform, child_of) in &mut lines {
+        // Vertices are already converted frame→Bevy; a GeoRotation basis on
+        // this entity would double-apply the frame change.
+        commands
+            .entity(entity)
+            .remove::<bevy_geo_frames::GeoRotation>();
+
+        let frame = resolve_line_frame(geo_pos, line_3d);
+        let Some(anchor) = line_first_point_bevy(&line_assets, &handles.0, frame, &geo_ctx) else {
+            continue;
+        };
+
+        #[cfg(feature = "big_space")]
+        {
+            let (grid_cell, translation) = settings.translation_to_grid(anchor);
+            *transform = Transform {
+                translation,
+                rotation: Quat::IDENTITY,
+                scale: Vec3::ONE,
+            };
+            commands
+                .entity(entity)
+                .insert(grid_cell)
+                .insert(GlobalTransform::default());
+            if child_of.map(|c| c.parent()) != Some(root) {
+                commands.entity(entity).insert(ChildOf(root));
+            }
+        }
+        #[cfg(not(feature = "big_space"))]
+        {
+            let _ = child_of;
+            *transform = Transform {
+                translation: anchor.as_vec3(),
+                rotation: Quat::IDENTITY,
+                scale: Vec3::ONE,
+            };
+        }
+    }
+}
+
+/// Build dense first-point-relative XYZ value buffers + remapped strip indices.
+///
+/// `anchor` is the line's first sample in Bevy space (entity world pose).
+/// Vertices are `p - anchor`. Index layout matches the historical NaN-sentinel
+/// strip: leading/trailing `0` (NaN slot), samples at `1..n`.
+#[allow(clippy::too_many_arguments)]
+fn write_anchor_local_line_buffers(
+    xs: &[f32],
+    ys: &[f32],
+    zs: &[f32],
+    frame: GeoFrame,
+    geo_ctx: &GeoContext,
+    anchor: DVec3,
+    render_device: &RenderDevice,
+    render_queue: &RenderQueue,
+) -> Option<([Buffer; 3], [Buffer; 3], u32)> {
+    let n = xs.len().min(ys.len()).min(zs.len());
+    if n < 2 {
+        return None;
+    }
+    // Slot 0 = NaN sentinel; samples occupy 1..=n (capped to buffer length).
+    let max_samples = LOCAL_VALUE_BUFFER_LEN.saturating_sub(1);
+    let n = n.min(max_samples);
+    let mut x_local = vec![f32::NAN; n + 1];
+    let mut y_local = vec![f32::NAN; n + 1];
+    let mut z_local = vec![f32::NAN; n + 1];
+    for i in 0..n {
+        let p = frame_point_to_bevy(frame, xs[i], ys[i], zs[i], geo_ctx);
+        let local = (p - anchor).as_vec3();
+        x_local[i + 1] = local.x;
+        y_local[i + 1] = local.y;
+        z_local[i + 1] = local.z;
+    }
+
+    // Single contiguous strip with NaN sentinels (one logical chunk).
+    let mut indices: Vec<u32> = Vec::with_capacity(n + 2);
+    indices.push(0);
+    for i in 0..n {
+        indices.push((i + 1) as u32);
+    }
+    indices.push(0);
+    if indices.len() > INDEX_BUFFER_LEN {
+        indices.truncate(INDEX_BUFFER_LEN);
+    }
+    let count = indices.len() as u32;
+    if count < 2 {
+        return None;
+    }
+
+    let value_bufs = [x_local, y_local, z_local].map(|data| {
+        let mut bytes = vec![0u8; LOCAL_VALUE_BUFFER_SIZE.get() as usize];
+        let src = data.as_bytes();
+        bytes[..src.len()].copy_from_slice(src);
+        render_device.create_buffer_with_data(&BufferInitDescriptor {
+            label: Some("line_3d anchor-local values"),
+            contents: &bytes,
+            usage: BufferUsages::STORAGE | BufferUsages::COPY_DST,
+        })
+    });
+
+    let index_bufs = ['x', 'y', 'z'].map(|_| {
+        let mut bytes = vec![0u8; INDEX_BUFFER_LEN * size_of::<u32>()];
+        let src = indices.as_bytes();
+        bytes[..src.len()].copy_from_slice(src);
+        render_device.create_buffer_with_data(&BufferInitDescriptor {
+            label: Some("line_3d anchor-local indices"),
+            contents: &bytes,
+            usage: BufferUsages::STORAGE | BufferUsages::COPY_DST,
+        })
+    });
+
+    let _ = render_queue;
+
+    Some((value_bufs, index_bufs, count))
+}
 
 fn extract_lines(
     mut main_world: ResMut<MainWorld>,
@@ -515,10 +741,11 @@ fn extract_lines(
     index_layout: Res<LineIndexLayout>,
 ) {
     main_world.resource_scope(|world, mut cached_state: Mut<CachedSystemState>| {
+        let geo_ctx = world.resource::<GeoContext>().clone();
         let replay_mode = world.contains_resource::<crate::ReplayMode>();
         let (
             mut lines,
-            mut line_assets,
+            line_assets,
             mut _main_commands,
             selected_time_range,
             earliest_timestamp,
@@ -535,6 +762,7 @@ fn extract_lines(
                 crate::TRAILING_RANGE_QUANTUM_MICROS,
             )
         };
+        let selected_span_micros = selected_range.end.0.saturating_sub(selected_range.start.0);
         let sampling_range = if replay_mode && earliest_timestamp.0 < latest_timestamp.0 {
             earliest_timestamp.0..latest_timestamp.0
         } else {
@@ -574,21 +802,37 @@ fn extract_lines(
         // the split back onto the previous sample boundary instead.
         let split = selected_range.start.max(quantized_playhead);
 
-        'outer: for (entity, line_handles, config, uniform, trail_colors, mut index_cache) in
-            lines.iter_mut()
+        'outer: for (
+            entity,
+            line_handles,
+            config,
+            uniform,
+            trail_colors,
+            geo_pos,
+            line_3d,
+            mut index_cache,
+        ) in lines.iter_mut()
         {
+            let frame = resolve_line_frame(geo_pos, line_3d);
+            let geo_key = geo_context_cache_key(&geo_ctx, frame);
             let (played_color, future_color) = trail_colors.copied().unwrap_or_default().resolve(
                 played_timeline_color,
                 future_timeline_color,
                 future_trail_alpha,
             );
             for line in &line_handles.0 {
-                let Some(line) = line_assets.get_mut(line) else {
+                if line_assets.get(line).is_none() {
                     continue 'outer;
-                };
-                line.data
-                    .queue_load_range(selected_range.clone(), &render_queue, &render_device);
+                }
             }
+
+            // Shared geographic anchor = first sample of the full line. Entity
+            // pose (GlobalTransform → model) is placed there in main world.
+            let Some(line_anchor) =
+                line_first_point_bevy(&line_assets, &line_handles.0, frame, &geo_ctx)
+            else {
+                continue 'outer;
+            };
 
             // Replay grows the revealed prefix every frame. If the decimation
             // step is derived from only that prefix, the full trail gets
@@ -610,37 +854,39 @@ fn extract_lines(
                 .map(|(_, count)| *count)
                 .max()
                 .unwrap_or(0);
-            let sampling_step = crate::ui::plot::data::index_sampling_step(
+            let sampling_step = crate::ui::plot::data::index_sampling_step_for_selection(
+                selected_span_micros,
                 sampling_chunk_count,
                 sampling_index_count,
                 INDEX_BUFFER_LEN,
             );
 
-            let cached_values = index_cache
-                .as_ref()
-                .and_then(|c| c.played.as_ref().or(c.future.as_ref()))
-                .map(|g| g.values_bind_group.clone());
-            let values_bind_group = if let Some(bg) = cached_values {
-                bg
-            } else {
-                let entries = [0, 1, 2].map(|i| {
-                    let line = &line_handles.0[i];
-                    let line = line_assets.get(line).expect("line missing");
-                    BindGroupEntry {
-                        binding: i as u32,
-                        resource: BindingResource::Buffer(BufferBinding {
-                            buffer: line
-                                .data
-                                .data_buffer_shard_alloc()
-                                .expect("no data buf")
-                                .buffer(),
-                            offset: 0,
-                            size: Some(VALUE_BUFFER_SIZE),
-                        }),
-                    }
-                });
-                render_device.create_bind_group("line values", &values_layout.layout, &entries)
-            };
+            // let cached_values = index_cache
+            //     .as_ref()
+            //     .and_then(|c| c.played.as_ref().or(c.future.as_ref()))
+            //     .map(|g| g.values_bind_group.clone());
+            // XXX: This is not used. Delete?
+            // let _values_bind_group = if let Some(bg) = cached_values {
+            //     bg
+            // } else {
+            //     let entries = [0, 1, 2].map(|i| {
+            //         let line = &line_handles.0[i];
+            //         let line = line_assets.get(line).expect("line missing");
+            //         BindGroupEntry {
+            //             binding: i as u32,
+            //             resource: BindingResource::Buffer(BufferBinding {
+            //                 buffer: line
+            //                     .data
+            //                     .data_buffer_shard_alloc()
+            //                     .expect("no data buf")
+            //                     .buffer(),
+            //                 offset: 0,
+            //                 size: Some(VALUE_BUFFER_SIZE),
+            //             }),
+            //         }
+            //     });
+            //     render_device.create_bind_group("line values", &values_layout.layout, &entries)
+            // };
 
             let build_gpu_line = |range: std::ops::Range<impeller2::types::Timestamp>,
                                   cached: Option<&GpuLine>| {
@@ -659,12 +905,17 @@ fn extract_lines(
                     content_gens[0],
                     content_gens[1],
                     content_gens[2],
+                    geo_key,
                 );
                 if let Some(prev) = cached
                     && prev.last_index_key == Some(index_key)
                 {
                     return Some(prev.clone());
                 }
+                // Always start from the selection-derived step (1 for short
+                // windows). Double until the strip fits the index budget so we
+                // never silently truncate the newest tip when a short window
+                // somehow exceeds LOCAL_VALUE_BUFFER_LEN (~4.4 kHz x 30 s).
                 let mut step = sampling_step.max(1);
                 const MAX_INDEX_U32: u32 = INDEX_BUFFER_LEN as u32;
                 for _ in 0..26 {
@@ -680,17 +931,46 @@ fn extract_lines(
                     }
                     step = step.saturating_mul(2).max(2);
                 }
-                let index_buffers = ['x', 'y', 'z'].map(|axis| {
-                    render_device.create_buffer(
-                        &(BufferDescriptor {
-                            label: Some(&format!("Line {} Index Buffer", axis)),
-                            size: (INDEX_BUFFER_LEN * size_of::<u32>()) as u64,
-                            usage: BufferUsages::STORAGE | BufferUsages::COPY_DST,
-                            mapped_at_creation: false,
-                        }),
-                    )
+
+                let xs = line_assets
+                    .get(&line_handles.0[0])
+                    .map(|l| l.data.collect_strip_values(range.clone(), step))
+                    .unwrap_or_default();
+                let ys = line_assets
+                    .get(&line_handles.0[1])
+                    .map(|l| l.data.collect_strip_values(range.clone(), step))
+                    .unwrap_or_default();
+                let zs = line_assets
+                    .get(&line_handles.0[2])
+                    .map(|l| l.data.collect_strip_values(range.clone(), step))
+                    .unwrap_or_default();
+
+                let (value_buffers, index_buffers, count) = write_anchor_local_line_buffers(
+                    &xs,
+                    &ys,
+                    &zs,
+                    frame,
+                    &geo_ctx,
+                    line_anchor,
+                    &render_device,
+                    &render_queue,
+                )?;
+
+                let value_entries = [0, 1, 2].map(|i| BindGroupEntry {
+                    binding: i as u32,
+                    resource: BindingResource::Buffer(BufferBinding {
+                        buffer: &value_buffers[i],
+                        offset: 0,
+                        size: Some(LOCAL_VALUE_BUFFER_SIZE),
+                    }),
                 });
-                let entries = [0, 1, 2].map(|i| BindGroupEntry {
+                let values_bind_group = render_device.create_bind_group(
+                    "line_3d anchor-local values",
+                    &values_layout.layout,
+                    &value_entries,
+                );
+
+                let index_entries = [0, 1, 2].map(|i| BindGroupEntry {
                     binding: i as u32,
                     resource: BindingResource::Buffer(BufferBinding {
                         buffer: &index_buffers[i],
@@ -698,25 +978,16 @@ fn extract_lines(
                         size: Some(INDEX_BUFFER_SIZE),
                     }),
                 });
-                let index_bind_group =
-                    render_device.create_bind_group("line indexes", &index_layout.layout, &entries);
-                let counts = [0, 1, 2].map(|i| {
-                    let line = &line_handles.0[i];
-                    let line = line_assets.get(line).expect("line missing");
-                    line.data.write_to_index_buffer_with_step(
-                        &index_buffers[i],
-                        &render_queue,
-                        range.clone(),
-                        step,
-                    )
-                });
-                let count = counts.into_iter().min().unwrap_or_default();
-                if count < 2 {
-                    return None;
-                }
+                let index_bind_group = render_device.create_bind_group(
+                    "line_3d anchor-local indexes",
+                    &index_layout.layout,
+                    &index_entries,
+                );
+
                 Some(GpuLine {
-                    values_bind_group: values_bind_group.clone(),
+                    values_bind_group,
                     index_bind_group,
+                    value_buffers,
                     index_buffers,
                     count,
                     last_index_key: Some(index_key),
@@ -728,6 +999,7 @@ fn extract_lines(
             if let Some(gpu_line) = build_gpu_line(played_range.clone(), played_cached.as_ref()) {
                 let mut played_uniform = *uniform;
                 played_uniform.color = played_color;
+                // `uniform.model` is the entity GlobalTransform (first-point pose).
                 next_cache.played = Some(gpu_line.clone());
                 commands.spawn((
                     MainEntity::from(entity),
@@ -736,8 +1008,6 @@ fn extract_lines(
                     played_uniform,
                     GlobalTransform::default(),
                     Transform::default(),
-                    #[cfg(feature = "big_space")]
-                    crate::spatial::GridCell::default(),
                     gpu_line,
                     TemporaryRenderEntity,
                 ));
@@ -770,8 +1040,6 @@ fn extract_lines(
                     future_uniform,
                     GlobalTransform::default(),
                     Transform::default(),
-                    #[cfg(feature = "big_space")]
-                    crate::spatial::GridCell::default(),
                     gpu_line,
                     TemporaryRenderEntity,
                 ));
@@ -933,5 +1201,69 @@ mod tests {
             future: Some(half),
         });
         assert_eq!(future, half);
+    }
+
+    #[test]
+    fn frame_point_to_bevy_matches_geoposition() {
+        let ctx = GeoContext::default();
+        let p_frame = DVec3::new(10.0, 20.0, 30.0);
+        let expected = GeoPosition(GeoFrame::ENU, p_frame).to_bevy(&ctx);
+        let actual = frame_point_to_bevy(
+            GeoFrame::ENU,
+            p_frame.x as f32,
+            p_frame.y as f32,
+            p_frame.z as f32,
+            &ctx,
+        );
+        assert!((actual - expected).length() < 1e-6);
+    }
+
+    #[test]
+    fn relative_vertices_plus_entity_pose_recover_bevy_point() {
+        // Entity at first sample; vertex = p - first; model*vertex ≈ p - fo
+        // when model is the FO-local entity pose (first - fo).
+        let ctx = GeoContext::default();
+        let start_frame = DVec3::new(1.0, 2.0, 3.0);
+        let tip_frame = DVec3::new(11.0, 22.0, 33.0);
+        let anchor = frame_point_to_bevy(
+            GeoFrame::ENU,
+            start_frame.x as f32,
+            start_frame.y as f32,
+            start_frame.z as f32,
+            &ctx,
+        );
+        let tip = frame_point_to_bevy(
+            GeoFrame::ENU,
+            tip_frame.x as f32,
+            tip_frame.y as f32,
+            tip_frame.z as f32,
+            &ctx,
+        );
+        let tip_local = (tip - anchor).as_vec3();
+        let fo = DVec3::new(100.0, 200.0, 300.0);
+        let model = Mat4::from_translation((anchor - fo).as_vec3());
+        let placed_tip = model.transform_point3(tip_local);
+        assert!((placed_tip.as_dvec3() + fo - tip).length() < 1e-3);
+        let placed_start = model.transform_point3(Vec3::ZERO);
+        assert!((placed_start.as_dvec3() + fo - anchor).length() < 1e-3);
+    }
+
+    #[test]
+    fn geo_context_cache_key_changes_with_origin() {
+        let a = GeoContext::default();
+        let mut b = a.clone();
+        b.origin.latitude += 1e-6;
+        assert_ne!(
+            geo_context_cache_key(&a, GeoFrame::ENU),
+            geo_context_cache_key(&b, GeoFrame::ENU)
+        );
+        assert_eq!(
+            geo_context_cache_key(&a, GeoFrame::ENU),
+            geo_context_cache_key(&a, GeoFrame::ENU)
+        );
+        assert_ne!(
+            geo_context_cache_key(&a, GeoFrame::ENU),
+            geo_context_cache_key(&a, GeoFrame::ECEF)
+        );
     }
 }

--- a/libs/elodin-editor/src/ui/plot_3d/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/gpu.rs
@@ -2,7 +2,7 @@ use crate::{
     SelectedTimeRange,
     ui::plot::{
         Line,
-        gpu::{INDEX_BUFFER_LEN, INDEX_BUFFER_SIZE, VALUE_BUFFER_SIZE},
+        gpu::{INDEX_BUFFER_LEN, INDEX_BUFFER_SIZE},
     },
     ui::timeline::TimelineSettings,
 };
@@ -19,7 +19,6 @@ use bevy::{
     ecs::{
         component::Component,
         entity::Entity,
-        hierarchy::ChildOf,
         query::Has,
         schedule::{IntoScheduleConfigs, SystemSet},
         system::{
@@ -29,10 +28,10 @@ use bevy::{
         world::{FromWorld, Mut, World},
     },
     image::BevyDefault,
-    math::{DVec3, Mat4, Quat, Vec3, Vec4},
+    math::{DVec3, Mat4, Vec4},
     mesh::VertexBufferLayout,
     pbr::{MeshPipeline, MeshPipelineKey, SetMeshViewBindGroup},
-    prelude::{Color, Reflect, Resource, With},
+    prelude::{Color, Reflect, Resource},
     render::{
         ExtractSchedule, MainWorld, Render, RenderApp, RenderSystems,
         extract_component::{ComponentUniforms, DynamicUniformIndex, UniformComponentPlugin},
@@ -49,7 +48,7 @@ use bevy::{
         components::{GlobalTransform, Transform},
     },
 };
-use bevy_geo_frames::{GeoContext, GeoFrame, GeoPosition, Present};
+use bevy_geo_frames::{GeoFrame, GeoPosition};
 use bevy_render::{
     extract_component::ExtractComponent,
     sync_world::{MainEntity, SyncToRenderWorld, TemporaryRenderEntity},
@@ -81,14 +80,7 @@ impl Plugin for Plot3dGpuPlugin {
             .init_asset::<Line>()
             .add_systems(
                 PostUpdate,
-                (
-                    // After geo rotation so we own Transform; before propagate
-                    // so big_space sees the first-point GridCell pose.
-                    place_line_3d_at_first_point
-                        .after(bevy_geo_frames::apply_geo_rotation)
-                        .before(TransformSystems::Propagate),
-                    update_uniform_model.after(TransformSystems::Propagate),
-                ),
+                update_uniform_model.after(TransformSystems::Propagate),
             );
 
         load_internal_asset!(app, LINE_SHADER_HANDLE, "./line.wgsl", Shader::from_wgsl);
@@ -176,8 +168,8 @@ impl Plugin for Plot3dGpuPlugin {
 }
 
 fn update_uniform_model(mut query: Query<(&mut LineUniform, &GlobalTransform)>) {
-    // Entity sits at the line's first sample under BigSpaceRoot; big_space
-    // puts that in FO-local GlobalTransform. Vertices are (p - first).
+    // Entity GeoPosition is the first sample; GeoRotation carries the
+    // frame→Bevy basis. Vertices are (p_frame - first_frame).
     for (mut uniform, transform) in query.iter_mut() {
         uniform.model = transform.to_matrix();
     }
@@ -418,8 +410,8 @@ pub struct GpuLine {
     #[allow(dead_code)]
     index_buffers: [Buffer; 3],
     count: u32,
-    /// Last range + LineTree `content_gen`s + GeoContext/frame hash written
-    /// into the GPU buffers. Placement comes from the entity GlobalTransform.
+    /// Last range + LineTree `content_gen`s + frame/anchor hash written into
+    /// the GPU buffers. Placement comes from the entity GlobalTransform.
     #[allow(clippy::type_complexity)]
     last_index_key: Option<(i64, i64, u64, u64, u64, u64)>,
 }
@@ -528,26 +520,21 @@ type LineQueryMut = (
     Option<&'static mut GpuLineIndexCache>,
 );
 
-/// Hash of GeoContext fields that affect frame→Bevy conversion, plus the
-/// resolved line frame. Buffers built under a different context (e.g. before
-/// the schematic origin lands) must not be reused.
-fn geo_context_cache_key(ctx: &GeoContext, frame: GeoFrame) -> u64 {
+/// Cache key for frame-relative vertex buffers: frame discriminant + anchor
+/// (first sample in frame coords). Independent of GeoContext — FO/origin
+/// changes are handled by the entity's GeoPosition → GlobalTransform.
+fn anchor_cache_key(frame: GeoFrame, anchor: DVec3) -> u64 {
     use std::hash::{Hash, Hasher};
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    ctx.origin.latitude.to_bits().hash(&mut hasher);
-    ctx.origin.longitude.to_bits().hash(&mut hasher);
-    ctx.origin.altitude.to_bits().hash(&mut hasher);
-    match ctx.present {
-        Present::Plane => 0u8,
-        Present::Sphere => 1u8,
-    }
-    .hash(&mut hasher);
     match frame {
         GeoFrame::ENU => 0u8,
         GeoFrame::NED => 1u8,
         GeoFrame::ECEF => 2u8,
     }
     .hash(&mut hasher);
+    anchor.x.to_bits().hash(&mut hasher);
+    anchor.y.to_bits().hash(&mut hasher);
+    anchor.z.to_bits().hash(&mut hasher);
     hasher.finish()
 }
 
@@ -558,116 +545,28 @@ fn resolve_line_frame(geo_pos: Option<&GeoPosition>, line: Option<&Line3d>) -> G
     line.and_then(|l| l.frame).unwrap_or_default()
 }
 
-/// Convert a frame-space sample to absolute Bevy coordinates (f64).
-fn frame_point_to_bevy(frame: GeoFrame, x: f32, y: f32, z: f32, geo_ctx: &GeoContext) -> DVec3 {
-    GeoPosition(frame, DVec3::new(x as f64, y as f64, z as f64)).to_bevy(geo_ctx)
-}
-
-/// First sample of the line (full recording), in Bevy space. Stable geographic
-/// anchor for both the entity pose and relative vertex buffers.
-fn line_first_point_bevy(
+/// First sample of the line (full recording), in the line's own frame.
+fn line_first_point_frame(
     line_assets: &Assets<Line>,
     handles: &[Handle<Line>; 3],
-    frame: GeoFrame,
-    geo_ctx: &GeoContext,
 ) -> Option<DVec3> {
-    let full = impeller2::types::Timestamp(i64::MIN)..impeller2::types::Timestamp(i64::MAX);
-    // Huge step still keeps the first sample (and last); we only need the first.
-    let step = usize::MAX;
-    let xs = line_assets
-        .get(&handles[0])?
-        .data
-        .collect_strip_values(full.clone(), step);
-    let ys = line_assets
-        .get(&handles[1])?
-        .data
-        .collect_strip_values(full.clone(), step);
-    let zs = line_assets
-        .get(&handles[2])?
-        .data
-        .collect_strip_values(full, step);
-    let x = *xs.first()?;
-    let y = *ys.first()?;
-    let z = *zs.first()?;
-    Some(frame_point_to_bevy(frame, x, y, z, geo_ctx))
-}
-
-/// Place each `line_3d` entity at its first sample under [`BigSpaceRoot`] so
-/// big_space owns FO-local `GlobalTransform`. Vertices are stored relative to
-/// that same first point.
-#[allow(clippy::type_complexity)]
-fn place_line_3d_at_first_point(
-    mut commands: Commands,
-    mut lines: Query<(
-        Entity,
-        &LineHandles,
-        Option<&GeoPosition>,
-        Option<&Line3d>,
-        &mut Transform,
-        Option<&ChildOf>,
-    )>,
-    line_assets: Res<Assets<Line>>,
-    geo_ctx: Res<GeoContext>,
-    #[cfg(feature = "big_space")] settings: Res<crate::spatial::FloatingOriginSettings>,
-    #[cfg(feature = "big_space")] roots: Query<Entity, With<crate::spatial::BigSpaceRoot>>,
-) {
-    #[cfg(feature = "big_space")]
-    let Some(root) = roots.iter().next() else {
-        return;
-    };
-
-    for (entity, handles, geo_pos, line_3d, mut transform, child_of) in &mut lines {
-        // Vertices are already converted frame→Bevy; a GeoRotation basis on
-        // this entity would double-apply the frame change.
-        commands
-            .entity(entity)
-            .remove::<bevy_geo_frames::GeoRotation>();
-
-        let frame = resolve_line_frame(geo_pos, line_3d);
-        let Some(anchor) = line_first_point_bevy(&line_assets, &handles.0, frame, &geo_ctx) else {
-            continue;
-        };
-
-        #[cfg(feature = "big_space")]
-        {
-            let (grid_cell, translation) = settings.translation_to_grid(anchor);
-            *transform = Transform {
-                translation,
-                rotation: Quat::IDENTITY,
-                scale: Vec3::ONE,
-            };
-            commands
-                .entity(entity)
-                .insert(grid_cell)
-                .insert(GlobalTransform::default());
-            if child_of.map(|c| c.parent()) != Some(root) {
-                commands.entity(entity).insert(ChildOf(root));
-            }
-        }
-        #[cfg(not(feature = "big_space"))]
-        {
-            let _ = child_of;
-            *transform = Transform {
-                translation: anchor.as_vec3(),
-                rotation: Quat::IDENTITY,
-                scale: Vec3::ONE,
-            };
-        }
-    }
+    let x = line_assets.get(&handles[0])?.data.first_sample()?;
+    let y = line_assets.get(&handles[1])?.data.first_sample()?;
+    let z = line_assets.get(&handles[2])?.data.first_sample()?;
+    Some(DVec3::new(x as f64, y as f64, z as f64))
 }
 
 /// Build dense first-point-relative XYZ value buffers + remapped strip indices.
 ///
-/// `anchor` is the line's first sample in Bevy space (entity world pose).
-/// Vertices are `p - anchor`. Index layout matches the historical NaN-sentinel
-/// strip: leading/trailing `0` (NaN slot), samples at `1..n`.
-#[allow(clippy::too_many_arguments)]
+/// `anchor` is the line's first sample in frame coordinates (entity
+/// `GeoPosition`). Vertices are `p_frame - anchor`. The entity's
+/// `GeoRotation::absolute` carries the frame→Bevy basis via GlobalTransform.
+/// Index layout matches the historical NaN-sentinel strip: leading/trailing
+/// `0` (NaN slot), samples at `1..n`.
 fn write_anchor_local_line_buffers(
     xs: &[f32],
     ys: &[f32],
     zs: &[f32],
-    frame: GeoFrame,
-    geo_ctx: &GeoContext,
     anchor: DVec3,
     render_device: &RenderDevice,
     render_queue: &RenderQueue,
@@ -683,11 +582,10 @@ fn write_anchor_local_line_buffers(
     let mut y_local = vec![f32::NAN; n + 1];
     let mut z_local = vec![f32::NAN; n + 1];
     for i in 0..n {
-        let p = frame_point_to_bevy(frame, xs[i], ys[i], zs[i], geo_ctx);
-        let local = (p - anchor).as_vec3();
-        x_local[i + 1] = local.x;
-        y_local[i + 1] = local.y;
-        z_local[i + 1] = local.z;
+        let local = DVec3::new(xs[i] as f64, ys[i] as f64, zs[i] as f64) - anchor;
+        x_local[i + 1] = local.x as f32;
+        y_local[i + 1] = local.y as f32;
+        z_local[i + 1] = local.z as f32;
     }
 
     // Single contiguous strip with NaN sentinels (one logical chunk).
@@ -741,7 +639,6 @@ fn extract_lines(
     index_layout: Res<LineIndexLayout>,
 ) {
     main_world.resource_scope(|world, mut cached_state: Mut<CachedSystemState>| {
-        let geo_ctx = world.resource::<GeoContext>().clone();
         let replay_mode = world.contains_resource::<crate::ReplayMode>();
         let (
             mut lines,
@@ -814,7 +711,6 @@ fn extract_lines(
         ) in lines.iter_mut()
         {
             let frame = resolve_line_frame(geo_pos, line_3d);
-            let geo_key = geo_context_cache_key(&geo_ctx, frame);
             let (played_color, future_color) = trail_colors.copied().unwrap_or_default().resolve(
                 played_timeline_color,
                 future_timeline_color,
@@ -826,13 +722,12 @@ fn extract_lines(
                 }
             }
 
-            // Shared geographic anchor = first sample of the full line. Entity
-            // pose (GlobalTransform → model) is placed there in main world.
-            let Some(line_anchor) =
-                line_first_point_bevy(&line_assets, &line_handles.0, frame, &geo_ctx)
-            else {
+            // Frame-space first sample. Entity GeoPosition is synced to this;
+            // GeoRotation carries the frame→Bevy basis into GlobalTransform.
+            let Some(line_anchor) = line_first_point_frame(&line_assets, &line_handles.0) else {
                 continue 'outer;
             };
+            let anchor_key = anchor_cache_key(frame, line_anchor);
 
             // Replay grows the revealed prefix every frame. If the decimation
             // step is derived from only that prefix, the full trail gets
@@ -861,33 +756,6 @@ fn extract_lines(
                 INDEX_BUFFER_LEN,
             );
 
-            // let cached_values = index_cache
-            //     .as_ref()
-            //     .and_then(|c| c.played.as_ref().or(c.future.as_ref()))
-            //     .map(|g| g.values_bind_group.clone());
-            // XXX: This is not used. Delete?
-            // let _values_bind_group = if let Some(bg) = cached_values {
-            //     bg
-            // } else {
-            //     let entries = [0, 1, 2].map(|i| {
-            //         let line = &line_handles.0[i];
-            //         let line = line_assets.get(line).expect("line missing");
-            //         BindGroupEntry {
-            //             binding: i as u32,
-            //             resource: BindingResource::Buffer(BufferBinding {
-            //                 buffer: line
-            //                     .data
-            //                     .data_buffer_shard_alloc()
-            //                     .expect("no data buf")
-            //                     .buffer(),
-            //                 offset: 0,
-            //                 size: Some(VALUE_BUFFER_SIZE),
-            //             }),
-            //         }
-            //     });
-            //     render_device.create_bind_group("line values", &values_layout.layout, &entries)
-            // };
-
             let build_gpu_line = |range: std::ops::Range<impeller2::types::Timestamp>,
                                   cached: Option<&GpuLine>| {
                 if range.start >= range.end {
@@ -905,7 +773,7 @@ fn extract_lines(
                     content_gens[0],
                     content_gens[1],
                     content_gens[2],
-                    geo_key,
+                    anchor_key,
                 );
                 if let Some(prev) = cached
                     && prev.last_index_key == Some(index_key)
@@ -949,8 +817,6 @@ fn extract_lines(
                     &xs,
                     &ys,
                     &zs,
-                    frame,
-                    &geo_ctx,
                     line_anchor,
                     &render_device,
                     &render_queue,
@@ -1204,66 +1070,40 @@ mod tests {
     }
 
     #[test]
-    fn frame_point_to_bevy_matches_geoposition() {
-        let ctx = GeoContext::default();
-        let p_frame = DVec3::new(10.0, 20.0, 30.0);
-        let expected = GeoPosition(GeoFrame::ENU, p_frame).to_bevy(&ctx);
-        let actual = frame_point_to_bevy(
-            GeoFrame::ENU,
-            p_frame.x as f32,
-            p_frame.y as f32,
-            p_frame.z as f32,
-            &ctx,
-        );
-        assert!((actual - expected).length() < 1e-6);
-    }
-
-    #[test]
     fn relative_vertices_plus_entity_pose_recover_bevy_point() {
-        // Entity at first sample; vertex = p - first; model*vertex ≈ p - fo
-        // when model is the FO-local entity pose (first - fo).
+        // Vertices are frame-relative; entity pose = GeoPosition(first) +
+        // GeoRotation::absolute(frame). model * (p - first) recovers Bevy p.
+        use bevy_geo_frames::{GeoContext, GeoRotation};
         let ctx = GeoContext::default();
         let start_frame = DVec3::new(1.0, 2.0, 3.0);
         let tip_frame = DVec3::new(11.0, 22.0, 33.0);
-        let anchor = frame_point_to_bevy(
-            GeoFrame::ENU,
-            start_frame.x as f32,
-            start_frame.y as f32,
-            start_frame.z as f32,
-            &ctx,
-        );
-        let tip = frame_point_to_bevy(
-            GeoFrame::ENU,
-            tip_frame.x as f32,
-            tip_frame.y as f32,
-            tip_frame.z as f32,
-            &ctx,
-        );
-        let tip_local = (tip - anchor).as_vec3();
-        let fo = DVec3::new(100.0, 200.0, 300.0);
-        let model = Mat4::from_translation((anchor - fo).as_vec3());
+        let tip_local = (tip_frame - start_frame).as_vec3();
+        let translation = GeoPosition(GeoFrame::ENU, start_frame).to_bevy(&ctx);
+        let rotation =
+            GeoRotation::absolute(GeoFrame::ENU, bevy::math::DQuat::IDENTITY).to_bevy(&ctx);
+        let model = Mat4::from_rotation_translation(rotation.as_quat(), translation.as_vec3());
         let placed_tip = model.transform_point3(tip_local);
-        assert!((placed_tip.as_dvec3() + fo - tip).length() < 1e-3);
-        let placed_start = model.transform_point3(Vec3::ZERO);
-        assert!((placed_start.as_dvec3() + fo - anchor).length() < 1e-3);
+        let expected_tip = GeoPosition(GeoFrame::ENU, tip_frame).to_bevy(&ctx);
+        assert!((placed_tip.as_dvec3() - expected_tip).length() < 1e-3);
+        let placed_start = model.transform_point3(bevy::math::Vec3::ZERO);
+        assert!((placed_start.as_dvec3() - translation).length() < 1e-3);
     }
 
     #[test]
-    fn geo_context_cache_key_changes_with_origin() {
-        let a = GeoContext::default();
-        let mut b = a.clone();
-        b.origin.latitude += 1e-6;
+    fn anchor_cache_key_changes_with_frame_and_anchor() {
+        let a = DVec3::new(1.0, 2.0, 3.0);
+        let b = DVec3::new(1.0, 2.0, 3.001);
         assert_ne!(
-            geo_context_cache_key(&a, GeoFrame::ENU),
-            geo_context_cache_key(&b, GeoFrame::ENU)
+            anchor_cache_key(GeoFrame::ENU, a),
+            anchor_cache_key(GeoFrame::ENU, b)
         );
         assert_eq!(
-            geo_context_cache_key(&a, GeoFrame::ENU),
-            geo_context_cache_key(&a, GeoFrame::ENU)
+            anchor_cache_key(GeoFrame::ENU, a),
+            anchor_cache_key(GeoFrame::ENU, a)
         );
         assert_ne!(
-            geo_context_cache_key(&a, GeoFrame::ENU),
-            geo_context_cache_key(&a, GeoFrame::ECEF)
+            anchor_cache_key(GeoFrame::ENU, a),
+            anchor_cache_key(GeoFrame::ECEF, a)
         );
     }
 }

--- a/libs/elodin-editor/src/ui/plot_3d/mod.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/mod.rs
@@ -7,10 +7,9 @@ use bevy::{
         query::{With, Without},
         system::{Commands, Query, Res, ResMut},
     },
-    math::{DQuat, Mat4, Vec4},
-    prelude::{Color, warn_once},
+    math::Vec4,
+    prelude::{Color, GlobalTransform, Transform, warn_once},
 };
-use bevy_geo_frames::GeoRotation;
 use impeller2_bevy::ComponentMetadataRegistry;
 use impeller2_wkt::Line3d;
 
@@ -100,13 +99,15 @@ pub fn sync_line_plot_3d(
 
         let trail = line_trail_colors(line_plot);
         if let Ok(mut entity) = commands.get_entity(entity) {
+            // Pose is set each frame to the first sample under BigSpaceRoot;
+            // vertices are stored relative to that point (frame→Bevy on CPU).
             entity.try_insert((
                 gpu::LineHandles([x, y, z]),
                 LineUniform {
                     line_width: line_plot.line_width,
                     color: trail.played.unwrap_or(Vec4::ZERO),
                     depth_bias: 0.0,
-                    model: Mat4::IDENTITY,
+                    model: bevy::math::Mat4::IDENTITY,
                     perspective: if line_plot.perspective { 1 } else { 0 },
                     #[cfg(target_arch = "wasm32")]
                     _padding: Default::default(),
@@ -115,12 +116,14 @@ pub fn sync_line_plot_3d(
                 LineConfig {
                     render_layers: RenderLayers::layer(crate::plugins::gizmos::GIZMO_RENDER_LAYER),
                 },
+                Transform::default(),
+                GlobalTransform::default(),
+                #[cfg(feature = "big_space")]
+                crate::spatial::GridCell::default(),
             ));
-            if let Some(frame) = line_plot.frame {
-                // Absolute: the line's vertex data is raw frame coordinates, so
-                // its transform must carry the frame -> Bevy basis change.
-                entity.try_insert(GeoRotation::absolute(frame, DQuat::IDENTITY));
-            }
+            // Remove legacy absolute GeoRotation: it would double-apply the
+            // frame→Bevy basis now done when building vertex buffers.
+            entity.remove::<bevy_geo_frames::GeoRotation>();
         }
     }
     for (entity, line_plot, mut uniform, trail) in uniforms.iter_mut() {

--- a/libs/elodin-editor/src/ui/plot_3d/mod.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/mod.rs
@@ -1,22 +1,23 @@
 use bevy::{
-    app::Update,
-    asset::Handle,
+    app::{PreUpdate, Update},
+    asset::{Assets, Handle},
     camera::visibility::RenderLayers,
     ecs::{
         entity::Entity,
         query::{With, Without},
         system::{Commands, Query, Res, ResMut},
     },
-    math::Vec4,
-    prelude::{Color, GlobalTransform, Transform, warn_once},
+    math::{DVec3, Vec4},
+    prelude::{Color, GlobalTransform, IntoScheduleConfigs, Transform, warn_once},
 };
+use bevy_geo_frames::GeoPosition;
 use impeller2_bevy::ComponentMetadataRegistry;
 use impeller2_wkt::Line3d;
 
 use gpu::{LineConfig, LineUniform};
 
 use super::plot::{CollectedGraphData, Line, PlotDataComponent};
-use crate::{EqlContext, ui::schematic::EqlExt};
+use crate::{EqlContext, PositionSync, ui::schematic::EqlExt};
 
 pub mod gpu;
 
@@ -40,6 +41,39 @@ fn line_trail_colors(line_plot: &Line3d) -> gpu::LineTrailColors {
     }
 }
 
+/// Write the line's first sample into `GeoPosition` (frame coords). The geo
+/// pipeline then owns Transform/GridCell; GPU vertices stay frame-relative to
+/// that same first point.
+fn sync_line_3d_anchor(
+    mut lines: Query<(&gpu::LineHandles, &mut GeoPosition), With<Line3d>>,
+    line_assets: Res<Assets<Line>>,
+) {
+    for (handles, mut geo) in &mut lines {
+        let Some(x) = line_assets
+            .get(&handles.0[0])
+            .and_then(|l| l.data.first_sample())
+        else {
+            continue;
+        };
+        let Some(y) = line_assets
+            .get(&handles.0[1])
+            .and_then(|l| l.data.first_sample())
+        else {
+            continue;
+        };
+        let Some(z) = line_assets
+            .get(&handles.0[2])
+            .and_then(|l| l.data.first_sample())
+        else {
+            continue;
+        };
+        let first = DVec3::new(x as f64, y as f64, z as f64);
+        if geo.1 != first {
+            geo.1 = first;
+        }
+    }
+}
+
 pub fn sync_line_plot_3d(
     line_plot_3d_query: Query<(Entity, &Line3d), Without<gpu::LineHandles>>,
     mut uniforms: Query<
@@ -55,6 +89,7 @@ pub fn sync_line_plot_3d(
     eql_ctx: Res<EqlContext>,
     mut collected_graph_data: ResMut<CollectedGraphData>,
     metadata_store: Res<ComponentMetadataRegistry>,
+    #[cfg(feature = "big_space")] root: Option<Res<crate::spatial::BigSpaceRootEntity>>,
 ) {
     for (entity, line_plot) in line_plot_3d_query.iter() {
         // Parse and compile the EQL expression
@@ -99,8 +134,8 @@ pub fn sync_line_plot_3d(
 
         let trail = line_trail_colors(line_plot);
         if let Ok(mut entity) = commands.get_entity(entity) {
-            // Pose is set each frame to the first sample under BigSpaceRoot;
-            // vertices are stored relative to that point (frame→Bevy on CPU).
+            // Pose comes from GeoPosition(first sample) + GeoRotation::absolute;
+            // vertices are frame-relative to that first point.
             entity.try_insert((
                 gpu::LineHandles([x, y, z]),
                 LineUniform {
@@ -121,9 +156,8 @@ pub fn sync_line_plot_3d(
                 #[cfg(feature = "big_space")]
                 crate::spatial::GridCell::default(),
             ));
-            // Remove legacy absolute GeoRotation: it would double-apply the
-            // frame→Bevy basis now done when building vertex buffers.
-            entity.remove::<bevy_geo_frames::GeoRotation>();
+            #[cfg(feature = "big_space")]
+            crate::spatial::parent_under_big_space(&mut entity, root.as_deref());
         }
     }
     for (entity, line_plot, mut uniform, trail) in uniforms.iter_mut() {
@@ -151,7 +185,8 @@ impl bevy::app::Plugin for LinePlot3dPlugin {
     fn build(&self, app: &mut bevy::prelude::App) {
         app.init_resource::<CollectedGraphData>()
             .add_plugins(gpu::Plot3dGpuPlugin)
-            .add_systems(Update, sync_line_plot_3d);
+            .add_systems(Update, sync_line_plot_3d)
+            .add_systems(PreUpdate, sync_line_3d_anchor.before(PositionSync));
     }
 }
 

--- a/libs/elodin-editor/src/ui/plot_3d/mod.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/mod.rs
@@ -4,8 +4,8 @@ use bevy::{
     camera::visibility::RenderLayers,
     ecs::{
         entity::Entity,
-        query::{With, Without},
-        system::{Commands, Query, Res, ResMut},
+        query::{Added, With, Without},
+        system::{Commands, Local, Query, Res, ResMut},
     },
     math::{DVec3, Vec4},
     prelude::{Color, GlobalTransform, IntoScheduleConfigs, Transform, warn_once},
@@ -44,34 +44,46 @@ fn line_trail_colors(line_plot: &Line3d) -> gpu::LineTrailColors {
 /// Write the line's first sample into `GeoPosition` (frame coords). The geo
 /// pipeline then owns Transform/GridCell; GPU vertices stay frame-relative to
 /// that same first point.
+///
+/// Entities are queued when their `gpu::LineHandles` are added and stay queued
+/// until all three line assets have a first sample, so the anchor is written
+/// exactly once per handle insertion.
 fn sync_line_3d_anchor(
+    added: Query<Entity, (Added<gpu::LineHandles>, With<Line3d>)>,
+    mut queue: Local<Vec<Entity>>,
     mut lines: Query<(&gpu::LineHandles, &mut GeoPosition), With<Line3d>>,
     line_assets: Res<Assets<Line>>,
 ) {
-    for (handles, mut geo) in &mut lines {
+    queue.extend(&added);
+    queue.retain(|&entity| {
+        let Ok((handles, mut geo)) = lines.get_mut(entity) else {
+            // Entity despawned or lost its components; drop it from the queue.
+            return false;
+        };
         let Some(x) = line_assets
             .get(&handles.0[0])
             .and_then(|l| l.data.first_sample())
         else {
-            continue;
+            return true;
         };
         let Some(y) = line_assets
             .get(&handles.0[1])
             .and_then(|l| l.data.first_sample())
         else {
-            continue;
+            return true;
         };
         let Some(z) = line_assets
             .get(&handles.0[2])
             .and_then(|l| l.data.first_sample())
         else {
-            continue;
+            return true;
         };
         let first = DVec3::new(x as f64, y as f64, z as f64);
         if geo.1 != first {
             geo.1 = first;
         }
-    }
+        false
+    });
 }
 
 pub fn sync_line_plot_3d(

--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -234,6 +234,8 @@ pub struct LoadSchematicParams<'w, 's> {
     /// refetch can tell a window-only remote save apart from an unrelated
     /// asset write (RFD #724, Bug 2). Optional: absent in minimal test apps.
     last_content: Option<ResMut<'w, LastActiveSchematicContent>>,
+    #[cfg(feature = "big_space")]
+    big_space_root: Option<Res<'w, crate::spatial::BigSpaceRootEntity>>,
 }
 
 fn apply_theme(theme: Option<&impeller2_wkt::ThemeConfig>) -> colors::SchemeSelection {
@@ -904,7 +906,12 @@ impl LoadSchematicParams<'_, '_> {
         );
         match result {
             Ok(entity) => {
-                self.commands.entity(entity).insert(SchematicSpawned);
+                {
+                    let mut e = self.commands.entity(entity);
+                    e.insert(SchematicSpawned);
+                    #[cfg(feature = "big_space")]
+                    crate::spatial::parent_under_big_space(&mut e, self.big_space_root.as_deref());
+                }
                 if let Some(icon) = &icon {
                     crate::object_3d::spawn_billboard_icon(
                         &mut self.commands,
@@ -927,25 +934,22 @@ impl LoadSchematicParams<'_, '_> {
     }
 
     pub fn spawn_line_3d(&mut self, line_3d: Line3d) {
-        let frame = line_3d.frame;
+        let frame = line_3d.frame.or_default().unwrap_or_default();
         let mut spawn = self.commands.spawn(line_3d);
         spawn.insert((
             Name::new("line_3d"),
             Transform::default(),
             GlobalTransform::default(),
+            // Absolute: vertex data is frame-relative; GeoRotation carries
+            // the frame → Bevy basis. GeoPosition is the first sample (synced
+            // once LineHandles have data).
+            bevy_geo_frames::GeoPosition(frame, bevy::math::DVec3::ZERO),
+            bevy_geo_frames::GeoRotation::absolute(frame, bevy::math::DQuat::IDENTITY),
             #[cfg(feature = "big_space")]
             crate::spatial::GridCell::default(),
         ));
-
-        // Add GeoPosition and GeoRotation; use ENU if no frame is specified.
-        // The rotation is Absolute: the line's vertex data is raw frame
-        // coordinates, so its transform must carry the frame -> Bevy basis change.
-        if let Some(frame) = frame.or_default() {
-            spawn.insert((
-                bevy_geo_frames::GeoPosition(frame, bevy::math::DVec3::ZERO),
-                bevy_geo_frames::GeoRotation::absolute(frame, bevy::math::DQuat::IDENTITY),
-            ));
-        }
+        #[cfg(feature = "big_space")]
+        crate::spatial::parent_under_big_space(&mut spawn, self.big_space_root.as_deref());
         spawn.insert(SchematicSpawned);
     }
 
@@ -1000,9 +1004,10 @@ impl LoadSchematicParams<'_, '_> {
             &mut self.world_mesh_materials,
             &world_mesh,
         );
-        self.commands
-            .entity(entity)
-            .insert((SchematicSpawned, world_mesh));
+        let mut e = self.commands.entity(entity);
+        e.insert((SchematicSpawned, world_mesh));
+        #[cfg(feature = "big_space")]
+        crate::spatial::parent_under_big_space(&mut e, self.big_space_root.as_deref());
     }
 
     fn spawn_panel(
@@ -1034,7 +1039,10 @@ impl LoadSchematicParams<'_, '_> {
                     }
                 }
                 if let Some(parent) = pane.parent {
-                    self.commands.entity(parent).insert(SchematicSpawned);
+                    let mut e = self.commands.entity(parent);
+                    e.insert(SchematicSpawned);
+                    #[cfg(feature = "big_space")]
+                    crate::spatial::parent_under_big_space(&mut e, self.big_space_root.as_deref());
                 }
                 if let Some(grid) = pane.grid {
                     self.commands.entity(grid).insert(SchematicSpawned);

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -132,9 +132,12 @@ pub(crate) fn plugin(app: &mut App) {
         .add_systems(Update, sync_editor_cam_zoom_limits);
 }
 
-fn spawn_viewport_grids(mut commands: Commands) {
+fn spawn_viewport_grids(
+    mut commands: Commands,
+    #[cfg(feature = "big_space")] root: Option<Res<crate::spatial::BigSpaceRootEntity>>,
+) {
     for (frame, layer) in GRID_RENDER_LAYERS {
-        commands.spawn((
+        let mut entity = commands.spawn((
             bevy_infinite_grid::InfiniteGridBundle {
                 settings: viewport_grid_settings(frame),
                 visibility: Visibility::Visible,
@@ -150,6 +153,8 @@ fn spawn_viewport_grids(mut commands: Commands) {
                 bevy::math::DQuat::from_rotation_x(std::f64::consts::FRAC_PI_2),
             ),
         ));
+        #[cfg(feature = "big_space")]
+        crate::spatial::parent_under_big_space(&mut entity, root.as_deref());
     }
 }
 

--- a/libs/impeller2/bevy/src/lib.rs
+++ b/libs/impeller2/bevy/src/lib.rs
@@ -920,13 +920,13 @@ fn try_insert_entity<'a, 'w, 's>(
     metadata_reg: &mut ComponentMetadataRegistry,
     commands: &'a mut Commands<'w, 's>,
     component_path: &ComponentPart,
-) -> Option<EntityCommands<'a>> {
+) -> Option<(EntityCommands<'a>, bool)> {
     let component_id = component_path.id;
     if let Some(entity) = entity_map.get(&component_id) {
         let Ok(e) = commands.get_entity(*entity) else {
             return None;
         };
-        Some(e)
+        Some((e, false))
     } else {
         let mut e = commands.spawn((component_id, ComponentValueMap::default()));
         let metadata = metadata_reg
@@ -940,7 +940,7 @@ fn try_insert_entity<'a, 'w, 's>(
         e.insert(metadata.clone());
 
         entity_map.insert(component_id, e.id());
-        Some(e)
+        Some((e, true))
     }
 }
 
@@ -968,10 +968,12 @@ impl Decomponentize for WorldSink<'_, '_> {
             part,
         );
 
-        // Build parent-child hierarchy.
+        // Wire parent-child hierarchy only for newly created path segments.
+        // Re-inserting ChildOf every packet would undo editor reparenting of
+        // spatial leaves (GridCell under BigSpaceRoot).
         let mut last_entity: Option<Entity> = None;
         for parent in path.path.iter() {
-            let Some(mut e) = try_insert_entity(
+            let Some((mut e, newly_created)) = try_insert_entity(
                 &mut self.entity_map,
                 &mut self.metadata_reg,
                 &mut self.commands,
@@ -979,7 +981,7 @@ impl Decomponentize for WorldSink<'_, '_> {
             ) else {
                 continue;
             };
-            if let Some(last_entity) = last_entity {
+            if newly_created && let Some(last_entity) = last_entity {
                 e.insert(ChildOf(last_entity));
             }
             last_entity = Some(e.id());

--- a/typos.toml
+++ b/typos.toml
@@ -26,6 +26,7 @@
 "iy" = "iy"
 "PNGs" = "PNGs"
 "PN" = "PN"
+"FO" = "FO"
 
 [files]
 extend-exclude = [


### PR DESCRIPTION
Translates the line_3d to the floating origin so that we don't see degradation of f32 accuracy for f64 data. Also adds line_3d to use raw data when in a limited window.

Intent to merge this to @x46085's #740 PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches 3D line GPU extraction, geo/big_space hierarchy, and impeller entity parenting—areas where subtle regressions could show as visual jitter, wrong transforms, or broken scene trees.
> 
> **Overview**
> **Fixes `line_3d` jitter** by anchoring trails to the first sample instead of feeding large frame coordinates through `f32` GPU buffers. The entity’s `GeoPosition` is synced to that first point (`sync_line_3d_anchor` before `PositionSync`); extract builds dense **first-point-relative** XYZ buffers and places the line via the entity `GlobalTransform`. Short timeline windows use selection-based decimation (`index_sampling_step_for_selection`) and **double the step** when strip indices exceed the budget so the tip is not truncated.
> 
> **Big-space hierarchy** drops the per-frame `attach_parentless_grid_cells` janitor in favor of `BigSpaceRootEntity`, `parent_under_big_space` at schematic/gizmo/sensor/viewport/line spawn sites, and insert-time observers when `GridCell` is added or `ChildOf` is reparented under non-spatial parents.
> 
> **Impeller path wiring** only inserts `ChildOf` for **newly created** path segments so every telemetry packet no longer overwrites editor reparenting of spatial leaves.
> 
> Adds `LineTree::first_sample` / `collect_strip_values` and related tests; documents “spawn-time correctness” in the Bevy skill.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d912ce3f05d17c8edab71f74db5c96a3ad1dff2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->