### PR TITLE
fix(editor): update thruster test object state

### DIFF
--- a/libs/elodin-editor/src/plugins/thruster_particles/mod.rs
+++ b/libs/elodin-editor/src/plugins/thruster_particles/mod.rs
@@ -1350,6 +1350,7 @@ mod tests {
             scale_expr: None,
             scale_error: None,
             error_covariance_cholesky_expr: None,
+            error_covariance_expr: None,
             joint_animations: Vec::new(),
             data: impeller2_wkt::Object3D {
                 eql: "lander.world_pos".to_string(),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only struct literal update with no production code or behavior changes.
> 
> **Overview**
> Updates the thruster particles test helper **`test_object_state`** so its **`Object3DState`** literal includes the new **`error_covariance_expr: None`** field, matching the struct definition in **`object_3d`**.
> 
> No runtime thruster behavior changes—this is a **test compile fix** after **`Object3DState`** gained a covariance-driven ellipsoid expression slot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a971dd5e5ee62a6ff06450daa5e9d2b751dd3b86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->