### PR TITLE
Fix timer-wheel freezes and reduce live telemetry jitter

### DIFF
--- a/libs/stellarator/maitake/src/time/timer/wheel.rs
+++ b/libs/stellarator/maitake/src/time/timer/wheel.rs
@@ -379,8 +379,11 @@ impl Wheel {
         let distance = self.next_slot_distance(now)?;
 
         let slot = distance % Self::SLOTS;
-        // does the next slot wrap this wheel around from the now slot?
-        let skipped = distance.saturating_sub(Self::SLOTS);
+        // `next_set_bit` represents a wrapped slot as SLOTS + slot. Convert
+        // that to a rotation count (0 or 1), not the slot number after the
+        // wrap. Treating the latter as a rotation count can put the deadline
+        // in the past (slot 0) or several rotations into the future.
+        let skipped = distance / Self::SLOTS;
 
         debug_assert!(distance < Self::SLOTS * 2);
         debug_assert!(

--- a/libs/stellarator/maitake/tests/timer_wheel_wrap.rs
+++ b/libs/stellarator/maitake/tests/timer_wheel_wrap.rs
@@ -1,0 +1,45 @@
+use futures_util::task::noop_waker;
+use maitake::time::{Clock, Timer};
+use std::future::Future;
+use std::pin::pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+static NOW: AtomicU64 = AtomicU64::new(0);
+
+fn now() -> u64 {
+    NOW.load(Ordering::SeqCst)
+}
+
+#[test]
+fn top_level_slot_zero_wrap_stays_in_the_next_rotation() {
+    // Each top-level slot spans 2^30 ticks. Start halfway through slot 62,
+    // then schedule two seconds ahead so the deadline lands in slot 0 of the
+    // next rotation. This is the boundary that previously calculated a
+    // deadline in the past and made Timer::turn spin until the timeout elapsed.
+    const TOP_LEVEL_SLOT_TICKS: u64 = 1 << 30;
+    const START: u64 = 62 * TOP_LEVEL_SLOT_TICKS + TOP_LEVEL_SLOT_TICKS / 2;
+    const TIMEOUT_TICKS: u64 = 2_000_000_000;
+
+    NOW.store(START, Ordering::SeqCst);
+    let timer = Timer::new(Clock::new(Duration::from_nanos(1), now));
+    timer.turn();
+
+    let mut sleep = pin!(timer.sleep(Duration::from_secs(2)));
+    let waker = noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    assert_eq!(sleep.as_mut().poll(&mut cx), Poll::Pending);
+
+    let turn = timer.turn();
+    let until_next = turn
+        .time_to_next_deadline()
+        .expect("registered sleep should provide a deadline");
+    assert!(until_next > Duration::ZERO);
+    assert!(until_next <= Duration::from_secs(2));
+
+    NOW.store(START + TIMEOUT_TICKS, Ordering::SeqCst);
+    let turn = timer.turn();
+    assert_eq!(turn.expired, 1);
+    assert_eq!(sleep.as_mut().poll(&mut cx), Poll::Ready(()));
+}

--- a/libs/stellarator/src/net/tcp.rs
+++ b/libs/stellarator/src/net/tcp.rs
@@ -25,6 +25,11 @@ impl TcpStream {
         socket.set_nonblocking(!cfg!(target_os = "linux"))?;
         let addr: SockAddr = addr.into();
         Completion::run(ops::Connect::new(&socket, Box::new(addr.into()))?).await?;
+        // Stellarator TCP streams carry latency-sensitive telemetry and control
+        // packets. Do not let Nagle's algorithm batch a fresh value behind an
+        // earlier unacknowledged write; live views have no playback buffer to
+        // hide that delay.
+        socket.set_nodelay(true)?;
 
         Ok(TcpStream { socket })
     }
@@ -93,6 +98,8 @@ impl TcpListener {
         let socket = Completion::run(op).await.0?;
         #[cfg(not(target_os = "windows"))]
         socket.set_cloexec(true)?;
+        // Apply the same low-latency policy to the server side of the stream.
+        socket.set_nodelay(true)?;
         Ok(TcpStream { socket })
     }
 
@@ -114,12 +121,14 @@ mod tests {
         let addr = listener.local_addr().unwrap();
         let handle = crate::spawn(async move {
             let stream = listener.accept().await.unwrap();
+            assert!(stream.socket.nodelay().unwrap());
             let mut buf = vec![0u8; 128];
             let n = rent!(stream.read(buf).await, buf).unwrap();
             buf.truncate(n);
             stream.write(buf).await.0.unwrap();
         });
         let stream = TcpStream::connect(addr).await.unwrap();
+        assert!(stream.socket.nodelay().unwrap());
         stream.write(b"foo").await.0.unwrap();
         let mut buf = vec![0; 128];
         let n = rent!(stream.read(buf).await, buf).unwrap();


### PR DESCRIPTION
# Summary

This pull request fixes two independent sources of visible pauses in the Elodin editor:

1. A repeatable 1–2 second freeze approximately every 68.7 seconds, caused by incorrect timer-wheel wrap arithmetic in Maitake.
2. Short frame-pacing hitches when the editor follows the newest live telemetry sample with no playback buffer, caused by TCP batching latency on small telemetry and control writes.

The timer fix corrects the underlying deadline calculation and includes a deterministic boundary regression test. The live-telemetry fix enables `TCP_NODELAY` on both sides of Stellarator TCP connections and verifies the socket state in the existing echo test.

Neither fix adds an artificial delay to live playback.

# Demo videos

## Before

Freeze at about 32 seconds:

https://github.com/user-attachments/assets/b369c21a-6ac2-4930-ac2d-58d9472459dd



## After

No freeze


https://github.com/user-attachments/assets/f0a9c7d4-8e85-4a9f-963f-dc953c7f99c1



The additional recordings discussed under Validation were used for internal verification and will not be attached to the pull request.

# User-visible symptoms

## Periodic long freeze

While running the three-body example, the editor would stop updating for roughly one to two seconds. The freeze recurred at an interval of approximately 68 seconds.

The interval was highly repeatable:

```text
2^36 nanoseconds = 68.719476736 seconds
```

That timing corresponds to a wrap boundary in the highest level of Maitake's timer wheel.

## Short live-follow hitches

Playback remained smooth when the timeline was kept slightly behind the simulation, but occasional short pauses were visible when the timeline followed the latest available sample exactly.

Buffered playback could hide transport jitter because samples were already present in the local cache. The zero-buffer live-follow path could not: if several small telemetry writes were held and delivered together, the view briefly stopped and then jumped forward.

# Root cause: timer-wheel wrap arithmetic

`next_set_bit` represents a wrapped slot using a distance in the range:

```text
SLOTS .. (2 * SLOTS - 1)
```

In other words, a wrapped slot is encoded as:

```text
SLOTS + slot
```

The previous code attempted to derive the number of skipped rotations with:

```rust
let skipped = distance.saturating_sub(Self::SLOTS);
```

That computes the wrapped slot index, not the number of wheel rotations. Most importantly, when `distance == SLOTS`—the first slot after a wrap—it returns zero even though one complete rotation was crossed.

The reconstructed deadline could therefore be placed in the past. When this happened, `Timer::turn` repeatedly removed and rescheduled the same timeout until real time caught up with that past deadline. The executor remained occupied in timer advancement during that loop, producing the visible freeze.

# Timer-wheel fix

Convert the encoded distance into an actual rotation count:

```rust
let skipped = distance / Self::SLOTS;
```

Given the existing invariant that `distance < Self::SLOTS * 2`, this correctly yields either:

- `0` for a slot in the current rotation, or
- `1` for a slot after the wheel wraps.

## Regression test

The new `timer_wheel_wrap` integration test uses a synthetic nanosecond clock and deliberately crosses the problematic top-level boundary:

1. Start halfway through top-level slot 62.
2. Schedule a two-second sleep so its deadline lands in slot 0 of the next rotation.
3. Poll the sleep and verify it remains pending.
4. Turn the timer and verify the next deadline is positive and no more than two seconds away.
5. Advance the synthetic clock exactly to the deadline.
6. Verify that one timer expires and the sleep becomes ready.

With the old arithmetic, this scenario places the deadline in the past and causes timer advancement to spin. With the corrected rotation count, it completes immediately and deterministically.

# Root cause: live TCP batching

Stellarator TCP streams carry small, latency-sensitive telemetry and control messages. They previously used the platform default TCP behavior, leaving Nagle's algorithm enabled.

Nagle's algorithm is useful for throughput-oriented traffic because it can combine several small writes into fewer packets. That policy is undesirable for live telemetry: a newly produced value may wait behind an earlier unacknowledged write and then arrive in a burst with later values.

This distinction explains why the issue was most noticeable in true live-follow mode:

- Delayed playback reads from an existing sample cache and can absorb packet-arrival variation.
- Live-follow playback has no buffer and exposes transport latency directly as a pause followed by a jump.

# Live-telemetry fix

Enable `TCP_NODELAY` after both outgoing connections and accepted connections are established:

- `TcpStream::connect` applies the low-latency policy to the client endpoint.
- `TcpListener::accept` applies the same policy to the server endpoint.

Applying the setting on both paths ensures latency-sensitive writes are not accidentally batched in either direction.

The existing TCP echo test now inspects both endpoints and asserts that `TCP_NODELAY` is enabled. This prevents later socket setup changes from silently restoring the previous behavior.

# Validation

## Timer-wheel validation

Three independent post-fix Gamescope recordings of the three-body example were captured for approximately 105 seconds each. This duration crosses the 68.7-second top-level wheel boundary that previously triggered the long freeze.

FFmpeg freeze detection, excluding approximately the first 10 seconds of startup, reported no freezes in all three trials:

| Trial | Duration | Detected freezes |
| --- | ---: | ---: |
| 1 | 104.7663 s | 0 |
| 2 | 104.9345 s | 0 |
| 3 | 104.9332 s | 0 |

These recordings and their matching Gamescope logs, FFmpeg logs, and metadata were used for internal validation. They are not included as reviewer-facing attachments.

## Zero-buffer live-follow validation

The normal three-body schematic does not automatically pin the timeline to the newest packet, so validation used a temporary schematic with:

```kdl
timeline follow_latest=#true
```

This exercises the exact path where the editor has no playback buffer available to hide telemetry jitter.

The final release-build recording produced:

```text
Duration: 104.9655 seconds
Frames:   6,299
```

After excluding the first 10 seconds, FFmpeg found:

| Minimum freeze duration | Detected freezes |
| --- | ---: |
| 100 ms | 0 |
| 200 ms | 0 |
| 350 ms | 0 |
| 500 ms | 0 |

This recording was used for internal validation and is not included as a reviewer-facing attachment.

## Instrumented long live trial

A separate 180-second live-follow run combined:

- a 60 FPS Gamescope/PipeWire recording,
- FFmpeg freeze detection,
- temporary editor frame/latest-data gap diagnostics, and
- a loopback TCP packet capture.

Results after startup:

- No FFmpeg-detected freezes at 100, 200, 350, or 500 ms.
- No sustained latest-data gaps.
- The largest observed gap between server telemetry payload packets was approximately 13 ms.

The recording and packet capture were used for internal validation and are not included as reviewer-facing attachments. The temporary diagnostics and temporary live-follow schematic were also not included in this pull request.

# Automated checks

The following merge-readiness checks pass:

```text
cargo fmt -p elodin-editor
cargo clippy --release -p elodin
cargo test --release -p elodin-editor
```

Editor test result:

```text
248 passed
0 failed
2 ignored
```

The affected lower-level crates were also tested directly:

```text
cargo test --release -p stellarator -p maitake
cargo test --release -p maitake --test timer_wheel_wrap
cargo test --release -p stellarator test_echo_server
```

This includes all Maitake and Stellarator unit tests, integration tests, and Maitake doctests.

Additional checks completed successfully:

```text
cargo build --release -p elodin
cargo fmt --check -p stellarator -p maitake
git diff --check
```

# Files changed

```text
libs/stellarator/maitake/src/time/timer/wheel.rs
libs/stellarator/maitake/tests/timer_wheel_wrap.rs
libs/stellarator/src/net/tcp.rs
```

# Commit structure

The changes are split into two independently reviewable commits:

1. `fix(maitake): preserve timer rotation across wheel wrap`
   - Corrects the timer-wheel rotation calculation.
   - Adds the deterministic wrap-boundary regression test.

2. `fix(stellarator): disable TCP batching for live telemetry`
   - Enables `TCP_NODELAY` for connected and accepted streams.
   - Adds socket-level assertions to the TCP echo test.

# Risk and compatibility

## Timer-wheel change

The timer-wheel change is narrow and preserves the existing distance encoding. It only corrects how that distance is converted into a rotation count. The existing debug invariant constrains the result to zero or one rotation.

The regression test directly covers the boundary that caused the production freeze.

## TCP behavior change

Disabling Nagle's algorithm can increase the number of small TCP packets compared with throughput-oriented batching. Stellarator streams are primarily used for latency-sensitive telemetry and control traffic, where prompt delivery is preferable to minimizing packet count.

No framing, serialization, protocol, or public API changes are introduced. Both endpoints remain ordinary TCP sockets, and peers that do not use Stellarator remain protocol-compatible.

# Reviewer notes

The two fixes address separate timing layers:

- The Maitake change prevents the runtime itself from spinning during a timer-wheel wrap.
- The Stellarator change prevents the transport from intentionally batching fresh live values.

The previously considered one-millisecond database timeout grace period was rejected because it only masked the timer-wheel symptom and depended on incidental write timing. It is not part of this pull request.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Timer fix touches core async scheduling deadlines; TCP nodelay is a behavioral transport change (more small packets) but limited to Stellarator sockets with a narrow arithmetic fix and regression test coverage.
> 
> **Overview**
> Fixes two sources of editor pauses: **Maitake timer-wheel wrap math** and **TCP Nagle batching** on Stellarator streams.
> 
> In `Wheel::next_deadline`, wrapped slot distances (`SLOTS + slot`) are now turned into a **rotation count** with `distance / Self::SLOTS` instead of `distance.saturating_sub(Self::SLOTS)`, which had treated the wrapped slot index as rotations and could schedule the next deadline **in the past**, making `Timer::turn` spin until real time caught up (~68s freezes). A new `timer_wheel_wrap` integration test pins the top-level slot-0 wrap boundary.
> 
> **Stellarator** enables `TCP_NODELAY` on `TcpStream::connect` and `TcpListener::accept` so small live telemetry/control writes are not delayed behind unacked data; the echo test asserts nodelay on both ends.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b1b4a276151c4b2fa3e9138163c7ef6b85836c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->