### PR TITLE
Feature: Add error covariance to ellipsoid.

### DIFF
--- a/docs/public/content/reference/schematic.md
+++ b/docs/public/content/reference/schematic.md
@@ -141,7 +141,8 @@ viewport hdr=#true {
         | c e f |
         The editor Cholesky-decomposes P at runtime. When both
         `error_covariance_cholesky` and `error_covariance` are set, Cholesky
-        takes precedence.
+        takes precedence based on field presence (even if the Cholesky
+        expression fails to compile).
       - `error_confidence_interval` (default `70`) the percentage that if this
         were repeated 100 times, we would expect that in 70 cases, the true
         value would be within the bounds. In practice this means that the

--- a/docs/public/content/reference/schematic.md
+++ b/docs/public/content/reference/schematic.md
@@ -133,6 +133,15 @@ viewport hdr=#true {
         | a 0 0 |
         | b c 0 |
         | d e f |
+      - `error_covariance` as an alternative to Cholesky, specify the
+        symmetric covariance matrix P directly as a 6-pack. Example
+        `"(a,b,c,d,e,f)"` which describes:
+        | a b c |
+        | b d e |
+        | c e f |
+        The editor Cholesky-decomposes P at runtime. When both
+        `error_covariance_cholesky` and `error_covariance` are set, Cholesky
+        takes precedence.
       - `error_confidence_interval` (default `70`) the percentage that if this
         were repeated 100 times, we would expect that in 70 cases, the true
         value would be within the bounds. In practice this means that the

--- a/examples/covariance-ellipsoids/README.md
+++ b/examples/covariance-ellipsoids/README.md
@@ -5,8 +5,10 @@ Displays the same positive-definite covariance as two ellipsoids:
 - `error_covariance_cholesky` receives the lower-triangular factor `L`.
 - `error_covariance` receives `P = LLᵀ` directly.
 
-Both viewports use the same camera offset and confidence interval, so the
-ellipsoids should have identical shape and orientation.
+The Cholesky factor varies continuously over an eight-second cycle, while the
+direct covariance is recomputed as `P = LLᵀ` every simulation tick. Their
+principal extents should remain synchronized. The direct covariance side uses
+the example's explicit ECEF frame, while the Cholesky side inherits ENU.
 
 Run from the repository root:
 

--- a/examples/covariance-ellipsoids/README.md
+++ b/examples/covariance-ellipsoids/README.md
@@ -1,0 +1,15 @@
+# Covariance Ellipsoids
+
+Displays the same positive-definite covariance as two ellipsoids:
+
+- `error_covariance_cholesky` receives the lower-triangular factor `L`.
+- `error_covariance` receives `P = LLᵀ` directly.
+
+Both viewports use the same camera offset and confidence interval, so the
+ellipsoids should have identical shape and orientation.
+
+Run from the repository root:
+
+```sh
+nix develop --command elodin editor examples/covariance-ellipsoids/main.py
+```

--- a/examples/covariance-ellipsoids/README.md
+++ b/examples/covariance-ellipsoids/README.md
@@ -7,8 +7,8 @@ Displays the same positive-definite covariance as two ellipsoids:
 
 The Cholesky factor varies continuously over an eight-second cycle, while the
 direct covariance is recomputed as `P = LLᵀ` every simulation tick. Their
-principal extents should remain synchronized. The direct covariance side uses
-the example's explicit ECEF frame, while the Cholesky side inherits ENU.
+principal extents and orientation should remain synchronized because both use
+the same ENU frame.
 
 Run from the repository root:
 

--- a/examples/covariance-ellipsoids/main.py
+++ b/examples/covariance-ellipsoids/main.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env uv run
+"""Compare equivalent Cholesky and direct covariance ellipsoids."""
+
+import elodin as el
+import jax.numpy as jnp
+import numpy as np
+
+CHOLESKY = np.array(
+    [
+        [1.2, 0.0, 0.0],
+        [0.4, 0.8, 0.0],
+        [-0.2, 0.3, 0.5],
+    ]
+)
+COVARIANCE = CHOLESKY @ CHOLESKY.T
+
+
+def pack_cholesky(matrix: np.ndarray) -> tuple[float, ...]:
+    indices = ((0, 0), (1, 0), (1, 1), (2, 0), (2, 1), (2, 2))
+    return tuple(round(float(matrix[row, col]), 12) for row, col in indices)
+
+
+def pack_covariance(matrix: np.ndarray) -> tuple[float, ...]:
+    indices = ((0, 0), (0, 1), (0, 2), (1, 1), (1, 2), (2, 2))
+    return tuple(round(float(matrix[row, col]), 12) for row, col in indices)
+
+
+def body(x: float) -> el.Body:
+    return el.Body(
+        world_pos=el.SpatialTransform(linear=jnp.array([x, 0.0, 0.0])),
+        inertia=el.SpatialInertia(mass=1.0),
+    )
+
+
+def world() -> el.World:
+    world = el.World()
+    world.spawn(body(-4.0), name="cholesky")
+    world.spawn(body(4.0), name="covariance")
+
+    cholesky = pack_cholesky(CHOLESKY)
+    covariance = pack_covariance(COVARIANCE)
+    world.schematic(
+        f"""
+        coordinate frame=ENU
+        hsplit {{
+            viewport name="Cholesky: P = LLᵀ" pos="(0,0,0,1, 0,-6,4)" look_at="cholesky.world_pos" far=30.0 show_grid=#true active=#true
+            viewport frame=ECEF name="Direct covariance: P" pos="(0,0,0,1, 8,-6,4)" look_at="covariance.world_pos" far=30.0 show_grid=#true active=#true
+        }}
+
+        object_3d cholesky.world_pos {{
+            ellipsoid error_covariance_cholesky="{cholesky}" error_confidence_interval=70.0 show_grid=#true {{
+                color 255 152 0 72
+                grid_color 255 193 7 220
+            }}
+        }}
+        object_3d frame=ECEF covariance.world_pos {{
+            ellipsoid error_covariance="{covariance}" error_confidence_interval=70.0 show_grid=#true {{
+                color 3 169 244 72
+                grid_color 0 188 212 220
+            }}
+        }}
+        """,
+        "covariance-ellipsoids.kdl",
+    )
+    return world
+
+
+@el.map
+def no_force(force: el.Force) -> el.Force:
+    return force
+
+
+if __name__ == "__main__":
+    world().run(
+        el.six_dof(sys=no_force),
+        simulation_rate=60.0,
+        generate_real_time=True,
+    )

--- a/examples/covariance-ellipsoids/main.py
+++ b/examples/covariance-ellipsoids/main.py
@@ -1,28 +1,70 @@
 #!/usr/bin/env uv run
 """Compare equivalent Cholesky and direct covariance ellipsoids."""
 
+import math
+import typing as ty
+
 import elodin as el
+import jax
 import jax.numpy as jnp
 import numpy as np
 
-CHOLESKY = np.array(
-    [
-        [1.2, 0.0, 0.0],
-        [0.4, 0.8, 0.0],
-        [-0.2, 0.3, 0.5],
-    ]
-)
-COVARIANCE = CHOLESKY @ CHOLESKY.T
+SIM_RATE = 60.0
+CYCLE_SECONDS = 8.0
+
+CholeskyFactor = ty.Annotated[
+    jax.Array,
+    el.Component(
+        "cholesky_factor",
+        el.ComponentType(el.PrimitiveType.F64, (6,)),
+    ),
+]
+ErrorCovariance = ty.Annotated[
+    jax.Array,
+    el.Component(
+        "error_covariance",
+        el.ComponentType(el.PrimitiveType.F64, (6,)),
+    ),
+]
 
 
-def pack_cholesky(matrix: np.ndarray) -> tuple[float, ...]:
+@el.dataclass
+class CholeskyData(el.Archetype):
+    cholesky_factor: CholeskyFactor
+
+
+@el.dataclass
+class CovarianceData(el.Archetype):
+    error_covariance: ErrorCovariance
+
+
+def covariance_at(t: float) -> tuple[np.ndarray, np.ndarray]:
+    phase = 2.0 * math.pi * t / CYCLE_SECONDS
+    cholesky = np.array(
+        [
+            [1.2 + 0.3 * math.sin(phase), 0.0, 0.0],
+            [0.4 * math.sin(phase * 0.7), 0.8 + 0.2 * math.cos(phase), 0.0],
+            [
+                -0.25 * math.cos(phase * 0.8),
+                0.3 * math.sin(phase * 1.3),
+                0.5 + 0.15 * math.sin(phase + 0.5),
+            ],
+        ]
+    )
+    return cholesky, cholesky @ cholesky.T
+
+
+CHOLESKY, COVARIANCE = covariance_at(0.0)
+
+
+def pack_cholesky(matrix: np.ndarray) -> np.ndarray:
     indices = ((0, 0), (1, 0), (1, 1), (2, 0), (2, 1), (2, 2))
-    return tuple(round(float(matrix[row, col]), 12) for row, col in indices)
+    return np.array([matrix[row, col] for row, col in indices])
 
 
-def pack_covariance(matrix: np.ndarray) -> tuple[float, ...]:
+def pack_covariance(matrix: np.ndarray) -> np.ndarray:
     indices = ((0, 0), (0, 1), (0, 2), (1, 1), (1, 2), (2, 2))
-    return tuple(round(float(matrix[row, col]), 12) for row, col in indices)
+    return np.array([matrix[row, col] for row, col in indices])
 
 
 def body(x: float) -> el.Body:
@@ -34,31 +76,41 @@ def body(x: float) -> el.Body:
 
 def world() -> el.World:
     world = el.World()
-    world.spawn(body(-4.0), name="cholesky")
-    world.spawn(body(4.0), name="covariance")
+    world.spawn(
+        [
+            body(-4.0),
+            CholeskyData(cholesky_factor=jnp.array(pack_cholesky(CHOLESKY))),
+        ],
+        name="cholesky",
+    )
+    world.spawn(
+        [
+            body(4.0),
+            CovarianceData(error_covariance=jnp.array(pack_covariance(COVARIANCE))),
+        ],
+        name="covariance",
+    )
 
