### PR TITLE
Bump to v0.18.1-alpha.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-serial-bridge"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "anyhow",
  "blackbox",
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-setup"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "anyhow",
  "fastrand 1.9.0",
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-status"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "anyhow",
  "db-macros",
@@ -1354,7 +1354,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_ai_skybox"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "bevy",
  "chrono",
@@ -3196,7 +3196,7 @@ dependencies = [
 
 [[package]]
 name = "blackbox"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "zerocopy",
 ]
@@ -4272,7 +4272,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-mlir"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "blake3",
  "cranelift-codegen",
@@ -5205,7 +5205,7 @@ dependencies = [
 
 [[package]]
 name = "db-macros"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "convert_case 0.6.0",
  "darling 0.20.11",
@@ -5509,7 +5509,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elodin"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "base64 0.22.1",
  "bevy",
@@ -5541,7 +5541,7 @@ dependencies = [
 
 [[package]]
 name = "elodin-db"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5624,7 +5624,7 @@ dependencies = [
 
 [[package]]
 name = "elodin-db-tests"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "arrow",
  "elodin-db",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "elodin-editor"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "ab_glyph",
  "arc-swap",
@@ -5733,7 +5733,7 @@ dependencies = [
 
 [[package]]
 name = "elodin-macros"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "convert_case 0.6.0",
  "darling 0.20.11",
@@ -5932,7 +5932,7 @@ checksum = "f8970033a4282a7bcf899b38b5ed3a58b732fe093d03785d58648515d8d309da"
 
 [[package]]
 name = "eql"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "hifitime",
  "impeller2",
@@ -7049,7 +7049,7 @@ checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
 
 [[package]]
 name = "gst-elodin-plugin"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "anyhow",
  "gst-plugin-version-helper",
@@ -7243,7 +7243,7 @@ dependencies = [
 
 [[package]]
 name = "hamann-chen-line"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "anyhow",
  "clap 4.6.1",
@@ -7912,7 +7912,7 @@ checksum = "40fac9d56ed6437b198fddba683305e8e2d651aa42647f00f5ae542e7f5c94a2"
 
 [[package]]
 name = "impeller2"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "bevy",
  "const-fnv1a-hash",
@@ -7934,7 +7934,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-bbq"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "bbqueue",
  "impeller2",
@@ -7943,7 +7943,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-bevy"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "bbqueue",
  "bevy",
@@ -7967,7 +7967,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-cli"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -7996,7 +7996,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-frame"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "cobs 0.2.3",
  "impeller2",
@@ -8004,7 +8004,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-kdl"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "bevy_geo_frames",
  "impeller2",
@@ -8019,7 +8019,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-stellar"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "bbqueue",
  "fastrand 2.4.1",
@@ -8040,7 +8040,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-wkt"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "bevy",
  "bevy_geo_frames",
@@ -8197,7 +8197,7 @@ checksum = "d57a1694cff80cdd6c8a4cae63984578e2617528d3c266e53f56dfd3e279e9f7"
 
 [[package]]
 name = "inscriber"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "anyhow",
  "clap 4.6.1",
@@ -8872,7 +8872,7 @@ dependencies = [
 
 [[package]]
 name = "lqr"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "anyhow",
  "clap 4.6.1",
@@ -9144,7 +9144,7 @@ dependencies = [
 
 [[package]]
 name = "mekf"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "anyhow",
  "clap 4.6.1",
@@ -9345,7 +9345,7 @@ dependencies = [
 
 [[package]]
 name = "monte-carlo"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "chrono",
  "csv",
@@ -9885,7 +9885,7 @@ dependencies = [
 
 [[package]]
 name = "nox"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "approx",
  "bevy_math",
@@ -9914,14 +9914,14 @@ dependencies = [
 
 [[package]]
 name = "nox-array"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "zerocopy",
 ]
 
 [[package]]
 name = "nox-frames"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "approx",
  "hifitime",
@@ -9931,7 +9931,7 @@ dependencies = [
 
 [[package]]
 name = "nox-py"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "approx",
  "arrow",
@@ -11264,7 +11264,7 @@ dependencies = [
 
 [[package]]
 name = "postcard-c-codegen"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "clap 4.6.1",
  "convert_case 0.6.0",
@@ -12081,7 +12081,7 @@ dependencies = [
 
 [[package]]
 name = "rc-jet-controller"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "anyhow",
  "clap 4.6.1",
@@ -12451,7 +12451,7 @@ dependencies = [
 
 [[package]]
 name = "roci"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "anyhow",
  "bbqueue",
@@ -12477,7 +12477,7 @@ dependencies = [
 
 [[package]]
 name = "roci-adcs"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "approx",
  "nox",
@@ -12550,14 +12550,14 @@ dependencies = [
 
 [[package]]
 name = "rtsp-ingest"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "rtsp-streamer"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "anyhow",
  "clap 4.6.1",
@@ -12754,7 +12754,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s10"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "async-watcher",
  "cargo_metadata",
@@ -13481,7 +13481,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stellarator"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "blocking",
  "futures",
@@ -13509,11 +13509,11 @@ dependencies = [
 
 [[package]]
 name = "stellarator-buf"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 
 [[package]]
 name = "stellarator-macros"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -13921,7 +13921,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tegrastats-bridge"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "anyhow",
  "db-macros",
@@ -15032,7 +15032,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "video-streamer"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -15051,7 +15051,7 @@ dependencies = [
 
 [[package]]
 name = "video-toolbox"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "bitflags 2.11.1",
  "block2 0.6.2",
@@ -16386,7 +16386,7 @@ dependencies = [
 
 [[package]]
 name = "wmm"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 dependencies = [
  "approx",
  "bindgen 0.70.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ members = [
 exclude = ["fsw/sensor-fw", "fsw/blackbox", "docs/memserve"]
 
 [workspace.package]
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 edition = "2024"
 repository = "https://github.com/elodin-sys/elodin"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version-only change with no runtime or API edits; risk is limited to release tagging and dependency resolution consistency.
> 
> **Overview**
> Bumps the monorepo release version from **0.18.0** to **0.18.1-alpha.0** via `[workspace.package].version` in the root `Cargo.toml`, with `Cargo.lock` refreshed so every in-tree crate that inherits that version (elodin, impeller2, stellarator, roci, etc.) reports the new alpha tag.
> 
> No application or library source changes—only versioning metadata for an alpha release line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0efc4f733dfb219a40a4c6916b5acb102f710e6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->