### PR TITLE
Fix windows build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7012,7 +7012,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.18",
- "windows 0.57.0",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -7682,7 +7682,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]

--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -453,7 +453,11 @@ impl Plugin for EditorPlugin {
         embedded_asset!(app, "./assets/diffuse.ktx2");
         embedded_asset!(app, "./assets/specular.ktx2");
         if cfg!(not(target_arch = "wasm32")) {
-            app.insert_resource(DirectionalLightShadowMap { size: 8192 });
+            // Bevy allocates this Depth32Float texture even before a shadow-casting
+            // directional light exists. At 8192 this costs 256 MiB per array layer
+            // (1 GiB for the default four sun cascades), which can exceed the graphics
+            // memory budget on lower-memory GPUs and invalidate the render device.
+            app.insert_resource(DirectionalLightShadowMap { size: 2048 });
         }
         app.configure_sets(
             PreUpdate,

--- a/libs/elodin-editor/src/plugins/kdl_document/mod.rs
+++ b/libs/elodin-editor/src/plugins/kdl_document/mod.rs
@@ -8,9 +8,11 @@ mod types;
 pub use commands::*;
 pub use messages::*;
 pub use operations::{
-    apply_initial_kdl_path, fetch_active_schematic_kdl, reload_sticky_kdl_when_eql_ready,
-    sync_document_from_config, sync_document_skybox,
+    apply_initial_kdl_path, reload_sticky_kdl_when_eql_ready, sync_document_from_config,
+    sync_document_skybox,
 };
+#[cfg(all(not(target_family = "wasm"), target_family = "unix"))]
+pub use operations::fetch_active_schematic_kdl;
 pub(crate) use operations::{
     fetch_schematic_index, plan_db_save, schematic_name_from_key, schematic_save_key_from_name,
     upload_db_save_plan,

--- a/libs/elodin-editor/src/plugins/kdl_document/mod.rs
+++ b/libs/elodin-editor/src/plugins/kdl_document/mod.rs
@@ -7,12 +7,12 @@ mod types;
 
 pub use commands::*;
 pub use messages::*;
+#[cfg(all(not(target_family = "wasm"), target_family = "unix"))]
+pub use operations::fetch_active_schematic_kdl;
 pub use operations::{
     apply_initial_kdl_path, reload_sticky_kdl_when_eql_ready, sync_document_from_config,
     sync_document_skybox,
 };
-#[cfg(all(not(target_family = "wasm"), target_family = "unix"))]
-pub use operations::fetch_active_schematic_kdl;
 pub(crate) use operations::{
     fetch_schematic_index, plan_db_save, schematic_name_from_key, schematic_save_key_from_name,
     upload_db_save_plan,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized startup/rendering defaults and lockfile bumps; shadow resolution reduction may slightly soften directional shadows on high-end GPUs but improves stability on memory-constrained devices.
> 
> **Overview**
> Fixes **Windows build / startup** issues tied to graphics memory and dependency versions.
> 
> **Directional light shadow map:** On native (non-wasm) builds, the default `DirectionalLightShadowMap` size drops from **8192 → 2048**. Bevy allocates the depth texture even before any shadow-casting light exists; at 8192 that was ~256 MiB per layer (~1 GiB with four cascades), which could blow the graphics budget on lower-memory GPUs and **invalidate the render device** (called out explicitly for Windows-class hardware).
> 
> **Lockfile:** `gpu-allocator` and `chrono` now pull **`windows` / `windows-core` 0.62.2** instead of 0.57.0, keeping the Windows dependency graph consistent with the rest of the stack.
> 
> **KDL plugin API:** `fetch_active_schematic_kdl` is only **re-exported** from `kdl_document` on **non-wasm Unix** (matching the existing Unix-only `headless` consumer); the GUI path still uses it internally via `operations`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d17b054e0a051777d2e0c6bba0f23de20d80987. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->