### PR TITLE
feat(editor): artificial horizon gauge.

### DIFF
--- a/examples/apollo-lander/apollo-lander.kdl
+++ b/examples/apollo-lander/apollo-lander.kdl
@@ -28,12 +28,6 @@ hsplit {
     }
     vsplit share=0.536157 {
         hsplit {
-            // ADI alongside the main view. The scene is ENU and the LM's
-            // identity attitude is upright (DPS thrust along body +Z), so
-            // wings-level reads as upright and the horizon tracks the same
-            // pitch-back the graph below plots — no `source`/`reference`
-            // needed.
-            horizon_gauge "lander.world_pos" name="Attitude (ADI)" share=0.5
             graph "lander.altitude[0], lander_truth.altitude[0], lander_truth.slant_range[0]" name="Altitude vs real + radar slant (m)" {
                 color 106 155 165
                 color 114 87 179

--- a/examples/apollo-lander/apollo-lander.kdl
+++ b/examples/apollo-lander/apollo-lander.kdl
@@ -28,6 +28,12 @@ hsplit {
     }
     vsplit share=0.536157 {
         hsplit {
+            // ADI alongside the main view. The scene is ENU and the LM's
+            // identity attitude is upright (DPS thrust along body +Z), so
+            // wings-level reads as upright and the horizon tracks the same
+            // pitch-back the graph below plots — no `source`/`reference`
+            // needed.
+            horizon_gauge "lander.world_pos" name="Attitude (ADI)" share=0.5
             graph "lander.altitude[0], lander_truth.altitude[0], lander_truth.slant_range[0]" name="Altitude vs real + radar slant (m)" {
                 color 106 155 165
                 color 114 87 179

--- a/examples/rc-jet/README.md
+++ b/examples/rc-jet/README.md
@@ -55,6 +55,19 @@ The controller automatically:
 - Accepts input from both simultaneously (gamepad is primary)
 - Sends control commands at 60Hz to the simulation
 
+#### Idle Demo
+
+Until you touch a control, the controller flies itself: after a short lead-in it
+banks alternately right and left every ~14 s, reaching about ±30°, so the ADI and
+the attitude graphs have something to show on an untouched run. Each burst is a
+whole sine period of aileron, so the wings come back level and the average
+heading holds. The first stick or key input hands the aircraft over for good —
+it never takes control back. Start wings-level instead with:
+
+```bash
+cargo run -p rc-jet-controller -- --no-demo
+```
+
 #### Control Mapping (Mode 2 - US Standard)
 
 | Gamepad | Keyboard | Control |

--- a/examples/rc-jet/README.md
+++ b/examples/rc-jet/README.md
@@ -61,8 +61,10 @@ Until you touch a control, the controller flies itself: after a short lead-in it
 banks alternately right and left every ~14 s, reaching about ±30°, so the ADI and
 the attitude graphs have something to show on an untouched run. Each burst is a
 whole sine period of aileron, so the wings come back level and the average
-heading holds. The first stick or key input hands the aircraft over for good —
-it never takes control back.
+heading holds. The first elevator, aileron or rudder input — stick or arrow key
+— hands the aircraft over for good; it never takes control back. Throttle is
+not a handover: a ratcheted transmitter sits far off centre from the moment it
+is plugged in, and the demo would never fly.
 
 #### Control Mapping (Mode 2 - US Standard)
 

--- a/examples/rc-jet/README.md
+++ b/examples/rc-jet/README.md
@@ -63,9 +63,11 @@ the attitude graphs have something to show on an untouched run. The aileron is a
 cosine, which is what makes the bank a sine — the wings pass through level twice
 a cycle and the average heading holds. The first elevator, aileron or rudder input
 — stick or arrow key
-— hands the aircraft over for good; it never takes control back. Throttle is
-not a handover: a ratcheted transmitter sits far off centre from the moment it
-is plugged in, and the demo would never fly.
+— hands the aircraft over for good; it never takes control back. Handover wants a
+real input, a tenth of full throw, so a stick left a little off centre by trim or
+calibration is not mistaken for one. Throttle is not a handover at all: a
+ratcheted transmitter sits far off centre from the moment it is plugged in, and
+the demo would never fly.
 
 #### Control Mapping (Mode 2 - US Standard)
 

--- a/examples/rc-jet/README.md
+++ b/examples/rc-jet/README.md
@@ -57,11 +57,12 @@ The controller automatically:
 
 #### Idle Demo
 
-Until you touch a control, the controller flies itself: after a short lead-in it
-banks alternately right and left every ~14 s, reaching about ±30°, so the ADI and
-the attitude graphs have something to show on an untouched run. Each burst is a
-whole sine period of aileron, so the wings come back level and the average
-heading holds. The first elevator, aileron or rudder input — stick or arrow key
+Until you touch a control, the controller flies itself: it rolls slowly right
+then left, one full cycle every 14 s, reaching about ±30° of bank, so the ADI and
+the attitude graphs have something to show on an untouched run. The aileron is a
+cosine, which is what makes the bank a sine — the wings pass through level twice
+a cycle and the average heading holds. The first elevator, aileron or rudder input
+— stick or arrow key
 — hands the aircraft over for good; it never takes control back. Throttle is
 not a handover: a ratcheted transmitter sits far off centre from the moment it
 is plugged in, and the demo would never fly.

--- a/examples/rc-jet/README.md
+++ b/examples/rc-jet/README.md
@@ -62,11 +62,7 @@ banks alternately right and left every ~14 s, reaching about ±30°, so the ADI 
 the attitude graphs have something to show on an untouched run. Each burst is a
 whole sine period of aileron, so the wings come back level and the average
 heading holds. The first stick or key input hands the aircraft over for good —
-it never takes control back. Start wings-level instead with:
-
-```bash
-cargo run -p rc-jet-controller -- --no-demo
-```
+it never takes control back.
 
 #### Control Mapping (Mode 2 - US Standard)
 

--- a/examples/rc-jet/controller/src/demo.rs
+++ b/examples/rc-jet/controller/src/demo.rs
@@ -1,4 +1,4 @@
-//! Idle pilot: gentle periodic banks while nobody is on the sticks.
+//! Idle pilot: a slow roll left and right while nobody is on the sticks.
 //!
 //! Left alone the jet flies straight and the attitude instruments never move,
 //! which makes the ADI look broken. This nudges the ailerons until the first
@@ -8,22 +8,17 @@
 use std::f64::consts::TAU;
 use std::time::Instant;
 
-/// Wings-level lead-in, so the jet settles into trimmed flight before the
-/// first bank.
-const LEAD_IN_S: f64 = 5.0;
-/// Length of one bank-and-recover burst.
-const BURST_S: f64 = 6.0;
-/// Wings-level pause between bursts.
-const PAUSE_S: f64 = 8.0;
-/// Peak aileron during a burst, in radians (~0.9°).
+/// One full right-then-left roll.
+const PERIOD_S: f64 = 14.0;
+/// Peak aileron, in radians (~0.85°).
 ///
 /// Roll rate at cruise is roughly `(C_lda / -C_lp) * (2V/b) * delta_a`, about
-/// 16 rad/s per radian of aileron, and roll damping settles in tens of
-/// milliseconds — so half a burst integrates to a bank of a few tens of
-/// degrees. Full throw is 25°: this is a fingertip input.
-const PEAK_AILERON_RAD: f64 = 0.017;
+/// [`ROLL_RATE_PER_RAD`] for this airframe, and roll damping settles in tens of
+/// milliseconds, so the bank is essentially the integral of this. That puts the
+/// peak near 30° of bank — a fingertip input against the 25° of full throw.
+const PEAK_AILERON_RAD: f64 = 0.0148;
 
-/// Flies [`bank_burst`] until a human takes over.
+/// Flies [`roll_aileron`] until a human takes over.
 pub struct IdlePilot {
     start: Instant,
     flying: bool,
@@ -44,80 +39,75 @@ impl IdlePilot {
     pub fn aileron(&mut self, pilot_input: bool) -> Option<f64> {
         self.flying &= !pilot_input;
         self.flying
-            .then(|| bank_burst(self.start.elapsed().as_secs_f64()))
+            .then(|| roll_aileron(self.start.elapsed().as_secs_f64()))
     }
 }
 
-/// Aileron of the burst sequence `t` seconds after start: bursts alternating
-/// right and left, each a whole sine period so the wings come back level on
-/// their own and the jet holds its average heading.
-fn bank_burst(t: f64) -> f64 {
-    let t = t - LEAD_IN_S;
-    if t < 0.0 {
-        return 0.0;
-    }
-    let cycle = BURST_S + PAUSE_S;
-    let phase = t % cycle;
-    if phase >= BURST_S {
-        return 0.0;
-    }
-    let sign = if ((t / cycle) as u64).is_multiple_of(2) {
-        1.0
-    } else {
-        -1.0
-    };
-    sign * PEAK_AILERON_RAD * (TAU * phase / BURST_S).sin()
+/// Aileron `t` seconds in.
+///
+/// A cosine, not a sine: bank is the integral of roll rate, so this is what
+/// makes the bank itself a sine — swinging evenly either side of level, wings
+/// passing through flat twice a period, average heading held. Driving with a
+/// sine would bank one way only and turn the jet in circles.
+fn roll_aileron(t: f64) -> f64 {
+    PEAK_AILERON_RAD * (TAU * t / PERIOD_S).cos()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    const CYCLE_S: f64 = BURST_S + PAUSE_S;
+    /// Roll rate per radian of aileron at cruise, from the airframe's
+    /// `C_lda = 0.15`, `C_lp = -0.5`, `b = 2.65 m` at 70 m/s.
+    const ROLL_RATE_PER_RAD: f64 = 15.85;
 
+    /// Bank angle over one period, integrating `p = ROLL_RATE_PER_RAD * aileron`
+    /// from level. Roll damping settles far faster than the 14 s drive, so the
+    /// quasi-steady rate is a fair stand-in for the airframe.
+    fn bank_samples() -> Vec<f64> {
+        let steps = 14_000;
+        let dt = PERIOD_S / f64::from(steps);
+        let mut bank = 0.0;
+        (0..steps)
+            .map(|i| {
+                bank += ROLL_RATE_PER_RAD * roll_aileron((f64::from(i) + 0.5) * dt) * dt;
+                bank
+            })
+            .collect()
+    }
+
+    /// The point of the whole thing: the ADI shows a bank of a few tens of
+    /// degrees, and the same amount each way.
     #[test]
-    fn stays_level_during_lead_in_and_pauses() {
-        for t in [0.0, 1.0, LEAD_IN_S - 0.01] {
-            assert_eq!(bank_burst(t), 0.0, "lead-in at {t}");
-        }
-        for t in [BURST_S, BURST_S + 1.0, CYCLE_S - 0.01] {
-            assert_eq!(bank_burst(LEAD_IN_S + t), 0.0, "pause at {t}");
-        }
+    fn banks_about_thirty_degrees_either_side() {
+        let bank: Vec<f64> = bank_samples();
+        let max = bank.iter().copied().fold(f64::MIN, f64::max).to_degrees();
+        let min = bank.iter().copied().fold(f64::MAX, f64::min).to_degrees();
+        assert!((25.0..35.0).contains(&max), "peak bank {max}°");
+        assert!((-35.0..=-25.0).contains(&min), "opposite bank {min}°");
+        assert!((max + min).abs() < 1.0, "lopsided: {max}° vs {min}°");
+    }
+
+    /// Wings level at the end of a period, so the jet holds its heading on
+    /// average instead of spiralling.
+    #[test]
+    fn a_period_leaves_the_wings_level() {
+        let bank = bank_samples();
+        assert!(
+            bank.last().unwrap().abs() < 1e-3,
+            "residual {:?}",
+            bank.last()
+        );
     }
 
     #[test]
-    fn each_burst_starts_and_ends_neutral() {
-        for burst in 0..4 {
-            let base = LEAD_IN_S + f64::from(burst) * CYCLE_S;
-            assert!(bank_burst(base).abs() < 1e-12);
-            assert!(bank_burst(base + BURST_S - 1e-9).abs() < 1e-6);
-        }
-    }
-
-    #[test]
-    fn bursts_alternate_direction_and_stay_gentle() {
-        let peak = |burst: u32| bank_burst(LEAD_IN_S + f64::from(burst) * CYCLE_S + BURST_S / 4.0);
-        assert!((peak(0) - PEAK_AILERON_RAD).abs() < 1e-12);
-        assert!((peak(1) + PEAK_AILERON_RAD).abs() < 1e-12);
-        assert!((peak(2) - PEAK_AILERON_RAD).abs() < 1e-12);
+    fn stays_a_fingertip_input() {
         let max = (0..2000)
-            .map(|i| bank_burst(f64::from(i) * 0.05).abs())
+            .map(|i| roll_aileron(f64::from(i) * 0.05).abs())
             .fold(0.0, f64::max);
-        assert!(max <= PEAK_AILERON_RAD + 1e-12, "peak {max}");
+        assert!(max <= PEAK_AILERON_RAD + 1e-12, "peak aileron {max}");
         // Never more than a tenth of the 25° full throw.
         assert!(PEAK_AILERON_RAD < 25f64.to_radians() / 10.0);
-    }
-
-    /// A burst is a full sine period, so the net roll impulse (and hence the
-    /// bank it leaves behind) cancels.
-    #[test]
-    fn a_burst_integrates_to_zero() {
-        let steps = 60_000;
-        let dt = BURST_S / f64::from(steps);
-        let area: f64 = (0..steps)
-            .map(|i| bank_burst(LEAD_IN_S + (f64::from(i) + 0.5) * dt) * dt)
-            .sum();
-        assert!(area.abs() < 1e-6, "net aileron impulse {area}");
     }
 
     #[test]

--- a/examples/rc-jet/controller/src/demo.rs
+++ b/examples/rc-jet/controller/src/demo.rs
@@ -1,0 +1,134 @@
+//! Idle pilot: gentle periodic banks while nobody is on the sticks.
+//!
+//! Left alone the jet flies straight and the attitude instruments never move,
+//! which makes the ADI look broken. This nudges the ailerons until the first
+//! real pilot input, then hands the aircraft over for good — an attract mode,
+//! not an autopilot.
+
+use std::f64::consts::TAU;
+use std::time::Instant;
+
+/// Wings-level lead-in, so the jet settles into trimmed flight before the
+/// first bank.
+const LEAD_IN_S: f64 = 5.0;
+/// Length of one bank-and-recover burst.
+const BURST_S: f64 = 6.0;
+/// Wings-level pause between bursts.
+const PAUSE_S: f64 = 8.0;
+/// Peak aileron during a burst, in radians (~0.9°).
+///
+/// Roll rate at cruise is roughly `(C_lda / -C_lp) * (2V/b) * delta_a`, about
+/// 16 rad/s per radian of aileron, and roll damping settles in tens of
+/// milliseconds — so half a burst integrates to a bank of a few tens of
+/// degrees. Full throw is 25°: this is a fingertip input.
+const PEAK_AILERON_RAD: f64 = 0.017;
+
+/// Flies [`bank_burst`] until a human takes over.
+pub struct IdlePilot {
+    start: Instant,
+    flying: bool,
+}
+
+impl IdlePilot {
+    pub fn new(enabled: bool) -> Self {
+        Self {
+            start: Instant::now(),
+            flying: enabled,
+        }
+    }
+
+    /// Aileron the idle pilot wants now, or `None` once `pilot_input` has been
+    /// seen even once.
+    pub fn aileron(&mut self, pilot_input: bool) -> Option<f64> {
+        self.flying &= !pilot_input;
+        self.flying
+            .then(|| bank_burst(self.start.elapsed().as_secs_f64()))
+    }
+}
+
+/// Aileron of the burst sequence `t` seconds after start: bursts alternating
+/// right and left, each a whole sine period so the wings come back level on
+/// their own and the jet holds its average heading.
+fn bank_burst(t: f64) -> f64 {
+    let t = t - LEAD_IN_S;
+    if t < 0.0 {
+        return 0.0;
+    }
+    let cycle = BURST_S + PAUSE_S;
+    let phase = t % cycle;
+    if phase >= BURST_S {
+        return 0.0;
+    }
+    let sign = if ((t / cycle) as u64).is_multiple_of(2) {
+        1.0
+    } else {
+        -1.0
+    };
+    sign * PEAK_AILERON_RAD * (TAU * phase / BURST_S).sin()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CYCLE_S: f64 = BURST_S + PAUSE_S;
+
+    #[test]
+    fn stays_level_during_lead_in_and_pauses() {
+        for t in [0.0, 1.0, LEAD_IN_S - 0.01] {
+            assert_eq!(bank_burst(t), 0.0, "lead-in at {t}");
+        }
+        for t in [BURST_S, BURST_S + 1.0, CYCLE_S - 0.01] {
+            assert_eq!(bank_burst(LEAD_IN_S + t), 0.0, "pause at {t}");
+        }
+    }
+
+    #[test]
+    fn each_burst_starts_and_ends_neutral() {
+        for burst in 0..4 {
+            let base = LEAD_IN_S + f64::from(burst) * CYCLE_S;
+            assert!(bank_burst(base).abs() < 1e-12);
+            assert!(bank_burst(base + BURST_S - 1e-9).abs() < 1e-6);
+        }
+    }
+
+    #[test]
+    fn bursts_alternate_direction_and_stay_gentle() {
+        let peak = |burst: u32| bank_burst(LEAD_IN_S + f64::from(burst) * CYCLE_S + BURST_S / 4.0);
+        assert!((peak(0) - PEAK_AILERON_RAD).abs() < 1e-12);
+        assert!((peak(1) + PEAK_AILERON_RAD).abs() < 1e-12);
+        assert!((peak(2) - PEAK_AILERON_RAD).abs() < 1e-12);
+        let max = (0..2000)
+            .map(|i| bank_burst(f64::from(i) * 0.05).abs())
+            .fold(0.0, f64::max);
+        assert!(max <= PEAK_AILERON_RAD + 1e-12, "peak {max}");
+        // Never more than a tenth of the 25° full throw.
+        assert!(PEAK_AILERON_RAD < 25f64.to_radians() / 10.0);
+    }
+
+    /// A burst is a full sine period, so the net roll impulse (and hence the
+    /// bank it leaves behind) cancels.
+    #[test]
+    fn a_burst_integrates_to_zero() {
+        let steps = 60_000;
+        let dt = BURST_S / f64::from(steps);
+        let area: f64 = (0..steps)
+            .map(|i| bank_burst(LEAD_IN_S + (f64::from(i) + 0.5) * dt) * dt)
+            .sum();
+        assert!(area.abs() < 1e-6, "net aileron impulse {area}");
+    }
+
+    #[test]
+    fn hands_over_permanently_on_first_pilot_input() {
+        let mut pilot = IdlePilot::new(true);
+        assert!(pilot.aileron(false).is_some());
+        assert!(pilot.aileron(true).is_none());
+        // Releasing the stick must not bring the demo back.
+        assert!(pilot.aileron(false).is_none());
+    }
+
+    #[test]
+    fn disabled_pilot_never_flies() {
+        assert!(IdlePilot::new(false).aileron(false).is_none());
+    }
+}

--- a/examples/rc-jet/controller/src/demo.rs
+++ b/examples/rc-jet/controller/src/demo.rs
@@ -29,14 +29,16 @@ pub struct IdlePilot {
     flying: bool,
 }
 
-impl IdlePilot {
-    pub fn new(enabled: bool) -> Self {
+impl Default for IdlePilot {
+    fn default() -> Self {
         Self {
             start: Instant::now(),
-            flying: enabled,
+            flying: true,
         }
     }
+}
 
+impl IdlePilot {
     /// Aileron the idle pilot wants now, or `None` once `pilot_input` has been
     /// seen even once.
     pub fn aileron(&mut self, pilot_input: bool) -> Option<f64> {
@@ -120,15 +122,10 @@ mod tests {
 
     #[test]
     fn hands_over_permanently_on_first_pilot_input() {
-        let mut pilot = IdlePilot::new(true);
+        let mut pilot = IdlePilot::default();
         assert!(pilot.aileron(false).is_some());
         assert!(pilot.aileron(true).is_none());
         // Releasing the stick must not bring the demo back.
         assert!(pilot.aileron(false).is_none());
-    }
-
-    #[test]
-    fn disabled_pilot_never_flies() {
-        assert!(IdlePilot::new(false).aileron(false).is_none());
     }
 }

--- a/examples/rc-jet/controller/src/input.rs
+++ b/examples/rc-jet/controller/src/input.rs
@@ -17,6 +17,24 @@ use crate::demo::IdlePilot;
 /// Throttle held when no one is on the sticks: enough for level flight.
 const IDLE_THROTTLE: f64 = 0.3;
 
+/// Stick travel around centre that reads as neutral.
+const DEADZONE: f64 = 0.1;
+/// Full elevator/aileron throw, in radians (25°).
+const MAX_DEFLECTION_RAD: f64 = 25.0 * PI / 180.0;
+/// Full rudder throw, in radians (30°).
+const MAX_RUDDER_RAD: f64 = 30.0 * PI / 180.0;
+
+/// Fraction of full throw a surface must move before someone counts as flying.
+///
+/// A tenth of throw sits between the two cases that matter. Below it: a gamepad
+/// axis that trim or a sloppy calibration parks a little past the deadzone,
+/// which the `(axis - deadzone) / (1 - deadzone)` rescale then multiplies by the
+/// throw — a raw 0.15 is only 1.4° of elevator, and a raw 0.1021 is the 0.057°
+/// that a bare `1e-3` rad test would have read as a pilot on the sticks. Above
+/// it: every input a pilot can actually make, the smallest being the half-throw
+/// of an arrow key.
+const PILOT_INPUT_FRACTION: f64 = 0.1;
+
 /// Stick mode configuration
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum StickMode {
@@ -47,14 +65,18 @@ impl ControlInput {
     }
 }
 
-/// Whether a human is on the sticks: any control surface off neutral.
+/// Whether a human is on the sticks: any control surface deliberately moved,
+/// i.e. past [`PILOT_INPUT_FRACTION`] of its throw. Merely off neutral is not
+/// enough — a resting gamepad axis is rarely exactly centred.
 ///
 /// The throttle is deliberately no evidence at all. A ratcheted transmitter
 /// reports a throttle stick far off centre from the moment it is plugged in,
 /// so reading that as "someone is flying" would retire the idle pilot before
 /// it ever flew a bank.
 fn is_flying(input: &ControlInput) -> bool {
-    input.elevator.abs() > 1e-3 || input.aileron.abs() > 1e-3 || input.rudder.abs() > 1e-3
+    input.elevator.abs() > PILOT_INPUT_FRACTION * MAX_DEFLECTION_RAD
+        || input.aileron.abs() > PILOT_INPUT_FRACTION * MAX_DEFLECTION_RAD
+        || input.rudder.abs() > PILOT_INPUT_FRACTION * MAX_RUDDER_RAD
 }
 
 /// Merge the two input sources. Each gamepad axis wins while it is off
@@ -90,11 +112,6 @@ pub struct InputReader {
     gilrs: Option<Gilrs>,
     device_state: DeviceState,
     stick_mode: StickMode,
-    deadzone: f64,
-    /// Max deflection for elevator/aileron in radians (25°)
-    max_deflection_rad: f64,
-    /// Max deflection for rudder in radians (30°)
-    max_rudder_rad: f64,
     /// Current throttle state (keyboard is incremental)
     keyboard_throttle: f64,
     /// Last control input for smoothing
@@ -145,9 +162,6 @@ impl InputReader {
             gilrs,
             device_state: DeviceState::new(),
             stick_mode,
-            deadzone: 0.1,
-            max_deflection_rad: 25.0 * PI / 180.0, // 25° in radians
-            max_rudder_rad: 30.0 * PI / 180.0,     // 30° in radians
             keyboard_throttle: IDLE_THROTTLE,
             last_input: ControlInput {
                 throttle: IDLE_THROTTLE,
@@ -213,10 +227,10 @@ impl InputReader {
             return None;
         };
 
-        let left_x = self.apply_deadzone(left_x);
-        let left_y = self.apply_deadzone(left_y);
-        let right_x = self.apply_deadzone(right_x);
-        let right_y = self.apply_deadzone(right_y);
+        let left_x = apply_deadzone(left_x);
+        let left_y = apply_deadzone(left_y);
+        let right_x = apply_deadzone(right_x);
+        let right_y = apply_deadzone(right_y);
 
         // The deadzone reads exactly zero at centre, so any other value means
         // the throttle stick has been moved (or never self-centred).
@@ -232,18 +246,18 @@ impl InputReader {
                 // Mode 2: Left = Throttle(Y)/Rudder(X), Right = Elevator(Y)/Aileron(X)
                 ControlInput {
                     throttle: (left_y + 1.0) / 2.0, // Convert -1..1 to 0..1
-                    rudder: left_x * self.max_rudder_rad,
-                    elevator: -right_y * self.max_deflection_rad, // Inverted: stick up = nose up = negative
-                    aileron: right_x * self.max_deflection_rad,
+                    rudder: left_x * MAX_RUDDER_RAD,
+                    elevator: -right_y * MAX_DEFLECTION_RAD, // Inverted: stick up = nose up = negative
+                    aileron: right_x * MAX_DEFLECTION_RAD,
                 }
             }
             StickMode::Mode1 => {
                 // Mode 1: Left = Elevator(Y)/Rudder(X), Right = Throttle(Y)/Aileron(X)
                 ControlInput {
-                    elevator: -left_y * self.max_deflection_rad, // Inverted
-                    rudder: left_x * self.max_rudder_rad,
+                    elevator: -left_y * MAX_DEFLECTION_RAD, // Inverted
+                    rudder: left_x * MAX_RUDDER_RAD,
                     throttle: (right_y + 1.0) / 2.0,
-                    aileron: right_x * self.max_deflection_rad,
+                    aileron: right_x * MAX_DEFLECTION_RAD,
                 }
             }
         })
@@ -263,27 +277,27 @@ impl InputReader {
 
         // Rudder (A/D)
         let rudder = if keys.contains(&Keycode::A) {
-            -self.max_rudder_rad * 0.5 // Half max deflection
+            -MAX_RUDDER_RAD * 0.5 // Half max deflection
         } else if keys.contains(&Keycode::D) {
-            self.max_rudder_rad * 0.5
+            MAX_RUDDER_RAD * 0.5
         } else {
             0.0
         };
 
         // Elevator (Up/Down arrows)
         let elevator = if keys.contains(&Keycode::Up) {
-            -self.max_deflection_rad * 0.5 // Up arrow = nose up = negative elevator
+            -MAX_DEFLECTION_RAD * 0.5 // Up arrow = nose up = negative elevator
         } else if keys.contains(&Keycode::Down) {
-            self.max_deflection_rad * 0.5
+            MAX_DEFLECTION_RAD * 0.5
         } else {
             0.0
         };
 
         // Aileron (Left/Right arrows)
         let aileron = if keys.contains(&Keycode::Left) {
-            -self.max_deflection_rad * 0.5
+            -MAX_DEFLECTION_RAD * 0.5
         } else if keys.contains(&Keycode::Right) {
-            self.max_deflection_rad * 0.5
+            MAX_DEFLECTION_RAD * 0.5
         } else {
             0.0
         };
@@ -295,17 +309,17 @@ impl InputReader {
             throttle: self.keyboard_throttle,
         }
     }
+}
 
-    /// Apply deadzone to axis value
-    fn apply_deadzone(&self, value: f64) -> f64 {
-        if value.abs() < self.deadzone {
-            0.0
-        } else {
-            // Rescale to remove deadzone gap
-            let sign = value.signum();
-            let magnitude = (value.abs() - self.deadzone) / (1.0 - self.deadzone);
-            sign * magnitude
-        }
+/// Apply deadzone to axis value
+fn apply_deadzone(value: f64) -> f64 {
+    if value.abs() < DEADZONE {
+        0.0
+    } else {
+        // Rescale to remove deadzone gap
+        let sign = value.signum();
+        let magnitude = (value.abs() - DEADZONE) / (1.0 - DEADZONE);
+        sign * magnitude
     }
 }
 
@@ -363,6 +377,79 @@ mod tests {
             IdlePilot::default().aileron(is_flying(&combined)).is_some(),
             "a connected transmitter must not retire the idle pilot"
         );
+    }
+
+    /// A gamepad axis that trim or calibration parks a little past the
+    /// deadzone. The rescale makes such an axis map to a fraction of a degree
+    /// of surface, which is nobody flying — the idle banks must still run, on
+    /// the very FrSky-style hardware the README highlights.
+    #[test]
+    fn a_trimmed_gamepad_axis_still_lets_the_idle_pilot_fly() {
+        for raw in [0.1021, 0.11, 0.15, -0.15, 0.17] {
+            let gamepad = ControlInput {
+                elevator: apply_deadzone(raw) * MAX_DEFLECTION_RAD,
+                aileron: apply_deadzone(raw) * MAX_DEFLECTION_RAD,
+                rudder: apply_deadzone(raw) * MAX_RUDDER_RAD,
+                ..IDLE_GAMEPAD
+            };
+            let combined = combine(gamepad, IDLE_KEYBOARD, false);
+            assert!(!is_flying(&combined), "raw axis {raw} read as flying");
+            assert!(
+                IdlePilot::default().aileron(is_flying(&combined)).is_some(),
+                "raw axis {raw} retired the idle pilot"
+            );
+        }
+    }
+
+    /// The idle pilot's own fingertip aileron is not a pilot input either, or
+    /// the demo would retire itself on the tick after it started.
+    #[test]
+    fn the_idle_pilot_does_not_retire_itself() {
+        let aileron = IdlePilot::default()
+            .aileron(false)
+            .expect("idle pilot flies");
+        let combined = combine(
+            ControlInput {
+                aileron,
+                ..IDLE_GAMEPAD
+            },
+            IDLE_KEYBOARD,
+            false,
+        );
+        assert!(!is_flying(&combined));
+    }
+
+    /// The smallest input a pilot can actually make, from either device, has to
+    /// hand over: arrow keys and A/D are half throw.
+    #[test]
+    fn the_smallest_keyboard_input_flies() {
+        for keyboard in [
+            ControlInput {
+                elevator: MAX_DEFLECTION_RAD * 0.5,
+                ..IDLE_KEYBOARD
+            },
+            ControlInput {
+                aileron: MAX_DEFLECTION_RAD * 0.5,
+                ..IDLE_KEYBOARD
+            },
+            ControlInput {
+                rudder: MAX_RUDDER_RAD * 0.5,
+                ..IDLE_KEYBOARD
+            },
+        ] {
+            assert!(is_flying(&combine(IDLE_GAMEPAD, keyboard, false)));
+        }
+    }
+
+    /// A stick moved well clear of the deadzone: a quarter of throw is already
+    /// a deliberate input.
+    #[test]
+    fn a_deflected_stick_flies() {
+        let gamepad = ControlInput {
+            aileron: apply_deadzone(0.35) * MAX_DEFLECTION_RAD,
+            ..IDLE_GAMEPAD
+        };
+        assert!(is_flying(&combine(gamepad, IDLE_KEYBOARD, false)));
     }
 
     #[test]

--- a/examples/rc-jet/controller/src/input.rs
+++ b/examples/rc-jet/controller/src/input.rs
@@ -47,13 +47,43 @@ impl ControlInput {
     }
 }
 
-/// Whether a human is actually flying: any surface off neutral, or a throttle
-/// moved away from the idle default.
-fn is_flying(input: &ControlInput) -> bool {
-    input.elevator.abs() > 1e-3
+/// Whether a human is actually flying: any surface off neutral, a throttle
+/// stick the pilot has moved, or a keyboard throttle away from the idle
+/// default.
+fn is_flying(input: &ControlInput, gamepad_throttle: bool) -> bool {
+    gamepad_throttle
+        || input.elevator.abs() > 1e-3
         || input.aileron.abs() > 1e-3
         || input.rudder.abs() > 1e-3
         || (input.throttle - IDLE_THROTTLE).abs() > 0.01
+}
+
+/// Merge the two input sources. Each gamepad axis wins while it is off
+/// neutral; the throttle is the gamepad's only once its stick has been moved,
+/// since a centred stick means "untouched", not "half throttle".
+fn combine(gamepad: ControlInput, keyboard: ControlInput, gamepad_throttle: bool) -> ControlInput {
+    ControlInput {
+        elevator: if gamepad.elevator.abs() > 0.001 {
+            gamepad.elevator
+        } else {
+            keyboard.elevator
+        },
+        aileron: if gamepad.aileron.abs() > 0.001 {
+            gamepad.aileron
+        } else {
+            keyboard.aileron
+        },
+        rudder: if gamepad.rudder.abs() > 0.001 {
+            gamepad.rudder
+        } else {
+            keyboard.rudder
+        },
+        throttle: if gamepad_throttle {
+            gamepad.throttle
+        } else {
+            keyboard.throttle
+        },
+    }
 }
 
 /// Input reader combining gamepad and keyboard
@@ -70,6 +100,12 @@ pub struct InputReader {
     keyboard_throttle: f64,
     /// Last control input for smoothing
     last_input: ControlInput,
+    /// Whether the gamepad's throttle stick has ever left neutral.
+    ///
+    /// A gamepad self-centres its sticks and centre maps to mid-throttle, so
+    /// an untouched pad would otherwise out-vote the keyboard. A transmitter's
+    /// ratcheted throttle sits off centre, so it latches on the first read.
+    gamepad_throttle_engaged: bool,
     /// Flies gentle banks until the human takes over
     idle_pilot: IdlePilot,
 }
@@ -118,6 +154,7 @@ impl InputReader {
                 throttle: IDLE_THROTTLE,
                 ..Default::default()
             },
+            gamepad_throttle_engaged: false,
             idle_pilot: IdlePilot::new(demo),
         }
     }
@@ -137,33 +174,15 @@ impl InputReader {
         // Read keyboard input
         let keyboard_input = self.read_keyboard();
 
-        // Combine inputs - gamepad takes priority for each axis if non-zero
-        let mut combined = ControlInput {
-            elevator: if gamepad_input.elevator.abs() > 0.001 {
-                gamepad_input.elevator
-            } else {
-                keyboard_input.elevator
-            },
-            aileron: if gamepad_input.aileron.abs() > 0.001 {
-                gamepad_input.aileron
-            } else {
-                keyboard_input.aileron
-            },
-            rudder: if gamepad_input.rudder.abs() > 0.001 {
-                gamepad_input.rudder
-            } else {
-                keyboard_input.rudder
-            },
-            throttle: if (gamepad_input.throttle - IDLE_THROTTLE).abs() > 0.01 {
-                gamepad_input.throttle
-            } else {
-                keyboard_input.throttle
-            },
-        };
+        let gamepad_throttle = self.gamepad_throttle_engaged;
+        let mut combined = combine(gamepad_input, keyboard_input, gamepad_throttle);
 
         // Hand the ailerons to the idle pilot until the human flies. Done
         // before smoothing so the handover blends like any other input.
-        if let Some(aileron) = self.idle_pilot.aileron(is_flying(&combined)) {
+        if let Some(aileron) = self
+            .idle_pilot
+            .aileron(is_flying(&combined, gamepad_throttle))
+        {
             combined.aileron = aileron;
         }
 
@@ -181,7 +200,7 @@ impl InputReader {
     }
 
     /// Read gamepad input
-    fn read_gamepad(&self) -> ControlInput {
+    fn read_gamepad(&mut self) -> ControlInput {
         let Some(ref gilrs) = self.gilrs else {
             return ControlInput {
                 throttle: IDLE_THROTTLE,
@@ -202,6 +221,14 @@ impl InputReader {
         let left_y = self.apply_deadzone(gamepad.value(Axis::LeftStickY) as f64);
         let right_x = self.apply_deadzone(gamepad.value(Axis::RightStickX) as f64);
         let right_y = self.apply_deadzone(gamepad.value(Axis::RightStickY) as f64);
+
+        // The deadzone reads exactly zero at centre, so any other value means
+        // the throttle stick has been moved (or never self-centred).
+        let throttle_axis = match self.stick_mode {
+            StickMode::Mode2 => left_y,
+            StickMode::Mode1 => right_y,
+        };
+        self.gamepad_throttle_engaged |= throttle_axis != 0.0;
 
         // Map based on stick mode
         match self.stick_mode {
@@ -283,5 +310,81 @@ impl InputReader {
             let magnitude = (value.abs() - self.deadzone) / (1.0 - self.deadzone);
             sign * magnitude
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// An untouched gamepad: sticks centred, which the throttle mapping
+    /// `(axis + 1) / 2` turns into mid-throttle.
+    const IDLE_GAMEPAD: ControlInput = ControlInput {
+        elevator: 0.0,
+        aileron: 0.0,
+        rudder: 0.0,
+        throttle: 0.5,
+    };
+
+    /// The keyboard at rest, before any key is pressed.
+    const IDLE_KEYBOARD: ControlInput = ControlInput {
+        elevator: 0.0,
+        aileron: 0.0,
+        rudder: 0.0,
+        throttle: IDLE_THROTTLE,
+    };
+
+    #[test]
+    fn untouched_gamepad_keeps_the_idle_throttle() {
+        let combined = combine(IDLE_GAMEPAD, IDLE_KEYBOARD, false);
+        assert_eq!(combined.throttle, IDLE_THROTTLE);
+        assert!(!is_flying(&combined, false));
+    }
+
+    #[test]
+    fn untouched_gamepad_does_not_out_vote_the_keyboard_throttle() {
+        let keyboard = ControlInput {
+            throttle: 0.8,
+            ..IDLE_KEYBOARD
+        };
+        assert_eq!(combine(IDLE_GAMEPAD, keyboard, false).throttle, 0.8);
+    }
+
+    #[test]
+    fn moved_throttle_stick_wins_and_counts_as_flying() {
+        let gamepad = ControlInput {
+            throttle: 0.75,
+            ..IDLE_GAMEPAD
+        };
+        let combined = combine(gamepad, IDLE_KEYBOARD, true);
+        assert_eq!(combined.throttle, 0.75);
+        assert!(is_flying(&combined, true));
+    }
+
+    /// A transmitter parked at a throttle that happens to match the idle
+    /// default is still a pilot at the controls.
+    #[test]
+    fn a_moved_stick_flies_even_at_idle_throttle() {
+        assert!(is_flying(&IDLE_KEYBOARD, true));
+    }
+
+    #[test]
+    fn stick_deflection_flies() {
+        let gamepad = ControlInput {
+            aileron: 0.1,
+            ..IDLE_GAMEPAD
+        };
+        let combined = combine(gamepad, IDLE_KEYBOARD, false);
+        assert_eq!(combined.aileron, 0.1);
+        assert!(is_flying(&combined, false));
+    }
+
+    #[test]
+    fn keyboard_throttle_off_idle_flies() {
+        let keyboard = ControlInput {
+            throttle: IDLE_THROTTLE + 0.05,
+            ..IDLE_KEYBOARD
+        };
+        assert!(is_flying(&combine(IDLE_GAMEPAD, keyboard, false), false));
     }
 }

--- a/examples/rc-jet/controller/src/input.rs
+++ b/examples/rc-jet/controller/src/input.rs
@@ -168,8 +168,9 @@ impl InputReader {
             }
         }
 
-        // Read gamepad input
-        let gamepad_input = self.read_gamepad();
+        // Read gamepad input; absent, it contributes nothing and every axis
+        // falls through to the keyboard.
+        let gamepad_input = self.read_gamepad().unwrap_or_default();
 
         // Read keyboard input
         let keyboard_input = self.read_keyboard();
@@ -199,28 +200,28 @@ impl InputReader {
         smoothed
     }
 
-    /// Read gamepad input
-    fn read_gamepad(&mut self) -> ControlInput {
-        let Some(ref gilrs) = self.gilrs else {
-            return ControlInput {
-                throttle: IDLE_THROTTLE,
-                ..Default::default()
-            };
+    /// Read the connected gamepad, or `None` when there is no pad to read.
+    fn read_gamepad(&mut self) -> Option<ControlInput> {
+        let axes = self.gilrs.as_ref().and_then(|gilrs| {
+            let (_id, gamepad) = gilrs.gamepads().find(|(_, g)| g.is_connected())?;
+            Some((
+                gamepad.value(Axis::LeftStickX) as f64,
+                gamepad.value(Axis::LeftStickY) as f64,
+                gamepad.value(Axis::RightStickX) as f64,
+                gamepad.value(Axis::RightStickY) as f64,
+            ))
+        });
+        let Some((left_x, left_y, right_x, right_y)) = axes else {
+            // The latch goes away with the pad it speaks for, so unplugging
+            // one hands the throttle back to the keyboard.
+            self.gamepad_throttle_engaged = false;
+            return None;
         };
 
-        // Find first connected gamepad
-        let Some((_id, gamepad)) = gilrs.gamepads().find(|(_, g)| g.is_connected()) else {
-            return ControlInput {
-                throttle: IDLE_THROTTLE,
-                ..Default::default()
-            };
-        };
-
-        // Read stick axes
-        let left_x = self.apply_deadzone(gamepad.value(Axis::LeftStickX) as f64);
-        let left_y = self.apply_deadzone(gamepad.value(Axis::LeftStickY) as f64);
-        let right_x = self.apply_deadzone(gamepad.value(Axis::RightStickX) as f64);
-        let right_y = self.apply_deadzone(gamepad.value(Axis::RightStickY) as f64);
+        let left_x = self.apply_deadzone(left_x);
+        let left_y = self.apply_deadzone(left_y);
+        let right_x = self.apply_deadzone(right_x);
+        let right_y = self.apply_deadzone(right_y);
 
         // The deadzone reads exactly zero at centre, so any other value means
         // the throttle stick has been moved (or never self-centred).
@@ -231,7 +232,7 @@ impl InputReader {
         self.gamepad_throttle_engaged |= throttle_axis != 0.0;
 
         // Map based on stick mode
-        match self.stick_mode {
+        Some(match self.stick_mode {
             StickMode::Mode2 => {
                 // Mode 2: Left = Throttle(Y)/Rudder(X), Right = Elevator(Y)/Aileron(X)
                 ControlInput {
@@ -250,7 +251,7 @@ impl InputReader {
                     aileron: right_x * self.max_deflection_rad,
                 }
             }
-        }
+        })
     }
 
     /// Read keyboard input
@@ -377,6 +378,21 @@ mod tests {
         let combined = combine(gamepad, IDLE_KEYBOARD, false);
         assert_eq!(combined.aileron, 0.1);
         assert!(is_flying(&combined, false));
+    }
+
+    /// A pad that goes away contributes a zeroed input with its throttle latch
+    /// cleared, so W/S drive the throttle again instead of being out-voted by
+    /// a controller that is no longer there.
+    #[test]
+    fn a_vanished_gamepad_hands_the_throttle_back() {
+        let keyboard = ControlInput {
+            throttle: 0.9,
+            elevator: 0.2,
+            ..IDLE_KEYBOARD
+        };
+        let combined = combine(ControlInput::default(), keyboard, false);
+        assert_eq!(combined.throttle, 0.9);
+        assert_eq!(combined.elevator, 0.2);
     }
 
     #[test]

--- a/examples/rc-jet/controller/src/input.rs
+++ b/examples/rc-jet/controller/src/input.rs
@@ -47,15 +47,14 @@ impl ControlInput {
     }
 }
 
-/// Whether a human is actually flying: any surface off neutral, a throttle
-/// stick the pilot has moved, or a keyboard throttle away from the idle
-/// default.
-fn is_flying(input: &ControlInput, gamepad_throttle: bool) -> bool {
-    gamepad_throttle
-        || input.elevator.abs() > 1e-3
-        || input.aileron.abs() > 1e-3
-        || input.rudder.abs() > 1e-3
-        || (input.throttle - IDLE_THROTTLE).abs() > 0.01
+/// Whether a human is on the sticks: any control surface off neutral.
+///
+/// The throttle is deliberately no evidence at all. A ratcheted transmitter
+/// reports a throttle stick far off centre from the moment it is plugged in,
+/// so reading that as "someone is flying" would retire the idle pilot before
+/// it ever flew a bank.
+fn is_flying(input: &ControlInput) -> bool {
+    input.elevator.abs() > 1e-3 || input.aileron.abs() > 1e-3 || input.rudder.abs() > 1e-3
 }
 
 /// Merge the two input sources. Each gamepad axis wins while it is off
@@ -175,15 +174,11 @@ impl InputReader {
         // Read keyboard input
         let keyboard_input = self.read_keyboard();
 
-        let gamepad_throttle = self.gamepad_throttle_engaged;
-        let mut combined = combine(gamepad_input, keyboard_input, gamepad_throttle);
+        let mut combined = combine(gamepad_input, keyboard_input, self.gamepad_throttle_engaged);
 
         // Hand the ailerons to the idle pilot until the human flies. Done
         // before smoothing so the handover blends like any other input.
-        if let Some(aileron) = self
-            .idle_pilot
-            .aileron(is_flying(&combined, gamepad_throttle))
-        {
+        if let Some(aileron) = self.idle_pilot.aileron(is_flying(&combined)) {
             combined.aileron = aileron;
         }
 
@@ -339,7 +334,7 @@ mod tests {
     fn untouched_gamepad_keeps_the_idle_throttle() {
         let combined = combine(IDLE_GAMEPAD, IDLE_KEYBOARD, false);
         assert_eq!(combined.throttle, IDLE_THROTTLE);
-        assert!(!is_flying(&combined, false));
+        assert!(!is_flying(&combined));
     }
 
     #[test]
@@ -351,22 +346,23 @@ mod tests {
         assert_eq!(combine(IDLE_GAMEPAD, keyboard, false).throttle, 0.8);
     }
 
+    /// A ratcheted transmitter (FrSky and friends) reports its throttle stick
+    /// far off centre the moment it is plugged in. It rightly wins the throttle,
+    /// but it must not pass for a pilot on the sticks, or the idle banks the
+    /// README promises would never fly with the very hardware it highlights.
     #[test]
-    fn moved_throttle_stick_wins_and_counts_as_flying() {
-        let gamepad = ControlInput {
+    fn a_ratcheted_transmitter_still_lets_the_idle_pilot_fly() {
+        let transmitter = ControlInput {
             throttle: 0.75,
             ..IDLE_GAMEPAD
         };
-        let combined = combine(gamepad, IDLE_KEYBOARD, true);
+        let combined = combine(transmitter, IDLE_KEYBOARD, true);
         assert_eq!(combined.throttle, 0.75);
-        assert!(is_flying(&combined, true));
-    }
-
-    /// A transmitter parked at a throttle that happens to match the idle
-    /// default is still a pilot at the controls.
-    #[test]
-    fn a_moved_stick_flies_even_at_idle_throttle() {
-        assert!(is_flying(&IDLE_KEYBOARD, true));
+        assert!(!is_flying(&combined));
+        assert!(
+            IdlePilot::default().aileron(is_flying(&combined)).is_some(),
+            "a connected transmitter must not retire the idle pilot"
+        );
     }
 
     #[test]
@@ -377,7 +373,7 @@ mod tests {
         };
         let combined = combine(gamepad, IDLE_KEYBOARD, false);
         assert_eq!(combined.aileron, 0.1);
-        assert!(is_flying(&combined, false));
+        assert!(is_flying(&combined));
     }
 
     /// A pad that goes away contributes a zeroed input with its throttle latch
@@ -395,12 +391,14 @@ mod tests {
         assert_eq!(combined.elevator, 0.2);
     }
 
+    /// Throttling up with W is not flying either: the demo keeps the wings
+    /// working until a surface moves, which is what the ADI is there to show.
     #[test]
-    fn keyboard_throttle_off_idle_flies() {
+    fn throttle_alone_is_not_flying() {
         let keyboard = ControlInput {
             throttle: IDLE_THROTTLE + 0.05,
             ..IDLE_KEYBOARD
         };
-        assert!(is_flying(&combine(IDLE_GAMEPAD, keyboard, false), false));
+        assert!(!is_flying(&combine(IDLE_GAMEPAD, keyboard, false)));
     }
 }

--- a/examples/rc-jet/controller/src/input.rs
+++ b/examples/rc-jet/controller/src/input.rs
@@ -12,6 +12,11 @@ use device_query::{DeviceQuery, DeviceState, Keycode};
 use gilrs::{Axis, Gilrs};
 use std::f64::consts::PI;
 
+use crate::demo::IdlePilot;
+
+/// Throttle held when no one is on the sticks: enough for level flight.
+const IDLE_THROTTLE: f64 = 0.3;
+
 /// Stick mode configuration
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum StickMode {
@@ -42,6 +47,15 @@ impl ControlInput {
     }
 }
 
+/// Whether a human is actually flying: any surface off neutral, or a throttle
+/// moved away from the idle default.
+fn is_flying(input: &ControlInput) -> bool {
+    input.elevator.abs() > 1e-3
+        || input.aileron.abs() > 1e-3
+        || input.rudder.abs() > 1e-3
+        || (input.throttle - IDLE_THROTTLE).abs() > 0.01
+}
+
 /// Input reader combining gamepad and keyboard
 pub struct InputReader {
     gilrs: Option<Gilrs>,
@@ -56,10 +70,12 @@ pub struct InputReader {
     keyboard_throttle: f64,
     /// Last control input for smoothing
     last_input: ControlInput,
+    /// Flies gentle banks until the human takes over
+    idle_pilot: IdlePilot,
 }
 
 impl InputReader {
-    pub fn new(stick_mode: StickMode) -> Self {
+    pub fn new(stick_mode: StickMode, demo: bool) -> Self {
         // Try to initialize gilrs, but don't fail if no gamepad available
         let gilrs = match Gilrs::new() {
             Ok(g) => {
@@ -97,11 +113,12 @@ impl InputReader {
             deadzone: 0.1,
             max_deflection_rad: 25.0 * PI / 180.0, // 25° in radians
             max_rudder_rad: 30.0 * PI / 180.0,     // 30° in radians
-            keyboard_throttle: 0.3,                // Start with some throttle for level flight
+            keyboard_throttle: IDLE_THROTTLE,
             last_input: ControlInput {
-                throttle: 0.3,
+                throttle: IDLE_THROTTLE,
                 ..Default::default()
             },
+            idle_pilot: IdlePilot::new(demo),
         }
     }
 
@@ -121,7 +138,7 @@ impl InputReader {
         let keyboard_input = self.read_keyboard();
 
         // Combine inputs - gamepad takes priority for each axis if non-zero
-        let combined = ControlInput {
+        let mut combined = ControlInput {
             elevator: if gamepad_input.elevator.abs() > 0.001 {
                 gamepad_input.elevator
             } else {
@@ -137,12 +154,18 @@ impl InputReader {
             } else {
                 keyboard_input.rudder
             },
-            throttle: if (gamepad_input.throttle - 0.3).abs() > 0.01 {
+            throttle: if (gamepad_input.throttle - IDLE_THROTTLE).abs() > 0.01 {
                 gamepad_input.throttle
             } else {
                 keyboard_input.throttle
             },
         };
+
+        // Hand the ailerons to the idle pilot until the human flies. Done
+        // before smoothing so the handover blends like any other input.
+        if let Some(aileron) = self.idle_pilot.aileron(is_flying(&combined)) {
+            combined.aileron = aileron;
+        }
 
         // Apply some smoothing
         let smoothing = 0.3;
@@ -161,7 +184,7 @@ impl InputReader {
     fn read_gamepad(&self) -> ControlInput {
         let Some(ref gilrs) = self.gilrs else {
             return ControlInput {
-                throttle: 0.3,
+                throttle: IDLE_THROTTLE,
                 ..Default::default()
             };
         };
@@ -169,7 +192,7 @@ impl InputReader {
         // Find first connected gamepad
         let Some((_id, gamepad)) = gilrs.gamepads().find(|(_, g)| g.is_connected()) else {
             return ControlInput {
-                throttle: 0.3,
+                throttle: IDLE_THROTTLE,
                 ..Default::default()
             };
         };

--- a/examples/rc-jet/controller/src/input.rs
+++ b/examples/rc-jet/controller/src/input.rs
@@ -79,31 +79,35 @@ fn is_flying(input: &ControlInput) -> bool {
         || input.rudder.abs() > PILOT_INPUT_FRACTION * MAX_RUDDER_RAD
 }
 
-/// Merge the two input sources. Each gamepad axis wins while it is off
-/// neutral; the throttle is the gamepad's only once its stick has been moved,
-/// since a centred stick means "untouched", not "half throttle".
+/// Merge the two input sources. Each surface takes whichever device asks for
+/// more of it, so the gamepad stays primary wherever it is actually deflected;
+/// the throttle is the gamepad's only once its stick has been moved, since a
+/// centred stick means "untouched", not "half throttle".
 fn combine(gamepad: ControlInput, keyboard: ControlInput, gamepad_throttle: bool) -> ControlInput {
     ControlInput {
-        elevator: if gamepad.elevator.abs() > 0.001 {
-            gamepad.elevator
-        } else {
-            keyboard.elevator
-        },
-        aileron: if gamepad.aileron.abs() > 0.001 {
-            gamepad.aileron
-        } else {
-            keyboard.aileron
-        },
-        rudder: if gamepad.rudder.abs() > 0.001 {
-            gamepad.rudder
-        } else {
-            keyboard.rudder
-        },
+        elevator: dominant(gamepad.elevator, keyboard.elevator),
+        aileron: dominant(gamepad.aileron, keyboard.aileron),
+        rudder: dominant(gamepad.rudder, keyboard.rudder),
         throttle: if gamepad_throttle {
             gamepad.throttle
         } else {
             keyboard.throttle
         },
+    }
+}
+
+/// The larger of two commands for one surface, gamepad winning a tie.
+///
+/// Comparing deflections rather than testing the gamepad against a small
+/// threshold is what keeps a stick left off centre by trim from swallowing a
+/// held key: such an axis is a thousandth of a radian of surface, which used to
+/// out-vote an arrow key's half throw and leave [`is_flying`] reading the trim
+/// instead of the pilot.
+fn dominant(gamepad: f64, keyboard: f64) -> f64 {
+    if gamepad.abs() >= keyboard.abs() {
+        gamepad
+    } else {
+        keyboard
     }
 }
 
@@ -398,6 +402,53 @@ mod tests {
                 IdlePilot::default().aileron(is_flying(&combined)).is_some(),
                 "raw axis {raw} retired the idle pilot"
             );
+        }
+    }
+
+    /// A trimmed axis is nobody flying, but it must not silence the pilot who
+    /// is: the keys have to reach the surfaces and hand the aircraft over, even
+    /// on the axis the trim sits on.
+    #[test]
+    fn a_trimmed_gamepad_axis_does_not_swallow_a_held_key() {
+        for raw in [0.1021, 0.11, 0.15, -0.15, 0.17] {
+            let gamepad = ControlInput {
+                elevator: apply_deadzone(raw) * MAX_DEFLECTION_RAD,
+                aileron: apply_deadzone(raw) * MAX_DEFLECTION_RAD,
+                rudder: apply_deadzone(raw) * MAX_RUDDER_RAD,
+                ..IDLE_GAMEPAD
+            };
+            let keyboard = ControlInput {
+                elevator: -MAX_DEFLECTION_RAD * 0.5,
+                aileron: MAX_DEFLECTION_RAD * 0.5,
+                rudder: -MAX_RUDDER_RAD * 0.5,
+                ..IDLE_KEYBOARD
+            };
+            let combined = combine(gamepad, keyboard, false);
+            assert_eq!(combined.elevator, keyboard.elevator, "raw axis {raw}");
+            assert_eq!(combined.aileron, keyboard.aileron, "raw axis {raw}");
+            assert_eq!(combined.rudder, keyboard.rudder, "raw axis {raw}");
+            assert!(is_flying(&combined), "raw axis {raw} hid the pilot");
+            assert!(
+                IdlePilot::default().aileron(is_flying(&combined)).is_none(),
+                "raw axis {raw} kept the idle pilot flying under a held key"
+            );
+        }
+    }
+
+    /// A real stick still beats the keyboard on the same axis, in either
+    /// direction: the gamepad is the primary control.
+    #[test]
+    fn a_deflected_stick_beats_a_held_key() {
+        for sign in [1.0, -1.0] {
+            let gamepad = ControlInput {
+                elevator: sign * apply_deadzone(0.8) * MAX_DEFLECTION_RAD,
+                ..IDLE_GAMEPAD
+            };
+            let keyboard = ControlInput {
+                elevator: MAX_DEFLECTION_RAD * 0.5,
+                ..IDLE_KEYBOARD
+            };
+            assert_eq!(combine(gamepad, keyboard, false).elevator, gamepad.elevator);
         }
     }
 

--- a/examples/rc-jet/controller/src/input.rs
+++ b/examples/rc-jet/controller/src/input.rs
@@ -111,7 +111,7 @@ pub struct InputReader {
 }
 
 impl InputReader {
-    pub fn new(stick_mode: StickMode, demo: bool) -> Self {
+    pub fn new(stick_mode: StickMode) -> Self {
         // Try to initialize gilrs, but don't fail if no gamepad available
         let gilrs = match Gilrs::new() {
             Ok(g) => {
@@ -155,7 +155,7 @@ impl InputReader {
                 ..Default::default()
             },
             gamepad_throttle_engaged: false,
-            idle_pilot: IdlePilot::new(demo),
+            idle_pilot: IdlePilot::default(),
         }
     }
 

--- a/examples/rc-jet/controller/src/main.rs
+++ b/examples/rc-jet/controller/src/main.rs
@@ -40,10 +40,6 @@ struct Args {
     #[arg(long)]
     mode1: bool,
 
-    /// Start wings-level instead of flying the idle demo banks
-    #[arg(long)]
-    no_demo: bool,
-
     /// Enable verbose logging
     #[arg(short, long)]
     verbose: bool,
@@ -75,14 +71,13 @@ async fn main() -> Result<()> {
         StickMode::Mode2
     };
 
-    let demo = !args.no_demo;
-    print_banner(stick_mode, demo);
+    print_banner(stick_mode);
 
     // Run controller
-    run_controller(addr, stick_mode, demo).await
+    run_controller(addr, stick_mode).await
 }
 
-fn print_banner(stick_mode: StickMode, demo: bool) {
+fn print_banner(stick_mode: StickMode) {
     println!();
     println!(
         "{}",
@@ -110,16 +105,14 @@ fn print_banner(stick_mode: StickMode, demo: bool) {
     println!("    {} Elevator up/down (pitch)", "↑/↓".green());
     println!("    {} Aileron left/right (roll)", "←/→".green());
     println!();
-    if demo {
-        println!(
-            "  {} flying gentle banks until you touch a control (--no-demo to skip)",
-            "Idle demo:".bold()
-        );
-        println!();
-    }
+    println!(
+        "  {} flying gentle banks until you touch a control",
+        "Idle demo:".bold()
+    );
+    println!();
 }
 
-async fn run_controller(addr: SocketAddr, stick_mode: StickMode, demo: bool) -> Result<()> {
+async fn run_controller(addr: SocketAddr, stick_mode: StickMode) -> Result<()> {
     info!("Connecting to elodin-db at {}", addr);
 
     // Connect with retry
@@ -149,7 +142,7 @@ async fn run_controller(addr: SocketAddr, stick_mode: StickMode, demo: bool) -> 
     stellarator::sleep(Duration::from_millis(100)).await;
 
     // Initialize input reader
-    let mut input_reader = InputReader::new(stick_mode, demo);
+    let mut input_reader = InputReader::new(stick_mode);
 
     println!();
     println!("  {} Streaming control inputs...", "📡".green());

--- a/examples/rc-jet/controller/src/main.rs
+++ b/examples/rc-jet/controller/src/main.rs
@@ -18,6 +18,7 @@ use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 mod control;
+mod demo;
 mod input;
 
 use control::ControlSender;
@@ -38,6 +39,10 @@ struct Args {
     /// Use Mode 1 stick layout (EU/Asia: Left=Pitch/Yaw, Right=Throttle/Roll)
     #[arg(long)]
     mode1: bool,
+
+    /// Start wings-level instead of flying the idle demo banks
+    #[arg(long)]
+    no_demo: bool,
 
     /// Enable verbose logging
     #[arg(short, long)]
@@ -70,13 +75,14 @@ async fn main() -> Result<()> {
         StickMode::Mode2
     };
 
-    print_banner(stick_mode);
+    let demo = !args.no_demo;
+    print_banner(stick_mode, demo);
 
     // Run controller
-    run_controller(addr, stick_mode).await
+    run_controller(addr, stick_mode, demo).await
 }
 
-fn print_banner(stick_mode: StickMode) {
+fn print_banner(stick_mode: StickMode, demo: bool) {
     println!();
     println!(
         "{}",
@@ -104,9 +110,16 @@ fn print_banner(stick_mode: StickMode) {
     println!("    {} Elevator up/down (pitch)", "↑/↓".green());
     println!("    {} Aileron left/right (roll)", "←/→".green());
     println!();
+    if demo {
+        println!(
+            "  {} flying gentle banks until you touch a control (--no-demo to skip)",
+            "Idle demo:".bold()
+        );
+        println!();
+    }
 }
 
-async fn run_controller(addr: SocketAddr, stick_mode: StickMode) -> Result<()> {
+async fn run_controller(addr: SocketAddr, stick_mode: StickMode, demo: bool) -> Result<()> {
     info!("Connecting to elodin-db at {}", addr);
 
     // Connect with retry
@@ -136,7 +149,7 @@ async fn run_controller(addr: SocketAddr, stick_mode: StickMode) -> Result<()> {
     stellarator::sleep(Duration::from_millis(100)).await;
 
     // Initialize input reader
-    let mut input_reader = InputReader::new(stick_mode);
+    let mut input_reader = InputReader::new(stick_mode, demo);
 
     println!();
     println!("  {} Streaming control inputs...", "📡".green());

--- a/examples/rc-jet/main.py
+++ b/examples/rc-jet/main.py
@@ -121,7 +121,9 @@ def setup_world(config: BDXConfig) -> tuple[el.World, el.EntityId, el.EntityId]:
                         // Primary-flight-display spot, top-right of the main viewport.
                         // With no `coordinate` node the source frame is ENU, matching this
                         // jet's X-fwd/Y-left/Z-up body frame; NED would invert the horizon.
-                        horizon_gauge "bdx.world_pos" name="ADI" share=1.3
+                        // A peer share of the graphs below it: the face is square, so extra
+                        // height buys it nothing and starves the graphs sharing the column.
+                        horizon_gauge "bdx.world_pos" name="ADI"
                         graph "bdx.alpha" name="Angle of Attack (rad)"
                         graph "bdx.thrust" name="Thrust (N)"
                         viewport name=TGTViewport pos="target.world_pos.translate_world(1,1,0.2)" look_at="bdx.world_pos" show_grid=#false

--- a/examples/rc-jet/main.py
+++ b/examples/rc-jet/main.py
@@ -118,11 +118,8 @@ def setup_world(config: BDXConfig) -> tuple[el.World, el.EntityId, el.EntityId]:
                 viewport name=Viewport pos="bdx.world_pos.translate_world(-8.0,-8.0,4.0)" look_at="bdx.world_pos" show_grid=#false show_frustums=#true active=#true far=100000
                 vsplit share=0.4 {
                     vsplit {
-                        // Primary-flight-display spot, top-right of the main viewport.
                         // With no `coordinate` node the source frame is ENU, matching this
                         // jet's X-fwd/Y-left/Z-up body frame; NED would invert the horizon.
-                        // A peer share of the graphs below it: the face is square, so extra
-                        // height buys it nothing and starves the graphs sharing the column.
                         horizon_gauge "bdx.world_pos" name="ADI"
                         graph "bdx.alpha" name="Angle of Attack (rad)"
                         graph "bdx.thrust" name="Thrust (N)"

--- a/examples/rc-jet/main.py
+++ b/examples/rc-jet/main.py
@@ -118,6 +118,10 @@ def setup_world(config: BDXConfig) -> tuple[el.World, el.EntityId, el.EntityId]:
                 viewport name=Viewport pos="bdx.world_pos.translate_world(-8.0,-8.0,4.0)" look_at="bdx.world_pos" show_grid=#false show_frustums=#true active=#true far=100000
                 vsplit share=0.4 {
                     vsplit {
+                        // Primary-flight-display spot, top-right of the main viewport.
+                        // With no `coordinate` node the source frame is ENU, matching this
+                        // jet's X-fwd/Y-left/Z-up body frame; NED would invert the horizon.
+                        horizon_gauge "bdx.world_pos" name="ADI" share=1.3
                         graph "bdx.alpha" name="Angle of Attack (rad)"
                         graph "bdx.thrust" name="Thrust (N)"
                         viewport name=TGTViewport pos="target.world_pos.translate_world(1,1,0.2)" look_at="bdx.world_pos" show_grid=#false

--- a/examples/rc-jet/main.py
+++ b/examples/rc-jet/main.py
@@ -114,21 +114,26 @@ def setup_world(config: BDXConfig) -> tuple[el.World, el.EntityId, el.EntityId]:
         telemetry_mode #true
 
         tabs {
+            // Instruments left, camera views right, chase view between them: the
+            // shares are weights against the viewport's default 1.0, so 0.4 each
+            // side leaves the chase view a bit over half the width.
             hsplit name="Main View" {
+                vsplit share=0.4 {
+                    // With no `coordinate` node the source frame is ENU, matching this
+                    // jet's X-fwd/Y-left/Z-up body frame; NED would invert the horizon.
+                    // The face is square and the column is narrow, so the pane's
+                    // height is what sets its size. Three shares against the
+                    // graphs' one apiece makes the instrument about twice the
+                    // size it is on an even split.
+                    horizon_gauge "bdx.world_pos" name="ADI" share=3.0
+                    graph "bdx.alpha" name="Angle of Attack (rad)"
+                    graph "bdx.thrust" name="Thrust (N)"
+                }
                 viewport name=Viewport pos="bdx.world_pos.translate_world(-8.0,-8.0,4.0)" look_at="bdx.world_pos" show_grid=#false show_frustums=#true active=#true far=100000
                 vsplit share=0.4 {
-                    vsplit {
-                        // With no `coordinate` node the source frame is ENU, matching this
-                        // jet's X-fwd/Y-left/Z-up body frame; NED would invert the horizon.
-                        horizon_gauge "bdx.world_pos" name="ADI"
-                        graph "bdx.alpha" name="Angle of Attack (rad)"
-                        graph "bdx.thrust" name="Thrust (N)"
-                        viewport name=TGTViewport pos="target.world_pos.translate_world(1,1,0.2)" look_at="bdx.world_pos" show_grid=#false
-                        hsplit {
-                            viewport name=FPVViewport pos="bdx.world_pos.rotate_z(-90).translate_y(-2.0)" show_grid=#false
-                            sensor_view "bdx.fpv_cam" name="FPV (sensor_camera)"
-                        }
-                    }
+                    viewport name=TGTViewport pos="target.world_pos.translate_world(1,1,0.2)" look_at="bdx.world_pos" show_grid=#false
+                    viewport name=FPVViewport pos="bdx.world_pos.rotate_z(-90).translate_y(-2.0)" show_grid=#false
+                    sensor_view "bdx.fpv_cam" name="FPV (sensor_camera)"
                 }
             }
             vsplit name="Flight Data" {

--- a/libs/bevy_geo_frames/src/geo.rs
+++ b/libs/bevy_geo_frames/src/geo.rs
@@ -8,7 +8,7 @@
 use crate::{GeoFrame, RotationKind};
 use bevy::math::{DMat3, DMat4, DQuat, DVec3};
 use bevy::prelude::*;
-use map_3d::Ellipsoid;
+pub use map_3d::Ellipsoid;
 
 /// Earth sidereal spin
 pub const EARTH_SIDEREAL_SPIN: f64 = 7.292_115_0e-5;

--- a/libs/db/src/export_mcap.rs
+++ b/libs/db/src/export_mcap.rs
@@ -1812,7 +1812,8 @@ impl<'a> LayoutBuilder<'a> {
             | Panel::SchematicTree(_)
             | Panel::DataOverview(_)
             | Panel::GeoPositionGauge(_)
-            | Panel::OrientationGauge(_) => None,
+            | Panel::OrientationGauge(_)
+            | Panel::HorizonGauge(_) => None,
         }
     }
 
@@ -3642,6 +3643,7 @@ mod tests {
                 timeline: None,
                 frame: None,
                 origin: None,
+                body: None,
                 skybox: None,
                 environment: None,
                 telemetry_mode: false,

--- a/libs/elodin-editor/src/headless.rs
+++ b/libs/elodin-editor/src/headless.rs
@@ -304,10 +304,7 @@ fn load_headless_scene(
     let fallback_frame = schematic.frame;
     coordinate.0 = schematic.frame;
 
-    if let Some(o) = schematic.origin {
-        geo_context.origin =
-            bevy_geo_frames::GeoOrigin::new_from_degrees(o.latitude, o.longitude, o.altitude);
-    }
+    geo_context.origin = crate::ui::schematic::schematic_geo_origin(&schematic);
 
     let mut entities = Vec::new();
     for elem in &schematic.elems {

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -1022,7 +1022,9 @@ pub fn update_object_3d_system(
     component_value_maps: Query<&'static ComponentValue>,
     geo_context: Res<GeoContext>,
     coordinate: Res<Coordinate>,
+    eql_ctx: Res<EqlContext>,
 ) {
+    let eql_ctx_changed = eql_ctx.is_changed();
     for (entity, mut object_3d, mut pos, ellipse, has_received, children_maybe) in
         objects_query.iter_mut()
     {
@@ -1047,10 +1049,18 @@ pub fn update_object_3d_system(
         else {
             continue;
         };
+        let error_confidence_interval = *error_confidence_interval;
 
         let Some(shape_mode) = ellipsoid_shape_mode(&object_3d.data.mesh) else {
             continue;
         };
+
+        // Schematics can load before the sim registers its components, in
+        // which case the spawn-time compile of the shape-driver expression
+        // fails. Retry whenever the EQL context gains components.
+        if eql_ctx_changed {
+            retry_ellipsoid_expr_compile(&mut object_3d, shape_mode, &eql_ctx.0);
+        }
 
         let covariance_frame = resolve_covariance_frame(&object_3d.data, &coordinate);
 
@@ -1085,7 +1095,7 @@ pub fn update_object_3d_system(
                 {
                     let linear = covariance_linear_from_l(
                         &l,
-                        *error_confidence_interval,
+                        error_confidence_interval,
                         covariance_frame,
                         &geo_context,
                     );
@@ -1107,7 +1117,7 @@ pub fn update_object_3d_system(
                     if let Some(l) = cholesky_3x3_spd(&p_mat) {
                         let linear = covariance_linear_from_l(
                             &l,
-                            *error_confidence_interval,
+                            error_confidence_interval,
                             covariance_frame,
                             &geo_context,
                         );
@@ -1144,6 +1154,11 @@ pub fn update_object_3d_system(
                         }
                     }
                     Err(err) => {
+                        warn_once!(
+                            entity = ?entity,
+                            error = %err,
+                            "ellipsoid scale failed to evaluate"
+                        );
                         object_3d.scale_error = Some(err.into());
                         ellipse.oversized = false;
                         ellipse.max_extent = 0.0;
@@ -1425,6 +1440,54 @@ pub fn warn_imported_cameras(
                  embedded cameras stay active. Remove the camera from the asset if this is unintended."
             );
         }
+    }
+}
+
+/// Retries the spawn-time compile of the field-selected shape-driver
+/// expression if it failed (e.g. the schematic loaded before the sim's
+/// components were registered).
+fn retry_ellipsoid_expr_compile(
+    state: &mut Object3DState,
+    shape_mode: EllipsoidShapeMode,
+    ctx: &eql::Context,
+) {
+    let (scale, cholesky, covariance) = match &state.data.mesh {
+        impeller2_wkt::Object3DMesh::Ellipsoid {
+            scale,
+            error_covariance_cholesky,
+            error_covariance,
+            ..
+        } => (
+            scale.clone(),
+            error_covariance_cholesky.clone(),
+            error_covariance.clone(),
+        ),
+        _ => return,
+    };
+    match shape_mode {
+        EllipsoidShapeMode::Scale if state.scale_expr.is_none() => {
+            match compile_scale_eql(&scale, ctx) {
+                Ok(compiled) => {
+                    state.scale_expr = Some(compiled);
+                    state.scale_error = None;
+                }
+                Err(err) => {
+                    warn_once!(scale = %scale, error = %err, "ellipsoid scale failed to compile");
+                    state.scale_error = Some(err);
+                }
+            }
+        }
+        EllipsoidShapeMode::Cholesky if state.error_covariance_cholesky_expr.is_none() => {
+            if let Some(expr) = cholesky {
+                state.error_covariance_cholesky_expr = compile_cholesky_eql(&expr, ctx).ok();
+            }
+        }
+        EllipsoidShapeMode::Covariance if state.error_covariance_expr.is_none() => {
+            if let Some(expr) = covariance {
+                state.error_covariance_expr = compile_covariance_eql(&expr, ctx).ok();
+            }
+        }
+        _ => {}
     }
 }
 

--- a/libs/elodin-editor/src/ui/command_palette/palette_items.rs
+++ b/libs/elodin-editor/src/ui/command_palette/palette_items.rs
@@ -659,10 +659,27 @@ pub fn create_orientation_gauge(tile_id: Option<TileId>) -> PaletteItem {
     )
 }
 
+pub fn create_horizon_gauge(tile_id: Option<TileId>) -> PaletteItem {
+    PaletteItem::new(
+        "Create Horizon Gauge",
+        TILES_LABEL,
+        move |_: In<String>, eql: Res<EqlContext>| {
+            PalettePage::new(gauge_parts(
+                &eql.0.component_parts,
+                tile_id,
+                GaugeKind::Horizon,
+            ))
+            .prompt("Select a pose component to monitor")
+            .into_event()
+        },
+    )
+}
+
 #[derive(Clone, Copy)]
 enum GaugeKind {
     Position,
     Orientation,
+    Horizon,
 }
 
 fn gauge_parts(
@@ -690,6 +707,8 @@ fn gauge_parts(
                                 .create_geo_position_gauge_tile(component.name.clone(), tile_id),
                             GaugeKind::Orientation => tile_state
                                 .create_orientation_gauge_tile(component.name.clone(), tile_id),
+                            GaugeKind::Horizon => tile_state
+                                .create_horizon_gauge_tile(component.name.clone(), tile_id),
                         }
                         PaletteEvent::Exit
                     } else {
@@ -2165,6 +2184,7 @@ pub fn create_tiles(tile_id: TileId) -> PalettePage {
         create_monitor(Some(tile_id)),
         create_geo_position_gauge(Some(tile_id)),
         create_orientation_gauge(Some(tile_id)),
+        create_horizon_gauge(Some(tile_id)),
         create_viewport(Some(tile_id)),
         create_query_table(Some(tile_id)),
         create_query_plot(Some(tile_id)),
@@ -2237,6 +2257,7 @@ impl Default for PalettePage {
             create_monitor(None),
             create_geo_position_gauge(None),
             create_orientation_gauge(None),
+            create_horizon_gauge(None),
             create_viewport(None),
             create_query_table(None),
             create_query_plot(None),

--- a/libs/elodin-editor/src/ui/gauges/geo_position.rs
+++ b/libs/elodin-editor/src/ui/gauges/geo_position.rs
@@ -9,7 +9,11 @@ use impeller2_bevy::{EntityMap, TelemetryCache};
 use impeller2_wkt::{ComponentValue, CurrentTimestamp, DisplayFrame};
 
 use super::{EqlBinding, GaugePane};
-use crate::ui::widgets::{SystemStateExt, WidgetSystem};
+use crate::ui::{
+    SelectedObject,
+    tiles::WindowState,
+    widgets::{SystemStateExt, WidgetSystem},
+};
 
 /// Backing data for a geo-position gauge pane; the EQL lives in the sibling
 /// [`EqlBinding`] component.
@@ -45,17 +49,18 @@ pub struct GeoPositionGaugeWidget<'w, 's> {
     current_timestamp: Res<'w, CurrentTimestamp>,
     geo_context: Res<'w, GeoContext>,
     coordinate: Res<'w, crate::Coordinate>,
+    window_states: Query<'w, 's, &'static mut WindowState>,
 }
 
 impl WidgetSystem for GeoPositionGaugeWidget<'_, '_> {
-    type Args = GaugePane;
+    type Args = (GaugePane, Entity);
     type Output = ();
 
     fn ui_system(
         world: &mut bevy::prelude::World,
         state: &mut bevy::ecs::system::SystemState<Self>,
         ui: &mut egui::Ui,
-        pane: Self::Args,
+        (pane, target_window): Self::Args,
     ) -> Self::Output {
         let GeoPositionGaugeWidget {
             mut gauges,
@@ -65,6 +70,7 @@ impl WidgetSystem for GeoPositionGaugeWidget<'_, '_> {
             current_timestamp,
             geo_context,
             coordinate,
+            mut window_states,
         } = state.params_mut(world);
         let Ok((mut data, binding)) = gauges.get_mut(pane.entity) else {
             return;
@@ -76,6 +82,16 @@ impl WidgetSystem for GeoPositionGaugeWidget<'_, '_> {
         // Keep inherit (`source = None`) live against `Coordinate` changes.
         let source = data.effective_source(coordinate.0);
         let combo_id = egui::Id::new(("geo_position_gauge_display", pane.entity));
+
+        // Clicking the panel selects it, since a pane in a split has no tab.
+        let panel = super::panel_select_target(ui, pane.entity);
+        if panel.clicked()
+            && let Ok(mut window_state) = window_states.get_mut(target_window)
+        {
+            window_state.ui_state.selected_object = SelectedObject::GeoPositionGauge {
+                gauge_id: pane.entity,
+            };
+        }
 
         // Value cards read like the component monitor; the in-panel display
         // dropdown mirrors the orientation gauge so the frame can be switched

--- a/libs/elodin-editor/src/ui/gauges/horizon.rs
+++ b/libs/elodin-editor/src/ui/gauges/horizon.rs
@@ -20,7 +20,9 @@ use impeller2_wkt::{ComponentValue, CurrentTimestamp};
 
 use super::{BARE_QUAT_UNIT_TOLERANCE, EqlBinding, GaugePane, gauge_title, text_with_halo};
 use crate::ui::{
+    SelectedObject,
     colors::get_scheme,
+    tiles::WindowState,
     widgets::{SystemStateExt, WidgetSystem},
 };
 
@@ -538,17 +540,18 @@ pub struct HorizonGaugeWidget<'w, 's> {
     current_timestamp: Res<'w, CurrentTimestamp>,
     geo_context: Res<'w, GeoContext>,
     coordinate: Res<'w, crate::Coordinate>,
+    window_states: Query<'w, 's, &'static mut WindowState>,
 }
 
 impl WidgetSystem for HorizonGaugeWidget<'_, '_> {
-    type Args = GaugePane;
+    type Args = (GaugePane, Entity);
     type Output = ();
 
     fn ui_system(
         world: &mut bevy::prelude::World,
         state: &mut bevy::ecs::system::SystemState<Self>,
         ui: &mut egui::Ui,
-        pane: Self::Args,
+        (pane, target_window): Self::Args,
     ) -> Self::Output {
         let HorizonGaugeWidget {
             gauges,
@@ -558,6 +561,7 @@ impl WidgetSystem for HorizonGaugeWidget<'_, '_> {
             current_timestamp,
             geo_context,
             coordinate,
+            mut window_states,
         } = state.params_mut(world);
         let Ok((data, binding)) = gauges.get(pane.entity) else {
             return;
@@ -569,6 +573,16 @@ impl WidgetSystem for HorizonGaugeWidget<'_, '_> {
         // Keep inherit (`source = None`) live against `Coordinate` changes.
         let source = data.effective_source(coordinate.0);
         let solved = solve_attitude(value.as_ref(), source, data.reference, &geo_context);
+
+        // Clicking the panel selects it, since a pane in a split has no tab.
+        let panel = super::panel_select_target(ui, pane.entity);
+        if panel.clicked()
+            && let Ok(mut window_state) = window_states.get_mut(target_window)
+        {
+            window_state.ui_state.selected_object = SelectedObject::HorizonGauge {
+                gauge_id: pane.entity,
+            };
+        }
 
         egui::Frame::NONE
             .inner_margin(egui::Margin::same(super::GAUGE_PANEL_MARGIN))

--- a/libs/elodin-editor/src/ui/gauges/horizon.rs
+++ b/libs/elodin-editor/src/ui/gauges/horizon.rs
@@ -335,20 +335,24 @@ const READOUT_GAP: f32 = 3.0;
 /// only as readable as the face is big — but a maximised tile should not turn
 /// into a wall of sky.
 const FACE_MAX: f32 = 320.0;
-/// Below this the ladder and roll scale collapse into noise, so the face is
-/// dropped and the pane keeps the numbers alone.
-const FACE_MIN: f32 = 60.0;
+/// Below this the ladder and roll scale collapse into a smudge, so the face
+/// goes unpainted and the pane keeps the numbers alone. It still claims its
+/// space, so a pane being squeezed shrinks smoothly instead of snapping.
+const FACE_MIN: f32 = 40.0;
 /// Face the symbology's type and line weights are quoted for; they scale from
 /// here so a bigger instrument reads bigger instead of just emptier.
 const REFERENCE_FACE: f32 = 170.0;
 
 /// Side of the square face for a pane of `avail`, once `readout_room` is set
-/// aside for the numbers underneath. `None` when what's left is too small to
-/// draw a legible instrument — the readout outranks the face, since a horizon
-/// nobody can read is worth less than the two figures it stands for.
-fn face_size(avail: Vec2, readout_room: f32) -> Option<f32> {
-    let size = avail.x.min(avail.y - readout_room).min(FACE_MAX);
-    (size >= FACE_MIN).then_some(size)
+/// aside for the numbers underneath: the largest square left over, capped at
+/// [`FACE_MAX`] and floored at nothing.
+///
+/// The readout outranks the face — a horizon nobody can read is worth less
+/// than the two figures it stands for — but the face gives its space up
+/// continuously, like the sibling gauges, so dragging a divider never makes the
+/// instrument jump.
+fn face_size(avail: Vec2, readout_room: f32) -> f32 {
+    avail.x.min(avail.y - readout_room).clamp(0.0, FACE_MAX)
 }
 
 /// Scale of type and line weights for a given face, damped and bounded so the
@@ -361,19 +365,19 @@ fn symbol_scale(size: f32) -> f32 {
 /// ladder and roll scale, and the fixed aircraft symbol. An inactive state
 /// draws a dimmed empty rim with its reason.
 ///
-/// Draws nothing at all when the pane is too short to hold both the face and
-/// the readout the caller adds underneath.
+/// Takes the space left over the readout the caller adds underneath, and leaves
+/// it blank once that is too little to paint a legible face.
 fn paint_horizon(ui: &mut egui::Ui, state: Result<Attitude, InactiveReason>) {
     let scheme = get_scheme();
     let readout_room =
         READOUT_GAP + ui.fonts_mut(|fonts| fonts.row_height(&FontId::monospace(READOUT_FONT_SIZE)));
-    let Some(size) = face_size(ui.available_size(), readout_room) else {
-        return;
-    };
-    let k = symbol_scale(size);
-    let avail = ui.available_width();
+    let size = face_size(ui.available_size(), readout_room);
     let (full_rect, _response) =
-        ui.allocate_exact_size(Vec2::new(avail.max(size), size), Sense::hover());
+        ui.allocate_exact_size(Vec2::new(ui.available_width(), size), Sense::hover());
+    if size < FACE_MIN {
+        return;
+    }
+    let k = symbol_scale(size);
     let rect = egui::Rect::from_center_size(full_rect.center(), Vec2::splat(size));
     let painter = ui.painter_at(rect);
     let center = rect.center();
@@ -1019,14 +1023,12 @@ mod tests {
 
     #[test]
     fn the_face_never_eats_the_readouts_room() {
-        for height in [0.0, 40.0, 77.0, 120.0, 200.0, 400.0, 2000.0] {
-            let avail = Vec2::new(400.0, height);
-            if let Some(size) = face_size(avail, READOUT_ROOM) {
-                assert!(
-                    size + READOUT_ROOM <= height + 1e-3,
-                    "face {size} + readout leaves nothing of {height}"
-                );
-            }
+        for height in [0.0, 10.0, 40.0, 77.0, 120.0, 200.0, 400.0, 2000.0] {
+            let size = face_size(Vec2::new(400.0, height), READOUT_ROOM);
+            assert!(
+                size <= (height - READOUT_ROOM).max(0.0) + 1e-3,
+                "face {size} leaves no room for the readout in {height}"
+            );
         }
     }
 
@@ -1037,37 +1039,46 @@ mod tests {
         // shrinks the instrument.
         let mut prev = 0.0;
         for step in 0..200u16 {
-            let Some(size) = at(50.0 + f32::from(step) * 10.0) else {
-                continue;
-            };
+            let size = at(f32::from(step) * 10.0);
             assert!(size >= prev - 1e-3, "shrank from {prev} to {size}");
             prev = size;
         }
         // It does grow past the old fixed 200 px, and stops at the cap.
-        assert!(at(300.0).expect("drawable") > 200.0);
-        assert_eq!(at(4000.0), Some(FACE_MAX));
+        assert!(at(300.0) > 200.0);
+        assert_eq!(at(4000.0), FACE_MAX);
         // A narrow pane is bounded by its width instead.
-        assert_eq!(
-            face_size(Vec2::new(120.0, 4000.0), READOUT_ROOM),
-            Some(120.0)
-        );
+        assert_eq!(face_size(Vec2::new(120.0, 4000.0), READOUT_ROOM), 120.0);
+    }
+
+    /// A pane being squeezed gives the face up a pixel at a time — the failure
+    /// mode of a legibility floor applied to the *size* instead of the
+    /// painting, which made the instrument vanish mid-drag.
+    #[test]
+    fn the_face_gives_up_its_space_continuously() {
+        let at = |h: f32| face_size(Vec2::new(400.0, h), READOUT_ROOM);
+        let mut prev = at(0.0);
+        assert_eq!(prev, 0.0, "a pane with no height claims none");
+        for step in 1..=600u16 {
+            let size = at(f32::from(step) * 0.5);
+            assert!(size - prev <= 0.5 + 1e-3, "jumped from {prev} to {size}");
+            prev = size;
+        }
     }
 
     #[test]
-    fn a_pane_too_short_for_both_keeps_the_readout() {
-        // Anything that would leave a face below the legibility floor draws no
-        // face at all, so the caller's readout is all that remains.
-        for height in [0.0, 20.0, FACE_MIN, FACE_MIN + READOUT_ROOM - 1.0] {
+    fn a_pane_too_short_for_a_face_keeps_the_readout() {
+        // Nothing is left over for a face, so the readout is all the pane draws.
+        for height in [0.0, READOUT_ROOM / 2.0, READOUT_ROOM] {
             assert_eq!(
                 face_size(Vec2::new(400.0, height), READOUT_ROOM),
-                None,
-                "height {height} should drop the face"
+                0.0,
+                "height {height} should leave no face"
             );
         }
-        assert_eq!(
-            face_size(Vec2::new(400.0, FACE_MIN + READOUT_ROOM), READOUT_ROOM),
-            Some(FACE_MIN)
-        );
+        // Below the legibility floor the space is claimed but left unpainted,
+        // which is what keeps the shrink smooth.
+        let squeezed = face_size(Vec2::new(400.0, 50.0), READOUT_ROOM);
+        assert!(squeezed > 0.0 && squeezed < FACE_MIN, "face {squeezed}");
     }
 
     #[test]

--- a/libs/elodin-editor/src/ui/gauges/horizon.rs
+++ b/libs/elodin-editor/src/ui/gauges/horizon.rs
@@ -326,58 +326,86 @@ fn horizon_palette() -> (Color32, Color32, Color32) {
 /// Amber of the screen-fixed symbology, shared with the gimbal's reticle.
 const SYMBOL: Color32 = Color32::from_rgb(255, 179, 0);
 
-/// A graduation of the roll scale: its bank angle, its length as a fraction of
-/// the face radius, and its stroke weight before the symbol scale.
+/// How a graduation of the roll scale is drawn.
+enum Mark {
+    /// A radial tick, its length a fraction of the face radius and its weight
+    /// the stroke width before the symbol scale.
+    Tick { len: f32, weight: f32 },
+    /// The dot 45° carries by convention. Differing in kind rather than in
+    /// size is what stops it being read as one more step of the sequence.
+    Dot,
+}
+
+/// A graduation of the roll scale: the bank angle it stands for, and its mark.
 struct BankTick {
     deg: f64,
-    len: f32,
-    weight: f32,
+    mark: Mark,
 }
+
+/// Length of a minor graduation as a fraction of the face radius, and of the
+/// anchors that have to stand out from it.
+const MINOR_LEN: f32 = 0.07;
+const MAJOR_LEN: f32 = 0.13;
 
 /// Graduations of the roll scale, mirrored either side of the card's zero.
 ///
 /// The scale is not uniform — 10, 20, 30, then 45, 60, which is the convention —
 /// so drawing them alike would read as equal steps and be counted rather than
-/// read. Long, heavy marks at 30° and 60° give the eye two anchors, leaving 10°,
-/// 20° and 45° as minor marks between them.
+/// read. Long, heavy marks anchor 30° and 60°, 10° and 20° stay minor between
+/// them, and 45°, which breaks the sequence, is a dot.
 const BANK_TICKS: [BankTick; 5] = [
     BankTick {
         deg: 10.0,
-        len: 0.07,
-        weight: 1.0,
+        mark: Mark::Tick {
+            len: MINOR_LEN,
+            weight: 1.0,
+        },
     },
     BankTick {
         deg: 20.0,
-        len: 0.07,
-        weight: 1.0,
+        mark: Mark::Tick {
+            len: MINOR_LEN,
+            weight: 1.0,
+        },
     },
     BankTick {
         deg: 30.0,
-        len: 0.13,
-        weight: 2.0,
+        mark: Mark::Tick {
+            len: MAJOR_LEN,
+            weight: 2.0,
+        },
     },
     BankTick {
         deg: 45.0,
-        len: 0.07,
-        weight: 1.0,
+        mark: Mark::Dot,
     },
     BankTick {
         deg: 60.0,
-        len: 0.13,
-        weight: 2.0,
+        mark: Mark::Tick {
+            len: MAJOR_LEN,
+            weight: 2.0,
+        },
     },
 ];
 
 /// The card's own wings-level mark, which the index covers at zero bank.
 const ZERO_TICK: BankTick = BankTick {
     deg: 0.0,
-    len: 0.15,
-    weight: 2.2,
+    mark: Mark::Tick {
+        len: 0.15,
+        weight: 2.2,
+    },
 };
 
 /// Where the roll scale starts, as a fraction of the face radius: just clear of
 /// the rim, leaving the longest graduation short of the face's corner.
 const SCALE_INNER: f32 = 1.02;
+/// Centre of the 45° dot, inside the band the minor ticks occupy so the scale
+/// keeps one silhouette.
+const DOT_CENTER: f32 = SCALE_INNER + MINOR_LEN / 2.0;
+/// Dot radius in pixels before the symbol scale — quoted like a stroke weight
+/// rather than as a fraction of the face, so it stays a dot on a small one.
+const DOT_RADIUS: f32 = 1.8;
 
 /// Screen direction (y-down) of the roll index: straight up, i.e. always
 /// directly above the aircraft symbol, because the index belongs to the
@@ -401,7 +429,7 @@ const READOUT_GAP: f32 = 3.0;
 /// Largest face we draw. The instrument follows its pane — pitch and bank are
 /// only as readable as the face is big — but a maximised tile should not turn
 /// into a wall of sky.
-const FACE_MAX: f32 = 320.0;
+const FACE_MAX: f32 = 672.0;
 /// Below this the ladder and roll scale collapse into a smudge, so the face
 /// goes unpainted and the pane keeps the numbers alone. It still claims its
 /// space, so a pane being squeezed shrinks smoothly instead of snapping.
@@ -548,13 +576,24 @@ fn paint_horizon(ui: &mut egui::Ui, state: Result<Attitude, InactiveReason>) {
             .flat_map(|tick| [(tick.deg, tick), (-tick.deg, tick)]),
     ) {
         let dir = bank_tick_dir(attitude.roll, bank_deg);
-        painter.line_segment(
-            [
-                center + dir * radius * SCALE_INNER,
-                center + dir * radius * (SCALE_INNER + tick.len),
-            ],
-            Stroke::new(tick.weight * k, scheme.text_secondary),
-        );
+        match tick.mark {
+            Mark::Tick { len, weight } => {
+                painter.line_segment(
+                    [
+                        center + dir * radius * SCALE_INNER,
+                        center + dir * radius * (SCALE_INNER + len),
+                    ],
+                    Stroke::new(weight * k, scheme.text_secondary),
+                );
+            }
+            Mark::Dot => {
+                painter.circle_filled(
+                    center + dir * radius * DOT_CENTER,
+                    DOT_RADIUS * k,
+                    scheme.text_secondary,
+                );
+            }
+        }
     }
 
     // Roll index: part of the airframe, so it stays directly above the aircraft
@@ -1073,35 +1112,47 @@ mod tests {
     }
 
     /// 10, 20, 30, 45, 60 is the convention, and it is not a uniform scale, so
-    /// the marks must not be drawn alike: 30° and 60° anchor the reading and
-    /// have to stand out from their neighbours.
+    /// the marks must not be drawn alike: 30° and 60° anchor the reading, and
+    /// 45°, which breaks the sequence, is a dot rather than a shorter tick.
     #[test]
-    fn the_anchor_graduations_stand_out() {
-        let tick = |deg: f64| {
-            BANK_TICKS
+    fn the_marks_show_a_scale_that_is_not_uniform() {
+        let mark = |deg: f64| {
+            &BANK_TICKS
                 .iter()
                 .find(|t| t.deg == deg)
                 .unwrap_or_else(|| panic!("no {deg}° graduation"))
+                .mark
+        };
+        let tick = |deg: f64| match mark(deg) {
+            Mark::Tick { len, weight } => (*len, *weight),
+            Mark::Dot => panic!("{deg}° is a dot, not a tick"),
         };
         for anchor in [30.0, 60.0] {
-            for minor in [10.0, 20.0, 45.0] {
+            for minor in [10.0, 20.0] {
                 assert!(
-                    tick(anchor).len > tick(minor).len * 1.5,
+                    tick(anchor).0 > tick(minor).0 * 1.5,
                     "{anchor}° is not clearly longer than {minor}°"
                 );
                 assert!(
-                    tick(anchor).weight > tick(minor).weight,
+                    tick(anchor).1 > tick(minor).1,
                     "{anchor}° is not heavier than {minor}°"
                 );
             }
         }
-        // The card's wings-level mark leads them all, and every graduation
-        // stays inside the square face rather than being clipped at a corner.
+        assert!(matches!(mark(45.0), Mark::Dot));
+
+        // The card's wings-level mark leads the ticks, the dot sits within the
+        // band they occupy, and nothing reaches past the square face.
+        let lengths = |t: &BankTick| match t.mark {
+            Mark::Tick { len, .. } => len,
+            Mark::Dot => 0.0,
+        };
         let longest = std::iter::once(&ZERO_TICK)
             .chain(BANK_TICKS.iter())
-            .map(|t| t.len)
+            .map(lengths)
             .fold(0.0, f32::max);
-        assert_eq!(longest, ZERO_TICK.len);
+        assert_eq!(longest, lengths(&ZERO_TICK));
+        assert!((SCALE_INNER..SCALE_INNER + MINOR_LEN).contains(&DOT_CENTER));
         assert!(
             SCALE_INNER + longest < 0.5 / FACE_RADIUS_FRAC,
             "the roll scale reaches past the face"

--- a/libs/elodin-editor/src/ui/gauges/horizon.rs
+++ b/libs/elodin-editor/src/ui/gauges/horizon.rs
@@ -326,8 +326,73 @@ fn horizon_palette() -> (Color32, Color32, Color32) {
 /// Amber of the screen-fixed symbology, shared with the gimbal's reticle.
 const SYMBOL: Color32 = Color32::from_rgb(255, 179, 0);
 
-/// Bank angles ticked on the roll scale (mirrored either side of zero).
-const BANK_TICKS_DEG: [f64; 5] = [10.0, 20.0, 30.0, 45.0, 60.0];
+/// A graduation of the roll scale: its bank angle, its length as a fraction of
+/// the face radius, and its stroke weight before the symbol scale.
+struct BankTick {
+    deg: f64,
+    len: f32,
+    weight: f32,
+}
+
+/// Graduations of the roll scale, mirrored either side of the card's zero.
+///
+/// The scale is not uniform — 10, 20, 30, then 45, 60, which is the convention —
+/// so drawing them alike would read as equal steps and be counted rather than
+/// read. Long, heavy marks at 30° and 60° give the eye two anchors, leaving 10°,
+/// 20° and 45° as minor marks between them.
+const BANK_TICKS: [BankTick; 5] = [
+    BankTick {
+        deg: 10.0,
+        len: 0.07,
+        weight: 1.0,
+    },
+    BankTick {
+        deg: 20.0,
+        len: 0.07,
+        weight: 1.0,
+    },
+    BankTick {
+        deg: 30.0,
+        len: 0.13,
+        weight: 2.0,
+    },
+    BankTick {
+        deg: 45.0,
+        len: 0.07,
+        weight: 1.0,
+    },
+    BankTick {
+        deg: 60.0,
+        len: 0.13,
+        weight: 2.0,
+    },
+];
+
+/// The card's own wings-level mark, which the index covers at zero bank.
+const ZERO_TICK: BankTick = BankTick {
+    deg: 0.0,
+    len: 0.15,
+    weight: 2.2,
+};
+
+/// Where the roll scale starts, as a fraction of the face radius: just clear of
+/// the rim, leaving the longest graduation short of the face's corner.
+const SCALE_INNER: f32 = 1.02;
+
+/// Screen direction (y-down) of the roll index: straight up, i.e. always
+/// directly above the aircraft symbol, because the index belongs to the
+/// airframe and not to the world turning behind it.
+const ROLL_INDEX_DIR: Vec2 = Vec2::new(0.0, -1.0);
+
+/// Screen direction of the graduation engraved at `bank_deg` on the roll scale,
+/// for an aircraft rolled by `roll`.
+///
+/// The scale is rigid with the world, so banking carries the matching
+/// graduation up to the fixed index: bank is read off which mark sits under the
+/// index, not off where a moving index has drifted to.
+fn bank_tick_dir(roll: f64, bank_deg: f64) -> Vec2 {
+    world_dirs(roll - bank_deg.to_radians()).0
+}
 
 /// Type size of the readout under the face, and the gap above it.
 const READOUT_FONT_SIZE: f32 = 10.0;
@@ -344,6 +409,9 @@ const FACE_MIN: f32 = 40.0;
 /// Face the symbology's type and line weights are quoted for; they scale from
 /// here so a bigger instrument reads bigger instead of just emptier.
 const REFERENCE_FACE: f32 = 170.0;
+/// Rim radius as a fraction of the square face, leaving the margin the roll
+/// scale is drawn in.
+const FACE_RADIUS_FRAC: f32 = 0.42;
 
 /// Side of the square face for a pane of `avail`, once `readout_room` is set
 /// aside for the numbers underneath: the largest square left over, capped at
@@ -383,7 +451,7 @@ fn paint_horizon(ui: &mut egui::Ui, state: Result<Attitude, InactiveReason>) {
     let rect = egui::Rect::from_center_size(full_rect.center(), Vec2::splat(size));
     let painter = ui.painter_at(rect);
     let center = rect.center();
-    let radius = size * 0.42;
+    let radius = size * FACE_RADIUS_FRAC;
 
     let attitude = match state {
         Ok(attitude) => attitude,
@@ -473,30 +541,32 @@ fn paint_horizon(ui: &mut egui::Ui, state: Result<Attitude, InactiveReason>) {
 
     painter.circle_stroke(center, radius, Stroke::new(1.5 * k, scheme.border_primary));
 
-    // Roll scale: fixed to the screen, ticked either side of top-dead-centre.
-    // The bank index belongs to the rolling world, so a right bank moves it
-    // left of zero (sky-pointer convention).
-    // Ticks and index share `world_dirs`' up, so the scale and the pointer
-    // cannot drift apart.
-    for (bank_deg, len) in std::iter::once((0.0, 0.13))
-        .chain(BANK_TICKS_DEG.iter().flat_map(|&b| [(b, 0.09), (-b, 0.09)]))
-    {
-        let (dir, _) = world_dirs(bank_deg.to_radians());
+    // Roll scale: engraved on the rolling world, so it turns under the index.
+    for (bank_deg, tick) in std::iter::once((ZERO_TICK.deg, &ZERO_TICK)).chain(
+        BANK_TICKS
+            .iter()
+            .flat_map(|tick| [(tick.deg, tick), (-tick.deg, tick)]),
+    ) {
+        let dir = bank_tick_dir(attitude.roll, bank_deg);
         painter.line_segment(
             [
-                center + dir * radius * 1.02,
-                center + dir * radius * (1.02 + len),
+                center + dir * radius * SCALE_INNER,
+                center + dir * radius * (SCALE_INNER + tick.len),
             ],
-            Stroke::new(1.0 * k, scheme.text_secondary),
+            Stroke::new(tick.weight * k, scheme.text_secondary),
         );
     }
-    let tip = center + up_dir * radius * 1.05;
-    let side = Vec2::new(-up_dir.y, up_dir.x);
+
+    // Roll index: part of the airframe, so it stays directly above the aircraft
+    // symbol and the scale moves instead. Drawn after the scale, which it
+    // covers at wings level as on a real instrument.
+    let tip = center + ROLL_INDEX_DIR * radius * SCALE_INNER;
+    let side = Vec2::new(-ROLL_INDEX_DIR.y, ROLL_INDEX_DIR.x);
     painter.add(Shape::convex_polygon(
         vec![
             tip,
-            tip + (up_dir * 7.0 + side * 4.0) * k,
-            tip + (up_dir * 7.0 - side * 4.0) * k,
+            tip + (ROLL_INDEX_DIR * 7.0 + side * 4.0) * k,
+            tip + (ROLL_INDEX_DIR * 7.0 - side * 4.0) * k,
         ],
         SYMBOL,
         Stroke::NONE,
@@ -961,6 +1031,81 @@ mod tests {
         let (up_dir, right_dir) = world_dirs(0.0);
         assert!((up_dir - Vec2::new(0.0, -1.0)).length() < 1e-6);
         assert!((right_dir - Vec2::new(1.0, 0.0)).length() < 1e-6);
+    }
+
+    /// The index belongs to the airframe, so whatever the bank, it is the
+    /// matching graduation that swings up to meet it — the reading is which
+    /// mark sits under the index.
+    #[test]
+    fn the_matching_graduation_swings_up_to_the_fixed_index() {
+        for deg in [
+            -179.0_f64, -60.0, -45.0, -30.0, -10.0, 0.0, 10.0, 30.0, 45.0, 60.0, 179.0,
+        ] {
+            let dir = bank_tick_dir(deg.to_radians(), deg);
+            assert!(
+                (dir - ROLL_INDEX_DIR).length() < 1e-6,
+                "the {deg}° graduation sits at {dir:?}, not under the index"
+            );
+        }
+    }
+
+    /// The scale turns with the world: a right-hand graduation starts right of
+    /// the index at wings level and climbs towards it as the bank builds, where
+    /// a moving index would instead drift away from a still scale.
+    #[test]
+    fn the_scale_turns_under_the_index() {
+        for tick in &BANK_TICKS {
+            let level = bank_tick_dir(0.0, tick.deg);
+            assert!(
+                level.x > 0.0,
+                "the {}° graduation should start right of the index: {level:?}",
+                tick.deg
+            );
+            let half_way = bank_tick_dir((tick.deg / 2.0).to_radians(), tick.deg);
+            assert!(
+                half_way.dot(ROLL_INDEX_DIR) > level.dot(ROLL_INDEX_DIR),
+                "the {}° graduation moved away from the index: {level:?} -> {half_way:?}",
+                tick.deg
+            );
+        }
+        // Zero bank leaves the card's own mark under the index.
+        assert!((bank_tick_dir(0.0, ZERO_TICK.deg) - ROLL_INDEX_DIR).length() < 1e-6);
+    }
+
+    /// 10, 20, 30, 45, 60 is the convention, and it is not a uniform scale, so
+    /// the marks must not be drawn alike: 30° and 60° anchor the reading and
+    /// have to stand out from their neighbours.
+    #[test]
+    fn the_anchor_graduations_stand_out() {
+        let tick = |deg: f64| {
+            BANK_TICKS
+                .iter()
+                .find(|t| t.deg == deg)
+                .unwrap_or_else(|| panic!("no {deg}° graduation"))
+        };
+        for anchor in [30.0, 60.0] {
+            for minor in [10.0, 20.0, 45.0] {
+                assert!(
+                    tick(anchor).len > tick(minor).len * 1.5,
+                    "{anchor}° is not clearly longer than {minor}°"
+                );
+                assert!(
+                    tick(anchor).weight > tick(minor).weight,
+                    "{anchor}° is not heavier than {minor}°"
+                );
+            }
+        }
+        // The card's wings-level mark leads them all, and every graduation
+        // stays inside the square face rather than being clipped at a corner.
+        let longest = std::iter::once(&ZERO_TICK)
+            .chain(BANK_TICKS.iter())
+            .map(|t| t.len)
+            .fold(0.0, f32::max);
+        assert_eq!(longest, ZERO_TICK.len);
+        assert!(
+            SCALE_INNER + longest < 0.5 / FACE_RADIUS_FRAC,
+            "the roll scale reaches past the face"
+        );
     }
 
     #[test]

--- a/libs/elodin-editor/src/ui/gauges/horizon.rs
+++ b/libs/elodin-editor/src/ui/gauges/horizon.rs
@@ -31,7 +31,11 @@ use crate::ui::{
 /// so the frame choice only matters as the `source` of the incoming attitude.
 #[derive(Component)]
 pub struct HorizonGaugeData {
-    /// Frame the EQL quaternion rotates from (body→source).
+    /// Frame the EQL pose is expressed in: the quaternion rotates body→source,
+    /// and a 7-vector's position tail is read in that same frame — as in the
+    /// [geo-position gauge](super::geo_position), `source` describes the data,
+    /// not just the rotation. Overriding it to ECEF therefore asserts the
+    /// positions are ECEF, whatever the scene's `coordinate` is.
     ///
     /// `None` means inherit the schematic global [`crate::Coordinate`] (same as
     /// omitting `source` in KDL), resolved via [`Self::effective_source`].
@@ -323,17 +327,50 @@ const SYMBOL: Color32 = Color32::from_rgb(255, 179, 0);
 /// Bank angles ticked on the roll scale (mirrored either side of zero).
 const BANK_TICKS_DEG: [f64; 5] = [10.0, 20.0, 30.0, 45.0, 60.0];
 
+/// Type size of the readout under the face, and the gap above it.
+const READOUT_FONT_SIZE: f32 = 10.0;
+const READOUT_GAP: f32 = 3.0;
+
+/// Largest face we draw. The instrument follows its pane — pitch and bank are
+/// only as readable as the face is big — but a maximised tile should not turn
+/// into a wall of sky.
+const FACE_MAX: f32 = 320.0;
+/// Below this the ladder and roll scale collapse into noise, so the face is
+/// dropped and the pane keeps the numbers alone.
+const FACE_MIN: f32 = 60.0;
+/// Face the symbology's type and line weights are quoted for; they scale from
+/// here so a bigger instrument reads bigger instead of just emptier.
+const REFERENCE_FACE: f32 = 170.0;
+
+/// Side of the square face for a pane of `avail`, once `readout_room` is set
+/// aside for the numbers underneath. `None` when what's left is too small to
+/// draw a legible instrument — the readout outranks the face, since a horizon
+/// nobody can read is worth less than the two figures it stands for.
+fn face_size(avail: Vec2, readout_room: f32) -> Option<f32> {
+    let size = avail.x.min(avail.y - readout_room).min(FACE_MAX);
+    (size >= FACE_MIN).then_some(size)
+}
+
+/// Scale of type and line weights for a given face, damped and bounded so the
+/// extremes stay legible rather than tracking the face exactly.
+fn symbol_scale(size: f32) -> f32 {
+    (size / REFERENCE_FACE).clamp(0.85, 1.5)
+}
+
 /// Paint the instrument face: two-tone sky/ground split by the horizon, a pitch
 /// ladder and roll scale, and the fixed aircraft symbol. An inactive state
 /// draws a dimmed empty rim with its reason.
+///
+/// Draws nothing at all when the pane is too short to hold both the face and
+/// the readout the caller adds underneath.
 fn paint_horizon(ui: &mut egui::Ui, state: Result<Attitude, InactiveReason>) {
     let scheme = get_scheme();
-    // Respect the tile's real estate; a larger cap than the gimbal's, since
-    // pitch legibility scales with the face.
-    let size = ui
-        .available_width()
-        .min(ui.available_height())
-        .clamp(0.0, 200.0);
+    let readout_room =
+        READOUT_GAP + ui.fonts_mut(|fonts| fonts.row_height(&FontId::monospace(READOUT_FONT_SIZE)));
+    let Some(size) = face_size(ui.available_size(), readout_room) else {
+        return;
+    };
+    let k = symbol_scale(size);
     let avail = ui.available_width();
     let (full_rect, _response) =
         ui.allocate_exact_size(Vec2::new(avail.max(size), size), Sense::hover());
@@ -348,20 +385,20 @@ fn paint_horizon(ui: &mut egui::Ui, state: Result<Attitude, InactiveReason>) {
             painter.circle_stroke(
                 center,
                 radius,
-                Stroke::new(1.5, scheme.border_primary.gamma_multiply(0.5)),
+                Stroke::new(1.5 * k, scheme.border_primary.gamma_multiply(0.5)),
             );
             painter.text(
                 center,
                 Align2::CENTER_CENTER,
                 "—",
-                FontId::monospace(15.0),
+                FontId::monospace(15.0 * k),
                 scheme.text_secondary,
             );
             painter.text(
                 Pos2::new(center.x, center.y + radius * 0.55),
                 Align2::CENTER_CENTER,
                 reason.label(),
-                FontId::monospace(9.0),
+                FontId::monospace(9.0 * k),
                 scheme.text_secondary,
             );
             return;
@@ -401,14 +438,14 @@ fn paint_horizon(ui: &mut egui::Ui, state: Result<Attitude, InactiveReason>) {
         let Some((a, b)) = clip_segment(center, radius, a, b) else {
             continue;
         };
-        painter.line_segment([a, b], Stroke::new(1.0, marking.gamma_multiply(0.9)));
+        painter.line_segment([a, b], Stroke::new(1.0 * k, marking.gamma_multiply(0.9)));
         if !major {
             continue;
         }
         let label = format!("{}", rung_deg.abs() as i32);
         for end in [a, b] {
             let outward = (end - mid).normalized();
-            let pos = end + outward * 10.0;
+            let pos = end + outward * 10.0 * k;
             if (pos - center).length() > radius * 0.98 {
                 continue;
             }
@@ -416,7 +453,7 @@ fn paint_horizon(ui: &mut egui::Ui, state: Result<Attitude, InactiveReason>) {
                 &painter,
                 pos,
                 &label,
-                FontId::monospace(9.0),
+                FontId::monospace(9.0 * k),
                 marking,
                 Color32::BLACK.gamma_multiply(0.7),
             );
@@ -425,10 +462,10 @@ fn paint_horizon(ui: &mut egui::Ui, state: Result<Attitude, InactiveReason>) {
 
     // Horizon line, brighter than the ladder.
     if let Some((a, b)) = line_chord(center, radius, horizon_point, up_dir) {
-        painter.line_segment([a, b], Stroke::new(1.8, marking));
+        painter.line_segment([a, b], Stroke::new(1.8 * k, marking));
     }
 
-    painter.circle_stroke(center, radius, Stroke::new(1.5, scheme.border_primary));
+    painter.circle_stroke(center, radius, Stroke::new(1.5 * k, scheme.border_primary));
 
     // Roll scale: fixed to the screen, ticked either side of top-dead-centre.
     // The bank index belongs to the rolling world, so a right bank moves it
@@ -444,7 +481,7 @@ fn paint_horizon(ui: &mut egui::Ui, state: Result<Attitude, InactiveReason>) {
                 center + dir * radius * 1.02,
                 center + dir * radius * (1.02 + len),
             ],
-            Stroke::new(1.0, scheme.text_secondary),
+            Stroke::new(1.0 * k, scheme.text_secondary),
         );
     }
     let tip = center + up_dir * radius * 1.05;
@@ -452,8 +489,8 @@ fn paint_horizon(ui: &mut egui::Ui, state: Result<Attitude, InactiveReason>) {
     painter.add(Shape::convex_polygon(
         vec![
             tip,
-            tip + up_dir * 7.0 + side * 4.0,
-            tip + up_dir * 7.0 - side * 4.0,
+            tip + (up_dir * 7.0 + side * 4.0) * k,
+            tip + (up_dir * 7.0 - side * 4.0) * k,
         ],
         SYMBOL,
         Stroke::NONE,
@@ -466,11 +503,11 @@ fn paint_horizon(ui: &mut egui::Ui, state: Result<Attitude, InactiveReason>) {
                 Pos2::new(center.x + sign * radius * 0.10, center.y),
                 Pos2::new(center.x + sign * radius * 0.34, center.y),
             ],
-            Stroke::new(2.5, SYMBOL),
+            Stroke::new(2.5 * k, SYMBOL),
         );
     }
     painter.rect_filled(
-        egui::Rect::from_center_size(center, Vec2::splat(4.0)),
+        egui::Rect::from_center_size(center, Vec2::splat(4.0 * k)),
         0.0,
         SYMBOL,
     );
@@ -533,13 +570,15 @@ impl WidgetSystem for HorizonGaugeWidget<'_, '_> {
             .inner_margin(egui::Margin::same(super::GAUGE_PANEL_MARGIN))
             .show(ui, |ui| {
                 super::gauge_header(ui, &title);
+                // The face yields its space to the readout, never the reverse:
+                // the numbers are what the pane is for.
                 paint_horizon(ui, solved);
-                ui.add_space(3.0);
+                ui.add_space(READOUT_GAP);
                 ui.vertical_centered(|ui| {
                     ui.label(
                         egui::RichText::new(attitude_readout(solved))
                             .monospace()
-                            .size(10.0)
+                            .size(READOUT_FONT_SIZE)
                             .color(get_scheme().text_secondary),
                     );
                 });
@@ -972,6 +1011,75 @@ mod tests {
             )
             .is_none()
         );
+    }
+
+    /// Room the readout takes at the sizes egui actually reports for a 10 px
+    /// monospace row.
+    const READOUT_ROOM: f32 = READOUT_GAP + 14.0;
+
+    #[test]
+    fn the_face_never_eats_the_readouts_room() {
+        for height in [0.0, 40.0, 77.0, 120.0, 200.0, 400.0, 2000.0] {
+            let avail = Vec2::new(400.0, height);
+            if let Some(size) = face_size(avail, READOUT_ROOM) {
+                assert!(
+                    size + READOUT_ROOM <= height + 1e-3,
+                    "face {size} + readout leaves nothing of {height}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_face_grows_with_the_pane_up_to_the_cap() {
+        let at = |h: f32| face_size(Vec2::new(1000.0, h), READOUT_ROOM);
+        // Monotone in the pane's height, so dragging a tile larger never
+        // shrinks the instrument.
+        let mut prev = 0.0;
+        for step in 0..200u16 {
+            let Some(size) = at(50.0 + f32::from(step) * 10.0) else {
+                continue;
+            };
+            assert!(size >= prev - 1e-3, "shrank from {prev} to {size}");
+            prev = size;
+        }
+        // It does grow past the old fixed 200 px, and stops at the cap.
+        assert!(at(300.0).expect("drawable") > 200.0);
+        assert_eq!(at(4000.0), Some(FACE_MAX));
+        // A narrow pane is bounded by its width instead.
+        assert_eq!(
+            face_size(Vec2::new(120.0, 4000.0), READOUT_ROOM),
+            Some(120.0)
+        );
+    }
+
+    #[test]
+    fn a_pane_too_short_for_both_keeps_the_readout() {
+        // Anything that would leave a face below the legibility floor draws no
+        // face at all, so the caller's readout is all that remains.
+        for height in [0.0, 20.0, FACE_MIN, FACE_MIN + READOUT_ROOM - 1.0] {
+            assert_eq!(
+                face_size(Vec2::new(400.0, height), READOUT_ROOM),
+                None,
+                "height {height} should drop the face"
+            );
+        }
+        assert_eq!(
+            face_size(Vec2::new(400.0, FACE_MIN + READOUT_ROOM), READOUT_ROOM),
+            Some(FACE_MIN)
+        );
+    }
+
+    #[test]
+    fn symbology_scales_with_the_face_within_bounds() {
+        assert!((symbol_scale(REFERENCE_FACE) - 1.0).abs() < 1e-6);
+        assert!(symbol_scale(FACE_MAX) > 1.0);
+        assert!(symbol_scale(FACE_MIN) < 1.0);
+        // Bounded at both ends: type stays readable, line weights stay thin.
+        for size in [0.0, FACE_MIN, 200.0, FACE_MAX, 10_000.0] {
+            let k = symbol_scale(size);
+            assert!((0.85..=1.5).contains(&k), "scale {k} at face {size}");
+        }
     }
 
     #[test]

--- a/libs/elodin-editor/src/ui/gauges/horizon.rs
+++ b/libs/elodin-editor/src/ui/gauges/horizon.rs
@@ -1,0 +1,989 @@
+//! Horizon gauge: a classic artificial horizon (attitude indicator), driven by
+//! an EQL-bound pose. Unlike the [orientation gauge](super::orientation), whose
+//! markings co-rotate with the body, this is a cockpit view — the world
+//! counter-rotates behind a screen-fixed aircraft symbol.
+//!
+//! The instrument only reads when a **local vertical** exists: NED/ENU are
+//! tangent frames that carry their own vertical, whereas ECEF is fixed to the
+//! whole body and needs the pose's position to know which way is up. Anything
+//! else draws an explicit inactive face — never a fake wings-level.
+
+use bevy::{
+    ecs::system::SystemParam,
+    math::{DQuat, DVec3},
+    prelude::*,
+};
+use bevy_egui::egui::{self, Align2, Color32, FontId, Pos2, Sense, Shape, Stroke, Vec2};
+use bevy_geo_frames::{GeoContext, GeoFrame, GeoOrigin, approx_radius, ecef_to_lla_deg};
+use impeller2_bevy::{EntityMap, TelemetryCache};
+use impeller2_wkt::{ComponentValue, CurrentTimestamp};
+
+use super::{BARE_QUAT_UNIT_TOLERANCE, EqlBinding, GaugePane, gauge_title, text_with_halo};
+use crate::ui::{
+    colors::get_scheme,
+    widgets::{SystemStateExt, WidgetSystem},
+};
+
+/// Backing data for a horizon gauge pane; the EQL lives in the sibling
+/// [`EqlBinding`] component.
+///
+/// There is deliberately no `display` field: a horizon is intrinsically local,
+/// so the frame choice only matters as the `source` of the incoming attitude.
+#[derive(Component)]
+pub struct HorizonGaugeData {
+    /// Frame the EQL quaternion rotates from (body→source).
+    ///
+    /// `None` means inherit the schematic global [`crate::Coordinate`] (same as
+    /// omitting `source` in KDL), resolved via [`Self::effective_source`].
+    pub source: Option<GeoFrame>,
+    /// Attitude (body→source) the gauge reads as level: it renders
+    /// `q · reference⁻¹`. Identity means the raw component attitude.
+    pub reference: DQuat,
+}
+
+impl HorizonGaugeData {
+    pub fn new(source: Option<GeoFrame>) -> Self {
+        Self {
+            source,
+            reference: DQuat::IDENTITY,
+        }
+    }
+
+    /// Set the level-attitude quaternion from its KDL form (`[x, y, z, w]`,
+    /// normalized here so hand-written schematics don't need to be exact).
+    pub fn with_reference(mut self, reference: Option<[f64; 4]>) -> Self {
+        if let Some([x, y, z, w]) = reference {
+            let q = DQuat::from_xyzw(x, y, z, w);
+            if q.length() > 1e-9 {
+                self.reference = q.normalize();
+            }
+        }
+        self
+    }
+
+    /// KDL form of [`Self::reference`]: `None` when it is (numerically) the
+    /// identity, so the common case serializes to nothing.
+    pub fn reference_kdl(&self) -> Option<[f64; 4]> {
+        let q = self.reference;
+        (q.dot(DQuat::IDENTITY).abs() < 1.0 - 1e-9).then_some([q.x, q.y, q.z, q.w])
+    }
+
+    /// Concrete source frame: explicit override, else schematic `coordinate`,
+    /// else ENU (same fallback as the sibling gauges).
+    pub fn effective_source(&self, coordinate: Option<GeoFrame>) -> GeoFrame {
+        self.source.or(coordinate).unwrap_or(GeoFrame::ENU)
+    }
+}
+
+/// Why the instrument cannot show an attitude. Each variant is surfaced to the
+/// user, so a blank gauge is always explained.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InactiveReason {
+    /// No telemetry sample at the playhead, or the EQL does not resolve.
+    NoSample,
+    /// The value carries no attitude (position-only, or a non-unit 4-vector).
+    NoAttitude,
+    /// ECEF attitude without a position: no way to know which way is up.
+    EcefWithoutPosition,
+    /// Too close to the body's centre for a vertical to be meaningful.
+    NearBodyCenter,
+}
+
+impl InactiveReason {
+    /// Short explanation drawn under the empty face.
+    pub fn label(self) -> &'static str {
+        match self {
+            InactiveReason::NoSample => "no sample",
+            InactiveReason::NoAttitude => "no attitude",
+            InactiveReason::EcefWithoutPosition => "ECEF needs a pose",
+            InactiveReason::NearBodyCenter => "no local vertical",
+        }
+    }
+}
+
+/// Attitude relative to the local level plane, in radians. Positive pitch is
+/// nose-up, positive roll is right-wing-down.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Attitude {
+    pub pitch: f64,
+    pub roll: f64,
+}
+
+/// A pose sample: attitude plus, for `world_pos`-style 7-vectors, position.
+struct Pose {
+    q: DQuat,
+    pos: Option<DVec3>,
+}
+
+/// Extract a pose from a component value, accepting (in `F32` or `F64`) a
+/// `SpatialTransform`/[`WorldPos`](impeller2_wkt::WorldPos) 7-vector (quaternion
+/// head + position tail) or a bare, near-unit-length 4-vector quaternion.
+///
+/// The unit-length gate on bare 4-vectors mirrors the orientation gauge: an
+/// arbitrary 4-element component (e.g. fin deflections) must not be normalized
+/// into a plausible-looking attitude.
+fn component_value_to_pose(value: &ComponentValue) -> Option<Pose> {
+    let data = super::component_buf_f64(value)?;
+    if data.len() >= 7 {
+        let q = DQuat::from_xyzw(data[0], data[1], data[2], data[3]);
+        return (q.length_squared() > 1e-12).then(|| Pose {
+            q: q.normalize(),
+            pos: Some(DVec3::new(data[4], data[5], data[6])),
+        });
+    }
+    if data.len() == 4 {
+        let q = DQuat::from_xyzw(data[0], data[1], data[2], data[3]);
+        return ((q.length_squared() - 1.0).abs() <= BARE_QUAT_UNIT_TOLERANCE).then(|| Pose {
+            q: q.normalize(),
+            pos: None,
+        });
+    }
+    None
+}
+
+/// The body's own "up" axis, numerically, for a body whose identity attitude
+/// aligns it with `frame` — i.e. Z-up frames give a Z-up body, NED gives the
+/// aerospace Z-down body. The nose is always the frame's `+X`.
+///
+/// Distinct from [`super::orientation`]'s display triad: that describes the
+/// axes the gimbal *draws*, this one the vehicle's own axes.
+fn body_up_axis(frame: GeoFrame) -> DVec3 {
+    match frame {
+        GeoFrame::NED => DVec3::NEG_Z,
+        GeoFrame::ENU | GeoFrame::ECEF => DVec3::Z,
+    }
+}
+
+/// Unit "up" of the local level plane, expressed in `source` coordinates.
+///
+/// NED/ENU are local tangent frames, so their vertical is a frame constant. In
+/// ECEF the vertical is the geodetic ellipsoid normal **at the vehicle's own
+/// position** — using the schematic origin instead would tilt the horizon by
+/// the angle travelled over the body.
+fn local_vertical(
+    source: GeoFrame,
+    pos: Option<DVec3>,
+    ctx: &GeoContext,
+) -> Result<DVec3, InactiveReason> {
+    match source {
+        GeoFrame::NED => Ok(DVec3::NEG_Z),
+        GeoFrame::ENU => Ok(DVec3::Z),
+        GeoFrame::ECEF => {
+            let pos = pos.ok_or(InactiveReason::EcefWithoutPosition)?;
+            // Deep inside the body the geodetic normal is meaningless (and
+            // numerically unstable); refuse rather than invent an orientation.
+            if pos.length() < 0.5 * approx_radius(&ctx.origin.ellipsoid) {
+                return Err(InactiveReason::NearBodyCenter);
+            }
+            let (lat, lon, _alt) = ecef_to_lla_deg(pos, &ctx.origin.ellipsoid);
+            let here =
+                GeoOrigin::new_from_degrees(lat, lon, 0.0).with_ellipsoid(ctx.origin.ellipsoid);
+            // The ENU basis at `here`, expressed in ECEF: its +U column is the
+            // geodetic normal.
+            Ok(GeoFrame::ecef_R_(&GeoFrame::ENU, &here) * DVec3::Z)
+        }
+    }
+}
+
+/// Resolve a sample into pitch/roll against the local level plane, or the
+/// reason the instrument stays blank.
+fn solve_attitude(
+    value: Option<&ComponentValue>,
+    source: GeoFrame,
+    reference: DQuat,
+    ctx: &GeoContext,
+) -> Result<Attitude, InactiveReason> {
+    let value = value.ok_or(InactiveReason::NoSample)?;
+    let pose = component_value_to_pose(value).ok_or(InactiveReason::NoAttitude)?;
+    let vertical = local_vertical(source, pose.pos, ctx)?;
+
+    // Rotation of the body in source space since the reference pose, so a
+    // vehicle sitting at its reference attitude reads level.
+    let delta = pose.q * reference.inverse();
+    Ok(attitude_against(delta, source, vertical))
+}
+
+/// Pitch and roll of a body rotated by `delta` against a given local vertical.
+///
+/// Both come from resolving the vertical onto the body axes rather than from
+/// Euler extraction, so they stay well-conditioned and sign-correct: positive
+/// pitch is nose-up, positive roll is right-wing-down.
+fn attitude_against(delta: DQuat, source: GeoFrame, vertical: DVec3) -> Attitude {
+    let nose = delta * DVec3::X;
+    let up = delta * body_up_axis(source);
+    let right = nose.cross(up);
+    Attitude {
+        pitch: nose.dot(vertical).clamp(-1.0, 1.0).asin(),
+        roll: (-right.dot(vertical)).atan2(up.dot(vertical)),
+    }
+}
+
+/// Half-angle of pitch visible between the face centre and its rim. Small
+/// attitudes are only legible as a symbol-to-horizon offset, so the scale is
+/// chosen (rather than inherited from the rung spacing) to keep a few degrees
+/// clearly visible; the numeric readout carries the precision.
+const PITCH_HALF_RANGE_DEG: f64 = 35.0;
+
+/// Screen-space (y-down) unit directions of the rolled world group: its "up"
+/// and its "right" along the horizon.
+///
+/// A right bank (positive roll) tilts the world's up to the *left*, so the
+/// horizon's right end rises — the world counter-rotates behind the fixed
+/// aircraft symbol.
+fn world_dirs(roll: f64) -> (Vec2, Vec2) {
+    let (s, c) = (roll.sin() as f32, roll.cos() as f32);
+    (Vec2::new(-s, -c), Vec2::new(c, -s))
+}
+
+/// Which part of a disc a half-plane covers.
+enum DiscSplit {
+    /// The half-plane covers the whole disc.
+    All,
+    /// It covers none of it.
+    Empty,
+    /// It covers this circular segment (convex, screen coords).
+    Segment(Vec<Pos2>),
+}
+
+/// Split a disc by the line through `line_point`, keeping the `normal` side.
+fn half_disc(center: Pos2, radius: f32, line_point: Pos2, normal: Vec2) -> DiscSplit {
+    // Signed distance of the centre from the line, along `normal`.
+    let h = (center - line_point).dot(normal);
+    if h >= radius {
+        return DiscSplit::All;
+    }
+    if h <= -radius {
+        return DiscSplit::Empty;
+    }
+    // Circle points are `center + radius * (normal cos t + tangent sin t)`, and
+    // sit on the kept side where `cos t >= -h / radius`.
+    let tangent = Vec2::new(-normal.y, normal.x);
+    let t0 = (-h / radius).clamp(-1.0, 1.0).acos();
+    let steps = ((t0 / 0.08).ceil() as usize).max(2);
+    let pts = (0..=2 * steps)
+        .map(|i| {
+            let t = -t0 + 2.0 * t0 * (i as f32 / (2 * steps) as f32);
+            center + (normal * t.cos() + tangent * t.sin()) * radius
+        })
+        .collect();
+    DiscSplit::Segment(pts)
+}
+
+/// Chord where the line through `line_point` with the given `normal` crosses
+/// the circle, or `None` when it misses.
+fn line_chord(center: Pos2, radius: f32, line_point: Pos2, normal: Vec2) -> Option<(Pos2, Pos2)> {
+    let h = (center - line_point).dot(normal);
+    if h.abs() >= radius {
+        return None;
+    }
+    let half = (radius * radius - h * h).max(0.0).sqrt();
+    let tangent = Vec2::new(-normal.y, normal.x);
+    let mid = center - normal * h;
+    Some((mid - tangent * half, mid + tangent * half))
+}
+
+/// Clip a segment to a circle, or `None` when it stays entirely outside.
+fn clip_segment(center: Pos2, radius: f32, a: Pos2, b: Pos2) -> Option<(Pos2, Pos2)> {
+    let d = b - a;
+    let f = a - center;
+    let aa = d.dot(d);
+    if aa <= f32::EPSILON {
+        return (f.length() <= radius).then_some((a, b));
+    }
+    let disc = d.dot(f) * d.dot(f) - aa * (f.dot(f) - radius * radius);
+    if disc < 0.0 {
+        return None;
+    }
+    let sq = disc.sqrt();
+    let t0 = ((-d.dot(f) - sq) / aa).max(0.0);
+    let t1 = ((-d.dot(f) + sq) / aa).min(1.0);
+    (t0 < t1).then(|| (a + d * t0, a + d * t1))
+}
+
+/// Sky, ground and marking tones for the current theme.
+fn horizon_palette() -> (Color32, Color32, Color32) {
+    if crate::ui::colors::is_light_mode() {
+        (
+            Color32::from_rgb(0x8F, 0xA3, 0xB8),
+            Color32::from_rgb(0xA8, 0x96, 0x8A),
+            Color32::from_rgb(0x1A, 0x1A, 0x1A),
+        )
+    } else {
+        (
+            Color32::from_rgb(0x3C, 0x4A, 0x5A),
+            Color32::from_rgb(0x4A, 0x40, 0x38),
+            Color32::from_rgb(0xFF, 0xFB, 0xF0),
+        )
+    }
+}
+
+/// Amber of the screen-fixed symbology, shared with the gimbal's reticle.
+const SYMBOL: Color32 = Color32::from_rgb(255, 179, 0);
+
+/// Bank angles ticked on the roll scale (mirrored either side of zero).
+const BANK_TICKS_DEG: [f64; 5] = [10.0, 20.0, 30.0, 45.0, 60.0];
+
+/// Paint the instrument face: two-tone sky/ground split by the horizon, a pitch
+/// ladder and roll scale, and the fixed aircraft symbol. An inactive state
+/// draws a dimmed empty rim with its reason.
+fn paint_horizon(ui: &mut egui::Ui, state: Result<Attitude, InactiveReason>) {
+    let scheme = get_scheme();
+    // Respect the tile's real estate; a larger cap than the gimbal's, since
+    // pitch legibility scales with the face.
+    let size = ui
+        .available_width()
+        .min(ui.available_height())
+        .clamp(0.0, 200.0);
+    let avail = ui.available_width();
+    let (full_rect, _response) =
+        ui.allocate_exact_size(Vec2::new(avail.max(size), size), Sense::hover());
+    let rect = egui::Rect::from_center_size(full_rect.center(), Vec2::splat(size));
+    let painter = ui.painter_at(rect);
+    let center = rect.center();
+    let radius = size * 0.42;
+
+    let attitude = match state {
+        Ok(attitude) => attitude,
+        Err(reason) => {
+            painter.circle_stroke(
+                center,
+                radius,
+                Stroke::new(1.5, scheme.border_primary.gamma_multiply(0.5)),
+            );
+            painter.text(
+                center,
+                Align2::CENTER_CENTER,
+                "—",
+                FontId::monospace(15.0),
+                scheme.text_secondary,
+            );
+            painter.text(
+                Pos2::new(center.x, center.y + radius * 0.55),
+                Align2::CENTER_CENTER,
+                reason.label(),
+                FontId::monospace(9.0),
+                scheme.text_secondary,
+            );
+            return;
+        }
+    };
+
+    let (sky, ground, marking) = horizon_palette();
+    let (up_dir, right_dir) = world_dirs(attitude.roll);
+    let px_per_deg = radius as f64 / PITCH_HALF_RANGE_DEG;
+    let pitch_deg = attitude.pitch.to_degrees();
+    // Nose-up pushes the world down, so the horizon sits below the symbol.
+    let horizon_point = center - up_dir * (pitch_deg * px_per_deg) as f32;
+
+    painter.circle_filled(center, radius, ground);
+    match half_disc(center, radius, horizon_point, up_dir) {
+        DiscSplit::All => {
+            painter.circle_filled(center, radius, sky);
+        }
+        DiscSplit::Segment(pts) => {
+            painter.add(Shape::convex_polygon(pts, sky, Stroke::NONE));
+        }
+        DiscSplit::Empty => {}
+    }
+
+    // Pitch ladder: rungs every 5°, labelled every 10°, all parallel to the
+    // horizon because the whole world group is rigid.
+    for step in -18..=18 {
+        let rung_deg = f64::from(step) * 5.0;
+        let major = step % 2 == 0;
+        if major && step == 0 {
+            continue; // the horizon line itself is drawn below
+        }
+        let offset = ((rung_deg - pitch_deg) * px_per_deg) as f32;
+        let mid = center + up_dir * offset;
+        let half = radius * if major { 0.34 } else { 0.16 };
+        let (a, b) = (mid - right_dir * half, mid + right_dir * half);
+        let Some((a, b)) = clip_segment(center, radius, a, b) else {
+            continue;
+        };
+        painter.line_segment([a, b], Stroke::new(1.0, marking.gamma_multiply(0.9)));
+        if !major {
+            continue;
+        }
+        let label = format!("{}", rung_deg.abs() as i32);
+        for end in [a, b] {
+            let outward = (end - mid).normalized();
+            let pos = end + outward * 10.0;
+            if (pos - center).length() > radius * 0.98 {
+                continue;
+            }
+            text_with_halo(
+                &painter,
+                pos,
+                &label,
+                FontId::monospace(9.0),
+                marking,
+                Color32::BLACK.gamma_multiply(0.7),
+            );
+        }
+    }
+
+    // Horizon line, brighter than the ladder.
+    if let Some((a, b)) = line_chord(center, radius, horizon_point, up_dir) {
+        painter.line_segment([a, b], Stroke::new(1.8, marking));
+    }
+
+    painter.circle_stroke(center, radius, Stroke::new(1.5, scheme.border_primary));
+
+    // Roll scale: fixed to the screen, ticked either side of top-dead-centre.
+    // The bank index belongs to the rolling world, so a right bank moves it
+    // left of zero (sky-pointer convention).
+    // Ticks and index share `world_dirs`' up, so the scale and the pointer
+    // cannot drift apart.
+    for (bank_deg, len) in std::iter::once((0.0, 0.13))
+        .chain(BANK_TICKS_DEG.iter().flat_map(|&b| [(b, 0.09), (-b, 0.09)]))
+    {
+        let (dir, _) = world_dirs(bank_deg.to_radians());
+        painter.line_segment(
+            [
+                center + dir * radius * 1.02,
+                center + dir * radius * (1.02 + len),
+            ],
+            Stroke::new(1.0, scheme.text_secondary),
+        );
+    }
+    let tip = center + up_dir * radius * 1.05;
+    let side = Vec2::new(-up_dir.y, up_dir.x);
+    painter.add(Shape::convex_polygon(
+        vec![
+            tip,
+            tip + up_dir * 7.0 + side * 4.0,
+            tip + up_dir * 7.0 - side * 4.0,
+        ],
+        SYMBOL,
+        Stroke::NONE,
+    ));
+
+    // Screen-fixed aircraft symbol: wings plus a centre dot.
+    for sign in [-1.0_f32, 1.0] {
+        painter.line_segment(
+            [
+                Pos2::new(center.x + sign * radius * 0.10, center.y),
+                Pos2::new(center.x + sign * radius * 0.34, center.y),
+            ],
+            Stroke::new(2.5, SYMBOL),
+        );
+    }
+    painter.rect_filled(
+        egui::Rect::from_center_size(center, Vec2::splat(4.0)),
+        0.0,
+        SYMBOL,
+    );
+}
+
+/// `PITCH … ROLL …` readout, or placeholders when the gauge is inactive.
+fn attitude_readout(state: Result<Attitude, InactiveReason>) -> String {
+    match state {
+        Ok(a) => format!(
+            "PITCH {:+.1}°  ROLL {:+.1}°",
+            a.pitch.to_degrees(),
+            a.roll.to_degrees()
+        ),
+        Err(_) => "PITCH —  ROLL —".to_string(),
+    }
+}
+
+#[derive(SystemParam)]
+pub struct HorizonGaugeWidget<'w, 's> {
+    gauges: Query<'w, 's, (&'static HorizonGaugeData, &'static EqlBinding)>,
+    entity_map: Res<'w, EntityMap>,
+    values: Query<'w, 's, &'static ComponentValue>,
+    telemetry_cache: Res<'w, TelemetryCache>,
+    current_timestamp: Res<'w, CurrentTimestamp>,
+    geo_context: Res<'w, GeoContext>,
+    coordinate: Res<'w, crate::Coordinate>,
+}
+
+impl WidgetSystem for HorizonGaugeWidget<'_, '_> {
+    type Args = GaugePane;
+    type Output = ();
+
+    fn ui_system(
+        world: &mut bevy::prelude::World,
+        state: &mut bevy::ecs::system::SystemState<Self>,
+        ui: &mut egui::Ui,
+        pane: Self::Args,
+    ) -> Self::Output {
+        let HorizonGaugeWidget {
+            gauges,
+            entity_map,
+            values,
+            telemetry_cache,
+            current_timestamp,
+            geo_context,
+            coordinate,
+        } = state.params_mut(world);
+        let Ok((data, binding)) = gauges.get(pane.entity) else {
+            return;
+        };
+
+        let ts = current_timestamp.0;
+        let value = binding.resolve(&entity_map, &values, &telemetry_cache, ts);
+        let title = gauge_title(&binding.eql, &pane.name);
+        // Keep inherit (`source = None`) live against `Coordinate` changes.
+        let source = data.effective_source(coordinate.0);
+        let solved = solve_attitude(value.as_ref(), source, data.reference, &geo_context);
+
+        egui::Frame::NONE
+            .inner_margin(egui::Margin::same(super::GAUGE_PANEL_MARGIN))
+            .show(ui, |ui| {
+                super::gauge_header(ui, &title);
+                paint_horizon(ui, solved);
+                ui.add_space(3.0);
+                ui.vertical_centered(|ui| {
+                    ui.label(
+                        egui::RichText::new(attitude_readout(solved))
+                            .monospace()
+                            .size(10.0)
+                            .color(get_scheme().text_secondary),
+                    );
+                });
+            });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::math::DMat3;
+    use bevy_geo_frames::Ellipsoid;
+    use nox::{Array, Dyn};
+    use std::f64::consts::{FRAC_PI_2, PI, TAU};
+
+    const MOON: Ellipsoid = Ellipsoid::Sphere {
+        radius: 1_737_400.0,
+    };
+
+    fn ctx_at(lat_deg: f64, lon_deg: f64) -> GeoContext {
+        GeoContext::from(GeoOrigin::new_from_degrees(lat_deg, lon_deg, 0.0))
+    }
+
+    fn f64_value(values: &[f64]) -> ComponentValue {
+        ComponentValue::F64(
+            Array::<f64, Dyn>::from_shape_vec(smallvec::smallvec![values.len()], values.to_vec())
+                .expect("f64 buffer"),
+        )
+    }
+
+    fn f32_value(values: &[f32]) -> ComponentValue {
+        ComponentValue::F32(
+            Array::<f32, Dyn>::from_shape_vec(smallvec::smallvec![values.len()], values.to_vec())
+                .expect("f32 buffer"),
+        )
+    }
+
+    /// A 7-vec pose value from a quaternion and position.
+    fn pose_value(q: DQuat, pos: DVec3) -> ComponentValue {
+        f64_value(&[q.x, q.y, q.z, q.w, pos.x, pos.y, pos.z])
+    }
+
+    fn solve(value: &ComponentValue, source: GeoFrame, ctx: &GeoContext) -> Attitude {
+        solve_attitude(Some(value), source, DQuat::IDENTITY, ctx).expect("active horizon")
+    }
+
+    #[test]
+    fn level_pose_reads_wings_level_in_tangent_frames() {
+        let ctx = ctx_at(34.72, -86.64);
+        // Identity attitude in a tangent frame is level by construction, with
+        // or without a position (a bare quaternion is enough here).
+        for source in [GeoFrame::ENU, GeoFrame::NED] {
+            let a = solve(&f64_value(&[0.0, 0.0, 0.0, 1.0]), source, &ctx);
+            assert!(a.pitch.abs() < 1e-12, "{source:?} pitch {}", a.pitch);
+            assert!(a.roll.abs() < 1e-12, "{source:?} roll {}", a.roll);
+        }
+    }
+
+    #[test]
+    fn pitch_and_roll_signs_follow_aerospace_convention() {
+        let ctx = ctx_at(0.0, 0.0);
+        // ENU body: +X nose (East), +Z up. Rotating about −Y lifts the nose.
+        let up30 = DQuat::from_rotation_y(-30f64.to_radians());
+        let a = solve(&pose_value(up30, DVec3::ZERO), GeoFrame::ENU, &ctx);
+        assert!((a.pitch.to_degrees() - 30.0).abs() < 1e-9, "{a:?}");
+        assert!(a.roll.abs() < 1e-9, "{a:?}");
+
+        // Rotating about the nose (+X) by a positive angle drops the right
+        // wing: a right bank must read positive roll.
+        let bank45 = DQuat::from_rotation_x(45f64.to_radians());
+        let a = solve(&pose_value(bank45, DVec3::ZERO), GeoFrame::ENU, &ctx);
+        assert!((a.roll.to_degrees() - 45.0).abs() < 1e-9, "{a:?}");
+        assert!(a.pitch.abs() < 1e-9, "{a:?}");
+
+        // Nose-down and left bank invert both signs.
+        let down = DQuat::from_rotation_y(20f64.to_radians());
+        assert!(solve(&pose_value(down, DVec3::ZERO), GeoFrame::ENU, &ctx).pitch < 0.0);
+        let left = DQuat::from_rotation_x(-20f64.to_radians());
+        assert!(solve(&pose_value(left, DVec3::ZERO), GeoFrame::ENU, &ctx).roll < 0.0);
+    }
+
+    #[test]
+    fn ned_pitch_and_roll_match_enu_for_the_same_physical_attitude() {
+        let ctx = ctx_at(10.0, 20.0);
+        // NED body: +X nose (North), +Z down. Nose-up is a rotation about +Y
+        // (East); right bank is about +X with the wing going toward +Z (down).
+        let a = solve(
+            &pose_value(DQuat::from_rotation_y(25f64.to_radians()), DVec3::ZERO),
+            GeoFrame::NED,
+            &ctx,
+        );
+        assert!((a.pitch.to_degrees() - 25.0).abs() < 1e-9, "{a:?}");
+        let a = solve(
+            &pose_value(DQuat::from_rotation_x(30f64.to_radians()), DVec3::ZERO),
+            GeoFrame::NED,
+            &ctx,
+        );
+        assert!((a.roll.to_degrees() - 30.0).abs() < 1e-9, "{a:?}");
+    }
+
+    /// Attitude of a vehicle parked level at `(lat, lon)`, nose north, as a
+    /// body→ECEF quaternion: body X→North, Y→West, Z→Up.
+    fn level_in_ecef(lat_deg: f64, lon_deg: f64, ellipsoid: Ellipsoid) -> (DQuat, DVec3) {
+        let here = GeoOrigin::new_from_degrees(lat_deg, lon_deg, 0.0).with_ellipsoid(ellipsoid);
+        let ecef_r_enu = GeoFrame::ecef_R_(&GeoFrame::ENU, &here);
+        let (east, north, up) = (
+            ecef_r_enu * DVec3::X,
+            ecef_r_enu * DVec3::Y,
+            ecef_r_enu * DVec3::Z,
+        );
+        let q = DQuat::from_mat3(&DMat3::from_cols(north, -east, up));
+        let pos = GeoFrame::ECEF
+            ._M_(&GeoFrame::ENU, &GeoContext::from(here))
+            .transform_point3(DVec3::ZERO);
+        (q, pos)
+    }
+
+    #[test]
+    fn ecef_horizon_follows_the_vehicle_position() {
+        // The schematic origin stays at (0, 0) while the vehicle sits level
+        // elsewhere on the ellipsoid: the horizon must come from the vehicle's
+        // own position, so it still reads level.
+        let ctx = ctx_at(0.0, 0.0);
+        for (lat, lon) in [(0.0, 0.0), (45.0, 90.0), (-33.9, 151.2), (89.0, 0.0)] {
+            let (q, pos) = level_in_ecef(lat, lon, ctx.origin.ellipsoid);
+            let a = solve(&pose_value(q, pos), GeoFrame::ECEF, &ctx);
+            assert!(
+                a.pitch.abs() < 1e-6 && a.roll.abs() < 1e-6,
+                "level at ({lat}, {lon}) read {a:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn ecef_vertical_at_the_origin_would_be_wrong_far_away() {
+        // Guards the reason the vertical is rebuilt per sample: reusing the
+        // schematic origin's vertical tilts the attitude by the arc travelled.
+        let ctx = ctx_at(0.0, 0.0);
+        let origin_vertical = GeoFrame::ecef_R_(&GeoFrame::ENU, &ctx.origin) * DVec3::Z;
+        for (lat, lon) in [(45.0, 0.0), (45.0, 90.0), (0.0, 60.0)] {
+            let (q, pos) = level_in_ecef(lat, lon, ctx.origin.ellipsoid);
+            let bogus = attitude_against(q, GeoFrame::ECEF, origin_vertical);
+            let worst = bogus
+                .pitch
+                .to_degrees()
+                .abs()
+                .max(bogus.roll.to_degrees().abs());
+            assert!(
+                worst > 30.0,
+                "origin-based vertical should be badly wrong at ({lat}, {lon}), got {bogus:?}"
+            );
+            // The real solver stays level for the same sample.
+            let a = solve(&pose_value(q, pos), GeoFrame::ECEF, &ctx);
+            assert!(a.pitch.abs() < 1e-6 && a.roll.abs() < 1e-6, "{a:?}");
+        }
+    }
+
+    #[test]
+    fn ecef_horizon_works_on_a_lunar_sphere() {
+        let mut ctx = ctx_at(0.0, 0.0);
+        ctx.origin = ctx.origin.with_ellipsoid(MOON);
+        for (lat, lon) in [(0.0, 0.0), (45.0, 90.0), (-70.0, -30.0)] {
+            let (q, pos) = level_in_ecef(lat, lon, MOON);
+            let a = solve(&pose_value(q, pos), GeoFrame::ECEF, &ctx);
+            assert!(
+                a.pitch.abs() < 1e-6 && a.roll.abs() < 1e-6,
+                "lunar level at ({lat}, {lon}) read {a:?}"
+            );
+        }
+        // An Earth-radius position is far outside the Moon, but still has a
+        // well-defined normal — only the body centre is refused.
+        let (q, _) = level_in_ecef(0.0, 0.0, MOON);
+        assert!(
+            solve_attitude(
+                Some(&pose_value(q, DVec3::new(6_378_137.0, 0.0, 0.0))),
+                GeoFrame::ECEF,
+                DQuat::IDENTITY,
+                &ctx
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn inactive_states_are_explicit() {
+        let ctx = ctx_at(0.0, 0.0);
+        let solve =
+            |v: Option<&ComponentValue>, source| solve_attitude(v, source, DQuat::IDENTITY, &ctx);
+
+        // No sample at the playhead.
+        assert_eq!(solve(None, GeoFrame::ENU), Err(InactiveReason::NoSample));
+
+        // A bare quaternion has no position, so ECEF has no vertical — while
+        // the very same value is fine in a tangent frame.
+        let bare = f64_value(&[0.0, 0.0, 0.0, 1.0]);
+        assert_eq!(
+            solve(Some(&bare), GeoFrame::ECEF),
+            Err(InactiveReason::EcefWithoutPosition)
+        );
+        assert!(solve(Some(&bare), GeoFrame::ENU).is_ok());
+
+        // Position-only and non-unit 4-vectors carry no attitude.
+        for v in [
+            f64_value(&[1.0, 2.0, 3.0]),
+            f64_value(&[0.1, 0.2, 0.3, 0.4]),
+            f64_value(&[0.0, 0.0, 0.0, 0.0]),
+            f64_value(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        ] {
+            assert_eq!(
+                solve(Some(&v), GeoFrame::ENU),
+                Err(InactiveReason::NoAttitude),
+                "{v:?} must not produce an attitude"
+            );
+        }
+
+        // At the body centre there is no vertical to speak of.
+        assert_eq!(
+            solve(
+                Some(&pose_value(DQuat::IDENTITY, DVec3::ZERO)),
+                GeoFrame::ECEF
+            ),
+            Err(InactiveReason::NearBodyCenter)
+        );
+
+        // Every reason is user-visible.
+        for reason in [
+            InactiveReason::NoSample,
+            InactiveReason::NoAttitude,
+            InactiveReason::EcefWithoutPosition,
+            InactiveReason::NearBodyCenter,
+        ] {
+            assert!(!reason.label().is_empty());
+        }
+    }
+
+    #[test]
+    fn f32_poses_are_accepted_like_f64() {
+        let ctx = ctx_at(0.0, 0.0);
+        let a = solve(
+            &f32_value(&[0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 100.0]),
+            GeoFrame::ENU,
+            &ctx,
+        );
+        assert!(a.pitch.abs() < 1e-6 && a.roll.abs() < 1e-6);
+    }
+
+    #[test]
+    fn inverted_flight_puts_the_ground_on_top() {
+        let ctx = ctx_at(0.0, 0.0);
+        let a = solve(
+            &pose_value(DQuat::from_rotation_x(PI), DVec3::ZERO),
+            GeoFrame::ENU,
+            &ctx,
+        );
+        assert!(a.roll.abs().to_degrees() > 179.0, "{a:?}");
+        // The world's up now points down the screen, so the sky fills the
+        // bottom of the face.
+        let (up_dir, _) = world_dirs(a.roll);
+        assert!(
+            up_dir.y > 0.9,
+            "world up should point screen-down: {up_dir:?}"
+        );
+    }
+
+    #[test]
+    fn roll_sweep_never_jumps() {
+        // A full roll must rotate the rendered world continuously — the failure
+        // mode of deriving the horizon from clamped `asin` scalars.
+        let ctx = ctx_at(0.0, 0.0);
+        let mut prev: Option<Vec2> = None;
+        for i in 0..=720 {
+            let theta = TAU * (i as f64 / 720.0);
+            let a = solve(
+                &pose_value(DQuat::from_rotation_x(theta), DVec3::ZERO),
+                GeoFrame::ENU,
+                &ctx,
+            );
+            let (up_dir, _) = world_dirs(a.roll);
+            if let Some(p) = prev {
+                assert!(
+                    (up_dir - p).length() < 0.05,
+                    "world up jumped at step {i}: {p:?} -> {up_dir:?}"
+                );
+            }
+            prev = Some(up_dir);
+        }
+    }
+
+    #[test]
+    fn pitch_sweep_through_vertical_stays_bounded() {
+        // Pitching up through the vertical and over the top: pitch folds back
+        // (as on any attitude indicator) but never leaves ±90°, and roll flips
+        // to keep the picture correct instead of producing NaNs.
+        let ctx = ctx_at(0.0, 0.0);
+        for i in 0..=720 {
+            let theta = TAU * (i as f64 / 720.0);
+            let a = solve(
+                &pose_value(DQuat::from_rotation_y(-theta), DVec3::ZERO),
+                GeoFrame::ENU,
+                &ctx,
+            );
+            assert!(a.pitch.is_finite() && a.roll.is_finite(), "{a:?}");
+            assert!(a.pitch.abs() <= FRAC_PI_2 + 1e-9, "{a:?}");
+        }
+    }
+
+    #[test]
+    fn reference_attitude_reads_level_and_round_trips() {
+        // Identity reference stays implicit in KDL.
+        let data = HorizonGaugeData::new(None);
+        assert_eq!(data.reference_kdl(), None);
+
+        // A nose-up-modelled body: its own attitude is the reference, so it
+        // must read level rather than permanently pitched.
+        let raw = [0.0, 2.0, 0.0, 2.0]; // unnormalized 90° about Y
+        let data = data.with_reference(Some(raw));
+        assert!((data.reference.length() - 1.0).abs() < 1e-12);
+        assert!(data.reference_kdl().is_some());
+
+        let ctx = ctx_at(0.0, 0.0);
+        let a = solve_attitude(
+            Some(&pose_value(data.reference, DVec3::ZERO)),
+            GeoFrame::ENU,
+            data.reference,
+            &ctx,
+        )
+        .expect("active");
+        assert!(a.pitch.abs() < 1e-9 && a.roll.abs() < 1e-9, "{a:?}");
+
+        // Without the reference the same pose reads steeply pitched.
+        let raw_read = solve(
+            &pose_value(data.reference, DVec3::ZERO),
+            GeoFrame::ENU,
+            &ctx,
+        );
+        assert!(raw_read.pitch.to_degrees().abs() > 80.0, "{raw_read:?}");
+    }
+
+    #[test]
+    fn effective_source_inherits_coordinate_then_enu() {
+        let inherit = HorizonGaugeData::new(None);
+        assert_eq!(inherit.effective_source(Some(GeoFrame::NED)), GeoFrame::NED);
+        assert_eq!(inherit.effective_source(None), GeoFrame::ENU);
+        let explicit = HorizonGaugeData::new(Some(GeoFrame::ECEF));
+        assert_eq!(
+            explicit.effective_source(Some(GeoFrame::ENU)),
+            GeoFrame::ECEF
+        );
+    }
+
+    #[test]
+    fn right_bank_raises_the_horizons_right_end() {
+        // The cockpit convention: a right bank tilts the world's up to the
+        // left, so the horizon's right end rises on screen (y grows downward).
+        let (up_dir, right_dir) = world_dirs(15f64.to_radians());
+        assert!(up_dir.x < 0.0, "world up should lean left: {up_dir:?}");
+        assert!(
+            right_dir.y < 0.0,
+            "horizon should rise to the right: {right_dir:?}"
+        );
+        // Level flight keeps it flat and upright.
+        let (up_dir, right_dir) = world_dirs(0.0);
+        assert!((up_dir - Vec2::new(0.0, -1.0)).length() < 1e-6);
+        assert!((right_dir - Vec2::new(1.0, 0.0)).length() < 1e-6);
+    }
+
+    #[test]
+    fn half_disc_covers_all_none_or_a_segment_inside_the_face() {
+        let center = Pos2::new(50.0, 50.0);
+        let radius = 20.0;
+        let up = Vec2::new(0.0, -1.0);
+
+        // Horizon far below the face: all sky. Far above: none.
+        assert!(matches!(
+            half_disc(center, radius, center + Vec2::new(0.0, 100.0), up),
+            DiscSplit::All
+        ));
+        assert!(matches!(
+            half_disc(center, radius, center - Vec2::new(0.0, 100.0), up),
+            DiscSplit::Empty
+        ));
+
+        // Horizon through the centre: a half-disc, entirely inside the face and
+        // entirely on the sky side.
+        let DiscSplit::Segment(pts) = half_disc(center, radius, center, up) else {
+            panic!("expected a segment");
+        };
+        assert!(pts.len() >= 3);
+        for p in &pts {
+            assert!(
+                (*p - center).length() <= radius + 1e-3,
+                "segment left the face: {p:?}"
+            );
+            assert!(
+                (*p - center).dot(up) >= -1e-3,
+                "segment crossed the horizon"
+            );
+        }
+    }
+
+    #[test]
+    fn line_chord_and_clip_segment_stay_inside_the_face() {
+        let center = Pos2::new(0.0, 0.0);
+        let radius = 10.0;
+        let up = Vec2::new(0.0, -1.0);
+
+        let (a, b) = line_chord(center, radius, center, up).expect("chord through centre");
+        assert!((a - center).length() <= radius + 1e-3);
+        assert!((b - center).length() <= radius + 1e-3);
+        assert!(((b - a).length() - 2.0 * radius).abs() < 1e-3, "diameter");
+        // A line that misses the disc has no chord.
+        assert!(line_chord(center, radius, center + Vec2::new(0.0, 50.0), up).is_none());
+
+        // A rung crossing the rim is truncated to the disc.
+        let (a, b) = clip_segment(
+            center,
+            radius,
+            Pos2::new(-100.0, 0.0),
+            Pos2::new(100.0, 0.0),
+        )
+        .expect("crossing segment");
+        assert!((a.x + radius).abs() < 1e-3 && (b.x - radius).abs() < 1e-3);
+        // A rung fully outside is dropped.
+        assert!(
+            clip_segment(
+                center,
+                radius,
+                Pos2::new(-100.0, 50.0),
+                Pos2::new(100.0, 50.0)
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn readout_shows_degrees_or_placeholders() {
+        let a = Attitude {
+            pitch: 14f64.to_radians(),
+            roll: -15f64.to_radians(),
+        };
+        assert_eq!(attitude_readout(Ok(a)), "PITCH +14.0°  ROLL -15.0°");
+        assert_eq!(
+            attitude_readout(Err(InactiveReason::NoSample)),
+            "PITCH —  ROLL —"
+        );
+    }
+}

--- a/libs/elodin-editor/src/ui/gauges/mod.rs
+++ b/libs/elodin-editor/src/ui/gauges/mod.rs
@@ -184,6 +184,21 @@ fn gauge_title(eql: &str, name: &PaneName) -> String {
 /// Uniform inner padding for both gauge panels, so sibling gauges line up.
 pub(crate) const GAUGE_PANEL_MARGIN: i8 = 6;
 
+/// Claims the whole gauge panel as a click target, so clicking it can put the
+/// gauge in the inspector.
+///
+/// A gauge pane living directly in a split gets no tab bar, and the title it
+/// draws is painted text, so without this there is nothing to click and the
+/// inspector is unreachable. Call it *before* drawing the panel's contents:
+/// widgets registered later keep their own clicks.
+pub(crate) fn panel_select_target(ui: &mut egui::Ui, gauge: Entity) -> egui::Response {
+    ui.interact(
+        ui.max_rect(),
+        ui.id().with(("gauge_panel", gauge)),
+        egui::Sense::click(),
+    )
+}
+
 /// Panel header shared by both gauges: the [`gauge_title`] in muted 10px mono,
 /// followed by a small gap before the panel body.
 pub(crate) fn gauge_header(ui: &mut egui::Ui, title: &str) {

--- a/libs/elodin-editor/src/ui/gauges/mod.rs
+++ b/libs/elodin-editor/src/ui/gauges/mod.rs
@@ -1,14 +1,15 @@
-//! Geo-position and orientation gauges: two EQL-bound panels that share the
-//! same telemetry-resolution machinery ([`EqlBinding`]). The position gauge
-//! shows three converted coordinates; the orientation gauge shows an attitude
-//! gimbal — split so numbers next to a gimbal are never mistaken for the
-//! orientation itself.
+//! EQL-bound gauge panels sharing the same telemetry-resolution machinery
+//! ([`EqlBinding`]). The position gauge shows three converted coordinates; the
+//! orientation gauge shows an attitude gimbal (split so numbers next to a
+//! gimbal are never mistaken for the orientation itself); the horizon gauge
+//! shows a cockpit-view artificial horizon.
 
 pub mod geo_position;
+pub mod horizon;
 pub mod orientation;
 
 use bevy::prelude::*;
-use bevy_egui::egui;
+use bevy_egui::egui::{self, Align2, Color32, FontId, Pos2, Vec2};
 use impeller2::types::{ComponentId, Timestamp};
 use impeller2_bevy::{EntityMap, TelemetryCache};
 use impeller2_wkt::ComponentValue;
@@ -19,7 +20,13 @@ use crate::object_3d::{CompiledExpr, compile_eql_expr};
 use super::PaneName;
 
 pub use geo_position::{GeoPositionGaugeData, GeoPositionGaugeWidget};
+pub use horizon::{HorizonGaugeData, HorizonGaugeWidget};
 pub use orientation::{OrientationGaugeData, OrientationGaugeWidget};
+
+/// Max deviation of a bare 4-vector's length² from 1 to still count as a
+/// quaternion. Loose enough for telemetry drift / un-renormalized integration,
+/// tight enough that arbitrary 4-vectors (e.g. fin deflections) are rejected.
+pub(crate) const BARE_QUAT_UNIT_TOLERANCE: f64 = 0.1;
 
 /// Read a numeric component buffer as `f64`, accepting both `F32` and `F64`
 /// telemetry so gauges treat single- and double-precision poses identically.
@@ -187,6 +194,27 @@ pub(crate) fn gauge_header(ui: &mut egui::Ui, title: &str) {
             .color(crate::ui::colors::get_scheme().text_secondary),
     );
     ui.add_space(3.0);
+}
+
+/// Draw `text` with a 1px halo so it reads over both hemisphere tones.
+pub(crate) fn text_with_halo(
+    painter: &egui::Painter,
+    pos: Pos2,
+    text: &str,
+    font: FontId,
+    color: Color32,
+    halo: Color32,
+) {
+    for (dx, dy) in [(-1.0, 0.0), (1.0, 0.0), (0.0, -1.0), (0.0, 1.0)] {
+        painter.text(
+            pos + Vec2::new(dx, dy),
+            Align2::CENTER_CENTER,
+            text,
+            font.clone(),
+            halo,
+        );
+    }
+    painter.text(pos, Align2::CENTER_CENTER, text, font, color);
 }
 
 /// Style the in-panel display ComboBox identically in both gauges: bordered

--- a/libs/elodin-editor/src/ui/gauges/orientation.rs
+++ b/libs/elodin-editor/src/ui/gauges/orientation.rs
@@ -14,7 +14,7 @@ use impeller2_bevy::{EntityMap, TelemetryCache};
 use impeller2_wkt::{ComponentValue, CurrentTimestamp};
 use std::f32::consts::TAU;
 
-use super::{EqlBinding, GaugePane, gauge_title};
+use super::{BARE_QUAT_UNIT_TOLERANCE, EqlBinding, GaugePane, gauge_title, text_with_halo};
 use crate::ui::{
     colors::get_scheme,
     widgets::{SystemStateExt, WidgetSystem},
@@ -198,11 +198,6 @@ fn canonical_hemisphere(q: DQuat) -> DQuat {
     }
     q
 }
-
-/// Max deviation of a bare 4-vector's length² from 1 to still count as a
-/// quaternion. Loose enough for telemetry drift / un-renormalized integration,
-/// tight enough that arbitrary 4-vectors (e.g. fin deflections) are rejected.
-const BARE_QUAT_UNIT_TOLERANCE: f64 = 0.1;
 
 /// Extract an attitude quaternion from a component value.
 ///
@@ -630,27 +625,6 @@ fn paint_frame_sphere(
             Color32::BLACK.gamma_multiply(alpha * 0.9),
         );
     }
-}
-
-/// Draw `text` with a 1px halo so it reads over both hemisphere tones.
-fn text_with_halo(
-    painter: &egui::Painter,
-    pos: Pos2,
-    text: &str,
-    font: FontId,
-    color: Color32,
-    halo: Color32,
-) {
-    for (dx, dy) in [(-1.0, 0.0), (1.0, 0.0), (0.0, -1.0), (0.0, 1.0)] {
-        painter.text(
-            pos + Vec2::new(dx, dy),
-            Align2::CENTER_CENTER,
-            text,
-            font.clone(),
-            halo,
-        );
-    }
-    painter.text(pos, Align2::CENTER_CENTER, text, font, color);
 }
 
 #[cfg(test)]

--- a/libs/elodin-editor/src/ui/gauges/orientation.rs
+++ b/libs/elodin-editor/src/ui/gauges/orientation.rs
@@ -16,7 +16,9 @@ use std::f32::consts::TAU;
 
 use super::{BARE_QUAT_UNIT_TOLERANCE, EqlBinding, GaugePane, gauge_title, text_with_halo};
 use crate::ui::{
+    SelectedObject,
     colors::get_scheme,
+    tiles::WindowState,
     widgets::{SystemStateExt, WidgetSystem},
 };
 
@@ -86,17 +88,18 @@ pub struct OrientationGaugeWidget<'w, 's> {
     current_timestamp: Res<'w, CurrentTimestamp>,
     geo_context: Res<'w, GeoContext>,
     coordinate: Res<'w, crate::Coordinate>,
+    window_states: Query<'w, 's, &'static mut WindowState>,
 }
 
 impl WidgetSystem for OrientationGaugeWidget<'_, '_> {
-    type Args = GaugePane;
+    type Args = (GaugePane, Entity);
     type Output = ();
 
     fn ui_system(
         world: &mut bevy::prelude::World,
         state: &mut bevy::ecs::system::SystemState<Self>,
         ui: &mut egui::Ui,
-        pane: Self::Args,
+        (pane, target_window): Self::Args,
     ) -> Self::Output {
         let OrientationGaugeWidget {
             mut gauges,
@@ -106,6 +109,7 @@ impl WidgetSystem for OrientationGaugeWidget<'_, '_> {
             current_timestamp,
             geo_context,
             coordinate,
+            mut window_states,
         } = state.params_mut(world);
         let Ok((mut data, binding)) = gauges.get_mut(pane.entity) else {
             return;
@@ -117,6 +121,16 @@ impl WidgetSystem for OrientationGaugeWidget<'_, '_> {
         // Keep inherit (`source = None`) live against `Coordinate` changes.
         let source = data.effective_source(coordinate.0);
         let combo_id = egui::Id::new(("orientation_gauge_display", pane.entity));
+
+        // Clicking the panel selects it, since a pane in a split has no tab.
+        let panel = super::panel_select_target(ui, pane.entity);
+        if panel.clicked()
+            && let Ok(mut window_state) = window_states.get_mut(target_window)
+        {
+            window_state.ui_state.selected_object = SelectedObject::OrientationGauge {
+                gauge_id: pane.entity,
+            };
+        }
 
         egui::Frame::NONE
             .inner_margin(egui::Margin::same(super::GAUGE_PANEL_MARGIN))

--- a/libs/elodin-editor/src/ui/inspector/gauges.rs
+++ b/libs/elodin-editor/src/ui/inspector/gauges.rs
@@ -9,7 +9,7 @@ use crate::{
     EqlContext,
     ui::{
         colors::get_scheme,
-        gauges::{EqlBinding, GeoPositionGaugeData, OrientationGaugeData},
+        gauges::{EqlBinding, GeoPositionGaugeData, HorizonGaugeData, OrientationGaugeData},
         inspector::{eql_autocomplete, inspector_text_field},
         theme,
         widgets::{SystemStateExt, WidgetSystem},
@@ -149,29 +149,81 @@ impl WidgetSystem for InspectorOrientationGauge<'_, '_> {
                         .color(get_scheme().text_secondary),
                 );
                 ui.add_space(4.0);
-                // Body→source quaternion the gimbal treats as neutral;
-                // normalized on edit so hand-typed values stay a rotation.
-                let q = &mut gauge.reference;
-                let mut parts = [q.x, q.y, q.z, q.w];
-                let mut changed = false;
-                ui.horizontal(|ui| {
-                    for part in &mut parts {
-                        changed |= ui
-                            .add(egui::DragValue::new(part).speed(0.01).range(-1.0..=1.0))
-                            .changed();
-                    }
-                    if ui.button("Reset").clicked() {
-                        parts = [0.0, 0.0, 0.0, 1.0];
-                        changed = true;
-                    }
-                });
-                if changed {
-                    let next = DQuat::from_xyzw(parts[0], parts[1], parts[2], parts[3]);
-                    if next.length() > 1e-9 {
-                        *q = next.normalize();
-                    }
-                }
+                // Body→source quaternion the gimbal treats as neutral.
+                reference_quat_ui(ui, &mut gauge.reference);
             });
+    }
+}
+
+#[derive(SystemParam)]
+pub struct InspectorHorizonGauge<'w, 's> {
+    gauges: Query<'w, 's, (&'static mut HorizonGaugeData, &'static mut EqlBinding)>,
+    eql_context: Res<'w, EqlContext>,
+}
+
+impl WidgetSystem for InspectorHorizonGauge<'_, '_> {
+    type Args = Entity;
+    type Output = ();
+
+    fn ui_system(
+        world: &mut bevy::prelude::World,
+        state: &mut bevy::ecs::system::SystemState<Self>,
+        ui: &mut egui::Ui,
+        entity: Self::Args,
+    ) -> Self::Output {
+        let InspectorHorizonGauge {
+            mut gauges,
+            eql_context,
+        } = state.params_mut(world);
+        let Ok((mut gauge, mut binding)) = gauges.get_mut(entity) else {
+            return;
+        };
+
+        egui::Frame::NONE
+            .inner_margin(egui::Margin::symmetric(0, 8))
+            .show(ui, |ui| {
+                // No display frame: the horizon is intrinsically local, so
+                // there is nothing to re-express the attitude into.
+                eql_and_source_ui(
+                    ui,
+                    &eql_context,
+                    &mut binding,
+                    &mut gauge.source,
+                    "Pose EQL (i.e a.world_pos)",
+                );
+
+                ui.add_space(12.0);
+                ui.label(
+                    egui::RichText::new("LEVEL ATTITUDE (X Y Z W)")
+                        .color(get_scheme().text_secondary),
+                );
+                ui.add_space(4.0);
+                reference_quat_ui(ui, &mut gauge.reference);
+            });
+    }
+}
+
+/// Editor for a gauge's reference quaternion: four drag values plus a reset,
+/// renormalized on edit so hand-typed values stay a rotation.
+fn reference_quat_ui(ui: &mut egui::Ui, q: &mut DQuat) {
+    let mut parts = [q.x, q.y, q.z, q.w];
+    let mut changed = false;
+    ui.horizontal(|ui| {
+        for part in &mut parts {
+            changed |= ui
+                .add(egui::DragValue::new(part).speed(0.01).range(-1.0..=1.0))
+                .changed();
+        }
+        if ui.button("Reset").clicked() {
+            parts = [0.0, 0.0, 0.0, 1.0];
+            changed = true;
+        }
+    });
+    if changed {
+        let next = DQuat::from_xyzw(parts[0], parts[1], parts[2], parts[3]);
+        if next.length() > 1e-9 {
+            *q = next.normalize();
+        }
     }
 }
 

--- a/libs/elodin-editor/src/ui/inspector/mod.rs
+++ b/libs/elodin-editor/src/ui/inspector/mod.rs
@@ -36,7 +36,7 @@ pub use widgets::*;
 use self::{
     data_overview::InspectorDataOverview,
     entity::InspectorEntity,
-    gauges::{InspectorGeoPositionGauge, InspectorOrientationGauge},
+    gauges::{InspectorGeoPositionGauge, InspectorHorizonGauge, InspectorOrientationGauge},
     graph::InspectorGraph,
     monitor::InspectorMonitor,
     object3d::InspectorObject3D,
@@ -181,6 +181,14 @@ impl WidgetSystem for InspectorContent<'_, '_> {
                                     ui.add_widget_with::<InspectorOrientationGauge>(
                                         world,
                                         "inspector_orientation_gauge",
+                                        gauge_id,
+                                    );
+                                    Default::default()
+                                }
+                                SelectedObject::HorizonGauge { gauge_id } => {
+                                    ui.add_widget_with::<InspectorHorizonGauge>(
+                                        world,
+                                        "inspector_horizon_gauge",
                                         gauge_id,
                                     );
                                     Default::default()

--- a/libs/elodin-editor/src/ui/mod.rs
+++ b/libs/elodin-editor/src/ui/mod.rs
@@ -162,6 +162,9 @@ pub enum SelectedObject {
     OrientationGauge {
         gauge_id: Entity,
     },
+    HorizonGauge {
+        gauge_id: Entity,
+    },
     DataOverview,
     DataOverviewComponent {
         component_id: ComponentId,
@@ -190,7 +193,8 @@ impl SelectedObject {
             SelectedObject::QueryTable { table_id } => Some(*table_id),
             SelectedObject::Monitor { monitor_id } => Some(*monitor_id),
             SelectedObject::GeoPositionGauge { gauge_id }
-            | SelectedObject::OrientationGauge { gauge_id } => Some(*gauge_id),
+            | SelectedObject::OrientationGauge { gauge_id }
+            | SelectedObject::HorizonGauge { gauge_id } => Some(*gauge_id),
             SelectedObject::DataOverview => None,
             SelectedObject::DataOverviewComponent { .. } => None,
             SelectedObject::Action { action_id } => Some(*action_id),

--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -120,6 +120,17 @@ fn tabs_parent_for_panels(tile_state: &TileState, panel_count: usize) -> Option<
     }
 }
 
+/// Reference ellipsoid for the schematic's `coordinate body=…`; absent means
+/// Earth, so existing schematics keep WGS84.
+fn body_ellipsoid(body: Option<impeller2_wkt::CelestialBody>) -> bevy_geo_frames::Ellipsoid {
+    match body.unwrap_or_default() {
+        impeller2_wkt::CelestialBody::Earth => bevy_geo_frames::Ellipsoid::WGS84,
+        impeller2_wkt::CelestialBody::Moon => bevy_geo_frames::Ellipsoid::Sphere {
+            radius: impeller2_wkt::CelestialBody::MOON_RADIUS_M,
+        },
+    }
+}
+
 fn apply_fallback_frame_to_panel(
     panel: &Panel,
     fallback_frame: Option<bevy_geo_frames::GeoFrame>,
@@ -399,10 +410,12 @@ impl LoadSchematicParams<'_, '_> {
             .map(|o| {
                 bevy_geo_frames::GeoOrigin::new_from_degrees(o.latitude, o.longitude, o.altitude)
             })
-            .unwrap_or_default();
+            .unwrap_or_default()
+            .with_ellipsoid(body_ellipsoid(schematic.body));
         let current = &self.geo_context.origin;
         if (current.latitude, current.longitude, current.altitude)
             != (origin.latitude, origin.longitude, origin.altitude)
+            || current.ellipsoid.parameters() != origin.ellipsoid.parameters()
         {
             self.geo_context.origin = origin;
         }
@@ -1289,6 +1302,22 @@ impl LoadSchematicParams<'_, '_> {
                 let pane = crate::ui::gauges::GaugePane::new(entity, label);
                 tile_state.insert_tile(Tile::Pane(Pane::OrientationGauge(pane)), parent_id, false)
             }
+            Panel::HorizonGauge(gauge) => {
+                let label = gauge
+                    .name
+                    .clone()
+                    .unwrap_or_else(|| "Horizon Gauge".to_string());
+                let entity = self
+                    .commands
+                    .spawn((
+                        crate::ui::gauges::HorizonGaugeData::new(gauge.source)
+                            .with_reference(gauge.reference),
+                        crate::ui::gauges::EqlBinding::new(gauge.eql.clone()),
+                    ))
+                    .id();
+                let pane = crate::ui::gauges::GaugePane::new(entity, label);
+                tile_state.insert_tile(Tile::Pane(Pane::HorizonGauge(pane)), parent_id, false)
+            }
             Panel::QueryTable(data) => {
                 let has_query = !data.query.trim().is_empty();
                 let entity = self
@@ -2037,6 +2066,98 @@ mod tests {
         assert_eq!(origin.latitude, default_origin.latitude);
         assert_eq!(origin.longitude, default_origin.longitude);
         assert_eq!(origin.altitude, default_origin.altitude);
+    }
+
+    #[test]
+    fn coordinate_body_sets_the_reference_ellipsoid() {
+        let mut app = test_app();
+        let earth_radius = app
+            .world()
+            .resource::<bevy_geo_frames::GeoContext>()
+            .origin
+            .ellipsoid
+            .parameters()
+            .0;
+
+        let schematic = Schematic::from_kdl(r#"coordinate frame=ECEF lat=0 lon=0 body="moon""#)
+            .expect("parse lunar schematic");
+        load_schematic(&mut app, &schematic);
+        let ellipsoid = app
+            .world()
+            .resource::<bevy_geo_frames::GeoContext>()
+            .origin
+            .ellipsoid;
+        assert_eq!(
+            ellipsoid.parameters().0,
+            impeller2_wkt::CelestialBody::MOON_RADIUS_M
+        );
+        // A lunar sphere has no flattening, unlike WGS84.
+        assert_eq!(ellipsoid.parameters().0, ellipsoid.parameters().1);
+
+        // Clearing the schematic restores Earth.
+        load_schematic(&mut app, &Schematic::default());
+        assert_eq!(
+            app.world()
+                .resource::<bevy_geo_frames::GeoContext>()
+                .origin
+                .ellipsoid
+                .parameters()
+                .0,
+            earth_radius
+        );
+    }
+
+    #[test]
+    fn horizon_gauge_round_trips_source_and_reference() {
+        let mut app = test_app();
+        let schematic = Schematic::from_kdl(
+            r#"
+            horizon_gauge "rocket.world_pos" name="ADI" source="ECEF" {
+                reference 0.0 0.7071068 0.0 0.7071068
+            }
+            "#,
+        )
+        .expect("parse test schematic");
+
+        load_schematic(&mut app, &schematic);
+
+        let mut query = app
+            .world_mut()
+            .query::<&crate::ui::gauges::HorizonGaugeData>();
+        let data = query
+            .iter(app.world())
+            .next()
+            .expect("horizon_gauge entity");
+        assert_eq!(data.source, Some(GeoFrame::ECEF));
+        // The reference is normalized on load and stays non-identity.
+        assert!((data.reference.length() - 1.0).abs() < 1e-9);
+        assert!(data.reference_kdl().is_some());
+    }
+
+    #[test]
+    fn horizon_gauge_omitted_source_keeps_inheriting_coordinate() {
+        let mut app = test_app();
+        let schematic = Schematic::from_kdl(
+            r#"
+            coordinate frame=NED
+            horizon_gauge "rocket.world_pos"
+            "#,
+        )
+        .expect("parse test schematic");
+
+        load_schematic(&mut app, &schematic);
+
+        let mut query = app
+            .world_mut()
+            .query::<&crate::ui::gauges::HorizonGaugeData>();
+        let data = query
+            .iter(app.world())
+            .next()
+            .expect("horizon_gauge entity");
+        // Stored as None so a later `coordinate` change still applies.
+        assert_eq!(data.source, None);
+        assert_eq!(data.effective_source(Some(GeoFrame::NED)), GeoFrame::NED);
+        assert_eq!(data.reference_kdl(), None);
     }
 
     #[test]

--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -122,13 +122,26 @@ fn tabs_parent_for_panels(tile_state: &TileState, panel_count: usize) -> Option<
 
 /// Reference ellipsoid for the schematic's `coordinate body=…`; absent means
 /// Earth, so existing schematics keep WGS84.
-fn body_ellipsoid(body: Option<impeller2_wkt::CelestialBody>) -> bevy_geo_frames::Ellipsoid {
+pub(crate) fn body_ellipsoid(
+    body: Option<impeller2_wkt::CelestialBody>,
+) -> bevy_geo_frames::Ellipsoid {
     match body.unwrap_or_default() {
         impeller2_wkt::CelestialBody::Earth => bevy_geo_frames::Ellipsoid::WGS84,
         impeller2_wkt::CelestialBody::Moon => bevy_geo_frames::Ellipsoid::Sphere {
             radius: impeller2_wkt::CelestialBody::MOON_RADIUS_M,
         },
     }
+}
+
+/// Inverse of [`body_ellipsoid`]: the `coordinate body=…` that reproduces a
+/// live [`bevy_geo_frames::GeoContext`] ellipsoid on reload. `None` for Earth
+/// (and for any ellipsoid no body maps to), so plain schematics stay unchanged.
+pub(crate) fn ellipsoid_body(
+    ellipsoid: bevy_geo_frames::Ellipsoid,
+) -> Option<impeller2_wkt::CelestialBody> {
+    [impeller2_wkt::CelestialBody::Moon]
+        .into_iter()
+        .find(|&body| body_ellipsoid(Some(body)).parameters() == ellipsoid.parameters())
 }
 
 fn apply_fallback_frame_to_panel(
@@ -1809,6 +1822,16 @@ mod tests {
         settle(app);
     }
 
+    /// Rebuilds `CurrentSchematic` from live editor state, as saving does.
+    fn save_schematic(app: &mut App) -> Schematic {
+        app.init_resource::<impeller2_bevy::ComponentMetadataRegistry>()
+            .init_resource::<crate::ui::schematic::CurrentWindowSchematics>();
+        app.world_mut()
+            .run_system_cached(crate::ui::schematic::tiles_to_schematic)
+            .expect("run tiles_to_schematic");
+        app.world().resource::<CurrentSchematic>().0.clone()
+    }
+
     #[test_case("line_3d \"(0,0,0)\""; "line_3d")]
     #[test_case("vector_arrow \"(0,0,1)\"" ; "vector_arrow")]
     #[test_case("object_3d \"(0,0,0,1, 0,0,0)\" { sphere radius=1.0 { color 0 0 0 } }" ; "object_3d")]
@@ -2104,6 +2127,55 @@ mod tests {
                 .parameters()
                 .0,
             earth_radius
+        );
+    }
+
+    #[test]
+    fn coordinate_body_survives_a_save() {
+        let mut app = test_app();
+        let schematic = Schematic::from_kdl(r#"coordinate frame=ECEF lat=0 lon=0 body="moon""#)
+            .expect("parse lunar schematic");
+        load_schematic(&mut app, &schematic);
+
+        let saved = save_schematic(&mut app);
+        assert_eq!(saved.frame, Some(GeoFrame::ECEF));
+        assert_eq!(saved.body, Some(impeller2_wkt::CelestialBody::Moon));
+        assert!(impeller2_kdl::serialize_schematic(&saved).contains(r#"body=moon"#));
+
+        // Reloading the saved schematic keeps the lunar ellipsoid.
+        load_schematic(&mut app, &saved);
+        let ellipsoid = app
+            .world()
+            .resource::<bevy_geo_frames::GeoContext>()
+            .origin
+            .ellipsoid;
+        assert_eq!(
+            ellipsoid.parameters().0,
+            impeller2_wkt::CelestialBody::MOON_RADIUS_M
+        );
+
+        // Earth stays implicit, and a stale lunar body does not linger.
+        load_schematic(&mut app, &Schematic::default());
+        assert_eq!(save_schematic(&mut app).body, None);
+    }
+
+    #[test]
+    fn celestial_bodies_round_trip_through_their_ellipsoids() {
+        use impeller2_wkt::CelestialBody;
+        assert_eq!(super::ellipsoid_body(super::body_ellipsoid(None)), None);
+        assert_eq!(
+            super::ellipsoid_body(super::body_ellipsoid(Some(CelestialBody::Earth))),
+            None,
+            "Earth is the default, so it stays implicit"
+        );
+        assert_eq!(
+            super::ellipsoid_body(super::body_ellipsoid(Some(CelestialBody::Moon))),
+            Some(CelestialBody::Moon)
+        );
+        assert_eq!(
+            super::ellipsoid_body(bevy_geo_frames::Ellipsoid::Sphere { radius: 1.0 }),
+            None,
+            "an ellipsoid no body maps to must not claim one"
         );
     }
 

--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -120,6 +120,21 @@ fn tabs_parent_for_panels(tile_state: &TileState, panel_count: usize) -> Option<
     }
 }
 
+/// The [`bevy_geo_frames::GeoContext`] origin a schematic asks for: its
+/// `coordinate` lat/lon/alt on the body's reference ellipsoid, reset to the
+/// default when absent so reloads are deterministic.
+///
+/// Shared with the headless loader ([`crate::headless`]), which spawns the
+/// same `object_3d`/`world_mesh` entities and so needs the same ellipsoid for
+/// its ECEF/LLA conversions.
+pub(crate) fn schematic_geo_origin(schematic: &Schematic) -> bevy_geo_frames::GeoOrigin {
+    schematic
+        .origin
+        .map(|o| bevy_geo_frames::GeoOrigin::new_from_degrees(o.latitude, o.longitude, o.altitude))
+        .unwrap_or_default()
+        .with_ellipsoid(body_ellipsoid(schematic.body))
+}
+
 /// Reference ellipsoid for the schematic's `coordinate body=…`; absent means
 /// Earth, so existing schematics keep WGS84.
 pub(crate) fn body_ellipsoid(
@@ -414,17 +429,10 @@ impl LoadSchematicParams<'_, '_> {
         // Set global coordinate frame from schematic
         self.coordinate.0 = schematic.frame;
 
-        // Set the GeoContext origin from the schematic (degrees -> radians),
-        // resetting to the default when absent so reloads are deterministic.
+        // Set the GeoContext origin from the schematic (degrees -> radians).
         // Only write on change: mutating GeoContext re-touches every
         // GeoPosition/GeoRotation in the world.
-        let origin = schematic
-            .origin
-            .map(|o| {
-                bevy_geo_frames::GeoOrigin::new_from_degrees(o.latitude, o.longitude, o.altitude)
-            })
-            .unwrap_or_default()
-            .with_ellipsoid(body_ellipsoid(schematic.body));
+        let origin = schematic_geo_origin(schematic);
         let current = &self.geo_context.origin;
         if (current.latitude, current.longitude, current.altitude)
             != (origin.latitude, origin.longitude, origin.altitude)
@@ -2157,6 +2165,43 @@ mod tests {
         // Earth stays implicit, and a stale lunar body does not linger.
         load_schematic(&mut app, &Schematic::default());
         assert_eq!(save_schematic(&mut app).body, None);
+    }
+
+    /// `schematic_geo_origin` is what both the editor and the headless render
+    /// server load, so the body must survive with or without an explicit
+    /// lat/lon.
+    #[test]
+    fn schematic_geo_origin_carries_the_body_ellipsoid() {
+        let moon_radius = impeller2_wkt::CelestialBody::MOON_RADIUS_M;
+        let earth_radius = bevy_geo_frames::GeoOrigin::default()
+            .ellipsoid
+            .parameters()
+            .0;
+
+        let lunar_site = super::schematic_geo_origin(
+            &Schematic::from_kdl(r#"coordinate frame=ECEF lat=10 lon=20 body="moon""#)
+                .expect("parse lunar schematic"),
+        );
+        assert_eq!(lunar_site.ellipsoid.parameters().0, moon_radius);
+        assert_eq!(lunar_site.latitude, 10f64.to_radians());
+
+        // A body with no launch site still selects its ellipsoid.
+        let lunar_bare = super::schematic_geo_origin(
+            &Schematic::from_kdl(r#"coordinate frame=ECEF body="moon""#)
+                .expect("parse lunar schematic"),
+        );
+        assert_eq!(lunar_bare.ellipsoid.parameters().0, moon_radius);
+
+        // Earth and an empty schematic both give the default origin.
+        for kdl in [r#"coordinate frame=ECEF lat=1 lon=2 body="earth""#, ""] {
+            let origin =
+                super::schematic_geo_origin(&Schematic::from_kdl(kdl).expect("parse schematic"));
+            assert_eq!(origin.ellipsoid.parameters().0, earth_radius, "{kdl:?}");
+        }
+        assert_eq!(
+            super::schematic_geo_origin(&Schematic::default()).latitude,
+            bevy_geo_frames::GeoOrigin::default().latitude
+        );
     }
 
     #[test]

--- a/libs/elodin-editor/src/ui/schematic/mod.rs
+++ b/libs/elodin-editor/src/ui/schematic/mod.rs
@@ -20,9 +20,9 @@ use bevy_geo_frames::{GeoFrame, GeoPosition};
 use egui_tiles::{Tile, TileId};
 use impeller2_bevy::ComponentMetadataRegistry;
 use impeller2_wkt::{
-    ActionPane, ComponentMonitor, ComponentPath, GeoPositionGauge, Line3d, OrientationGauge, Panel,
-    Schematic, SchematicElem, Split, VectorArrow3d, VideoStream as WktVideoStream, Viewport,
-    WindowSchematic, WorldMesh,
+    ActionPane, ComponentMonitor, ComponentPath, GeoPositionGauge, HorizonGauge, Line3d,
+    OrientationGauge, Panel, Schematic, SchematicElem, Split, VectorArrow3d,
+    VideoStream as WktVideoStream, Viewport, WindowSchematic, WorldMesh,
 };
 
 pub mod bindings;
@@ -57,6 +57,7 @@ pub struct SchematicParam<'w, 's> {
     pub monitors: Query<'w, 's, &'static monitor::MonitorData>,
     pub geo_position_gauges: Query<'w, 's, &'static gauges::GeoPositionGaugeData>,
     pub orientation_gauges: Query<'w, 's, &'static gauges::OrientationGaugeData>,
+    pub horizon_gauges: Query<'w, 's, &'static gauges::HorizonGaugeData>,
     pub eql_bindings: Query<'w, 's, &'static gauges::EqlBinding>,
     pub action_tiles: Query<'w, 's, &'static actions::ActionTile>,
     pub graph_states: Query<'w, 's, &'static plot::GraphState>,
@@ -103,9 +104,9 @@ impl SchematicParam<'_, '_> {
                 .ok()
                 .map(|state| state.label.clone()),
             Pane::Monitor(monitor) => Some(monitor.name.clone()),
-            Pane::GeoPositionGauge(gauge) | Pane::OrientationGauge(gauge) => {
-                Some(gauge.name.clone())
-            }
+            Pane::GeoPositionGauge(gauge)
+            | Pane::OrientationGauge(gauge)
+            | Pane::HorizonGauge(gauge) => Some(gauge.name.clone()),
             Pane::QueryTable(table) => Some(table.name.clone()),
             Pane::QueryPlot(plot) => self
                 .graph_states
@@ -336,6 +337,21 @@ impl SchematicParam<'_, '_> {
                             eql: binding.eql.clone(),
                             source: data.source,
                             display: data.display,
+                            // None when identity so the default stays implicit.
+                            reference: data.reference_kdl(),
+                            name: pane_name,
+                            node_id,
+                        }))
+                    }
+
+                    Pane::HorizonGauge(gauge) => {
+                        let data = self.horizon_gauges.get(gauge.entity).ok()?;
+                        let binding = self.eql_bindings.get(gauge.entity).ok()?;
+                        let node_id = impeller2_wkt::NodeId::next();
+                        bindings.bind_ephemeral(node_id, gauge.entity);
+                        Some(Panel::HorizonGauge(HorizonGauge {
+                            eql: binding.eql.clone(),
+                            source: data.source,
                             // None when identity so the default stays implicit.
                             reference: data.reference_kdl(),
                             name: pane_name,

--- a/libs/elodin-editor/src/ui/schematic/mod.rs
+++ b/libs/elodin-editor/src/ui/schematic/mod.rs
@@ -494,6 +494,9 @@ pub fn tiles_to_schematic(
             longitude: origin.longitude.to_degrees(),
             altitude: origin.altitude,
         });
+    // The ellipsoid rides along with the origin: without it a lunar schematic
+    // would reload as WGS84, breaking ECEF verticals and LLA conversions.
+    schematic.body = load::ellipsoid_body(origin.ellipsoid);
     bindings.clear_ephemeral();
 
     if let Some(root_panels) =

--- a/libs/elodin-editor/src/ui/schematic/tree.rs
+++ b/libs/elodin-editor/src/ui/schematic/tree.rs
@@ -125,7 +125,9 @@ fn panel(
         Panel::VSplit(_) | Panel::HSplit(_) => icons.container,
         Panel::Graph(_) => icons.plot,
         Panel::ComponentMonitor(_) => icons.viewport,
-        Panel::GeoPositionGauge(_) | Panel::OrientationGauge(_) => icons.viewport,
+        Panel::GeoPositionGauge(_) | Panel::OrientationGauge(_) | Panel::HorizonGauge(_) => {
+            icons.viewport
+        }
         Panel::ActionPane(_) => icons.viewport,
         Panel::QueryTable(_) => icons.viewport,
         Panel::QueryPlot(_) => icons.plot,
@@ -181,6 +183,11 @@ fn panel(
             Panel::OrientationGauge(gauge) => {
                 if let Some(gauge_id) = bindings.get(gauge.node_id) {
                     *selected_object = SelectedObject::OrientationGauge { gauge_id };
+                }
+            }
+            Panel::HorizonGauge(gauge) => {
+                if let Some(gauge_id) = bindings.get(gauge.node_id) {
+                    *selected_object = SelectedObject::HorizonGauge { gauge_id };
                 }
             }
             _ => {}

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -44,7 +44,7 @@ use super::{
     colors::{self, EColor, get_scheme, with_opacity},
     command_palette::{CommandPaletteState, palette_items},
     data_overview::{DataOverviewPane, DataOverviewWidget},
-    gauges::{GaugePane, GeoPositionGaugeWidget, OrientationGaugeWidget},
+    gauges::{GaugePane, GeoPositionGaugeWidget, HorizonGaugeWidget, OrientationGaugeWidget},
     hierarchy::{Hierarchy, HierarchyContent},
     images,
     input_owner::{PointerOwner, PointerOwnerPriority, UiBlocker, UiInputOwners},
@@ -768,6 +768,11 @@ impl TileState {
             .push(TreeAction::AddOrientationGauge(tile_id, eql));
     }
 
+    pub fn create_horizon_gauge_tile(&mut self, eql: String, tile_id: Option<TileId>) {
+        self.tree_actions
+            .push(TreeAction::AddHorizonGauge(tile_id, eql));
+    }
+
     pub fn create_action_tile(
         &mut self,
         button_name: String,
@@ -842,6 +847,7 @@ impl TileState {
                             Pane::OrientationGauge(gauge) => {
                                 ("OrientationGauge", gauge.name.as_str())
                             }
+                            Pane::HorizonGauge(gauge) => ("HorizonGauge", gauge.name.as_str()),
                             Pane::QueryTable(table) => ("QueryTable", table.name.as_str()),
                             Pane::QueryPlot(_) => ("QueryPlot", "QueryPlot"),
                             Pane::ActionTile(action) => ("Action", action.name.as_str()),
@@ -962,7 +968,11 @@ impl TileState {
                         e.despawn();
                     }
                 }
-                Tile::Pane(Pane::GeoPositionGauge(gauge) | Pane::OrientationGauge(gauge)) => {
+                Tile::Pane(
+                    Pane::GeoPositionGauge(gauge)
+                    | Pane::OrientationGauge(gauge)
+                    | Pane::HorizonGauge(gauge),
+                ) => {
                     if let Ok(mut e) = commands.get_entity(gauge.entity) {
                         e.despawn();
                     }
@@ -1033,6 +1043,7 @@ pub enum Pane {
     Monitor(MonitorPane),
     GeoPositionGauge(GaugePane),
     OrientationGauge(GaugePane),
+    HorizonGauge(GaugePane),
     QueryTable(QueryTablePane),
     QueryPlot(super::query_plot::QueryPlotPane),
     ActionTile(ActionTilePane),
@@ -1061,6 +1072,7 @@ impl Pane {
             Pane::Monitor(_)
             | Pane::GeoPositionGauge(_)
             | Pane::OrientationGauge(_)
+            | Pane::HorizonGauge(_)
             | Pane::QueryTable(_)
             | Pane::ActionTile(_)
             | Pane::LogStream(_)
@@ -1079,7 +1091,9 @@ impl Pane {
             }
             Pane::Viewport(viewport) => viewport.name.to_string(),
             Pane::Monitor(monitor) => monitor.name.to_string(),
-            Pane::GeoPositionGauge(gauge) | Pane::OrientationGauge(gauge) => gauge.name.to_string(),
+            Pane::GeoPositionGauge(gauge)
+            | Pane::OrientationGauge(gauge)
+            | Pane::HorizonGauge(gauge) => gauge.name.to_string(),
             Pane::QueryTable(table) => table.name.to_string(),
             Pane::QueryPlot(query_plot) => {
                 if let Ok(graph_state) = graph_states.get(query_plot.entity) {
@@ -1109,7 +1123,9 @@ impl Pane {
             Pane::Monitor(monitor) => {
                 monitor.name = title.to_string();
             }
-            Pane::GeoPositionGauge(gauge) | Pane::OrientationGauge(gauge) => {
+            Pane::GeoPositionGauge(gauge)
+            | Pane::OrientationGauge(gauge)
+            | Pane::HorizonGauge(gauge) => {
                 gauge.name = title.to_string();
             }
             Pane::QueryTable(table) => {
@@ -1422,6 +1438,18 @@ impl Pane {
                     "orientation_gauge",
                     pane.clone(),
                 );
+                egui_tiles::UiResponse::None
+            }
+            Pane::HorizonGauge(pane) => {
+                register_ui_blocker(
+                    world,
+                    ui,
+                    target_window,
+                    content_rect,
+                    UiBlocker::OtherPanel,
+                    PointerOwnerPriority::Panel,
+                );
+                ui.add_widget_with::<HorizonGaugeWidget>(world, "horizon_gauge", pane.clone());
                 egui_tiles::UiResponse::None
             }
             Pane::QueryTable(pane) => {
@@ -2018,6 +2046,7 @@ pub enum TreeAction {
     AddMonitor(Option<TileId>, PaneName),
     AddGeoPositionGauge(Option<TileId>, PaneName),
     AddOrientationGauge(Option<TileId>, PaneName),
+    AddHorizonGauge(Option<TileId>, PaneName),
     AddQueryTable(Option<TileId>),
     AddQueryPlot(Option<TileId>),
     AddActionTile(Option<TileId>, PaneName, String),
@@ -2899,7 +2928,7 @@ impl WidgetSystem for TileLayoutEmpty<'_, '_> {
         // Creatable panels shown on the empty layout, laid out as a centred
         // grid (rows of PER_ROW) so the list can grow without overflowing.
         type ItemFactory = fn(Option<TileId>) -> palette_items::PaletteItem;
-        const BUTTONS: [(&str, &str, ItemFactory); 5] = [
+        const BUTTONS: [(&str, &str, ItemFactory); 6] = [
             ("Viewport", "3D Output", palette_items::create_viewport),
             ("Graph", "Point Graph", palette_items::create_graph),
             ("Monitor", "Component Values", palette_items::create_monitor),
@@ -2912,6 +2941,11 @@ impl WidgetSystem for TileLayoutEmpty<'_, '_> {
                 "Orientation Gauge",
                 "Attitude Gimbal",
                 palette_items::create_orientation_gauge,
+            ),
+            (
+                "Horizon Gauge",
+                "Artificial Horizon",
+                palette_items::create_horizon_gauge,
             ),
         ];
         const PER_ROW: usize = 3;
@@ -3125,7 +3159,9 @@ impl WidgetSystem for TileLayout<'_, '_> {
                         };
 
                         if let egui_tiles::Tile::Pane(
-                            Pane::GeoPositionGauge(pane) | Pane::OrientationGauge(pane),
+                            Pane::GeoPositionGauge(pane)
+                            | Pane::OrientationGauge(pane)
+                            | Pane::HorizonGauge(pane),
                         ) = tile
                         {
                             state_mut.commands.entity(pane.entity).despawn();
@@ -3321,6 +3357,26 @@ impl WidgetSystem for TileLayout<'_, '_> {
                             tile_state.tree.make_active(|id, _| id == tile_id);
                         }
                     }
+                    TreeAction::AddHorizonGauge(parent_tile_id, eql) => {
+                        if read_only {
+                            continue;
+                        }
+                        let entity = state_mut
+                            .commands
+                            .spawn((
+                                super::gauges::HorizonGaugeData::new(None),
+                                super::gauges::EqlBinding::new(eql.clone()),
+                            ))
+                            .id();
+                        let pane = Pane::HorizonGauge(GaugePane::new(entity, eql.clone()));
+                        if let Some(tile_id) =
+                            tile_state.insert_tile(Tile::Pane(pane), parent_tile_id, true)
+                        {
+                            ui_state.selected_object =
+                                SelectedObject::HorizonGauge { gauge_id: entity };
+                            tile_state.tree.make_active(|id, _| id == tile_id);
+                        }
+                    }
                     TreeAction::AddVideoStream(parent_tile_id, msg_name, name) => {
                         if read_only {
                             continue;
@@ -3413,6 +3469,11 @@ impl WidgetSystem for TileLayout<'_, '_> {
                                         gauge_id: gauge.entity,
                                     };
                                 }
+                                Pane::HorizonGauge(gauge) => {
+                                    ui_state.selected_object = SelectedObject::HorizonGauge {
+                                        gauge_id: gauge.entity,
+                                    };
+                                }
                                 Pane::QueryTable(table) => {
                                     ui_state.selected_object = SelectedObject::QueryTable {
                                         table_id: table.entity,
@@ -3467,6 +3528,11 @@ impl WidgetSystem for TileLayout<'_, '_> {
                                 }
                                 Pane::OrientationGauge(gauge) => {
                                     ui_state.selected_object = SelectedObject::OrientationGauge {
+                                        gauge_id: gauge.entity,
+                                    };
+                                }
+                                Pane::HorizonGauge(gauge) => {
+                                    ui_state.selected_object = SelectedObject::HorizonGauge {
                                         gauge_id: gauge.entity,
                                     };
                                 }
@@ -3646,7 +3712,9 @@ impl WidgetSystem for TileLayout<'_, '_> {
                         }
                     }
                     Pane::Monitor(_) => {}
-                    Pane::GeoPositionGauge(_) | Pane::OrientationGauge(_) => {}
+                    Pane::GeoPositionGauge(_)
+                    | Pane::OrientationGauge(_)
+                    | Pane::HorizonGauge(_) => {}
                     Pane::QueryTable(_) => {}
                     Pane::QueryPlot(query_plot) => {
                         if visible {

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -1420,7 +1420,7 @@ impl Pane {
                 ui.add_widget_with::<GeoPositionGaugeWidget>(
                     world,
                     "geo_position_gauge",
-                    pane.clone(),
+                    (pane.clone(), target_window),
                 );
                 egui_tiles::UiResponse::None
             }
@@ -1436,7 +1436,7 @@ impl Pane {
                 ui.add_widget_with::<OrientationGaugeWidget>(
                     world,
                     "orientation_gauge",
-                    pane.clone(),
+                    (pane.clone(), target_window),
                 );
                 egui_tiles::UiResponse::None
             }
@@ -1449,7 +1449,11 @@ impl Pane {
                     UiBlocker::OtherPanel,
                     PointerOwnerPriority::Panel,
                 );
-                ui.add_widget_with::<HorizonGaugeWidget>(world, "horizon_gauge", pane.clone());
+                ui.add_widget_with::<HorizonGaugeWidget>(
+                    world,
+                    "horizon_gauge",
+                    (pane.clone(), target_window),
+                );
                 egui_tiles::UiResponse::None
             }
             Pane::QueryTable(pane) => {

--- a/libs/impeller2/kdl/src/de.rs
+++ b/libs/impeller2/kdl/src/de.rs
@@ -55,6 +55,7 @@ pub fn parse_schematic(input: &str) -> Result<Schematic, KdlSchematicError> {
             SchematicElem::Coordinate(coordinate) => {
                 schematic.frame = Some(coordinate.frame);
                 schematic.origin = coordinate.origin;
+                schematic.body = coordinate.body;
             }
             other => schematic.elems.push(other),
         }
@@ -202,10 +203,9 @@ fn parse_telemetry_mode(node: &KdlNode, src: &str) -> Result<bool, KdlSchematicE
 fn parse_schematic_elem(node: &KdlNode, src: &str) -> Result<SchematicElem, KdlSchematicError> {
     match node.name().value() {
         "tabs" | "hsplit" | "vsplit" | "viewport" | "graph" | "component_monitor"
-        | "geo_position_gauge" | "orientation_gauge" | "action_pane" | "query_table"
-        | "query_plot" | "inspector" | "hierarchy" | "schematic_tree" | "data_overview" => {
-            Ok(SchematicElem::Panel(parse_panel(node, src)?))
-        }
+        | "geo_position_gauge" | "orientation_gauge" | "horizon_gauge" | "action_pane"
+        | "query_table" | "query_plot" | "inspector" | "hierarchy" | "schematic_tree"
+        | "data_overview" => Ok(SchematicElem::Panel(parse_panel(node, src)?)),
         "window" => Ok(SchematicElem::Window(parse_window(node, src)?)),
         "theme" => Ok(SchematicElem::Theme(parse_theme(node, src)?)),
         "timeline" => Ok(SchematicElem::Timeline(parse_timeline(node, src)?)),
@@ -517,7 +517,25 @@ fn parse_coordinate(node: &KdlNode, src: &str) -> Result<CoordinateConfig, KdlSc
         }
     };
 
-    Ok(CoordinateConfig { frame, origin })
+    let body =
+        match node.get("body").and_then(|v| v.as_string()) {
+            Some(s) => Some(CelestialBody::from_str_ci(s).ok_or_else(|| {
+                KdlSchematicError::InvalidValue {
+                    property: "body".to_string(),
+                    node: "coordinate".to_string(),
+                    expected: "earth or moon".to_string(),
+                    src: src.to_string(),
+                    span: node.span(),
+                }
+            })?),
+            None => None,
+        };
+
+    Ok(CoordinateConfig {
+        frame,
+        origin,
+        body,
+    })
 }
 
 fn parse_world_mesh(node: &KdlNode, src: &str) -> Result<WorldMesh, KdlSchematicError> {
@@ -644,6 +662,7 @@ fn parse_panel(node: &KdlNode, kdl_src: &str) -> Result<Panel, KdlSchematicError
         "component_monitor" => parse_component_monitor(node, kdl_src),
         "geo_position_gauge" => parse_geo_position_gauge(node, kdl_src),
         "orientation_gauge" => parse_orientation_gauge(node, kdl_src),
+        "horizon_gauge" => parse_horizon_gauge(node, kdl_src),
         "action_pane" => parse_action_pane(node, kdl_src),
         "query_table" => parse_query_table(node),
         "query_plot" => parse_query_plot(node, kdl_src),
@@ -1143,13 +1162,7 @@ fn parse_orientation_gauge(node: &KdlNode, src: &str) -> Result<Panel, KdlSchema
 
     // Optional `reference x y z w` child: the body→source attitude shown as
     // neutral by the gimbal.
-    let reference = node
-        .children()
-        .into_iter()
-        .flat_map(|c| c.nodes())
-        .find(|child| child.name().value() == "reference")
-        .map(|child| parse_reference_quat(child, src))
-        .transpose()?;
+    let reference = parse_optional_reference(node, src, "orientation_gauge")?;
 
     Ok(Panel::OrientationGauge(OrientationGauge {
         eql,
@@ -1161,10 +1174,44 @@ fn parse_orientation_gauge(node: &KdlNode, src: &str) -> Result<Panel, KdlSchema
     }))
 }
 
-fn parse_reference_quat(node: &KdlNode, src: &str) -> Result<[f64; 4], KdlSchematicError> {
+fn parse_horizon_gauge(node: &KdlNode, src: &str) -> Result<Panel, KdlSchematicError> {
+    let name = parse_name(node);
+    // No `display`: a horizon is intrinsically local, so there is nothing to
+    // re-express the attitude into.
+    let (eql, source) = parse_gauge_eql_source(node, src, "horizon_gauge")?;
+    let reference = parse_optional_reference(node, src, "horizon_gauge")?;
+
+    Ok(Panel::HorizonGauge(HorizonGauge {
+        eql,
+        source,
+        reference,
+        name,
+        node_id: NodeId::default(),
+    }))
+}
+
+/// The optional `reference x y z w` child of a gauge node, if present.
+fn parse_optional_reference(
+    node: &KdlNode,
+    src: &str,
+    node_name: &str,
+) -> Result<Option<[f64; 4]>, KdlSchematicError> {
+    node.children()
+        .into_iter()
+        .flat_map(|c| c.nodes())
+        .find(|child| child.name().value() == "reference")
+        .map(|child| parse_reference_quat(child, src, node_name))
+        .transpose()
+}
+
+fn parse_reference_quat(
+    node: &KdlNode,
+    src: &str,
+    node_name: &str,
+) -> Result<[f64; 4], KdlSchematicError> {
     let invalid = || KdlSchematicError::InvalidValue {
         property: "reference".to_string(),
-        node: "orientation_gauge".to_string(),
+        node: node_name.to_string(),
         expected: "four numeric entries: reference x y z w".to_string(),
         src: src.to_string(),
         span: node.span(),
@@ -3737,14 +3784,14 @@ object_3d "a.world_pos" {
 
         let kdl = r#"
         orientation_gauge "a.q" display="NED" {
-            reference 0.0 0.7071 0.0 0.7071
+            reference 0.0 0.6 0.0 0.8
         }
         "#;
         let parsed = parse_schematic(kdl).unwrap();
         let SchematicElem::Panel(Panel::OrientationGauge(g)) = &parsed.elems[0] else {
             panic!("Expected orientation_gauge");
         };
-        assert_eq!(g.reference, Some([0.0, 0.7071, 0.0, 0.7071]));
+        assert_eq!(g.reference, Some([0.0, 0.6, 0.0, 0.8]));
         assert_eq!(g.display, Some(GeoFrame::NED));
 
         let serialized = crate::serialize_schematic(&parsed);
@@ -3759,6 +3806,83 @@ object_3d "a.world_pos" {
         assert!(parse_schematic(r#"orientation_gauge "a.q" { reference 1 0 0 }"#).is_err());
         // LLA is geodetic, not a rotation frame.
         assert!(parse_schematic(r#"orientation_gauge "a.q" display="LLA""#).is_err());
+    }
+
+    #[test]
+    fn test_horizon_gauge_round_trip() {
+        // Bare form: positional eql, everything else inherited.
+        let plain = parse_schematic(r#"horizon_gauge "bdx.world_pos""#).unwrap();
+        let SchematicElem::Panel(Panel::HorizonGauge(g)) = &plain.elems[0] else {
+            panic!("Expected horizon_gauge");
+        };
+        assert_eq!(g.eql, "bdx.world_pos");
+        assert_eq!(g.source, None);
+        assert_eq!(g.reference, None);
+        assert!(!crate::serialize_schematic(&plain).contains("reference"));
+
+        let kdl = r#"
+        horizon_gauge "bdx.world_pos" name="ADI" source="ECEF" {
+            reference 0.0 0.6 0.0 0.8
+        }
+        "#;
+        let parsed = parse_schematic(kdl).unwrap();
+        let SchematicElem::Panel(Panel::HorizonGauge(g)) = &parsed.elems[0] else {
+            panic!("Expected horizon_gauge");
+        };
+        assert_eq!(g.name.as_deref(), Some("ADI"));
+        assert_eq!(g.source, Some(GeoFrame::ECEF));
+        assert_eq!(g.reference, Some([0.0, 0.6, 0.0, 0.8]));
+
+        let serialized = crate::serialize_schematic(&parsed);
+        let reparsed = parse_schematic(&serialized).unwrap();
+        let SchematicElem::Panel(Panel::HorizonGauge(g2)) = &reparsed.elems[0] else {
+            panic!("Expected horizon_gauge after round-trip");
+        };
+        assert_eq!(g2.eql, g.eql);
+        assert_eq!(g2.name, g.name);
+        assert_eq!(g2.source, g.source);
+        assert_eq!(g2.reference, g.reference);
+
+        // Wrong reference arity is a parse error, and the eql is mandatory.
+        assert!(parse_schematic(r#"horizon_gauge "a.q" { reference 1 0 0 }"#).is_err());
+        assert!(parse_schematic(r#"horizon_gauge"#).is_err());
+        // The horizon has no display frame to re-express into: `display` is not
+        // a property of this node, so it is simply ignored rather than honoured.
+        let ignored = parse_schematic(r#"horizon_gauge "a.q" display="NED""#).unwrap();
+        assert!(!crate::serialize_schematic(&ignored).contains("display"));
+    }
+
+    #[test]
+    fn test_parse_coordinate_body() {
+        // Default: no body property means Earth's WGS84, left implicit.
+        let earth = parse_schematic(r#"coordinate frame="ECEF""#).unwrap();
+        assert_eq!(earth.body, None);
+        assert!(!crate::serialize_schematic(&earth).contains("body"));
+
+        for (spelling, expected) in [
+            ("moon", CelestialBody::Moon),
+            ("Moon", CelestialBody::Moon),
+            ("earth", CelestialBody::Earth),
+        ] {
+            let kdl = format!(r#"coordinate frame="ECEF" body="{spelling}""#);
+            let schematic = parse_schematic(&kdl).unwrap();
+            assert_eq!(schematic.body, Some(expected));
+            // Round-trips through the canonical lowercase spelling.
+            let reparsed = parse_schematic(&crate::serialize_schematic(&schematic)).unwrap();
+            assert_eq!(reparsed.body, Some(expected));
+        }
+
+        // The body travels with the origin and frame.
+        let full = parse_schematic(r#"coordinate frame="ECEF" lat=0 lon=0 body="moon""#).unwrap();
+        assert_eq!(full.frame, Some(GeoFrame::ECEF));
+        assert_eq!(full.body, Some(CelestialBody::Moon));
+        let reparsed = parse_schematic(&crate::serialize_schematic(&full)).unwrap();
+        assert_eq!(reparsed.origin, full.origin);
+        assert_eq!(reparsed.body, full.body);
+
+        // Unknown bodies are rejected rather than silently treated as Earth.
+        assert!(parse_schematic(r#"coordinate frame="ECEF" body="mars""#).is_err());
+        assert!(parse_schematic(r#"coordinate frame="ECEF" body="""#).is_err());
     }
 
     #[test]

--- a/libs/impeller2/kdl/src/ser.rs
+++ b/libs/impeller2/kdl/src/ser.rs
@@ -14,6 +14,7 @@ pub fn serialize_schematic(schematic: &Schematic) -> String {
             .push(serialize_coordinate(&CoordinateConfig {
                 frame,
                 origin: schematic.origin,
+                body: schematic.body,
             }));
     }
     if let Some(theme) = schematic.theme.as_ref() {
@@ -72,6 +73,10 @@ fn serialize_coordinate(coordinate: &CoordinateConfig) -> KdlNode {
             node.entries_mut()
                 .push(KdlEntry::new_prop("alt", origin.altitude));
         }
+    }
+    if let Some(body) = coordinate.body {
+        node.entries_mut()
+            .push(KdlEntry::new_prop("body", body.as_str()));
     }
     node
 }
@@ -204,6 +209,7 @@ fn serialize_panel(panel: &Panel) -> KdlNode {
         Panel::ComponentMonitor(monitor) => serialize_component_monitor(monitor),
         Panel::GeoPositionGauge(gauge) => serialize_geo_position_gauge(gauge),
         Panel::OrientationGauge(gauge) => serialize_orientation_gauge(gauge),
+        Panel::HorizonGauge(gauge) => serialize_horizon_gauge(gauge),
         Panel::ActionPane(action_pane) => serialize_action_pane(action_pane),
         Panel::QueryTable(query_table) => serialize_query_table(query_table),
         Panel::QueryPlot(query_plot) => serialize_query_plot(query_plot),
@@ -674,18 +680,37 @@ fn serialize_orientation_gauge(gauge: &OrientationGauge) -> KdlNode {
         node.entries_mut()
             .push(KdlEntry::new_prop("display", <&str>::from(display)));
     }
-    if let Some(q) = gauge.reference {
-        let mut reference = KdlNode::new("reference");
-        for v in q {
-            reference
-                .entries_mut()
-                .push(KdlEntry::new(round_float_default(v)));
-        }
-        let mut children = KdlDocument::new();
-        children.nodes_mut().push(reference);
-        node.set_children(children);
-    }
+    push_optional_reference(&mut node, gauge.reference);
     node
+}
+
+fn serialize_horizon_gauge(gauge: &HorizonGauge) -> KdlNode {
+    let mut node = KdlNode::new("horizon_gauge");
+    node.entries_mut().push(KdlEntry::new(gauge.eql.clone()));
+    push_optional_name_prop(&mut node, gauge.name.as_deref());
+    if let Some(source) = gauge.source {
+        node.entries_mut()
+            .push(KdlEntry::new_prop("source", <&str>::from(source)));
+    }
+    push_optional_reference(&mut node, gauge.reference);
+    node
+}
+
+/// Emit the `reference x y z w` child, if the gauge has one (an identity
+/// reference is stored as `None`, so the common case stays implicit).
+fn push_optional_reference(node: &mut KdlNode, reference: Option<[f64; 4]>) {
+    let Some(q) = reference else {
+        return;
+    };
+    let mut child = KdlNode::new("reference");
+    for v in q {
+        child
+            .entries_mut()
+            .push(KdlEntry::new(round_float_default(v)));
+    }
+    let mut children = KdlDocument::new();
+    children.nodes_mut().push(child);
+    node.set_children(children);
 }
 
 fn serialize_action_pane(action_pane: &ActionPane) -> KdlNode {

--- a/libs/impeller2/wkt/src/gui.rs
+++ b/libs/impeller2/wkt/src/gui.rs
@@ -58,6 +58,10 @@ pub struct Schematic {
     /// the viewer's `GeoContext` origin.
     #[serde(default)]
     pub origin: Option<GeoOriginConfig>,
+    /// Celestial body the coordinates sit on, selecting the reference
+    /// ellipsoid. `None` = Earth.
+    #[serde(default)]
+    pub body: Option<CelestialBody>,
     #[serde(default)]
     pub skybox: Option<SkyboxConfig>,
     /// Cinematic scene environment: sun light + shadows, ambient scaling, sky
@@ -219,12 +223,51 @@ pub struct GeoOriginConfig {
     pub altitude: f64,
 }
 
+/// Celestial body the schematic's coordinates sit on, selecting the reference
+/// ellipsoid used for geodetic conversions (LLA readouts, local verticals).
+///
+/// A body-fixed frame is called "ECEF" whatever the body; only its shape
+/// changes here.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CelestialBody {
+    /// WGS84 ellipsoid.
+    #[default]
+    Earth,
+    /// IAU mean lunar sphere.
+    Moon,
+}
+
+impl CelestialBody {
+    /// Radius of the IAU mean lunar reference sphere [m].
+    pub const MOON_RADIUS_M: f64 = 1_737_400.0;
+
+    /// KDL spelling of the body.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CelestialBody::Earth => "earth",
+            CelestialBody::Moon => "moon",
+        }
+    }
+
+    /// Parse the KDL spelling, case-insensitively.
+    pub fn from_str_ci(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "earth" => Some(CelestialBody::Earth),
+            "moon" => Some(CelestialBody::Moon),
+            _ => None,
+        }
+    }
+}
+
 /// Contents of the global `coordinate` schematic node.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct CoordinateConfig {
     pub frame: bevy_geo_frames::GeoFrame,
     #[serde(default)]
     pub origin: Option<GeoOriginConfig>,
+    /// Body whose ellipsoid the geodetic conversions use. `None` = Earth.
+    #[serde(default)]
+    pub body: Option<CelestialBody>,
 }
 
 #[cfg(feature = "bevy")]
@@ -314,6 +357,7 @@ pub enum Panel {
     ComponentMonitor(ComponentMonitor),
     GeoPositionGauge(GeoPositionGauge),
     OrientationGauge(OrientationGauge),
+    HorizonGauge(HorizonGauge),
     ActionPane(ActionPane),
     QueryTable(QueryTable),
     QueryPlot(QueryPlot),
@@ -339,6 +383,7 @@ impl Panel {
             }
             Panel::GeoPositionGauge(gauge) => gauge.name.as_deref().unwrap_or("Position Gauge"),
             Panel::OrientationGauge(gauge) => gauge.name.as_deref().unwrap_or("Orientation Gauge"),
+            Panel::HorizonGauge(gauge) => gauge.name.as_deref().unwrap_or("Horizon Gauge"),
             Panel::ActionPane(action_pane) => action_pane.name.as_str(),
             Panel::QueryTable(query_table) => query_table.name.as_deref().unwrap_or("Query Table"),
             Panel::QueryPlot(query_plot) => &query_plot.name,
@@ -383,6 +428,7 @@ impl Panel {
             Panel::Viewport(v) => Some(v.node_id),
             Panel::GeoPositionGauge(gauge) => Some(gauge.node_id),
             Panel::OrientationGauge(gauge) => Some(gauge.node_id),
+            Panel::HorizonGauge(gauge) => Some(gauge.node_id),
             _ => None,
         }
     }
@@ -1259,6 +1305,36 @@ pub struct OrientationGauge {
     /// Attitude quaternion (`[x, y, z, w]`, body→`source`) shown as neutral:
     /// the displayed attitude is `q · reference⁻¹`. `None` means identity
     /// (raw component attitude).
+    #[serde(default)]
+    pub reference: Option<[f64; 4]>,
+    pub name: Option<String>,
+    /// Ephemeral runtime id bound to the gauge entity (schematic tree
+    /// selection); not persisted in KDL. See [`crate::NodeId`].
+    #[serde(default)]
+    pub node_id: NodeId,
+}
+
+/// An artificial horizon (attitude indicator): reads an EQL-bound pose and
+/// renders pitch and bank as a cockpit-view horizon.
+///
+/// There is deliberately no `display` field: a horizon is intrinsically local,
+/// so the frame choice only matters as the `source` of the incoming attitude.
+/// In ECEF the local vertical is derived from the pose's own position, so the
+/// expression must yield a full pose there.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "bevy", derive(bevy::prelude::Component))]
+pub struct HorizonGauge {
+    /// EQL expression yielding a pose (`world_pos`-style 7-vector), or a bare
+    /// quaternion 4-vector when `source` is a local tangent frame.
+    pub eql: String,
+    /// Coordinate frame the quaternion rotates from (body→`source`).
+    ///
+    /// When `None`, inherits the schematic global `coordinate` frame; if that
+    /// is also unset, the editor falls back to ENU.
+    pub source: Option<bevy_geo_frames::GeoFrame>,
+    /// Attitude quaternion (`[x, y, z, w]`, body→`source`) shown as level: the
+    /// displayed attitude is `q · reference⁻¹`. `None` means identity (raw
+    /// component attitude).
     #[serde(default)]
     pub reference: Option<[f64; 4]>,
     pub name: Option<String>,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New attitude/geo math and schematic fields affect editor rendering and reload behavior, but Earth remains the default and the feature is heavily unit-tested; rc-jet changes are confined to the example controller.
> 
> **Overview**
> Introduces an **artificial horizon** panel (`horizon_gauge` in KDL): EQL-bound pose → pitch/roll against a local vertical (ENU/NED constants; **ECEF** uses geodetic normal at the vehicle position), with reference attitude, inspector, palette/tile creation, schematic round-trip, and inactive states when data is missing or invalid.
> 
> Schematics gain **`coordinate body=earth|moon`**, which sets the reference ellipsoid on load/save (shared with headless) so lunar ECEF horizons and LLA stay consistent.
> 
> The **rc-jet** example adds an **idle pilot** (slow ±bank until real stick/keyboard input above 10% throw; throttle/ratchet trim ignored), refactors gamepad/keyboard merging, documents the demo, and puts a **`horizon_gauge` ADI** in `main.py` beside chase views.
> 
> Also: gauge panes are **click-selectable** for the inspector; **ellipsoid shape EQL** recompiles when the EQL context gains components; MCAP export skips horizon panels like other gauges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22abf8deb707a08aea65c3e4e924bbd99823f956. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->