-    cholesky = pack_cholesky(CHOLESKY)
-    covariance = pack_covariance(COVARIANCE)
     world.schematic(
-        f"""
+        """
         coordinate frame=ENU
-        hsplit {{
+        hsplit {
             viewport name="Cholesky: P = LLᵀ" pos="(0,0,0,1, 0,-6,4)" look_at="cholesky.world_pos" far=30.0 show_grid=#true active=#true
-            viewport frame=ECEF name="Direct covariance: P" pos="(0,0,0,1, 8,-6,4)" look_at="covariance.world_pos" far=30.0 show_grid=#true active=#true
-        }}
+            viewport frame=ENU name="Direct covariance: P" pos="(0,0,0,1, 8,-6,4)" look_at="covariance.world_pos" far=30.0 show_grid=#true active=#true
+        }
 
-        object_3d cholesky.world_pos {{
-            ellipsoid error_covariance_cholesky="{cholesky}" error_confidence_interval=70.0 show_grid=#true {{
+        object_3d cholesky.world_pos {
+            ellipsoid error_covariance_cholesky="cholesky.cholesky_factor" error_confidence_interval=70.0 show_grid=#true {
                 color 255 152 0 72
                 grid_color 255 193 7 220
-            }}
-        }}
-        object_3d frame=ECEF covariance.world_pos {{
-            ellipsoid error_covariance="{covariance}" error_confidence_interval=70.0 show_grid=#true {{
+            }
+        }
+        object_3d frame=ENU covariance.world_pos {
+            ellipsoid error_covariance="covariance.error_covariance" error_confidence_interval=70.0 show_grid=#true {
                 color 3 169 244 72
                 grid_color 0 188 212 220
-            }}
-        }}
+            }
+        }
         """,
         "covariance-ellipsoids.kdl",
     )
@@ -70,9 +122,16 @@ def no_force(force: el.Force) -> el.Force:
     return force
 
 
+def post_step(tick: int, ctx: el.StepContext) -> None:
+    cholesky, covariance = covariance_at(tick / SIM_RATE)
+    ctx.write_component("cholesky.cholesky_factor", pack_cholesky(cholesky))
+    ctx.write_component("covariance.error_covariance", pack_covariance(covariance))
+
+
 if __name__ == "__main__":
     world().run(
         el.six_dof(sys=no_force),
-        simulation_rate=60.0,
+        simulation_rate=SIM_RATE,
         generate_real_time=True,
+        post_step=post_step,
     )

--- a/libs/elodin-editor/src/headless.rs
+++ b/libs/elodin-editor/src/headless.rs
@@ -146,6 +146,7 @@ impl Plugin for HeadlessEditorPlugin {
             )
             .add_systems(Startup, setup_headless_lighting)
             .init_resource::<crate::EqlContext>()
+            .init_resource::<crate::Coordinate>()
             .init_resource::<crate::SyncedObject3d>()
             .init_resource::<HeadlessSchematicSkybox>()
             .init_resource::<HeadlessSkyboxRenderGate>()
@@ -218,6 +219,7 @@ fn load_headless_scene(
     asset_server: Res<AssetServer>,
     connection_addr: Option<Res<ConnectionAddr>>,
     mut geo_context: ResMut<GeoContext>,
+    mut coordinate: ResMut<crate::Coordinate>,
 ) {
     // Poll an in-flight fetch. The blocking HTTP request runs on the IO pool
     // (RFD #724): a slow/unreachable DB Asset Server never freezes the app.
@@ -253,6 +255,7 @@ fn load_headless_scene(
             if let Some(previous) = pending.loaded.take() {
                 despawn_headless_scene(&mut commands, &previous);
                 schematic_skybox.0 = None;
+                coordinate.0 = None;
             }
             return;
         };
@@ -299,6 +302,7 @@ fn load_headless_scene(
     let connection_addr = connection_addr.as_ref().map(|addr| addr.0);
     schematic_skybox.0 = Some(schematic.skybox.as_ref().map(|skybox| skybox.name.clone()));
     let fallback_frame = schematic.frame;
+    coordinate.0 = schematic.frame;
 
     if let Some(o) = schematic.origin {
         geo_context.origin =

--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -580,7 +580,10 @@ fn run_egui_inspector(world: &mut World) {
     };
     let mut egui_context = egui_context.clone();
 
-    egui::CentralPanel::default().show_inside(egui_context.get_mut(), |ui| {
+    // CentralPanel::show(Context) is deprecated in egui 0.34 in favor of
+    // show_inside(Ui); top-level Context usage still requires show().
+    #[expect(deprecated)]
+    egui::CentralPanel::default().show(egui_context.get_mut(), |ui| {
         egui::ScrollArea::both().show(ui, |ui| {
             bevy_inspector_egui::bevy_inspector::ui_for_world(world, ui);
             ui.allocate_space(ui.available_size());

--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -580,7 +580,7 @@ fn run_egui_inspector(world: &mut World) {
     };
     let mut egui_context = egui_context.clone();
 
-    egui::CentralPanel::default().show(egui_context.get_mut(), |ui| {
+    egui::CentralPanel::default().show_inside(egui_context.get_mut(), |ui| {
         egui::ScrollArea::both().show(ui, |ui| {
             bevy_inspector_egui::bevy_inspector::ui_for_world(world, ui);
             ui.allocate_space(ui.available_size());

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -886,6 +886,30 @@ fn compile_6float_eql(
     ctx.parse_str(trimmed).map(compile_eql_expr)?
 }
 
+/// Ellipsoid shape driver selected by field presence.
+/// Cholesky takes precedence over symmetric covariance when both are set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EllipsoidShapeMode {
+    Scale,
+    Cholesky,
+    Covariance,
+}
+
+fn ellipsoid_shape_mode(mesh: &impeller2_wkt::Object3DMesh) -> Option<EllipsoidShapeMode> {
+    match mesh {
+        impeller2_wkt::Object3DMesh::Ellipsoid {
+            error_covariance_cholesky: Some(_),
+            ..
+        } => Some(EllipsoidShapeMode::Cholesky),
+        impeller2_wkt::Object3DMesh::Ellipsoid {
+            error_covariance: Some(_),
+            ..
+        } => Some(EllipsoidShapeMode::Covariance),
+        impeller2_wkt::Object3DMesh::Ellipsoid { .. } => Some(EllipsoidShapeMode::Scale),
+        _ => None,
+    }
+}
+
 const ELLIPSOID_OVERSIZED_THRESHOLD: f32 = 10_000.0;
 
 /// Chi-squared quantile for 3 degrees of freedom (confidence as fraction 0..1).
@@ -1024,6 +1048,10 @@ pub fn update_object_3d_system(
             continue;
         };
 
+        let Some(shape_mode) = ellipsoid_shape_mode(&object_3d.data.mesh) else {
+            continue;
+        };
+
         let covariance_frame = resolve_covariance_frame(&object_3d.data, &coordinate);
 
         let mesh_child = children_maybe.and_then(|children| {
@@ -1047,30 +1075,14 @@ pub fn update_object_3d_system(
             first
         });
 
-        if let Some(ref cholesky_expr) = object_3d.error_covariance_cholesky_expr {
-            if let Ok(cv) = cholesky_expr.execute(&entity_map, &component_value_maps)
-                && let Ok(l) = component_value_to_6floats(&cv)
-            {
-                let linear = covariance_linear_from_l(
-                    &l,
-                    *error_confidence_interval,
-                    covariance_frame,
-                    &geo_context,
-                );
-                if let Some(child) = mesh_child
-                    && let Ok(mut params) = mat3_params.get_mut(child)
+        // Branch on field presence (not successful compile) so a failed Cholesky/covariance
+        // compile stays on the Mat3 path instead of falling through to scale / the other mode.
+        match shape_mode {
+            EllipsoidShapeMode::Cholesky => {
+                if let Some(ref cholesky_expr) = object_3d.error_covariance_cholesky_expr
+                    && let Ok(cv) = cholesky_expr.execute(&entity_map, &component_value_maps)
+                    && let Ok(l) = component_value_to_6floats(&cv)
                 {
-                    params.set_if_neq(Mat3Params { linear });
-                }
-                ellipse.max_extent = max_linear_extent(&linear);
-                ellipse.oversized = ellipse.max_extent > ELLIPSOID_OVERSIZED_THRESHOLD;
-            }
-        } else if let Some(ref covariance_expr) = object_3d.error_covariance_expr {
-            if let Ok(cv) = covariance_expr.execute(&entity_map, &component_value_maps)
-                && let Ok(p) = component_value_to_6floats(&cv)
-            {
-                let p_mat = symmetric_6_to_mat3(&p);
-                if let Some(l) = cholesky_3x3_spd(&p_mat) {
                     let linear = covariance_linear_from_l(
                         &l,
                         *error_confidence_interval,
@@ -1084,34 +1096,58 @@ pub fn update_object_3d_system(
                     }
                     ellipse.max_extent = max_linear_extent(&linear);
                     ellipse.oversized = ellipse.max_extent > ELLIPSOID_OVERSIZED_THRESHOLD;
-                } else {
-                    warn_once!(
-                        entity = ?entity,
-                        "ellipsoid error_covariance is not positive-definite; skipping update"
-                    );
                 }
             }
-        } else {
-            match evaluate_scale(&object_3d, &entity_map, &component_value_maps) {
-                Ok(scale) => {
-                    let scale_enu = scale.max(Vec3::splat(f32::EPSILON));
-                    let scale = enu_scale_to_bevy(scale_enu);
-                    if let Some(child) = mesh_child {
-                        if let Ok(mut child_transform) = transforms.get_mut(child) {
-                            child_transform.scale = scale;
-                            child_transform.translation = Vec3::ZERO;
+            EllipsoidShapeMode::Covariance => {
+                if let Some(ref covariance_expr) = object_3d.error_covariance_expr
+                    && let Ok(cv) = covariance_expr.execute(&entity_map, &component_value_maps)
+                    && let Ok(p) = component_value_to_6floats(&cv)
+                {
+                    let p_mat = symmetric_6_to_mat3(&p);
+                    if let Some(l) = cholesky_3x3_spd(&p_mat) {
+                        let linear = covariance_linear_from_l(
+                            &l,
+                            *error_confidence_interval,
+                            covariance_frame,
+                            &geo_context,
+                        );
+                        if let Some(child) = mesh_child
+                            && let Ok(mut params) = mat3_params.get_mut(child)
+                        {
+                            params.set_if_neq(Mat3Params { linear });
                         }
-                        ellipse.max_extent = scale.max_element();
+                        ellipse.max_extent = max_linear_extent(&linear);
                         ellipse.oversized = ellipse.max_extent > ELLIPSOID_OVERSIZED_THRESHOLD;
-                        if object_3d.scale_expr.is_some() {
-                            object_3d.scale_error = None;
-                        }
+                    } else {
+                        warn_once!(
+                            entity = ?entity,
+                            "ellipsoid error_covariance is not positive-definite; skipping update"
+                        );
                     }
                 }
-                Err(err) => {
-                    object_3d.scale_error = Some(err.into());
-                    ellipse.oversized = false;
-                    ellipse.max_extent = 0.0;
+            }
+            EllipsoidShapeMode::Scale => {
+                match evaluate_scale(&object_3d, &entity_map, &component_value_maps) {
+                    Ok(scale) => {
+                        let scale_enu = scale.max(Vec3::splat(f32::EPSILON));
+                        let scale = enu_scale_to_bevy(scale_enu);
+                        if let Some(child) = mesh_child {
+                            if let Ok(mut child_transform) = transforms.get_mut(child) {
+                                child_transform.scale = scale;
+                                child_transform.translation = Vec3::ZERO;
+                            }
+                            ellipse.max_extent = scale.max_element();
+                            ellipse.oversized = ellipse.max_extent > ELLIPSOID_OVERSIZED_THRESHOLD;
+                            if object_3d.scale_expr.is_some() {
+                                object_3d.scale_error = None;
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        object_3d.scale_error = Some(err.into());
+                        ellipse.oversized = false;
+                        ellipse.max_extent = 0.0;
+                    }
                 }
             }
         }
@@ -1598,32 +1634,39 @@ pub fn create_object_3d_entity(
     geo_context: &GeoContext,
     connection_addr: Option<SocketAddr>,
 ) -> Result<Entity, CompileError> {
-    let (scale_expr, scale_error) = match &data.mesh {
-        impeller2_wkt::Object3DMesh::Ellipsoid {
-            scale,
-            error_covariance_cholesky: None,
-            error_covariance: None,
-            ..
-        } => match compile_scale_eql(scale, ctx) {
-            Ok(compiled) => (Some(compiled), None),
-            Err(err) => (None, Some(err)),
-        },
-        _ => (None, None),
-    };
-    let error_covariance_cholesky_expr = match &data.mesh {
-        impeller2_wkt::Object3DMesh::Ellipsoid {
-            error_covariance_cholesky: Some(cholesky),
-            ..
-        } => compile_cholesky_eql(cholesky, ctx).ok(),
-        _ => None,
-    };
-    let error_covariance_expr = match &data.mesh {
-        impeller2_wkt::Object3DMesh::Ellipsoid {
-            error_covariance: Some(covariance),
-            ..
-        } => compile_covariance_eql(covariance, ctx).ok(),
-        _ => None,
-    };
+    // Compile only the field-selected driver. Failed Cholesky/covariance compiles leave the
+    // expr as None but keep Mat3 spawning (spawn_mesh keys off field presence); update must
+    // not fall through to scale or the other covariance mode.
+    let (scale_expr, scale_error, error_covariance_cholesky_expr, error_covariance_expr) =
+        match (&data.mesh, ellipsoid_shape_mode(&data.mesh)) {
+            (
+                impeller2_wkt::Object3DMesh::Ellipsoid {
+                    error_covariance_cholesky: Some(cholesky),
+                    ..
+                },
+                Some(EllipsoidShapeMode::Cholesky),
+            ) => (None, None, compile_cholesky_eql(cholesky, ctx).ok(), None),
+            (
+                impeller2_wkt::Object3DMesh::Ellipsoid {
+                    error_covariance: Some(covariance),
+                    ..
+                },
+                Some(EllipsoidShapeMode::Covariance),
+            ) => (
+                None,
+                None,
+                None,
+                compile_covariance_eql(covariance, ctx).ok(),
+            ),
+            (
+                impeller2_wkt::Object3DMesh::Ellipsoid { scale, .. },
+                Some(EllipsoidShapeMode::Scale),
+            ) => match compile_scale_eql(scale, ctx) {
+                Ok(compiled) => (Some(compiled), None, None, None),
+                Err(err) => (None, Some(err), None, None),
+            },
+            _ => (None, None, None, None),
+        };
 
     let joint_animations = match &data.mesh {
         impeller2_wkt::Object3DMesh::Glb {
@@ -2476,15 +2519,58 @@ mod ellipsoid_covariance_tests {
     use crate::Coordinate;
 
     use super::{
-        cholesky_3x3_spd, covariance_linear_from_l, lower_cholesky_pack_to_mat3,
-        resolve_covariance_frame, symmetric_6_to_mat3,
+        EllipsoidShapeMode, cholesky_3x3_spd, covariance_linear_from_l, ellipsoid_shape_mode,
+        lower_cholesky_pack_to_mat3, resolve_covariance_frame, symmetric_6_to_mat3,
     };
-    use impeller2_wkt::{Object3D, Object3DMesh};
+    use impeller2_wkt::{
+        Object3D, Object3DMesh, default_ellipsoid_color, default_ellipsoid_confidence_interval,
+        default_ellipsoid_grid_color, default_ellipsoid_scale_expr, default_ellipsoid_show_grid,
+    };
 
     fn assert_mat3_close(actual: Mat3, expected: Mat3) {
         let delta = (actual - expected).to_cols_array();
         let max = delta.iter().map(|v| v.abs()).fold(0.0_f32, f32::max);
         assert!(max < 1e-4, "expected {expected:?}, got {actual:?}");
+    }
+
+    fn ellipsoid_mesh(cholesky: Option<&str>, covariance: Option<&str>) -> Object3DMesh {
+        Object3DMesh::Ellipsoid {
+            scale: default_ellipsoid_scale_expr(),
+            color: default_ellipsoid_color(),
+            error_covariance_cholesky: cholesky.map(str::to_string),
+            error_covariance: covariance.map(str::to_string),
+            error_confidence_interval: default_ellipsoid_confidence_interval(),
+            show_grid: default_ellipsoid_show_grid(),
+            grid_color: default_ellipsoid_grid_color(),
+        }
+    }
+
+    #[test]
+    fn shape_mode_prefers_cholesky_field_over_covariance() {
+        assert_eq!(
+            ellipsoid_shape_mode(&ellipsoid_mesh(
+                Some("(1,0,1,0,0,1)"),
+                Some("(1,0,0,1,0,1)")
+            )),
+            Some(EllipsoidShapeMode::Cholesky)
+        );
+        assert_eq!(
+            ellipsoid_shape_mode(&ellipsoid_mesh(None, Some("(1,0,0,1,0,1)"))),
+            Some(EllipsoidShapeMode::Covariance)
+        );
+        assert_eq!(
+            ellipsoid_shape_mode(&ellipsoid_mesh(None, None)),
+            Some(EllipsoidShapeMode::Scale)
+        );
+    }
+
+    #[test]
+    fn shape_mode_keeps_cholesky_when_expression_is_invalid() {
+        // Field presence alone selects the driver; a failed compile must not fall through.
+        assert_eq!(
+            ellipsoid_shape_mode(&ellipsoid_mesh(Some(""), Some("(1,0,0,1,0,1)"))),
+            Some(EllipsoidShapeMode::Cholesky)
+        );
     }
 
     #[test]

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -1080,7 +1080,7 @@ pub fn update_object_3d_system(
                     if let Some(child) = mesh_child
                         && let Ok(mut params) = mat3_params.get_mut(child)
                     {
-                        params.linear = linear;
+                        params.set_if_neq(Mat3Params { linear });
                     }
                     ellipse.max_extent = max_linear_extent(&linear);
                     ellipse.oversized = ellipse.max_extent > ELLIPSOID_OVERSIZED_THRESHOLD;

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -1482,11 +1482,7 @@ fn enu_scale_to_bevy(enu: Vec3) -> Vec3 {
 }
 
 fn resolve_covariance_frame(object: &Object3D, coordinate: &Coordinate) -> GeoFrame {
-    object
-        .frame_orientation
-        .or(object.frame)
-        .or(coordinate.0)
-        .unwrap_or(GeoFrame::ENU)
+    object.frame.or(coordinate.0).unwrap_or(GeoFrame::ENU)
 }
 
 /// Build symmetric covariance P from 6-pack (a,b,c,d,e,f) -> [[a,b,c],[b,d,e],[c,e,f]].
@@ -2523,12 +2519,12 @@ mod ellipsoid_covariance_tests {
     }
 
     #[test]
-    fn resolve_covariance_frame_inherits_object_frame() {
+    fn resolve_covariance_frame_uses_position_frame() {
         let object = Object3D {
             eql: "x".to_string(),
             mesh: Object3DMesh::glb("m.glb"),
             frame: Some(GeoFrame::NED),
-            frame_orientation: None,
+            frame_orientation: Some(GeoFrame::ECEF),
             orientation: Default::default(),
             icon: None,
             thrusters: Vec::new(),

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -2,11 +2,12 @@ use bevy::camera::visibility::RenderLayers;
 use bevy::ecs::{hierarchy::ChildOf, relationship::Relationship};
 use bevy::log::warn_once;
 use bevy::material::AlphaMode;
-use bevy::math::{DQuat, DVec3};
+use bevy::math::{DMat3, DQuat, DVec3};
 use bevy::prelude::Mesh;
 use bevy::prelude::*;
 use bevy::world_serialization::{WorldAssetRoot, WorldInstance, WorldInstanceSpawner};
-use bevy_geo_frames::{GeoPosition, GeoRotation};
+use bevy::scene::{SceneInstance, SceneRoot, SceneSpawner};
+use bevy_geo_frames::{GeoContext, GeoFrame, GeoPosition, GeoRotation};
 use bevy_mat3_material::{Mat3Material, Mat3Params, Mat3TransformExt, uv_sphere_grid_line_mesh};
 use bitvec::prelude::*;
 use eql::Expr;
@@ -20,7 +21,7 @@ use crate::iter::JoinDisplayExt;
 use crate::plugins::render_layer_alloc::RenderLayerLease;
 use crate::rim_glow_material::{RimGlowExt, RimGlowMaterial, RimGlowParams};
 use crate::ui::tiles::ViewportConfig;
-use crate::{BevyExt, EqlContext, MainCamera, plugins::navigation_gizmo::NavGizmoCamera};
+use crate::{BevyExt, Coordinate, EqlContext, MainCamera, plugins::navigation_gizmo::NavGizmoCamera};
 use bevy::platform::hash::FixedHasher;
 use bevy_geo_frames::prelude::*;
 use std::borrow::Cow;
@@ -77,6 +78,8 @@ pub struct Object3DState {
     pub scale_error: Option<CompileError>,
     /// When set, ellipsoid shape is driven by error covariance (Mat3 path); evaluated each frame.
     pub error_covariance_cholesky_expr: Option<CompiledExpr>,
+    /// When set, ellipsoid shape is driven by symmetric error covariance P; Cholesky-decomposed each frame.
+    pub error_covariance_expr: Option<CompiledExpr>,
     pub joint_animations: Vec<(String, String)>, // (joint_name, eql_expr) - compiled in attach_joint_animations
     pub data: Object3D,
 }
@@ -859,9 +862,22 @@ pub fn compile_scale_eql(scale: &str, ctx: &eql::Context) -> Result<CompiledExpr
 
 /// Compiles an EQL expression that must yield at least 6 floats (lower-triangular Cholesky L).
 pub fn compile_cholesky_eql(expr: &str, ctx: &eql::Context) -> Result<CompiledExpr, CompileError> {
+    compile_6float_eql(expr, "error_covariance_cholesky", ctx)
+}
+
+/// Compiles an EQL expression that must yield at least 6 floats (symmetric covariance P).
+pub fn compile_covariance_eql(expr: &str, ctx: &eql::Context) -> Result<CompiledExpr, CompileError> {
+    compile_6float_eql(expr, "error_covariance", ctx)
+}
+
+fn compile_6float_eql(
+    expr: &str,
+    field: &'static str,
+    ctx: &eql::Context,
+) -> Result<CompiledExpr, CompileError> {
     let trimmed = expr.trim();
     if trimmed.is_empty() {
-        return Err(ComponentError::InvalidEmptyIn("error_covariance_cholesky expression").into());
+        return Err(ComponentError::InvalidEmptyIn(field).into());
     }
     ctx.parse_str(trimmed).map(compile_eql_expr)?
 }
@@ -960,7 +976,7 @@ pub fn on_scene_ready(
 }
 
 /// System that updates 3D object entities based on their EQL expressions
-#[allow(clippy::type_complexity)]
+#[allow(clippy::type_complexity, clippy::too_many_arguments)]
 pub fn update_object_3d_system(
     mut commands: Commands,
     mut objects_query: Query<(
@@ -976,6 +992,8 @@ pub fn update_object_3d_system(
     mesh_child_markers: Query<(), With<Object3DMeshChild>>,
     entity_map: Res<EntityMap>,
     component_value_maps: Query<&'static ComponentValue>,
+    geo_context: Res<GeoContext>,
+    coordinate: Res<Coordinate>,
 ) {
     for (entity, mut object_3d, mut pos, ellipse, has_received, children_maybe) in
         objects_query.iter_mut()
@@ -994,12 +1012,16 @@ pub fn update_object_3d_system(
             continue;
         };
 
-        if !matches!(
-            object_3d.data.mesh,
-            impeller2_wkt::Object3DMesh::Ellipsoid { .. }
-        ) {
+        let impeller2_wkt::Object3DMesh::Ellipsoid {
+            error_confidence_interval,
+            ..
+        } = &object_3d.data.mesh
+        else {
             continue;
-        }
+        };
+
+        let covariance_frame =
+            resolve_covariance_frame(&object_3d.data, &coordinate);
 
         let mesh_child = children_maybe.and_then(|children| {
             let mut mesh_children = children
@@ -1023,22 +1045,48 @@ pub fn update_object_3d_system(
         });
 
         if let Some(ref cholesky_expr) = object_3d.error_covariance_cholesky_expr {
-            if let impeller2_wkt::Object3DMesh::Ellipsoid {
-                error_confidence_interval,
-                ..
-            } = &object_3d.data.mesh
-                && let Ok(cv) = cholesky_expr.execute(&entity_map, &component_value_maps)
+            if let Ok(cv) = cholesky_expr.execute(&entity_map, &component_value_maps)
                 && let Ok(l) = component_value_to_6floats(&cv)
             {
-                let linear = cholesky_6_to_mat3(&l, *error_confidence_interval);
+                let linear = covariance_linear_from_l(
+                    &l,
+                    *error_confidence_interval,
+                    covariance_frame,
+                    &geo_context,
+                );
                 if let Some(child) = mesh_child
                     && let Ok(mut params) = mat3_params.get_mut(child)
                 {
                     params.set_if_neq(Mat3Params { linear });
                 }
-                let scale = chi2_3_quantile((*error_confidence_interval) / 100.0).sqrt();
-                ellipse.max_extent = (l[0].abs().max(l[2].abs()).max(l[5].abs())) * scale;
+                ellipse.max_extent = max_linear_extent(&linear);
                 ellipse.oversized = ellipse.max_extent > ELLIPSOID_OVERSIZED_THRESHOLD;
+            }
+        } else if let Some(ref covariance_expr) = object_3d.error_covariance_expr {
+            if let Ok(cv) = covariance_expr.execute(&entity_map, &component_value_maps)
+                && let Ok(p) = component_value_to_6floats(&cv)
+            {
+                let p_mat = symmetric_6_to_mat3(&p);
+                if let Some(l) = cholesky_3x3_spd(&p_mat) {
+                    let linear = covariance_linear_from_l(
+                        &l,
+                        *error_confidence_interval,
+                        covariance_frame,
+                        &geo_context,
+                    );
+                    if let Some(child) = mesh_child
+                        && let Ok(mut params) = mat3_params.get_mut(child)
+                    {
+                        params.linear = linear;
+                    }
+                    ellipse.max_extent = max_linear_extent(&linear);
+                    ellipse.oversized = ellipse.max_extent > ELLIPSOID_OVERSIZED_THRESHOLD;
+                } else {
+                    warn_once!(
+                        entity = ?entity,
+                        "ellipsoid error_covariance is not positive-definite; skipping update"
+                    );
+                }
             }
         } else {
             match evaluate_scale(&object_3d, &entity_map, &component_value_maps) {
@@ -1430,27 +1478,96 @@ fn enu_scale_to_bevy(enu: Vec3) -> Vec3 {
     Vec3::new(enu.x, enu.z, enu.y)
 }
 
-/// ENU (East-North-Up) to Bevy (East-Up-South) basis change.
-/// ENU: X=East, Y=North, Z=Up. Bevy: X=East, Y=Up, Z=South.
-/// So Bevy = (ENU.x, ENU.z, -ENU.y).
-const ENU_TO_BEVY: Mat3 = Mat3::from_cols(
-    Vec3::new(1.0, 0.0, 0.0),  // ENU East  -> Bevy X
-    Vec3::new(0.0, 0.0, -1.0), // ENU North -> Bevy -Z
-    Vec3::new(0.0, 1.0, 0.0),  // ENU Up    -> Bevy Y
-);
+fn resolve_covariance_frame(object: &Object3D, coordinate: &Coordinate) -> GeoFrame {
+    object
+        .frame_orientation
+        .or(object.frame)
+        .or(coordinate.0)
+        .unwrap_or(GeoFrame::ENU)
+}
 
-/// Build Mat3 from lower-triangular Cholesky L in **ENU** (row-major: a,b,c,d,e,f -> L00,L10,L11,L20,L21,L22),
-/// scaled by sqrt(chi2_3(confidence)), then converted to Bevy (East-Up-South) so the ellipsoid displays correctly.
-fn cholesky_6_to_mat3(l: &[f32; 6], confidence_percent: f32) -> Mat3 {
+/// Build symmetric covariance P from 6-pack (a,b,c,d,e,f) -> [[a,b,c],[b,d,e],[c,e,f]].
+fn symmetric_6_to_mat3(p: &[f32; 6]) -> Mat3 {
+    Mat3::from_cols(
+        Vec3::new(p[0], p[1], p[2]),
+        Vec3::new(p[1], p[3], p[4]),
+        Vec3::new(p[2], p[4], p[5]),
+    )
+}
+
+/// Build lower-triangular Cholesky L from 6-pack (a,b,c,d,e,f).
+fn lower_cholesky_pack_to_mat3(l: &[f32; 6]) -> Mat3 {
+    Mat3::from_cols(
+        Vec3::new(l[0], l[1], l[3]),
+        Vec3::new(0.0, l[2], l[4]),
+        Vec3::new(0.0, 0.0, l[5]),
+    )
+}
+
+fn cholesky_3x3_spd(p: &Mat3) -> Option<[f32; 6]> {
+    let cols = p.to_cols_array();
+    let p00 = cols[0];
+    let p10 = cols[3];
+    let p20 = cols[6];
+    let p11 = cols[4];
+    let p21 = cols[7];
+    let p22 = cols[8];
+
+    if !(p00 > 0.0 && p00.is_finite()) {
+        return None;
+    }
+    let l00 = p00.sqrt();
+
+    let l10 = p10 / l00;
+    let l20 = p20 / l00;
+
+    let d11 = p11 - l10 * l10;
+    if !(d11 > 0.0 && d11.is_finite()) {
+        return None;
+    }
+    let l11 = d11.sqrt();
+
+    let l21 = (p21 - l20 * l10) / l11;
+
+    let d22 = p22 - l20 * l20 - l21 * l21;
+    if !(d22 > 0.0 && d22.is_finite()) {
+        return None;
+    }
+    let l22 = d22.sqrt();
+
+    Some([l00, l10, l11, l20, l21, l22])
+}
+
+fn dmat3_to_mat3(m: DMat3) -> Mat3 {
+    Mat3::from_cols(
+        m.x_axis.as_vec3(),
+        m.y_axis.as_vec3(),
+        m.z_axis.as_vec3(),
+    )
+}
+
+fn frame_rotation_to_bevy(frame: GeoFrame, geo_context: &GeoContext) -> Mat3 {
+    dmat3_to_mat3(GeoFrame::bevy_R_(&frame, geo_context))
+}
+
+fn covariance_linear_from_l(
+    l: &[f32; 6],
+    confidence_percent: f32,
+    frame: GeoFrame,
+    geo_context: &GeoContext,
+) -> Mat3 {
     let confidence_fraction = (confidence_percent / 100.0).clamp(0.01, 0.999);
     let scale = chi2_3_quantile(confidence_fraction).sqrt();
-    #[rustfmt::skip]
-    let l_enu = Mat3::from_cols_array(&[
-        l[0] * scale, 0.0,          0.0,
-        l[1] * scale, l[2] * scale, 0.0,
-        l[3] * scale, l[4] * scale, l[5] * scale,
-    ]);
-    ENU_TO_BEVY * l_enu
+    let l_mat = lower_cholesky_pack_to_mat3(l) * scale;
+    frame_rotation_to_bevy(frame, geo_context) * l_mat
+}
+
+fn max_linear_extent(linear: &Mat3) -> f32 {
+    let cols = linear.to_cols_array();
+    let c0 = Vec3::new(cols[0], cols[1], cols[2]).length();
+    let c1 = Vec3::new(cols[3], cols[4], cols[5]).length();
+    let c2 = Vec3::new(cols[6], cols[7], cols[8]).length();
+    c0.max(c1).max(c2)
 }
 
 pub trait ComponentArrayExt {
@@ -1490,6 +1607,7 @@ pub fn create_object_3d_entity(
         impeller2_wkt::Object3DMesh::Ellipsoid {
             scale,
             error_covariance_cholesky: None,
+            error_covariance: None,
             ..
         } => match compile_scale_eql(scale, ctx) {
             Ok(compiled) => (Some(compiled), None),
@@ -1502,6 +1620,13 @@ pub fn create_object_3d_entity(
             error_covariance_cholesky: Some(cholesky),
             ..
         } => compile_cholesky_eql(cholesky, ctx).ok(),
+        _ => None,
+    };
+    let error_covariance_expr = match &data.mesh {
+        impeller2_wkt::Object3DMesh::Ellipsoid {
+            error_covariance: Some(covariance),
+            ..
+        } => compile_covariance_eql(covariance, ctx).ok(),
         _ => None,
     };
 
@@ -1537,6 +1662,7 @@ pub fn create_object_3d_entity(
                 scale_expr,
                 scale_error,
                 error_covariance_cholesky_expr,
+                error_covariance_expr,
                 joint_animations,
                 data: data.clone(),
             },
@@ -1718,6 +1844,7 @@ pub fn spawn_mesh(
         impeller2_wkt::Object3DMesh::Ellipsoid {
             color,
             error_covariance_cholesky,
+            error_covariance,
             error_confidence_interval: _error_confidence_interval,
             show_grid,
             grid_color,
@@ -1731,7 +1858,7 @@ pub fn spawn_mesh(
                 AlphaMode::Opaque
             };
 
-            if error_covariance_cholesky.is_some() {
+            if error_covariance_cholesky.is_some() || error_covariance.is_some() {
                 let initial_linear = Mat3::IDENTITY;
                 let mat3_material = mat3_material_assets.add(Mat3Material {
                     base: StandardMaterial {
@@ -2343,6 +2470,76 @@ mod ellipsoid_scale_eql_tests {
 
             assert_vec3_close(scale, expected);
         }
+    }
+}
+
+#[cfg(test)]
+mod ellipsoid_covariance_tests {
+    use bevy::prelude::Mat3;
+    use bevy_geo_frames::{GeoContext, GeoFrame, Present};
+
+    use crate::Coordinate;
+
+    use super::{
+        cholesky_3x3_spd, covariance_linear_from_l, lower_cholesky_pack_to_mat3,
+        resolve_covariance_frame, symmetric_6_to_mat3,
+    };
+    use impeller2_wkt::{Object3D, Object3DMesh};
+
+    fn assert_mat3_close(actual: Mat3, expected: Mat3) {
+        let delta = (actual - expected).to_cols_array();
+        let max = delta.iter().map(|v| v.abs()).fold(0.0_f32, f32::max);
+        assert!(max < 1e-4, "expected {expected:?}, got {actual:?}");
+    }
+
+    #[test]
+    fn symmetric_cholesky_recovers_llt() {
+        let l_in = [2.0, 0.5, 3.0, 1.0, 0.25, 4.0];
+        let l = lower_cholesky_pack_to_mat3(&l_in);
+        let p = l * l.transpose();
+        let recovered = cholesky_3x3_spd(&p).expect("SPD matrix should factorize");
+        let l_out = lower_cholesky_pack_to_mat3(&recovered);
+        assert_mat3_close(l_out * l_out.transpose(), p);
+    }
+
+    #[test]
+    fn identity_symmetric_covariance_factors_to_identity_cholesky() {
+        let p = symmetric_6_to_mat3(&[1.0, 0.0, 0.0, 1.0, 0.0, 1.0]);
+        let l = cholesky_3x3_spd(&p).expect("identity covariance");
+        assert!((l[0] - 1.0).abs() < 1e-5);
+        assert!(l[1].abs() < 1e-5);
+        assert!((l[2] - 1.0).abs() < 1e-5);
+        assert!(l[3].abs() < 1e-5);
+        assert!(l[4].abs() < 1e-5);
+        assert!((l[5] - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn world_frame_enu_differs_from_ned() {
+        let ctx = GeoContext::default().with_present(Present::Plane);
+        let l = [1.0, 0.0, 1.0, 0.0, 0.0, 1.0];
+        let enu = covariance_linear_from_l(&l, 70.0, GeoFrame::ENU, &ctx);
+        let ned = covariance_linear_from_l(&l, 70.0, GeoFrame::NED, &ctx);
+        assert!(!enu.abs_diff_eq(ned, 1e-5));
+    }
+
+    #[test]
+    fn resolve_covariance_frame_inherits_object_frame() {
+        let object = Object3D {
+            eql: "x".to_string(),
+            mesh: Object3DMesh::glb("m.glb"),
+            frame: Some(GeoFrame::NED),
+            frame_orientation: None,
+            orientation: Default::default(),
+            icon: None,
+            thrusters: Vec::new(),
+            mesh_visibility_range: None,
+            node_id: Default::default(),
+        };
+        assert_eq!(
+            resolve_covariance_frame(&object, &Coordinate(None)),
+            GeoFrame::NED
+        );
     }
 }
 

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -21,7 +21,9 @@ use crate::iter::JoinDisplayExt;
 use crate::plugins::render_layer_alloc::RenderLayerLease;
 use crate::rim_glow_material::{RimGlowExt, RimGlowMaterial, RimGlowParams};
 use crate::ui::tiles::ViewportConfig;
-use crate::{BevyExt, Coordinate, EqlContext, MainCamera, plugins::navigation_gizmo::NavGizmoCamera};
+use crate::{
+    BevyExt, Coordinate, EqlContext, MainCamera, plugins::navigation_gizmo::NavGizmoCamera,
+};
 use bevy::platform::hash::FixedHasher;
 use bevy_geo_frames::prelude::*;
 use std::borrow::Cow;
@@ -866,7 +868,10 @@ pub fn compile_cholesky_eql(expr: &str, ctx: &eql::Context) -> Result<CompiledEx
 }
 
 /// Compiles an EQL expression that must yield at least 6 floats (symmetric covariance P).
-pub fn compile_covariance_eql(expr: &str, ctx: &eql::Context) -> Result<CompiledExpr, CompileError> {
+pub fn compile_covariance_eql(
+    expr: &str,
+    ctx: &eql::Context,
+) -> Result<CompiledExpr, CompileError> {
     compile_6float_eql(expr, "error_covariance", ctx)
 }
 
@@ -1020,8 +1025,7 @@ pub fn update_object_3d_system(
             continue;
         };
 
-        let covariance_frame =
-            resolve_covariance_frame(&object_3d.data, &coordinate);
+        let covariance_frame = resolve_covariance_frame(&object_3d.data, &coordinate);
 
         let mesh_child = children_maybe.and_then(|children| {
             let mut mesh_children = children
@@ -1539,11 +1543,7 @@ fn cholesky_3x3_spd(p: &Mat3) -> Option<[f32; 6]> {
 }
 
 fn dmat3_to_mat3(m: DMat3) -> Mat3 {
-    Mat3::from_cols(
-        m.x_axis.as_vec3(),
-        m.y_axis.as_vec3(),
-        m.z_axis.as_vec3(),
-    )
+    Mat3::from_cols(m.x_axis.as_vec3(), m.y_axis.as_vec3(), m.z_axis.as_vec3())
 }
 
 fn frame_rotation_to_bevy(frame: GeoFrame, geo_context: &GeoContext) -> Mat3 {

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -6,7 +6,6 @@ use bevy::math::{DMat3, DQuat, DVec3};
 use bevy::prelude::Mesh;
 use bevy::prelude::*;
 use bevy::world_serialization::{WorldAssetRoot, WorldInstance, WorldInstanceSpawner};
-use bevy::scene::{SceneInstance, SceneRoot, SceneSpawner};
 use bevy_geo_frames::{GeoContext, GeoFrame, GeoPosition, GeoRotation};
 use bevy_mat3_material::{Mat3Material, Mat3Params, Mat3TransformExt, uv_sphere_grid_line_mesh};
 use bitvec::prelude::*;

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -1862,6 +1862,9 @@ pub fn spawn_mesh(
             if matches!(mesh, impeller2_wkt::Mesh::Plane { .. }) {
                 material.double_sided = true;
                 material.cull_mode = None;
+                // Prefer losing depth tests against the editor infinite grid so
+                // coplanar ground planes (ball example) do not shimmer.
+                material.depth_bias = 2.0;
             }
             let material = material_assets.add(material);
             let mesh = mesh.clone().into_bevy();

--- a/libs/elodin-editor/src/plugins/world_mesh/mod.rs
+++ b/libs/elodin-editor/src/plugins/world_mesh/mod.rs
@@ -486,7 +486,7 @@ fn sync_terrain_view_positions(
 
         commands
             .entity(entity)
-            .insert(TerrainViewPosition(absolute));
+            .try_insert(TerrainViewPosition(absolute));
     }
 }
 
@@ -498,7 +498,7 @@ fn sync_terrain_view_positions(
     for (entity, transform) in &cameras {
         commands
             .entity(entity)
-            .insert(TerrainViewPosition(transform.translation.as_dvec3()));
+            .try_insert(TerrainViewPosition(transform.translation.as_dvec3()));
     }
 }
 

--- a/libs/elodin-editor/src/ui/inspector/object3d.rs
+++ b/libs/elodin-editor/src/ui/inspector/object3d.rs
@@ -493,8 +493,7 @@ impl WidgetSystem for InspectorObject3D<'_, '_> {
                         let mut s = covariance_str.to_string();
                         let response = eql_textfield(ui, true, &eql_context.0, &mut s);
                         if response.changed() {
-                            *error_covariance =
-                                if s.trim().is_empty() { None } else { Some(s) };
+                            *error_covariance = if s.trim().is_empty() { None } else { Some(s) };
                             covariance_expr_update = Some(
                                 error_covariance
                                     .as_ref()
@@ -537,27 +536,23 @@ impl WidgetSystem for InspectorObject3D<'_, '_> {
 
                     if !uses_cholesky && !uses_covariance {
                         ui.horizontal(|ui| {
-                            if ui
-                                .button("Use error covariance (Cholesky)")
-                                .clicked()
-                            {
-                                *error_covariance_cholesky =
-                                    Some("(1, 0, 1, 0, 0, 1)".to_string());
+                            if ui.button("Use error covariance (Cholesky)").clicked() {
+                                *error_covariance_cholesky = Some("(1, 0, 1, 0, 0, 1)".to_string());
                                 *error_covariance = None;
-                                *error_confidence_interval = default_ellipsoid_confidence_interval();
+                                *error_confidence_interval =
+                                    default_ellipsoid_confidence_interval();
                                 scale_expr_update = None;
                                 covariance_expr_update = Some(None);
                                 cholesky_expr_update = Some(
-                                    compile_cholesky_eql("(1, 0, 1, 0, 0, 1)", &eql_context.0)
-                                        .ok(),
+                                    compile_cholesky_eql("(1, 0, 1, 0, 0, 1)", &eql_context.0).ok(),
                                 );
                                 changed = true;
                             }
                             if ui.button("Use error covariance").clicked() {
-                                *error_covariance =
-                                    Some("(1, 0, 0, 1, 0, 1)".to_string());
+                                *error_covariance = Some("(1, 0, 0, 1, 0, 1)".to_string());
                                 *error_covariance_cholesky = None;
-                                *error_confidence_interval = default_ellipsoid_confidence_interval();
+                                *error_confidence_interval =
+                                    default_ellipsoid_confidence_interval();
                                 scale_expr_update = None;
                                 cholesky_expr_update = Some(None);
                                 covariance_expr_update = Some(
@@ -574,7 +569,8 @@ impl WidgetSystem for InspectorObject3D<'_, '_> {
                             if ui.button("Use scale instead").clicked() {
                                 *error_covariance_cholesky = None;
                                 *error_covariance = None;
-                                *error_confidence_interval = default_ellipsoid_confidence_interval();
+                                *error_confidence_interval =
+                                    default_ellipsoid_confidence_interval();
                                 cholesky_expr_update = Some(None);
                                 covariance_expr_update = Some(None);
                                 let default_scale = default_ellipsoid_scale_expr();
@@ -583,11 +579,8 @@ impl WidgetSystem for InspectorObject3D<'_, '_> {
                                     Some(compile_scale_eql(&default_scale, &eql_context.0));
                                 changed = true;
                             }
-                            if uses_cholesky
-                                && ui.button("Use symmetric covariance").clicked()
-                            {
-                                *error_covariance =
-                                    Some("(1, 0, 0, 1, 0, 1)".to_string());
+                            if uses_cholesky && ui.button("Use symmetric covariance").clicked() {
+                                *error_covariance = Some("(1, 0, 0, 1, 0, 1)".to_string());
                                 *error_covariance_cholesky = None;
                                 cholesky_expr_update = Some(None);
                                 covariance_expr_update = Some(
@@ -596,16 +589,12 @@ impl WidgetSystem for InspectorObject3D<'_, '_> {
                                 );
                                 changed = true;
                             }
-                            if uses_covariance
-                                && ui.button("Use Cholesky instead").clicked()
-                            {
-                                *error_covariance_cholesky =
-                                    Some("(1, 0, 1, 0, 0, 1)".to_string());
+                            if uses_covariance && ui.button("Use Cholesky instead").clicked() {
+                                *error_covariance_cholesky = Some("(1, 0, 1, 0, 0, 1)".to_string());
                                 *error_covariance = None;
                                 covariance_expr_update = Some(None);
                                 cholesky_expr_update = Some(
-                                    compile_cholesky_eql("(1, 0, 1, 0, 0, 1)", &eql_context.0)
-                                        .ok(),
+                                    compile_cholesky_eql("(1, 0, 1, 0, 0, 1)", &eql_context.0).ok(),
                                 );
                                 changed = true;
                             }

--- a/libs/elodin-editor/src/ui/inspector/object3d.rs
+++ b/libs/elodin-editor/src/ui/inspector/object3d.rs
@@ -16,7 +16,7 @@ use smallvec::SmallVec;
 
 use crate::object_3d::{
     CompileError, ComponentError, EllipsoidVisual, Object3DMeshChild, compile_cholesky_eql,
-    compile_scale_eql, spawn_mesh,
+    compile_covariance_eql, compile_scale_eql, spawn_mesh,
 };
 use crate::ui::inspector::{eql_textfield, node_color_picker};
 use crate::{
@@ -226,11 +226,13 @@ impl WidgetSystem for InspectorObject3D<'_, '_> {
                             scale: default_scale.clone(),
                             color: impeller2_wkt::Color::WHITE,
                             error_covariance_cholesky: None,
+                            error_covariance: None,
                             error_confidence_interval: default_ellipsoid_confidence_interval(),
                             show_grid: default_ellipsoid_show_grid(),
                             grid_color: default_ellipsoid_grid_color(),
                         };
                         object_3d_state.error_covariance_cholesky_expr = None;
+                        object_3d_state.error_covariance_expr = None;
                         match compile_scale_eql(&default_scale, &eql_context.0) {
                             Ok(expr) => {
                                 object_3d_state.scale_expr = Some(expr);
@@ -252,6 +254,7 @@ impl WidgetSystem for InspectorObject3D<'_, '_> {
                 Result<crate::object_3d::CompiledExpr, CompileError>,
             > = None;
             let mut cholesky_expr_update: Option<Option<crate::object_3d::CompiledExpr>> = None;
+            let mut covariance_expr_update: Option<Option<crate::object_3d::CompiledExpr>> = None;
             let scale_error_display = object_3d_state.scale_error.clone();
 
             match &mut object_3d_state.data.mesh {
@@ -450,6 +453,7 @@ impl WidgetSystem for InspectorObject3D<'_, '_> {
                     scale,
                     color,
                     error_covariance_cholesky,
+                    error_covariance,
                     error_confidence_interval,
                     show_grid,
                     grid_color,
@@ -460,7 +464,9 @@ impl WidgetSystem for InspectorObject3D<'_, '_> {
                         changed |= node_color_picker(ui, "Grid color", grid_color);
                     }
                     ui.separator();
-                    if error_covariance_cholesky.is_some() {
+                    let uses_cholesky = error_covariance_cholesky.is_some();
+                    let uses_covariance = !uses_cholesky && error_covariance.is_some();
+                    if uses_cholesky {
                         ui.label(
                             egui::RichText::new("Error covariance Cholesky (EQL, 6 values)")
                                 .color(get_scheme().text_secondary),
@@ -478,15 +484,24 @@ impl WidgetSystem for InspectorObject3D<'_, '_> {
                             );
                             changed = true;
                         }
-                        changed |= ui
-                            .add(
-                                egui::DragValue::new(error_confidence_interval)
-                                    .range(1.0..=99.0)
-                                    .speed(1.0)
-                                    .suffix("%")
-                                    .prefix("Confidence: "),
-                            )
-                            .changed();
+                    } else if uses_covariance {
+                        ui.label(
+                            egui::RichText::new("Error covariance (EQL, symmetric 6 values)")
+                                .color(get_scheme().text_secondary),
+                        );
+                        let covariance_str = error_covariance.as_deref().unwrap_or("");
+                        let mut s = covariance_str.to_string();
+                        let response = eql_textfield(ui, true, &eql_context.0, &mut s);
+                        if response.changed() {
+                            *error_covariance =
+                                if s.trim().is_empty() { None } else { Some(s) };
+                            covariance_expr_update = Some(
+                                error_covariance
+                                    .as_ref()
+                                    .and_then(|e| compile_covariance_eql(e, &eql_context.0).ok()),
+                            );
+                            changed = true;
+                        }
                     } else {
                         ui.label(
                             egui::RichText::new("Scale (EQL)").color(get_scheme().text_secondary),
@@ -506,29 +521,95 @@ impl WidgetSystem for InspectorObject3D<'_, '_> {
                         if let Some(err) = &scale_error_display {
                             ui.colored_label(get_scheme().error, format!("{}", err));
                         }
-                        if ui
-                            .button("Use error covariance (Cholesky) instead")
-                            .clicked()
-                        {
-                            *error_covariance_cholesky = Some("(1, 0, 1, 0, 0, 1)".to_string());
-                            *error_confidence_interval = default_ellipsoid_confidence_interval();
-                            scale_expr_update = None;
-                            cholesky_expr_update = Some(
-                                compile_cholesky_eql("(1, 0, 1, 0, 0, 1)", &eql_context.0).ok(),
-                            );
-                            changed = true;
-                        }
                     }
-                    if error_covariance_cholesky.is_some()
-                        && ui.button("Use scale instead").clicked()
-                    {
-                        *error_covariance_cholesky = None;
-                        *error_confidence_interval = default_ellipsoid_confidence_interval();
-                        cholesky_expr_update = Some(None);
-                        let default_scale = default_ellipsoid_scale_expr();
-                        *scale = default_scale.clone();
-                        scale_expr_update = Some(compile_scale_eql(&default_scale, &eql_context.0));
-                        changed = true;
+
+                    if uses_cholesky || uses_covariance {
+                        changed |= ui
+                            .add(
+                                egui::DragValue::new(error_confidence_interval)
+                                    .range(1.0..=99.0)
+                                    .speed(1.0)
+                                    .suffix("%")
+                                    .prefix("Confidence: "),
+                            )
+                            .changed();
+                    }
+
+                    if !uses_cholesky && !uses_covariance {
+                        ui.horizontal(|ui| {
+                            if ui
+                                .button("Use error covariance (Cholesky)")
+                                .clicked()
+                            {
+                                *error_covariance_cholesky =
+                                    Some("(1, 0, 1, 0, 0, 1)".to_string());
+                                *error_covariance = None;
+                                *error_confidence_interval = default_ellipsoid_confidence_interval();
+                                scale_expr_update = None;
+                                covariance_expr_update = Some(None);
+                                cholesky_expr_update = Some(
+                                    compile_cholesky_eql("(1, 0, 1, 0, 0, 1)", &eql_context.0)
+                                        .ok(),
+                                );
+                                changed = true;
+                            }
+                            if ui.button("Use error covariance").clicked() {
+                                *error_covariance =
+                                    Some("(1, 0, 0, 1, 0, 1)".to_string());
+                                *error_covariance_cholesky = None;
+                                *error_confidence_interval = default_ellipsoid_confidence_interval();
+                                scale_expr_update = None;
+                                cholesky_expr_update = Some(None);
+                                covariance_expr_update = Some(
+                                    compile_covariance_eql("(1, 0, 0, 1, 0, 1)", &eql_context.0)
+                                        .ok(),
+                                );
+                                changed = true;
+                            }
+                        });
+                    }
+
+                    if uses_cholesky || uses_covariance {
+                        ui.horizontal(|ui| {
+                            if ui.button("Use scale instead").clicked() {
+                                *error_covariance_cholesky = None;
+                                *error_covariance = None;
+                                *error_confidence_interval = default_ellipsoid_confidence_interval();
+                                cholesky_expr_update = Some(None);
+                                covariance_expr_update = Some(None);
+                                let default_scale = default_ellipsoid_scale_expr();
+                                *scale = default_scale.clone();
+                                scale_expr_update =
+                                    Some(compile_scale_eql(&default_scale, &eql_context.0));
+                                changed = true;
+                            }
+                            if uses_cholesky
+                                && ui.button("Use symmetric covariance").clicked()
+                            {
+                                *error_covariance =
+                                    Some("(1, 0, 0, 1, 0, 1)".to_string());
+                                *error_covariance_cholesky = None;
+                                cholesky_expr_update = Some(None);
+                                covariance_expr_update = Some(
+                                    compile_covariance_eql("(1, 0, 0, 1, 0, 1)", &eql_context.0)
+                                        .ok(),
+                                );
+                                changed = true;
+                            }
+                            if uses_covariance
+                                && ui.button("Use Cholesky instead").clicked()
+                            {
+                                *error_covariance_cholesky =
+                                    Some("(1, 0, 1, 0, 0, 1)".to_string());
+                                *error_covariance = None;
+                                covariance_expr_update = Some(None);
+                                cholesky_expr_update = Some(
+                                    compile_cholesky_eql("(1, 0, 1, 0, 0, 1)", &eql_context.0)
+                                        .ok(),
+                                );
+                                changed = true;
+                            }
+                        });
                     }
                 }
             }
@@ -547,6 +628,9 @@ impl WidgetSystem for InspectorObject3D<'_, '_> {
             }
             if let Some(update) = cholesky_expr_update {
                 object_3d_state.error_covariance_cholesky_expr = update;
+            }
+            if let Some(update) = covariance_expr_update {
+                object_3d_state.error_covariance_expr = update;
             }
 
             if changed {

--- a/libs/elodin-editor/src/ui/inspector/object3d.rs
+++ b/libs/elodin-editor/src/ui/inspector/object3d.rs
@@ -485,6 +485,8 @@ impl WidgetSystem for InspectorObject3D<'_, '_> {
                             // Field presence selects the driver. Clearing Cholesky must compile
                             // a dormant covariance expr (or scale); create_object_3d_entity only
                             // compiled Cholesky while both fields were set.
+                            // Respawn only when Mat3 <-> scale flips; keystrokes that keep a
+                            // Mat3 field set must only refresh the compiled expr.
                             if error_covariance_cholesky.is_none() {
                                 if let Some(cov) = error_covariance.as_ref() {
                                     covariance_expr_update =
@@ -492,9 +494,9 @@ impl WidgetSystem for InspectorObject3D<'_, '_> {
                                 } else {
                                     scale_expr_update =
                                         Some(compile_scale_eql(scale, &eql_context.0));
+                                    changed = true;
                                 }
                             }
-                            changed = true;
                         }
                     } else if uses_covariance {
                         ui.label(
@@ -511,10 +513,11 @@ impl WidgetSystem for InspectorObject3D<'_, '_> {
                                     .as_ref()
                                     .and_then(|e| compile_covariance_eql(e, &eql_context.0).ok()),
                             );
+                            // Mat3 -> scale only when the field is cleared.
                             if error_covariance.is_none() {
                                 scale_expr_update = Some(compile_scale_eql(scale, &eql_context.0));
+                                changed = true;
                             }
-                            changed = true;
                         }
                     } else {
                         ui.label(
@@ -602,7 +605,7 @@ impl WidgetSystem for InspectorObject3D<'_, '_> {
                                     compile_covariance_eql("(1, 0, 0, 1, 0, 1)", &eql_context.0)
                                         .ok(),
                                 );
-                                changed = true;
+                                // Both drivers use the Mat3 mesh path; only refresh exprs.
                             }
                             if uses_covariance && ui.button("Use Cholesky instead").clicked() {
                                 *error_covariance_cholesky = Some("(1, 0, 1, 0, 0, 1)".to_string());
@@ -611,7 +614,6 @@ impl WidgetSystem for InspectorObject3D<'_, '_> {
                                 cholesky_expr_update = Some(
                                     compile_cholesky_eql("(1, 0, 1, 0, 0, 1)", &eql_context.0).ok(),
                                 );
-                                changed = true;
                             }
                         });
                     }

--- a/libs/elodin-editor/src/ui/inspector/object3d.rs
+++ b/libs/elodin-editor/src/ui/inspector/object3d.rs
@@ -482,6 +482,18 @@ impl WidgetSystem for InspectorObject3D<'_, '_> {
                                     .as_ref()
                                     .and_then(|e| compile_cholesky_eql(e, &eql_context.0).ok()),
                             );
+                            // Field presence selects the driver. Clearing Cholesky must compile
+                            // a dormant covariance expr (or scale); create_object_3d_entity only
+                            // compiled Cholesky while both fields were set.
+                            if error_covariance_cholesky.is_none() {
+                                if let Some(cov) = error_covariance.as_ref() {
+                                    covariance_expr_update =
+                                        Some(compile_covariance_eql(cov, &eql_context.0).ok());
+                                } else {
+                                    scale_expr_update =
+                                        Some(compile_scale_eql(scale, &eql_context.0));
+                                }
+                            }
                             changed = true;
                         }
                     } else if uses_covariance {
@@ -499,6 +511,9 @@ impl WidgetSystem for InspectorObject3D<'_, '_> {
                                     .as_ref()
                                     .and_then(|e| compile_covariance_eql(e, &eql_context.0).ok()),
                             );
+                            if error_covariance.is_none() {
+                                scale_expr_update = Some(compile_scale_eql(scale, &eql_context.0));
+                            }
                             changed = true;
                         }
                     } else {

--- a/libs/elodin-editor/src/ui/inspector/viewport.rs
+++ b/libs/elodin-editor/src/ui/inspector/viewport.rs
@@ -993,6 +993,7 @@ mod tests {
             scale_expr: None,
             scale_error: None,
             error_covariance_cholesky_expr: None,
+            error_covariance_expr: None,
             joint_animations: Vec::new(),
             data: Object3D {
                 eql: eql.to_string(),

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -821,6 +821,30 @@ fn collect_eql_component_ids(eql: &str, eql_ctx: &EqlContext, out: &mut HashSet<
     }
 }
 
+fn collect_object_3d_mesh_component_ids(
+    mesh: &impeller2_wkt::Object3DMesh,
+    eql_ctx: &EqlContext,
+    out: &mut HashSet<ComponentId>,
+) {
+    let impeller2_wkt::Object3DMesh::Ellipsoid {
+        scale,
+        error_covariance_cholesky,
+        error_covariance,
+        ..
+    } = mesh
+    else {
+        return;
+    };
+
+    if let Some(cholesky) = error_covariance_cholesky {
+        collect_eql_component_ids(cholesky, eql_ctx, out);
+    } else if let Some(covariance) = error_covariance {
+        collect_eql_component_ids(covariance, eql_ctx, out);
+    } else {
+        collect_eql_component_ids(scale, eql_ctx, out);
+    }
+}
+
 /// Component IDs for plot LineTree sync / visible-window prefetch
 /// (graphs + Line3d + object_3d only).
 fn plot_fetch_component_ids(
@@ -840,6 +864,7 @@ fn plot_fetch_component_ids(
     }
     for obj in object_3ds.iter() {
         collect_eql_component_ids(&obj.data.eql, eql_ctx, &mut ids);
+        collect_object_3d_mesh_component_ids(&obj.data.mesh, eql_ctx, &mut ids);
         // Thruster particle intensity EQL (plume / cold_gas / motor smoke).
         for thruster in &obj.data.thrusters {
             collect_eql_component_ids(&thruster.intensity, eql_ctx, &mut ids);
@@ -2349,6 +2374,70 @@ mod tests {
         let adapter = ComponentId(7);
         let ids = build_series_store_allowlist(HashSet::new(), [adapter]);
         assert_eq!(ids, [adapter].into_iter().collect());
+    }
+
+    #[test]
+    fn ellipsoid_covariance_eql_components_are_allowlisted() {
+        use impeller2::schema::Schema;
+        use impeller2::types::PrimType;
+        use impeller2_wkt::{
+            Object3DMesh, default_ellipsoid_color, default_ellipsoid_confidence_interval,
+            default_ellipsoid_grid_color,
+        };
+
+        let components = ["shape.scale", "shape.cholesky", "shape.covariance"].map(|name| {
+            Arc::new(eql::Component::new(
+                name.to_string(),
+                ComponentId::new(name),
+                Schema::new(PrimType::F64, vec![6_u64]).expect("valid schema"),
+            ))
+        });
+        let eql_ctx = EqlContext(eql::Context::from_leaves(
+            components,
+            Timestamp(0),
+            Timestamp(1),
+        ));
+        let mut mesh = Object3DMesh::Ellipsoid {
+            scale: "shape.scale".into(),
+            color: default_ellipsoid_color(),
+            error_covariance_cholesky: Some("shape.cholesky".into()),
+            error_covariance: Some("shape.covariance".into()),
+            error_confidence_interval: default_ellipsoid_confidence_interval(),
+            show_grid: false,
+            grid_color: default_ellipsoid_grid_color(),
+        };
+
+        let mut ids = HashSet::new();
+        collect_object_3d_mesh_component_ids(&mesh, &eql_ctx, &mut ids);
+
+        assert_eq!(
+            ids,
+            [ComponentId::new("shape.cholesky")].into_iter().collect()
+        );
+
+        if let Object3DMesh::Ellipsoid {
+            error_covariance_cholesky,
+            ..
+        } = &mut mesh
+        {
+            *error_covariance_cholesky = None;
+        }
+        ids.clear();
+        collect_object_3d_mesh_component_ids(&mesh, &eql_ctx, &mut ids);
+        assert_eq!(
+            ids,
+            [ComponentId::new("shape.covariance")].into_iter().collect()
+        );
+
+        if let Object3DMesh::Ellipsoid {
+            error_covariance, ..
+        } = &mut mesh
+        {
+            *error_covariance = None;
+        }
+        ids.clear();
+        collect_object_3d_mesh_component_ids(&mesh, &eql_ctx, &mut ids);
+        assert_eq!(ids, [ComponentId::new("shape.scale")].into_iter().collect());
     }
 
     #[test]

--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -1637,7 +1637,7 @@ pub fn show_document_load_failures(
 
 #[cfg(test)]
 mod tests {
-    use super::LoadSchematicParams;
+    use super::{LoadSchematicParams, MonitorsRoot};
     use crate::ui::widgets::SystemStateExt;
     use crate::{
         Coordinate, EqlContext,
@@ -1701,6 +1701,7 @@ mod tests {
             .insert_resource(CurrentSchematic(Default::default()));
 
         app.world_mut().spawn((Window::default(), PrimaryWindow));
+        app.world_mut().spawn((MonitorsRoot, Name::new("monitors")));
         settle(&mut app);
         app
     }

--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -198,6 +198,13 @@ struct PendingWindowLoad {
 #[derive(Resource, Default)]
 pub struct PendingWindowSchematics {
     loads: Vec<PendingWindowLoad>,
+#[derive(Component)]
+pub struct MonitorsRoot;
+
+pub(crate) fn plugin(app: &mut App) {
+    app.add_systems(Startup, |mut commands: Commands| {
+        commands.spawn((MonitorsRoot, Name::new("monitors")));
+    });
 }
 
 #[derive(SystemParam)]
@@ -236,6 +243,7 @@ pub struct LoadSchematicParams<'w, 's> {
     last_content: Option<ResMut<'w, LastActiveSchematicContent>>,
     #[cfg(feature = "big_space")]
     big_space_root: Option<Res<'w, crate::spatial::BigSpaceRootEntity>>,
+    monitor_root: Single<'w, 's, Entity, With<MonitorsRoot>>,
 }
 
 fn apply_theme(theme: Option<&impeller2_wkt::ThemeConfig>) -> colors::SchemeSelection {
@@ -1231,6 +1239,7 @@ impl LoadSchematicParams<'_, '_> {
                             component_name: monitor.component_name.clone(),
                         },
                         Name::new(label.clone()),
+                        ChildOf(*self.monitor_root),
                     ))
                     .id();
                 let pane = MonitorPane::new(entity, label);

--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -245,7 +245,8 @@ pub struct LoadSchematicParams<'w, 's> {
     last_content: Option<ResMut<'w, LastActiveSchematicContent>>,
     #[cfg(feature = "big_space")]
     big_space_root: Option<Res<'w, crate::spatial::BigSpaceRootEntity>>,
-    monitor_root: Single<'w, 's, Entity, With<MonitorsRoot>>,
+    // Optional: missing/duplicate root must not invalidate schematic load.
+    monitor_root: Option<Single<'w, 's, Entity, With<MonitorsRoot>>>,
 }
 
 fn apply_theme(theme: Option<&impeller2_wkt::ThemeConfig>) -> colors::SchemeSelection {
@@ -1234,16 +1235,16 @@ impl LoadSchematicParams<'_, '_> {
                     .name
                     .clone()
                     .unwrap_or_else(|| monitor.component_name.clone());
-                let entity = self
-                    .commands
-                    .spawn((
-                        super::monitor::MonitorData {
-                            component_name: monitor.component_name.clone(),
-                        },
-                        Name::new(label.clone()),
-                        ChildOf(*self.monitor_root),
-                    ))
-                    .id();
+                let mut entity = self.commands.spawn((
+                    super::monitor::MonitorData {
+                        component_name: monitor.component_name.clone(),
+                    },
+                    Name::new(label.clone()),
+                ));
+                if let Some(root) = self.monitor_root.as_ref() {
+                    entity.insert(ChildOf(**root));
+                }
+                let entity = entity.id();
                 let pane = MonitorPane::new(entity, label);
                 tile_state.insert_tile(Tile::Pane(Pane::Monitor(pane)), parent_id, false)
             }

--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -1226,9 +1226,12 @@ impl LoadSchematicParams<'_, '_> {
                     .unwrap_or_else(|| monitor.component_name.clone());
                 let entity = self
                     .commands
-                    .spawn(super::monitor::MonitorData {
-                        component_name: monitor.component_name.clone(),
-                    })
+                    .spawn((
+                        super::monitor::MonitorData {
+                            component_name: monitor.component_name.clone(),
+                        },
+                        Name::new(label.clone()),
+                    ))
                     .id();
                 let pane = MonitorPane::new(entity, label);
                 tile_state.insert_tile(Tile::Pane(Pane::Monitor(pane)), parent_id, false)

--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -198,6 +198,8 @@ struct PendingWindowLoad {
 #[derive(Resource, Default)]
 pub struct PendingWindowSchematics {
     loads: Vec<PendingWindowLoad>,
+}
+
 #[derive(Component)]
 pub struct MonitorsRoot;
 

--- a/libs/elodin-editor/src/ui/schematic/mod.rs
+++ b/libs/elodin-editor/src/ui/schematic/mod.rs
@@ -576,6 +576,7 @@ impl Plugin for SchematicPlugin {
             .init_resource::<SchematicBindings>()
             .init_resource::<load::PendingWindowSchematics>()
             .init_resource::<load::PendingDataOverview>()
+            .add_plugins(load::plugin)
             .add_systems(PostUpdate, tiles_to_schematic)
             .add_systems(
                 PostUpdate,

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -52,7 +52,7 @@ use super::{
     plot::{GraphBundle, GraphState, PlotWidget},
     query_plot::QueryPlotData,
     query_table::{QueryTableData, QueryTablePane, QueryTableWidget},
-    schematic::{graph_label, viewport_label},
+    schematic::{MonitorsRoot, graph_label, viewport_label},
     video_stream::{IsTileVisible, VideoDecoderHandle, VideoFrameCache, VideoStreamWidgetArgs},
     widgets::{RootWidgetSystem, WidgetSystem, WidgetSystemExt},
 };
@@ -2891,6 +2891,7 @@ pub struct TileLayout<'w, 's> {
     query_plots: Query<'w, 's, &'static mut QueryPlotData>,
     query_tables: Query<'w, 's, &'static mut QueryTableData>,
     action_tiles: Query<'w, 's, &'static mut ActionTile>,
+    monitor_root: Single<'w, 's, Entity, With<MonitorsRoot>>,
 }
 
 #[derive(Clone)]
@@ -3161,6 +3162,7 @@ impl WidgetSystem for TileLayout<'_, '_> {
                                     component_name: eql.clone(),
                                 },
                                 Name::new(eql.clone()),
+                                ChildOf(*state_mut.monitor_root),
                             ))
                             .id();
                         let monitor = MonitorPane::new(entity, eql.clone());

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -130,7 +130,7 @@ pub(crate) fn plugin(app: &mut App) {
         .add_message::<WindowRelayout>()
         .add_systems(Startup, setup_primary_window_state)
         .add_systems(Update, sync_editor_cam_zoom_limits);
-    // Must run after the BigSpace root exists; otherwise grids stay unparented
+    // Must run after the BigSpace root exists; otherwise grids stay un-parented
     // and shimmer from float-origin precision loss.
     #[cfg(feature = "big_space")]
     app.add_systems(

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -130,7 +130,7 @@ pub(crate) fn plugin(app: &mut App) {
         .add_message::<WindowRelayout>()
         .add_systems(Startup, setup_primary_window_state)
         .add_systems(Update, sync_editor_cam_zoom_limits);
-    // Must run after the BigSpace root exists; otherwise grids stay un-parented
+    // Must run after the BigSpace root exists; otherwise grids stay parentless
     // and shimmer from float-origin precision loss.
     #[cfg(feature = "big_space")]
     app.add_systems(
@@ -144,7 +144,7 @@ pub(crate) fn plugin(app: &mut App) {
 fn spawn_viewport_grids(
     mut commands: Commands,
     // Optional so headless/test apps without the spatial plugin don't panic;
-    // grids simply stay un-parented there. In the editor the root always exists
+    // grids simply stay parentless there. In the editor the root always exists
     // because this runs after `setup_floating_origin`.
     #[cfg(feature = "big_space")] root: Option<Res<crate::spatial::BigSpaceRootEntity>>,
 ) {

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -3156,9 +3156,12 @@ impl WidgetSystem for TileLayout<'_, '_> {
                         }
                         let entity = state_mut
                             .commands
-                            .spawn(super::monitor::MonitorData {
-                                component_name: eql.clone(),
-                            })
+                            .spawn((
+                                super::monitor::MonitorData {
+                                    component_name: eql.clone(),
+                                },
+                                Name::new(eql.clone()),
+                            ))
                             .id();
                         let monitor = MonitorPane::new(entity, eql.clone());
 

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -143,7 +143,10 @@ pub(crate) fn plugin(app: &mut App) {
 
 fn spawn_viewport_grids(
     mut commands: Commands,
-    #[cfg(feature = "big_space")] root: Res<crate::spatial::BigSpaceRootEntity>,
+    // Optional so headless/test apps without the spatial plugin don't panic;
+    // grids simply stay un-parented there. In the editor the root always exists
+    // because this runs after `setup_floating_origin`.
+    #[cfg(feature = "big_space")] root: Option<Res<crate::spatial::BigSpaceRootEntity>>,
 ) {
     for (frame, layer) in GRID_RENDER_LAYERS {
         let mut entity = commands.spawn((
@@ -161,7 +164,7 @@ fn spawn_viewport_grids(
             ),
         ));
         #[cfg(feature = "big_space")]
-        crate::spatial::parent_under_big_space(&mut entity, Some(&root));
+        crate::spatial::parent_under_big_space(&mut entity, root.as_deref());
     }
 }
 

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -2902,7 +2902,8 @@ pub struct TileLayout<'w, 's> {
     query_plots: Query<'w, 's, &'static mut QueryPlotData>,
     query_tables: Query<'w, 's, &'static mut QueryTableData>,
     action_tiles: Query<'w, 's, &'static mut ActionTile>,
-    monitor_root: Single<'w, 's, Entity, With<MonitorsRoot>>,
+    // Optional: missing/duplicate root must not invalidate tile UI.
+    monitor_root: Option<Single<'w, 's, Entity, With<MonitorsRoot>>>,
 }
 
 #[derive(Clone)]
@@ -3166,16 +3167,16 @@ impl WidgetSystem for TileLayout<'_, '_> {
                         if read_only {
                             continue;
                         }
-                        let entity = state_mut
-                            .commands
-                            .spawn((
-                                super::monitor::MonitorData {
-                                    component_name: eql.clone(),
-                                },
-                                Name::new(eql.clone()),
-                                ChildOf(*state_mut.monitor_root),
-                            ))
-                            .id();
+                        let mut entity = state_mut.commands.spawn((
+                            super::monitor::MonitorData {
+                                component_name: eql.clone(),
+                            },
+                            Name::new(eql.clone()),
+                        ));
+                        if let Some(root) = state_mut.monitor_root.as_ref() {
+                            entity.insert(ChildOf(**root));
+                        }
+                        let entity = entity.id();
                         let monitor = MonitorPane::new(entity, eql.clone());
 
                         let pane = Pane::Monitor(monitor);

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -128,14 +128,22 @@ fn bloom_from_config(config: Option<&BloomConfig>) -> Bloom {
 pub(crate) fn plugin(app: &mut App) {
     app.register_type::<WindowId>()
         .add_message::<WindowRelayout>()
-        .add_systems(Startup, spawn_viewport_grids)
         .add_systems(Startup, setup_primary_window_state)
         .add_systems(Update, sync_editor_cam_zoom_limits);
+    // Must run after the BigSpace root exists; otherwise grids stay unparented
+    // and shimmer from float-origin precision loss.
+    #[cfg(feature = "big_space")]
+    app.add_systems(
+        Startup,
+        spawn_viewport_grids.after(crate::spatial::setup_floating_origin),
+    );
+    #[cfg(not(feature = "big_space"))]
+    app.add_systems(Startup, spawn_viewport_grids);
 }
 
 fn spawn_viewport_grids(
     mut commands: Commands,
-    #[cfg(feature = "big_space")] root: Option<Res<crate::spatial::BigSpaceRootEntity>>,
+    #[cfg(feature = "big_space")] root: Res<crate::spatial::BigSpaceRootEntity>,
 ) {
     for (frame, layer) in GRID_RENDER_LAYERS {
         let mut entity = commands.spawn((
@@ -153,7 +161,7 @@ fn spawn_viewport_grids(
             ),
         ));
         #[cfg(feature = "big_space")]
-        crate::spatial::parent_under_big_space(&mut entity, root.as_deref());
+        crate::spatial::parent_under_big_space(&mut entity, Some(&root));
     }
 }
 

--- a/libs/impeller2/bevy/src/lib.rs
+++ b/libs/impeller2/bevy/src/lib.rs
@@ -973,7 +973,7 @@ fn try_insert_entity<'a, 'w, 's>(
 /// `newly_created == false` in a value-only path loop.
 ///
 /// When `db_components_root` is `None`, segments are still created but the
-/// top-level entity is left unparented.
+/// top-level entity is left parentless.
 fn ensure_component_path_hierarchy(
     entity_map: &mut EntityMap,
     metadata_reg: &mut ComponentMetadataRegistry,

--- a/libs/impeller2/bevy/src/lib.rs
+++ b/libs/impeller2/bevy/src/lib.rs
@@ -628,7 +628,7 @@ fn sink_inner(
                     &mut world_sink.metadata_reg,
                     &mut world_sink.commands,
                     &path,
-                    *world_sink.db_components_root,
+                    world_sink.db_components_root.as_ref().map(|r| **r),
                 );
                 world_sink.path_reg.0.insert(metadata.component_id, path);
                 world_sink
@@ -644,7 +644,7 @@ fn sink_inner(
                         &mut world_sink.metadata_reg,
                         &mut world_sink.commands,
                         &path,
-                        *world_sink.db_components_root,
+                        world_sink.db_components_root.as_ref().map(|r| **r),
                     );
                     world_sink.path_reg.0.insert(metadata.component_id, path);
                     world_sink
@@ -926,7 +926,8 @@ pub struct WorldSink<'w, 's> {
     schema_reg: ResMut<'w, ComponentSchemaRegistry>,
     path_reg: ResMut<'w, ComponentPathRegistry>,
     db_config: ResMut<'w, DbConfig>,
-    db_components_root: Single<'w, 's, Entity, With<DbComponentsRoot>>,
+    // Optional: missing/duplicate root must not invalidate WorldSink.
+    db_components_root: Option<Single<'w, 's, Entity, With<DbComponentsRoot>>>,
 }
 
 #[allow(clippy::needless_lifetimes)] // removing these lifetimes causes an internal compiler error, so here we are
@@ -970,12 +971,15 @@ fn try_insert_entity<'a, 'w, 's>(
 /// BigSpaceRoot). Call this from metadata handlers so leaves are not orphaned:
 /// metadata often creates the leaf before `apply_value` runs, which would make
 /// `newly_created == false` in a value-only path loop.
+///
+/// When `db_components_root` is `None`, segments are still created but the
+/// top-level entity is left unparented.
 fn ensure_component_path_hierarchy(
     entity_map: &mut EntityMap,
     metadata_reg: &mut ComponentMetadataRegistry,
     commands: &mut Commands,
     path: &ComponentPath,
-    db_components_root: Entity,
+    db_components_root: Option<Entity>,
 ) {
     let mut last_entity: Option<Entity> = None;
     for part in path.path.iter() {
@@ -987,8 +991,8 @@ fn ensure_component_path_hierarchy(
         if newly_created {
             if let Some(parent) = last_entity {
                 e.insert(ChildOf(parent));
-            } else {
-                e.insert(ChildOf(db_components_root));
+            } else if let Some(root) = db_components_root {
+                e.insert(ChildOf(root));
             }
         }
         last_entity = Some(e.id());
@@ -1012,7 +1016,7 @@ impl Decomponentize for WorldSink<'_, '_> {
             &mut self.metadata_reg,
             &mut self.commands,
             &path,
-            *self.db_components_root,
+            self.db_components_root.as_ref().map(|r| **r),
         );
 
         // ComponentValue and adapter writes (WorldPos, etc.) are handled
@@ -1844,7 +1848,7 @@ mod db_components_hierarchy_tests {
                         &mut metadata_reg,
                         &mut commands,
                         &path,
-                        root,
+                        Some(root),
                     );
                 },
             )
@@ -1877,7 +1881,7 @@ mod db_components_hierarchy_tests {
                         &mut metadata_reg,
                         &mut commands,
                         &path,
-                        root,
+                        Some(root),
                     );
                 },
             )
@@ -1927,7 +1931,7 @@ mod db_components_hierarchy_tests {
                         &mut metadata_reg,
                         &mut commands,
                         &path,
-                        root,
+                        Some(root),
                     );
                 },
             )
@@ -1950,7 +1954,7 @@ mod db_components_hierarchy_tests {
                         &mut metadata_reg,
                         &mut commands,
                         &path,
-                        root,
+                        Some(root),
                     );
                 },
             )
@@ -2002,7 +2006,7 @@ mod db_components_hierarchy_tests {
                         &mut metadata_reg,
                         &mut commands,
                         &path,
-                        root,
+                        Some(root),
                     );
                 },
             )

--- a/libs/impeller2/bevy/src/lib.rs
+++ b/libs/impeller2/bevy/src/lib.rs
@@ -1935,7 +1935,9 @@ mod db_components_hierarchy_tests {
 
         let leaf_id = ComponentPath::from_name("solo").id;
         let leaf = *app.world().resource::<EntityMap>().get(&leaf_id).unwrap();
-        app.world_mut().entity_mut(leaf).insert(ChildOf(other_parent));
+        app.world_mut()
+            .entity_mut(leaf)
+            .insert(ChildOf(other_parent));
 
         let path = ComponentPath::from_name("solo");
         app.world_mut()

--- a/libs/impeller2/bevy/src/lib.rs
+++ b/libs/impeller2/bevy/src/lib.rs
@@ -4,12 +4,12 @@ use bevy::{
         hierarchy::ChildOf,
         system::{EntityCommands, SystemId},
     },
-    prelude::{Command, In, InRef, IntoSystem, Message, Mut, System},
+    prelude::{Command, In, InRef, IntoSystem, Message, Mut, Single, System, With},
 };
 use bevy::{ecs::system::SystemParam, prelude::World};
 use bevy::{
     ecs::system::SystemState,
-    prelude::{Commands, Component, Deref, DerefMut, Entity, Query, ResMut, Resource, debug},
+    prelude::{Commands, Component, Deref, DerefMut, Entity, Name, Query, ResMut, Resource, debug},
 };
 use impeller2::types::IntoLenPacket;
 use impeller2::types::RequestId;
@@ -904,6 +904,13 @@ pub struct ComponentSchemaRegistry(pub HashMap<ComponentId, Schema<Vec<u64>>>);
 #[derive(Resource, Default, Deref, DerefMut)]
 pub struct ComponentPathRegistry(pub HashMap<ComponentId, ComponentPath>);
 
+#[derive(Component)]
+pub struct DbComponentsRoot;
+
+fn ensure_db_components_root(mut commands: Commands) {
+    commands.spawn((DbComponentsRoot, Name::new("db components")));
+}
+
 #[derive(SystemParam)]
 pub struct WorldSink<'w, 's> {
     commands: Commands<'w, 's>,
@@ -916,6 +923,7 @@ pub struct WorldSink<'w, 's> {
     schema_reg: ResMut<'w, ComponentSchemaRegistry>,
     path_reg: ResMut<'w, ComponentPathRegistry>,
     db_config: ResMut<'w, DbConfig>,
+    db_components_root: Single<'w, 's, Entity, With<DbComponentsRoot>>,
 }
 
 #[allow(clippy::needless_lifetimes)] // removing these lifetimes causes an internal compiler error, so here we are
@@ -932,7 +940,6 @@ fn try_insert_entity<'a, 'w, 's>(
         };
         Some((e, false))
     } else {
-        let mut e = commands.spawn((component_id, ComponentValueMap::default()));
         let metadata = metadata_reg
             .entry(component_id)
             .or_insert_with(|| ComponentMetadata {
@@ -941,8 +948,12 @@ fn try_insert_entity<'a, 'w, 's>(
                 metadata: Default::default(),
             })
             .clone();
-        e.insert(metadata.clone());
-
+        let e = commands.spawn((
+            component_id,
+            ComponentValueMap::default(),
+            metadata.clone(),
+            Name::new(metadata.name.clone()),
+        ));
         entity_map.insert(component_id, e.id());
         Some((e, true))
     }
@@ -987,6 +998,8 @@ impl Decomponentize for WorldSink<'_, '_> {
             };
             if newly_created && let Some(last_entity) = last_entity {
                 e.insert(ChildOf(last_entity));
+            } else {
+                e.insert(ChildOf(*self.db_components_root));
             }
             last_entity = Some(e.id());
         }
@@ -1178,6 +1191,7 @@ impl Plugin for Impeller2Plugin {
     fn build(&self, app: &mut bevy::prelude::App) {
         app.add_message::<DbMessage>()
             .add_plugins(DefaultAdaptersPlugin)
+            .add_systems(bevy::prelude::Startup, ensure_db_components_root)
             .add_systems(bevy::prelude::Update, flush_msg_request_queue)
             .insert_resource(impeller2_wkt::SimulationTimeStep(0.001))
             .insert_resource(impeller2_wkt::CurrentTimestamp(Timestamp::EPOCH))

--- a/libs/impeller2/bevy/src/lib.rs
+++ b/libs/impeller2/bevy/src/lib.rs
@@ -9,7 +9,7 @@ use bevy::{
 use bevy::{ecs::system::SystemParam, prelude::World};
 use bevy::{
     ecs::system::SystemState,
-    prelude::{Commands, Component, Deref, DerefMut, Entity, Query, ResMut, Resource},
+    prelude::{Commands, Component, Deref, DerefMut, Entity, Query, ResMut, Resource, debug},
 };
 use impeller2::types::IntoLenPacket;
 use impeller2::types::RequestId;
@@ -1218,6 +1218,7 @@ where
 
     fn apply(self, world: &mut World) {
         let system_id = world.register_system(self.system);
+        debug!("registered req handler {system_id:?}");
         let mut handlers = world
             .get_resource_mut::<PacketIdHandlers>()
             .expect("missing packet handlers");
@@ -1254,6 +1255,7 @@ where
     fn apply(self, world: &mut World) {
         let system_id = world.register_system(self.system);
 
+        debug!("registered reply handler {system_id:?}");
         let req_id = {
             let handlers = world.resource::<RequestIdHandlers>();
             let occupied: std::collections::HashSet<RequestId> = handlers.keys().copied().collect();
@@ -1316,6 +1318,9 @@ where
     fn apply(self, world: &mut World) {
         let system_id = world.register_system(self.system);
 
+        // TODO: This runs fairly often, and it registers a system each time. We
+        // should look for a different way to do this.
+        debug!("registered msg reply handler {system_id:?}");
         let req_id = {
             let handlers = world.resource::<MsgRequestIdHandlers>();
             let occupied: std::collections::HashSet<RequestId> = handlers.keys().copied().collect();

--- a/libs/impeller2/bevy/src/lib.rs
+++ b/libs/impeller2/bevy/src/lib.rs
@@ -996,10 +996,12 @@ impl Decomponentize for WorldSink<'_, '_> {
             ) else {
                 continue;
             };
-            if newly_created && let Some(last_entity) = last_entity {
-                e.insert(ChildOf(last_entity));
-            } else {
-                e.insert(ChildOf(*self.db_components_root));
+            if newly_created {
+                if let Some(last_entity) = last_entity {
+                    e.insert(ChildOf(last_entity));
+                } else {
+                    e.insert(ChildOf(*self.db_components_root));
+                }
             }
             last_entity = Some(e.id());
         }

--- a/libs/impeller2/bevy/src/lib.rs
+++ b/libs/impeller2/bevy/src/lib.rs
@@ -620,13 +620,15 @@ fn sink_inner(
             }
             OwnedPacket::Msg(m) if m.id == ComponentMetadata::ID => {
                 let metadata = m.parse::<ComponentMetadata>()?;
-                // Create entity and register path so the component appears in UI
+                // Create the full path hierarchy so the component appears in UI
+                // under DbComponentsRoot (not just an orphaned leaf entity).
                 let path = ComponentPath::from_name(&metadata.name);
-                try_insert_entity(
+                ensure_component_path_hierarchy(
                     &mut world_sink.entity_map,
                     &mut world_sink.metadata_reg,
                     &mut world_sink.commands,
-                    path.path.last().unwrap(),
+                    &path,
+                    *world_sink.db_components_root,
                 );
                 world_sink.path_reg.0.insert(metadata.component_id, path);
                 world_sink
@@ -637,11 +639,12 @@ fn sink_inner(
                 let metadata = m.parse::<DumpMetadataResp>()?;
                 for metadata in metadata.component_metadata.into_iter() {
                     let path = ComponentPath::from_name(&metadata.name);
-                    try_insert_entity(
+                    ensure_component_path_hierarchy(
                         &mut world_sink.entity_map,
                         &mut world_sink.metadata_reg,
                         &mut world_sink.commands,
-                        path.path.last().unwrap(),
+                        &path,
+                        *world_sink.db_components_root,
                     );
                     world_sink.path_reg.0.insert(metadata.component_id, path);
                     world_sink
@@ -959,6 +962,39 @@ fn try_insert_entity<'a, 'w, 's>(
     }
 }
 
+/// Creates every segment of `path` and parents newly created ones under
+/// `db_components_root` (or the previous segment).
+///
+/// Hierarchy is wired only for `newly_created` entities so later value packets
+/// do not re-insert `ChildOf` and undo editor reparenting (e.g. GridCell under
+/// BigSpaceRoot). Call this from metadata handlers so leaves are not orphaned:
+/// metadata often creates the leaf before `apply_value` runs, which would make
+/// `newly_created == false` in a value-only path loop.
+fn ensure_component_path_hierarchy(
+    entity_map: &mut EntityMap,
+    metadata_reg: &mut ComponentMetadataRegistry,
+    commands: &mut Commands,
+    path: &ComponentPath,
+    db_components_root: Entity,
+) {
+    let mut last_entity: Option<Entity> = None;
+    for part in path.path.iter() {
+        let Some((mut e, newly_created)) =
+            try_insert_entity(entity_map, metadata_reg, commands, part)
+        else {
+            continue;
+        };
+        if newly_created {
+            if let Some(parent) = last_entity {
+                e.insert(ChildOf(parent));
+            } else {
+                e.insert(ChildOf(db_components_root));
+            }
+        }
+        last_entity = Some(e.id());
+    }
+}
+
 impl Decomponentize for WorldSink<'_, '_> {
     type Error = core::convert::Infallible;
     fn apply_value(
@@ -967,44 +1003,17 @@ impl Decomponentize for WorldSink<'_, '_> {
         _view: ComponentView<'_>,
         _timestamp: Option<Timestamp>,
     ) -> Result<(), Infallible> {
-        let Some(path) = self.path_reg.get(&component_id) else {
+        let Some(path) = self.path_reg.get(&component_id).cloned() else {
             return Ok(());
         };
 
-        let Some(part) = path.path.last() else {
-            return Ok(());
-        };
-
-        // Ensure the entity exists (creates if needed).
-        try_insert_entity(
+        ensure_component_path_hierarchy(
             &mut self.entity_map,
             &mut self.metadata_reg,
             &mut self.commands,
-            part,
+            &path,
+            *self.db_components_root,
         );
-
-        // Wire parent-child hierarchy only for newly created path segments.
-        // Re-inserting ChildOf every packet would undo editor reparenting of
-        // spatial leaves (GridCell under BigSpaceRoot).
-        let mut last_entity: Option<Entity> = None;
-        for parent in path.path.iter() {
-            let Some((mut e, newly_created)) = try_insert_entity(
-                &mut self.entity_map,
-                &mut self.metadata_reg,
-                &mut self.commands,
-                parent,
-            ) else {
-                continue;
-            };
-            if newly_created {
-                if let Some(last_entity) = last_entity {
-                    e.insert(ChildOf(last_entity));
-                } else {
-                    e.insert(ChildOf(*self.db_components_root));
-                }
-            }
-            last_entity = Some(e.id());
-        }
 
         // ComponentValue and adapter writes (WorldPos, etc.) are handled
         // exclusively by apply_cached_data from the TelemetryCache.
@@ -1800,5 +1809,215 @@ mod series_store_allowlist_tests {
         }
         assert_eq!(pending.len(), 1);
         assert_eq!(pending[0].0, ComponentId(1));
+    }
+}
+
+#[cfg(test)]
+mod db_components_hierarchy_tests {
+    use super::*;
+    use bevy::ecs::system::RunSystemOnce;
+    use bevy::prelude::App;
+
+    fn parent_of(world: &World, entity: Entity) -> Option<Entity> {
+        world.get::<ChildOf>(entity).map(|c| c.0)
+    }
+
+    #[test]
+    fn single_segment_path_parents_under_db_root() {
+        let mut app = App::new();
+        let root = app
+            .world_mut()
+            .spawn((DbComponentsRoot, Name::new("db components")))
+            .id();
+        app.world_mut().insert_resource(EntityMap::default());
+        app.world_mut()
+            .insert_resource(ComponentMetadataRegistry::default());
+
+        let path = ComponentPath::from_name("position");
+        app.world_mut()
+            .run_system_once(
+                move |mut commands: Commands,
+                      mut entity_map: ResMut<EntityMap>,
+                      mut metadata_reg: ResMut<ComponentMetadataRegistry>| {
+                    ensure_component_path_hierarchy(
+                        &mut entity_map,
+                        &mut metadata_reg,
+                        &mut commands,
+                        &path,
+                        root,
+                    );
+                },
+            )
+            .unwrap();
+
+        let leaf_id = ComponentPath::from_name("position").id;
+        let leaf = *app.world().resource::<EntityMap>().get(&leaf_id).unwrap();
+        assert_eq!(parent_of(app.world(), leaf), Some(root));
+    }
+
+    #[test]
+    fn nested_path_wires_full_chain_under_db_root() {
+        let mut app = App::new();
+        let root = app
+            .world_mut()
+            .spawn((DbComponentsRoot, Name::new("db components")))
+            .id();
+        app.world_mut().insert_resource(EntityMap::default());
+        app.world_mut()
+            .insert_resource(ComponentMetadataRegistry::default());
+
+        let path = ComponentPath::from_name("a.b.c");
+        app.world_mut()
+            .run_system_once(
+                move |mut commands: Commands,
+                      mut entity_map: ResMut<EntityMap>,
+                      mut metadata_reg: ResMut<ComponentMetadataRegistry>| {
+                    ensure_component_path_hierarchy(
+                        &mut entity_map,
+                        &mut metadata_reg,
+                        &mut commands,
+                        &path,
+                        root,
+                    );
+                },
+            )
+            .unwrap();
+
+        let a = *app
+            .world()
+            .resource::<EntityMap>()
+            .get(&ComponentPart::new("a").id)
+            .unwrap();
+        let ab = *app
+            .world()
+            .resource::<EntityMap>()
+            .get(&ComponentPart::new("a.b").id)
+            .unwrap();
+        let abc = *app
+            .world()
+            .resource::<EntityMap>()
+            .get(&ComponentPart::new("a.b.c").id)
+            .unwrap();
+
+        assert_eq!(parent_of(app.world(), a), Some(root));
+        assert_eq!(parent_of(app.world(), ab), Some(a));
+        assert_eq!(parent_of(app.world(), abc), Some(ab));
+    }
+
+    #[test]
+    fn second_call_does_not_reparent_existing_entities() {
+        let mut app = App::new();
+        let root = app
+            .world_mut()
+            .spawn((DbComponentsRoot, Name::new("db components")))
+            .id();
+        let other_parent = app.world_mut().spawn_empty().id();
+        app.world_mut().insert_resource(EntityMap::default());
+        app.world_mut()
+            .insert_resource(ComponentMetadataRegistry::default());
+
+        let path = ComponentPath::from_name("solo");
+        app.world_mut()
+            .run_system_once(
+                move |mut commands: Commands,
+                      mut entity_map: ResMut<EntityMap>,
+                      mut metadata_reg: ResMut<ComponentMetadataRegistry>| {
+                    ensure_component_path_hierarchy(
+                        &mut entity_map,
+                        &mut metadata_reg,
+                        &mut commands,
+                        &path,
+                        root,
+                    );
+                },
+            )
+            .unwrap();
+
+        let leaf_id = ComponentPath::from_name("solo").id;
+        let leaf = *app.world().resource::<EntityMap>().get(&leaf_id).unwrap();
+        app.world_mut().entity_mut(leaf).insert(ChildOf(other_parent));
+
+        let path = ComponentPath::from_name("solo");
+        app.world_mut()
+            .run_system_once(
+                move |mut commands: Commands,
+                      mut entity_map: ResMut<EntityMap>,
+                      mut metadata_reg: ResMut<ComponentMetadataRegistry>| {
+                    ensure_component_path_hierarchy(
+                        &mut entity_map,
+                        &mut metadata_reg,
+                        &mut commands,
+                        &path,
+                        root,
+                    );
+                },
+            )
+            .unwrap();
+
+        assert_eq!(parent_of(app.world(), leaf), Some(other_parent));
+    }
+
+    #[test]
+    fn leaf_created_before_hierarchy_stays_orphaned_without_metadata_helper() {
+        // Documents the bug: creating only the leaf first, then running the
+        // hierarchy helper, leaves the leaf without ChildOf because it is not
+        // newly_created. Metadata handlers must call ensure_component_path_hierarchy
+        // (full path) instead of try_insert_entity(leaf) alone.
+        let mut app = App::new();
+        let root = app
+            .world_mut()
+            .spawn((DbComponentsRoot, Name::new("db components")))
+            .id();
+        app.world_mut().insert_resource(EntityMap::default());
+        app.world_mut()
+            .insert_resource(ComponentMetadataRegistry::default());
+
+        let path = ComponentPath::from_name("x.y");
+        let leaf_part = path.path.last().unwrap().clone();
+        app.world_mut()
+            .run_system_once(
+                move |mut commands: Commands,
+                      mut entity_map: ResMut<EntityMap>,
+                      mut metadata_reg: ResMut<ComponentMetadataRegistry>| {
+                    let _ = try_insert_entity(
+                        &mut entity_map,
+                        &mut metadata_reg,
+                        &mut commands,
+                        &leaf_part,
+                    );
+                },
+            )
+            .unwrap();
+
+        let path = ComponentPath::from_name("x.y");
+        app.world_mut()
+            .run_system_once(
+                move |mut commands: Commands,
+                      mut entity_map: ResMut<EntityMap>,
+                      mut metadata_reg: ResMut<ComponentMetadataRegistry>| {
+                    ensure_component_path_hierarchy(
+                        &mut entity_map,
+                        &mut metadata_reg,
+                        &mut commands,
+                        &path,
+                        root,
+                    );
+                },
+            )
+            .unwrap();
+
+        let y = *app
+            .world()
+            .resource::<EntityMap>()
+            .get(&ComponentPart::new("x.y").id)
+            .unwrap();
+        let x = *app
+            .world()
+            .resource::<EntityMap>()
+            .get(&ComponentPart::new("x").id)
+            .unwrap();
+        assert_eq!(parent_of(app.world(), x), Some(root));
+        // Leaf was pre-created, so hierarchy helper must not invent a parent.
+        assert_eq!(parent_of(app.world(), y), None);
     }
 }

--- a/libs/impeller2/kdl/src/de.rs
+++ b/libs/impeller2/kdl/src/de.rs
@@ -1552,6 +1552,11 @@ fn parse_object_3d_mesh(
                 .and_then(|v| v.as_string())
                 .map(str::to_string);
 
+            let error_covariance = node
+                .get("error_covariance")
+                .and_then(|v| v.as_string())
+                .map(str::to_string);
+
             let error_confidence_interval = node
                 .get("error_confidence_interval")
                 .and_then(|v| v.as_float())
@@ -1573,6 +1578,7 @@ fn parse_object_3d_mesh(
                 scale,
                 color,
                 error_covariance_cholesky,
+                error_covariance,
                 error_confidence_interval,
                 show_grid,
                 grid_color,
@@ -3007,6 +3013,7 @@ object_3d "rocket.world_pos" {
                     scale,
                     color,
                     error_covariance_cholesky,
+                    error_covariance: _,
                     error_confidence_interval,
                     show_grid,
                     grid_color: _,
@@ -3047,6 +3054,7 @@ object_3d "satellite.world_pos" {
                     scale: _,
                     color,
                     error_covariance_cholesky,
+                    error_covariance: _,
                     error_confidence_interval,
                     show_grid,
                     grid_color: _,
@@ -3059,6 +3067,38 @@ object_3d "satellite.world_pos" {
                     assert!(*show_grid);
                     assert!((color.r - 200.0 / 255.0).abs() < f32::EPSILON);
                     assert!((color.a - 120.0 / 255.0).abs() < f32::EPSILON);
+                }
+                _ => panic!("Expected ellipsoid mesh"),
+            }
+        } else {
+            panic!("Expected object_3d");
+        }
+    }
+
+    #[test]
+    fn test_parse_object_3d_ellipsoid_symmetric_error_covariance() {
+        let kdl = r#"
+object_3d "satellite.world_pos" {
+    ellipsoid error_covariance="(1, 0, 0, 1, 0, 1)" error_confidence_interval=90.0 {
+        color white
+    }
+}
+"#;
+
+        let schematic = parse_schematic(kdl).unwrap();
+        assert_eq!(schematic.elems.len(), 1);
+
+        if let SchematicElem::Object3d(obj) = &schematic.elems[0] {
+            match &obj.mesh {
+                Object3DMesh::Ellipsoid {
+                    error_covariance_cholesky,
+                    error_covariance,
+                    error_confidence_interval,
+                    ..
+                } => {
+                    assert!(error_covariance_cholesky.is_none());
+                    assert_eq!(error_covariance.as_deref(), Some("(1, 0, 0, 1, 0, 1)"));
+                    assert!((*error_confidence_interval - 90.0).abs() < f32::EPSILON);
                 }
                 _ => panic!("Expected ellipsoid mesh"),
             }

--- a/libs/impeller2/kdl/src/ser.rs
+++ b/libs/impeller2/kdl/src/ser.rs
@@ -911,15 +911,14 @@ fn serialize_object_3d_mesh(mesh: &Object3DMesh) -> (KdlNode, Vec<KdlNode>) {
                 node.entries_mut()
                     .push(KdlEntry::new_prop("scale", scale.clone()));
             }
-            if uses_covariance {
-                if *error_confidence_interval
+            if uses_covariance
+                && *error_confidence_interval
                     != impeller2_wkt::default_ellipsoid_confidence_interval()
-                {
-                    node.entries_mut().push(KdlEntry::new_prop(
-                        "error_confidence_interval",
-                        *error_confidence_interval as f64,
-                    ));
-                }
+            {
+                node.entries_mut().push(KdlEntry::new_prop(
+                    "error_confidence_interval",
+                    *error_confidence_interval as f64,
+                ));
             }
             if *show_grid {
                 node.entries_mut()

--- a/libs/impeller2/kdl/src/ser.rs
+++ b/libs/impeller2/kdl/src/ser.rs
@@ -892,16 +892,26 @@ fn serialize_object_3d_mesh(mesh: &Object3DMesh) -> (KdlNode, Vec<KdlNode>) {
             scale,
             color,
             error_covariance_cholesky,
+            error_covariance,
             error_confidence_interval,
             show_grid,
             grid_color,
         } => {
             let mut node = KdlNode::new("ellipsoid");
+            let uses_covariance = error_covariance_cholesky.is_some() || error_covariance.is_some();
             if let Some(cholesky) = error_covariance_cholesky {
                 node.entries_mut().push(KdlEntry::new_prop(
                     "error_covariance_cholesky",
                     cholesky.clone(),
                 ));
+            } else if let Some(covariance) = error_covariance {
+                node.entries_mut()
+                    .push(KdlEntry::new_prop("error_covariance", covariance.clone()));
+            } else {
+                node.entries_mut()
+                    .push(KdlEntry::new_prop("scale", scale.clone()));
+            }
+            if uses_covariance {
                 if *error_confidence_interval
                     != impeller2_wkt::default_ellipsoid_confidence_interval()
                 {
@@ -910,9 +920,6 @@ fn serialize_object_3d_mesh(mesh: &Object3DMesh) -> (KdlNode, Vec<KdlNode>) {
                         *error_confidence_interval as f64,
                     ));
                 }
-            } else {
-                node.entries_mut()
-                    .push(KdlEntry::new_prop("scale", scale.clone()));
             }
             if *show_grid {
                 node.entries_mut()
@@ -1554,6 +1561,7 @@ object_3d lander.world_pos {
                 scale: "rocket.scale".to_string(),
                 color: Color::rgba(64.0 / 255.0, 128.0 / 255.0, 1.0, 96.0 / 255.0),
                 error_covariance_cholesky: None,
+                error_covariance: None,
                 error_confidence_interval: impeller2_wkt::default_ellipsoid_confidence_interval(),
                 show_grid: impeller2_wkt::default_ellipsoid_show_grid(),
                 grid_color: impeller2_wkt::default_ellipsoid_grid_color(),
@@ -1578,6 +1586,7 @@ object_3d lander.world_pos {
                     scale,
                     color,
                     error_covariance_cholesky,
+                    error_covariance: _,
                     error_confidence_interval: _,
                     show_grid: _,
                     grid_color: _,

--- a/libs/impeller2/wkt/src/gui.rs
+++ b/libs/impeller2/wkt/src/gui.rs
@@ -733,6 +733,8 @@ pub enum Object3DMesh {
         color: Color,
         #[serde(default)]
         error_covariance_cholesky: Option<String>,
+        #[serde(default)]
+        error_covariance: Option<String>,
         #[serde(default = "default_ellipsoid_confidence_interval")]
         error_confidence_interval: f32,
         #[serde(default = "default_ellipsoid_show_grid")]


### PR DESCRIPTION
# Problem

We can show ellipsoids using spatial dimensions or a Cholesky decomposition of a error covariance matrix, but we can't accept the error covariance matrix directly.

# Solution

Accept the error_covariance directly.

# Validate

Use the new example to check its behavior.

```sh
elodin editor examples/covariance-ellipsoids/main.py
```

https://github.com/user-attachments/assets/dbf96ff5-6c33-4ac5-8577-4b9b0d645d05



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ellipsoid math and frame handling in `object_3d` (user-visible 3D correctness) plus impeller2 Bevy entity parenting; covered by new unit tests but touches shared editor infrastructure.
> 
> **Overview**
> Ellipsoids can now be driven by a **symmetric 6-pack `error_covariance`** EQL field (alternative to `error_covariance_cholesky`). The editor factors **P** at runtime, applies the confidence scaling, and maps the shape through the object’s **`frame`** / schematic **`coordinate`** (replacing a fixed ENU→Bevy basis). **Cholesky wins** when both fields are present; driver choice follows **field presence**, so a bad compile does not fall through to scale or the other mode.
> 
> KDL/WKT serde, schematic docs, plot **SeriesStore** allowlisting, and the object_3d inspector gain the new property and UI to switch between scale, Cholesky, and symmetric covariance.
> 
> **`examples/covariance-ellipsoids`** animates equivalent Cholesky vs direct **P** side by side for manual validation.
> 
> Also in this PR: headless schematic load keeps **`Coordinate`** in sync; **DB component** entities parent under **`DbComponentsRoot`**; monitors under **`MonitorsRoot`**; viewport **infinite grids** spawn after the floating-origin root when `big_space` is on; minor rendering tweaks (plane **depth_bias**, terrain **`try_insert`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a68565486535b98581ba6cdb3f3fc8fc2260e8d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->