### PR TITLE
Feat/headless video capture

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.cursor/skills

--- a/.cursor/skills/elodin-headless-capture/SKILL.md
+++ b/.cursor/skills/elodin-headless-capture/SKILL.md
@@ -98,23 +98,28 @@ the editor's `ELODIN_SCREENSHOT` mechanism documented in the
 
 ## Record video
 
-In terminal 2, start this after the editor has loaded. Resolve the node name
-instead of hard-coding it: current PipeWire wraps the stream as
-`.gamescope-wrapped`, while older versions also accepted the media name
-`gamescope`.
+In terminal 2, start this after the editor has loaded. Resolve the newest
+Gamescope node's PipeWire object serial instead of hard-coding its name. Current
+PipeWire can publish multiple nodes with the same `.gamescope-wrapped` name, so
+the serial uniquely identifies the live compositor.
 
 ```bash
-GAMESCOPE_NODE="$(pw-dump | jq -r '
-  .[]
-  | select(.type == "PipeWire:Interface:Node")
-  | .info.props
-  | select(."media.name" == "gamescope")
-  | ."node.name"
-' | head -n1)"
-test -n "$GAMESCOPE_NODE"
+GAMESCOPE_TARGET="$(pw-dump | jq -r '
+  [
+    .[]
+    | select(.type == "PipeWire:Interface:Node")
+    | select(.info.props["media.name"] == "gamescope")
+    | select(.info.props["object.serial"] != null)
+    | {id: .id, serial: (.info.props["object.serial"] | tostring)}
+  ]
+  | sort_by(.id)
+  | last
+  | .serial // empty
+')"
+test -n "$GAMESCOPE_TARGET"
 
 gst-launch-1.0 -e \
-  pipewiresrc target-object="$GAMESCOPE_NODE" do-timestamp=true \
+  pipewiresrc target-object="$GAMESCOPE_TARGET" do-timestamp=true \
   ! video/x-raw,format=BGRx \
   ! queue \
   ! videoconvert \

--- a/.cursor/skills/elodin-headless-capture/SKILL.md
+++ b/.cursor/skills/elodin-headless-capture/SKILL.md
@@ -39,7 +39,30 @@ Gamescope and GStreamer must use the same user's PipeWire socket under
    graphics drivers for accelerated editor rendering; Nix supplies the
    user-space tools, not the kernel driver.
 
-## Start the editor
+## Automated capture (preferred)
+
+The repository provides `scripts/elodin_capture.sh`, which performs the
+PipeWire preflight, selects a vendor-compatible graphics path, starts Gamescope
+with Nix's Xwayland, validates a hardware encoder when available, falls back to
+x264, records, decodes a frame, rejects blank output, and cleans up all child
+processes:
+
+```bash
+./scripts/elodin_capture.sh --duration 10 --output /tmp/elodin.mp4 examples/cube-sat/main.py
+```
+
+Run it inside `nix develop`. The default readiness check waits for the
+simulation database server and then allows a two-second warmup. Use
+`--ready-regex` or `--warmup` for examples with unusual startup behavior. Use
+`--encoder x264` to force the portable fallback, or `--encoder vaapi` /
+`--encoder nvenc` when testing a specific hardware path. Set
+`ELODIN_GPU=mesa` or `ELODIN_GPU=nvidia` before entering the development shell
+to override automatic GPU selection. An explicitly set `GBM_BACKENDS_PATH` is
+always preserved.
+
+The manual workflow below remains useful for debugging capture infrastructure.
+
+## Start the editor manually
 
 Use the lowest practical resolution so the editor and encoder consume fewer GPU
 resources. In terminal 1:

--- a/.cursor/skills/elodin-headless-capture/SKILL.md
+++ b/.cursor/skills/elodin-headless-capture/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: elodin-headless-capture
+description: Run the Elodin Editor without a physical display in Gamescope, take screenshots, and record video through PipeWire and GStreamer. Use for visual testing or capture on a headless Linux GPU host.
+---
+
+# Headless Elodin capture
+
+This workflow is **Linux-only**. Gamescope's headless compositor, its PipeWire
+video source, and the host GPU-driver integration used here are Linux
+facilities. Keep the related Nix dependencies guarded by `stdenv.isLinux`.
+
+Run commands from the repository root inside `nix develop`. Do not use `sudo`:
+Gamescope and GStreamer must use the same user's PipeWire socket under
+`XDG_RUNTIME_DIR`.
+
+## Prerequisites
+
+1. Build the release editor:
+
+   ```bash
+   cargo build --release -p elodin
+   ```
+
+   Running a Python example also requires the project virtual environment. If
+   it is not already installed and active, run `just install` and then
+   `source .venv/bin/activate`.
+
+2. Check that the host PipeWire service and portable software encoder are
+   available:
+
+   ```bash
+   pw-cli info 0
+   gst-inspect-1.0 pipewiresrc >/dev/null
+   gst-inspect-1.0 x264enc >/dev/null
+   ```
+
+   On a systemd desktop, start a missing PipeWire service with
+   `systemctl --user start pipewire`. The host must expose its GPU devices and
+   graphics drivers for accelerated editor rendering; Nix supplies the
+   user-space tools, not the kernel driver.
+
+## Start the editor
+
+Use the lowest practical resolution so the editor and encoder consume fewer GPU
+resources. In terminal 1:
+
+```bash
+gamescope --backend headless \
+  -w 1280 -h 720 -W 1280 -H 720 -r 30 \
+  -- ./target/release/elodin editor examples/three-body/main.py
+```
+
+Gamescope starts a nested Xwayland display for the editor and publishes its
+composited output with the PipeWire media name `gamescope`. Wait for the editor
+to finish loading before capturing.
+
+If startup fails on a non-NixOS host because the dynamic linker has not noticed
+newly installed host driver libraries, run `sudo ldconfig` once outside the
+capture workflow and retry as the normal user.
+
+## Screenshot
+
+While Gamescope is running, use terminal 2:
+
+```bash
+gamescopectl screenshot /tmp/elodin.png
+```
+
+Use an absolute output path. Read the image afterward to verify that the scene
+and editor chrome rendered correctly.
+
+For a one-shot editor screenshot where a composited video is not needed, prefer
+the editor's `ELODIN_SCREENSHOT` mechanism documented in the
+`elodin-editor-dev` skill.
+
+## Record video
+
+In terminal 2, start this after the editor has loaded. Resolve the node name
+instead of hard-coding it: current PipeWire wraps the stream as
+`.gamescope-wrapped`, while older versions also accepted the media name
+`gamescope`.
+
+```bash
+GAMESCOPE_NODE="$(pw-dump | jq -r '
+  .[]
+  | select(.type == "PipeWire:Interface:Node")
+  | .info.props
+  | select(."media.name" == "gamescope")
+  | ."node.name"
+' | head -n1)"
+test -n "$GAMESCOPE_NODE"
+
+gst-launch-1.0 -e \
+  pipewiresrc target-object="$GAMESCOPE_NODE" do-timestamp=true \
+  ! video/x-raw,format=BGRx \
+  ! queue \
+  ! videoconvert \
+  ! video/x-raw,format=I420 \
+  ! x264enc bitrate=8000 speed-preset=veryfast \
+  ! video/x-h264,profile=main \
+  ! h264parse \
+  ! mp4mux faststart=true \
+  ! filesink location=/tmp/elodin.mp4
+```
+
+This software-encoding command is the reliable baseline and fallback across
+NVIDIA, AMD, and Intel systems. The first caps filter is required: forcing
+Gamescope to provide `BGRx` avoids capture paths that can produce an all-black
+video. `videoconvert` then converts the valid BGRx frames to the I420 input used
+by x264.
+
+The x264 command above is the known-good fallback, but an agent **should use a
+hardware encoder when one is detected and proven to work**. Inspect available
+GStreamer elements for NVENC on NVIDIA or VA-API on AMD/Intel, then validate the
+candidate before using it for the requested capture:
+
+1. Confirm that the candidate encoder is registered and can initialize.
+2. Keep the explicit BGRx filter immediately after `pipewiresrc` and convert to
+   a format accepted by the selected encoder.
+3. Make a short test recording, decode a frame from it, and verify that it is
+   nonblank. Plugin discovery and a valid MP4 alone are not sufficient.
+4. Verify hardware-engine activity with an appropriate vendor tool when
+   practical.
+5. Use the working hardware path for the full capture. Fall back to the x264
+   command only if hardware encoding is unavailable or fails validation.
+
+Prefer validated hardware encoding, but never skip output validation or retain
+a broken hardware path merely to avoid the software fallback.
+
+Stop recording with **Ctrl-C**. The `-e` option sends end-of-stream so `mp4mux`
+can finalize the MP4. Do not kill GStreamer with `SIGKILL`, or the output may be
+unplayable.
+
+Confirm the result:
+
+```bash
+ffprobe -v error \
+  -show_entries stream=codec_name,width,height,avg_frame_rate \
+  -of default=noprint_wrappers=1 /tmp/elodin.mp4
+```
+
+## Verify rendering and output
+
+Gamescope and Elodin should create graphics contexts and increase GPU
+utilization while the editor is rendering. Use the appropriate vendor tool if
+available. Software x264 encoding is expected to use the CPU.
+
+After every capture, check the stream metadata and decode a representative
+frame. Confirm visually, or with image statistics, that the decoded frame is
+not all black. This catches a valid-looking MP4 produced from invalid capture
+buffers.
+
+## Troubleshooting
+
+- **`pipewiresrc` is missing:** enter a fresh `nix develop`; the shell adds the
+  PipeWire GStreamer plugin to `GST_PLUGIN_PATH`.
+- **A hardware encoder is missing or fails to initialize:** use the documented
+  x264 pipeline. If hardware encoding is important, verify the host driver and
+  device permissions, re-enter `nix develop`, and clear a stale plugin cache
+  with `rm -f ~/.cache/gstreamer-1.0/registry.*.bin` before probing again.
+- **No `gamescope` source:** make sure Gamescope is already running. Inspect
+  video node names and media names with `pw-dump | jq '.[] | select(.type ==
+  "PipeWire:Interface:Node") | .info.props | select(."media.class" ==
+  "Video/Source") | {node_name: ."node.name", media_name: ."media.name"}'`.
+- **PipeWire connection refused:** check `echo "$XDG_RUNTIME_DIR"` and
+  `pw-cli info 0`; run both terminals as the same non-root user.
+- **All-black recording:** ensure the `video/x-raw,format=BGRx` filter appears
+  immediately after `pipewiresrc`. Do not let a downstream encoder negotiate
+  the source format directly.
+- **Partially loaded recording:** wait longer before starting GStreamer, or use
+  a lighter example and lower resolution.
+- **Stale editor process or port 2240 conflict:** stop the previous Gamescope
+  child before starting another editor.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,5 +39,6 @@ For in-depth instructions, read the relevant skill file below when working in th
 - **Aleph flight computer** (AlephOS deployment, NixOS modules, flight software services, firmware): `.cursor/skills/elodin-aleph/SKILL.md`
 - **Elodin DB** (running the database, client integrations, replication/follow mode, Lua REPL): `.cursor/skills/elodin-db/SKILL.md`
 - **Elodin Editor** (Bevy/Egui architecture, hot-reload, viewport, telemetry graphs, KDL schematics): `.cursor/skills/elodin-editor-dev/SKILL.md`
+- **Headless editor capture** (Gamescope, screenshots, PipeWire, video capture): `.cursor/skills/elodin-headless-capture/SKILL.md`
 - **Python SDK internals** (PyO3 bindings, nox-py, JAX integration, adding components/systems): `.cursor/skills/nox-py-dev/SKILL.md`
 - **Nix environment** (dev shell troubleshooting, OrbStack VMs, flake.nix, binary cache): `.cursor/skills/elodin-nix/SKILL.md`

--- a/docs/internal/nix.md
+++ b/docs/internal/nix.md
@@ -12,6 +12,22 @@ Elodin provides a unified development shell that includes all necessary tools fo
 - No need to switch between different shells for different tasks
 - git-lfs is included to handle large files in the repository
 
+## Linux headless capture
+
+The Linux shell includes Gamescope, Nix's Xwayland, PipeWire/GStreamer tools,
+and VA-API diagnostics. Run the capture helper from the repository root inside
+`nix develop`:
+
+```bash
+./scripts/elodin_capture.sh --duration 10 --output /tmp/elodin.mp4 examples/cube-sat/main.py
+```
+
+The helper keeps capture-specific GBM configuration scoped to Gamescope,
+automatically selects validated VA-API or NVENC encoding when available, and
+falls back to x264. It preserves an explicit `GBM_BACKENDS_PATH`. Set
+`ELODIN_GPU=mesa|nvidia` before entering the development shell for manual vendor
+selection.
+
 # macOS VM
 Often you want to build Linux binaries with Nix on your mac. This guide shows how to setup a VM using OrbStack, that supports remote builds.
 

--- a/nix/pkgs/common.nix
+++ b/nix/pkgs/common.nix
@@ -26,9 +26,18 @@
     shopt -s nullglob
 
     mode="''${ELODIN_GPU:-auto}"
+    nvidia_icd=""
+    for candidate in \
+      /usr/share/vulkan/icd.d/nvidia_icd.json \
+      /etc/vulkan/icd.d/nvidia_icd.json; do
+      if [ -e "$candidate" ]; then
+        nvidia_icd="$candidate"
+        break
+      fi
+    done
 
     nvidia_present() {
-      [ -e /proc/driver/nvidia/version ] && [ -e /usr/share/vulkan/icd.d/nvidia_icd.json ]
+      [ -e /proc/driver/nvidia/version ] && [ -n "$nvidia_icd" ]
     }
 
     # A Mesa-capable GPU (Intel 0x8086 / AMD 0x1002) means the editor has a
@@ -69,6 +78,8 @@
     have_glx=0
     for lib in /usr/lib/x86_64-linux-gnu/libGLX_nvidia.so* \
       /usr/lib/x86_64-linux-gnu/libEGL_nvidia.so* \
+      /usr/lib/x86_64-linux-gnu/libcuda.so* \
+      /usr/lib/x86_64-linux-gnu/libnvcuvid.so* \
       /usr/lib/x86_64-linux-gnu/libnvidia-*.so*; do
       [ -e "$lib" ] || continue
       ln -sf "$lib" "$nvidia_lib_dir/$(basename "$lib")"
@@ -83,8 +94,8 @@
     # defaults when the host driver libraries are not present.
     [ "$have_glx" = 1 ] || exit 0
 
-    printf 'export VK_ICD_FILENAMES=%s\n' /usr/share/vulkan/icd.d/nvidia_icd.json
-    printf 'export VK_DRIVER_FILES=%s\n' /usr/share/vulkan/icd.d/nvidia_icd.json
+    printf 'export VK_ICD_FILENAMES=%s\n' "$nvidia_icd"
+    printf 'export VK_DRIVER_FILES=%s\n' "$nvidia_icd"
     printf 'export __GLX_VENDOR_LIBRARY_NAME=nvidia\n'
     printf 'export LD_LIBRARY_PATH="%s''${LD_LIBRARY_PATH:+:''${LD_LIBRARY_PATH}}"\n' "$nvidia_lib_dir"
     printf 'unset LIBGL_ALWAYS_SOFTWARE\n'

--- a/nix/pkgs/common.nix
+++ b/nix/pkgs/common.nix
@@ -27,6 +27,7 @@
     ) [
       "radeon"
       "intel"
+      "lvp"
     ];
   gpuDetectScript = pkgs.writeShellScript "elodin-gpu-detect" ''
     set -u

--- a/nix/pkgs/common.nix
+++ b/nix/pkgs/common.nix
@@ -23,7 +23,7 @@
   '';
   mesaVulkanIcdPath =
     lib.concatMapStringsSep ":" (
-      manifest: "${pkgs.mesa}/share/vulkan/icd.d/${manifest}_icd.${pkgs.stdenv.hostPlatform.linuxArch}.json"
+      manifest: "${pkgs.mesa}/share/vulkan/icd.d/${manifest}_icd.${pkgs.stdenv.hostPlatform.uname.processor}.json"
     ) [
       "radeon"
       "intel"

--- a/nix/pkgs/common.nix
+++ b/nix/pkgs/common.nix
@@ -84,6 +84,7 @@
     nvidia_lib_dir="''${TMPDIR:-/tmp}/elodin-nvidia-libs"
     mkdir -p "$nvidia_lib_dir"
     have_glx=0
+    declare -A linked_libs=()
     for lib_dir in \
       /run/opengl-driver/lib \
       /usr/lib/x86_64-linux-gnu \
@@ -95,7 +96,11 @@
         "$lib_dir"/libnvcuvid.so* \
         "$lib_dir"/libnvidia-*.so*; do
         [ -e "$lib" ] || continue
-        ln -sf "$lib" "$nvidia_lib_dir/$(basename "$lib")"
+        lib_name="$(basename "$lib")"
+        # Keep the first match so later fallback directories cannot replace it.
+        [ -z "''${linked_libs[$lib_name]+x}" ] || continue
+        ln -sf "$lib" "$nvidia_lib_dir/$lib_name"
+        linked_libs["$lib_name"]=1
         case "$lib" in
           */libGLX_nvidia.so*) have_glx=1 ;;
         esac

--- a/nix/pkgs/common.nix
+++ b/nix/pkgs/common.nix
@@ -21,6 +21,13 @@
       type pulse
     }
   '';
+  mesaVulkanIcdPath =
+    lib.concatMapStringsSep ":" (
+      manifest: "${pkgs.mesa}/share/vulkan/icd.d/${manifest}_icd.${pkgs.stdenv.hostPlatform.linuxArch}.json"
+    ) [
+      "radeon"
+      "intel"
+    ];
   gpuDetectScript = pkgs.writeShellScript "elodin-gpu-detect" ''
     set -u
     shopt -s nullglob
@@ -28,8 +35,9 @@
     mode="''${ELODIN_GPU:-auto}"
     nvidia_icd=""
     for candidate in \
-      /usr/share/vulkan/icd.d/nvidia_icd.json \
-      /etc/vulkan/icd.d/nvidia_icd.json; do
+      /run/opengl-driver/share/vulkan/icd.d/nvidia_icd*.json \
+      /usr/share/vulkan/icd.d/nvidia_icd*.json \
+      /etc/vulkan/icd.d/nvidia_icd*.json; do
       if [ -e "$candidate" ]; then
         nvidia_icd="$candidate"
         break
@@ -76,16 +84,22 @@
     nvidia_lib_dir="''${TMPDIR:-/tmp}/elodin-nvidia-libs"
     mkdir -p "$nvidia_lib_dir"
     have_glx=0
-    for lib in /usr/lib/x86_64-linux-gnu/libGLX_nvidia.so* \
-      /usr/lib/x86_64-linux-gnu/libEGL_nvidia.so* \
-      /usr/lib/x86_64-linux-gnu/libcuda.so* \
-      /usr/lib/x86_64-linux-gnu/libnvcuvid.so* \
-      /usr/lib/x86_64-linux-gnu/libnvidia-*.so*; do
-      [ -e "$lib" ] || continue
-      ln -sf "$lib" "$nvidia_lib_dir/$(basename "$lib")"
-      case "$lib" in
-        */libGLX_nvidia.so*) have_glx=1 ;;
-      esac
+    for lib_dir in \
+      /run/opengl-driver/lib \
+      /usr/lib/x86_64-linux-gnu \
+      /usr/lib/aarch64-linux-gnu \
+      /usr/lib64; do
+      for lib in "$lib_dir"/libGLX_nvidia.so* \
+        "$lib_dir"/libEGL_nvidia.so* \
+        "$lib_dir"/libcuda.so* \
+        "$lib_dir"/libnvcuvid.so* \
+        "$lib_dir"/libnvidia-*.so*; do
+        [ -e "$lib" ] || continue
+        ln -sf "$lib" "$nvidia_lib_dir/$(basename "$lib")"
+        case "$lib" in
+          */libGLX_nvidia.so*) have_glx=1 ;;
+        esac
+      done
     done
 
     # libGLX_nvidia provides both the NVIDIA Vulkan ICD (per nvidia_icd.json) and
@@ -104,7 +118,7 @@
     eval "$(${gpuDetectScript})"
   '';
 in {
-  inherit alsaPluginDir asoundConf nvidiaHookScript;
+  inherit alsaPluginDir asoundConf mesaVulkanIcdPath nvidiaHookScript;
 
   src = let
     includeSrc = orig_path: type: let
@@ -256,7 +270,8 @@ in {
     LIBGL_DRIVERS_PATH = "${pkgs.mesa}/lib/dri";
     __GLX_VENDOR_LIBRARY_NAME = "mesa";
     LIBVA_DRIVERS_PATH = "${pkgs.mesa}/lib/dri";
-    VK_ICD_FILENAMES = "${pkgs.mesa}/share/vulkan/icd.d/radeon_icd.x86_64.json:${pkgs.mesa}/share/vulkan/icd.d/intel_icd.x86_64.json:${pkgs.mesa}/share/vulkan/icd.d/lvp_icd.x86_64.json";
+    VK_ICD_FILENAMES = mesaVulkanIcdPath;
+    VK_DRIVER_FILES = mesaVulkanIcdPath;
     VK_LAYER_PATH = "${pkgs.vulkan-validation-layers}/share/vulkan/explicit_layer.d";
     ALSA_PLUGIN_DIR = "${alsaPluginDir}/lib/alsa-lib";
     ALSA_CONFIG_PATH = "${asoundConf}";
@@ -309,7 +324,8 @@ in {
       --set LIBGL_DRIVERS_PATH "${pkgs.mesa}/lib/dri" \
       --set __GLX_VENDOR_LIBRARY_NAME "mesa" \
       --set LIBVA_DRIVERS_PATH "${pkgs.mesa}/lib/dri" \
-      --set VK_ICD_FILENAMES "${pkgs.mesa}/share/vulkan/icd.d/radeon_icd.x86_64.json:${pkgs.mesa}/share/vulkan/icd.d/intel_icd.x86_64.json:${pkgs.mesa}/share/vulkan/icd.d/lvp_icd.x86_64.json" \
+      --set VK_ICD_FILENAMES "${mesaVulkanIcdPath}" \
+      --set VK_DRIVER_FILES "${mesaVulkanIcdPath}" \
       --prefix VK_LAYER_PATH : "${pkgs.vulkan-validation-layers}/share/vulkan/explicit_layer.d" \
       --set ALSA_PLUGIN_DIR "${alsaPluginDir}/lib/alsa-lib" \
       --set ALSA_CONFIG_PATH "${asoundConf}" \

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -97,6 +97,8 @@ with pkgs; let
         ++ [
           # Additional Linux-specific tools not in common
           gamescope
+          xwayland
+          libva-utils
           alsa-oss
           alsa-utils
           gtk3

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -64,8 +64,8 @@ with pkgs; let
         gst_all_1.gstreamer
         gst_all_1.gst-plugins-base
         gst_all_1.gst-plugins-good
-        gst_all_1.gst-plugins-bad # For h264parse
-        gst_all_1.gst-plugins-ugly # For x264enc (H.264 encoding)
+        gst_all_1.gst-plugins-bad # For h264parse and hardware encoders
+        gst_all_1.gst-plugins-ugly # For portable x264 H.264 encoding
         config.packages.elodinsink # GStreamer plugin for Elodin-DB video streaming
         flip-link
 
@@ -96,6 +96,7 @@ with pkgs; let
         common.linuxGraphicsAudioDeps
         ++ [
           # Additional Linux-specific tools not in common
+          gamescope
           alsa-oss
           alsa-utils
           gtk3
@@ -128,15 +129,18 @@ with pkgs; let
     # the surplus so Python can import the extension without ENOMEM.
     GLIBC_TUNABLES = "glibc.rtld.optional_static_tls=16384";
 
-    # GStreamer plugin path for elodinsink
-    GST_PLUGIN_PATH = lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" [
-      gst_all_1.gstreamer
-      gst_all_1.gst-plugins-base
-      gst_all_1.gst-plugins-good
-      gst_all_1.gst-plugins-bad
-      gst_all_1.gst-plugins-ugly
-      config.packages.elodinsink
-    ];
+    # GStreamer plugin path for capture and elodinsink
+    GST_PLUGIN_PATH = lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" (
+      [
+        gst_all_1.gstreamer
+        gst_all_1.gst-plugins-base
+        gst_all_1.gst-plugins-good
+        gst_all_1.gst-plugins-bad
+        gst_all_1.gst-plugins-ugly
+        config.packages.elodinsink
+      ]
+      ++ lib.optionals pkgs.stdenv.isLinux [pipewire]
+    );
 
     LLDB_DEBUGSERVER_PATH = lib.optionalString pkgs.stdenv.isDarwin "/Applications/Xcode.app/Contents/SharedFrameworks/LLDB.framework/Versions/A/Resources/debugserver";
 

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -98,6 +98,7 @@ with pkgs; let
           # Additional Linux-specific tools not in common
           gamescope
           xwayland
+          util-linux # Provides setsid for capture process-group cleanup
           libva-utils
           alsa-oss
           alsa-utils

--- a/scripts/elodin_capture.sh
+++ b/scripts/elodin_capture.sh
@@ -1,0 +1,416 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Capture an Elodin example through headless Gamescope.
+
+Usage:
+  ./scripts/elodin_capture.sh [options] <simulation.py>
+
+Options:
+  -d, --duration SECONDS   Video duration (default: 10)
+  -o, --output PATH        Output MP4 (default: /tmp/elodin-capture.mp4)
+      --width PIXELS       Capture width (default: 1280)
+      --height PIXELS      Capture height (default: 720)
+      --refresh HZ         Gamescope refresh rate (default: 30)
+      --bitrate KBIT       H.264 bitrate (default: 8000)
+      --encoder NAME       auto, vaapi, nvenc, or x264 (default: auto)
+      --editor PATH        Editor executable (default: target/release/elodin)
+      --ready-regex REGEX  Editor-log readiness expression
+      --ready-timeout SEC  Maximum readiness wait (default: 120)
+      --warmup SECONDS     Delay after readiness (default: 2)
+      --keep-log PATH      Copy the Gamescope/editor log to PATH
+  -h, --help               Show this help
+
+Environment:
+  GPU selection comes from the Nix development shell. Set ELODIN_GPU before
+  entering the shell to override automatic selection. An explicitly set
+  GBM_BACKENDS_PATH is always preserved.
+EOF
+}
+
+fail() {
+  echo "elodin-capture: $*" >&2
+  exit 1
+}
+
+is_positive_number() {
+  awk -v value="$1" 'BEGIN { exit !(value ~ /^[0-9]+([.][0-9]+)?$/ && value > 0) }'
+}
+
+duration=10
+output=/tmp/elodin-capture.mp4
+width=1280
+height=720
+refresh=30
+bitrate=8000
+encoder=auto
+editor="${ELODIN_EDITOR_BIN:-$PWD/target/release/elodin}"
+ready_regex='running server with cancellation'
+ready_timeout=120
+warmup=2
+keep_log=
+simulation=
+
+while (($#)); do
+  case "$1" in
+    -d | --duration)
+      (($# >= 2)) || fail "$1 requires a value"
+      duration=$2
+      shift 2
+      ;;
+    -o | --output)
+      (($# >= 2)) || fail "$1 requires a value"
+      output=$2
+      shift 2
+      ;;
+    --width)
+      (($# >= 2)) || fail "$1 requires a value"
+      width=$2
+      shift 2
+      ;;
+    --height)
+      (($# >= 2)) || fail "$1 requires a value"
+      height=$2
+      shift 2
+      ;;
+    --refresh)
+      (($# >= 2)) || fail "$1 requires a value"
+      refresh=$2
+      shift 2
+      ;;
+    --bitrate)
+      (($# >= 2)) || fail "$1 requires a value"
+      bitrate=$2
+      shift 2
+      ;;
+    --encoder)
+      (($# >= 2)) || fail "$1 requires a value"
+      encoder=$2
+      shift 2
+      ;;
+    --editor)
+      (($# >= 2)) || fail "$1 requires a value"
+      editor=$2
+      shift 2
+      ;;
+    --ready-regex)
+      (($# >= 2)) || fail "$1 requires a value"
+      ready_regex=$2
+      shift 2
+      ;;
+    --ready-timeout)
+      (($# >= 2)) || fail "$1 requires a value"
+      ready_timeout=$2
+      shift 2
+      ;;
+    --warmup)
+      (($# >= 2)) || fail "$1 requires a value"
+      warmup=$2
+      shift 2
+      ;;
+    --keep-log)
+      (($# >= 2)) || fail "$1 requires a value"
+      keep_log=$2
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      (($# == 1)) || fail "expected exactly one simulation after --"
+      simulation=$1
+      shift
+      ;;
+    -*)
+      fail "unknown option: $1"
+      ;;
+    *)
+      [[ -z "$simulation" ]] || fail "expected exactly one simulation"
+      simulation=$1
+      shift
+      ;;
+  esac
+done
+
+[[ "$(uname -s)" == Linux ]] || fail "headless capture is Linux-only"
+[[ -n "$simulation" ]] || {
+  usage >&2
+  exit 2
+}
+[[ -f "$simulation" ]] || fail "simulation not found: $simulation"
+[[ -x "$editor" ]] || fail "editor not found at $editor; run 'cargo build --release -p elodin' or pass --editor"
+is_positive_number "$duration" || fail "duration must be positive"
+is_positive_number "$warmup" || [[ "$warmup" == 0 ]] || fail "warmup must be non-negative"
+for value_name in width height refresh bitrate ready_timeout; do
+  value=${!value_name}
+  [[ "$value" =~ ^[1-9][0-9]*$ ]] || fail "$value_name must be a positive integer"
+done
+case "$encoder" in
+  auto | vaapi | nvenc | x264) ;;
+  *) fail "encoder must be auto, vaapi, nvenc, or x264" ;;
+esac
+
+for command in gamescope Xwayland pw-cli pw-dump jq gst-inspect-1.0 gst-launch-1.0 ffmpeg ffprobe timeout; do
+  command -v "$command" >/dev/null || fail "missing required command: $command"
+done
+pw-cli info 0 >/dev/null 2>&1 || fail "PipeWire is unavailable; start the user PipeWire service"
+for element in pipewiresrc h264parse mp4mux; do
+  gst-inspect-1.0 "$element" >/dev/null 2>&1 || fail "missing GStreamer element: $element"
+done
+
+output=$(realpath -m "$output")
+mkdir -p "$(dirname "$output")"
+if [[ -n "$keep_log" ]]; then
+  keep_log=$(realpath -m "$keep_log")
+  mkdir -p "$(dirname "$keep_log")"
+fi
+
+tmp_dir=$(mktemp -d -t elodin-capture.XXXXXX)
+gamescope_log=$tmp_dir/gamescope.log
+gamescope_pid=
+
+cleanup() {
+  status=$?
+  trap - EXIT INT TERM
+  if [[ -n "$gamescope_pid" ]] && kill -0 "$gamescope_pid" 2>/dev/null; then
+    kill "$gamescope_pid" 2>/dev/null || true
+    for _ in $(seq 1 20); do
+      kill -0 "$gamescope_pid" 2>/dev/null || break
+      sleep 0.1
+    done
+    kill -KILL "$gamescope_pid" 2>/dev/null || true
+    wait "$gamescope_pid" 2>/dev/null || true
+  fi
+  if [[ -n "$keep_log" && -f "$gamescope_log" ]]; then
+    cp "$gamescope_log" "$keep_log"
+  fi
+  if ((status != 0)) && [[ -f "$gamescope_log" ]]; then
+    echo "--- recent Gamescope/editor log ---" >&2
+    tail -80 "$gamescope_log" >&2
+  fi
+  rm -rf "$tmp_dir"
+  exit "$status"
+}
+trap cleanup EXIT INT TERM
+
+# The script intentionally relies on nix develop for a coherent graphics and
+# GStreamer environment. In particular, Gamescope must not launch the host's
+# Xwayland with Nix libraries injected into it.
+[[ "$(command -v Xwayland)" == /nix/store/* ]] \
+  || fail "Xwayland is not from Nix; enter a fresh 'nix develop' shell"
+mesa_dri=${LIBGL_DRIVERS_PATH:-}
+[[ "$mesa_dri" == /nix/store/*/lib/dri ]] \
+  || fail "Mesa driver environment is missing; enter a fresh 'nix develop' shell"
+mesa_prefix=${mesa_dri%/lib/dri}
+
+selected_gpu=mesa
+if [[ "${__GLX_VENDOR_LIBRARY_NAME:-mesa}" == nvidia ]]; then
+  selected_gpu=nvidia
+fi
+case "${ELODIN_GPU:-auto}" in
+  auto) ;;
+  mesa) selected_gpu=mesa ;;
+  nvidia)
+    [[ "$selected_gpu" == nvidia ]] \
+      || fail "NVIDIA is not configured; set ELODIN_GPU=nvidia before entering nix develop"
+    ;;
+  *) fail "ELODIN_GPU must be auto, mesa, or nvidia" ;;
+esac
+
+if [[ "$selected_gpu" == mesa ]]; then
+  mesa_manifests=()
+  for manifest in radeon intel; do
+    path="$mesa_prefix/share/vulkan/icd.d/${manifest}_icd.$(uname -m).json"
+    [[ -e "$path" ]] && mesa_manifests+=("$path")
+  done
+  ((${#mesa_manifests[@]})) || fail "no supported Mesa Vulkan manifests were found"
+  mesa_vulkan_icds=$(IFS=:; echo "${mesa_manifests[*]}")
+  export LIBGL_DRIVERS_PATH="$mesa_dri"
+  export LIBVA_DRIVERS_PATH="$mesa_dri"
+  export VK_ICD_FILENAMES="$mesa_vulkan_icds"
+  export VK_DRIVER_FILES="$mesa_vulkan_icds"
+  export __GLX_VENDOR_LIBRARY_NAME=mesa
+fi
+
+if [[ -z "${GBM_BACKENDS_PATH+x}" ]]; then
+  if [[ "$selected_gpu" == mesa ]]; then
+    export GBM_BACKENDS_PATH="$mesa_prefix/lib/gbm"
+  else
+    for candidate in \
+      /run/opengl-driver/lib/gbm \
+      /usr/lib/x86_64-linux-gnu/gbm \
+      /usr/lib/aarch64-linux-gnu/gbm \
+      /usr/lib64/gbm; do
+      if compgen -G "$candidate/nvidia*_gbm.so*" >/dev/null; then
+        export GBM_BACKENDS_PATH=$candidate
+        break
+      fi
+    done
+  fi
+fi
+
+echo "GPU path: $selected_gpu"
+echo "Gamescope: $(command -v gamescope)"
+echo "Xwayland: $(command -v Xwayland)"
+echo "GBM backends: ${GBM_BACKENDS_PATH:-driver default}"
+
+child_path=$PATH
+if [[ -x "$PWD/.venv/bin/python" ]]; then
+  child_path="$PWD/.venv/bin:$child_path"
+fi
+
+gamescope --backend headless \
+  -w "$width" -h "$height" -W "$width" -H "$height" -r "$refresh" \
+  -- env PATH="$child_path" "$editor" editor "$simulation" \
+  >"$gamescope_log" 2>&1 &
+gamescope_pid=$!
+
+pipewire_node=
+for _ in $(seq 1 "$ready_timeout"); do
+  kill -0 "$gamescope_pid" 2>/dev/null || fail "Gamescope/editor exited during startup"
+  pipewire_node=$(pw-dump 2>/dev/null | jq -r '
+    [
+      .[]
+      | select(.type == "PipeWire:Interface:Node")
+      | select(.info.props["media.name"] == "gamescope")
+      | {id: .id, name: .info.props["node.name"]}
+    ]
+    | sort_by(.id)
+    | last
+    | .name // empty
+  ')
+  [[ -n "$pipewire_node" ]] && break
+  sleep 1
+done
+[[ -n "$pipewire_node" ]] || fail "Gamescope did not publish a PipeWire source"
+
+for _ in $(seq 1 "$ready_timeout"); do
+  kill -0 "$gamescope_pid" 2>/dev/null || fail "Gamescope/editor exited before becoming ready"
+  grep -Eq "$ready_regex" "$gamescope_log" && break
+  sleep 1
+done
+grep -Eq "$ready_regex" "$gamescope_log" || fail "editor readiness timed out (regex: $ready_regex)"
+sleep "$warmup"
+
+run_pipeline() {
+  local selected_encoder=$1
+  local location=$2
+  local requested_duration=$3
+  local wall_duration
+  local status
+  wall_duration=$(awk -v duration="$requested_duration" 'BEGIN { printf "%.3f", duration + 0.30 }')
+
+  set +e
+  case "$selected_encoder" in
+    vaapi)
+      timeout --signal=INT --kill-after=8s "${wall_duration}s" gst-launch-1.0 -q -e \
+        pipewiresrc target-object="$pipewire_node" do-timestamp=true \
+        ! video/x-raw,format=BGRx \
+        ! queue \
+        ! videoconvert \
+        ! video/x-raw,format=NV12 \
+        ! vah264enc bitrate="$bitrate" \
+        ! video/x-h264,profile=main \
+        ! h264parse \
+        ! mp4mux faststart=true \
+        ! filesink location="$location"
+      status=$?
+      ;;
+    nvenc)
+      timeout --signal=INT --kill-after=8s "${wall_duration}s" gst-launch-1.0 -q -e \
+        pipewiresrc target-object="$pipewire_node" do-timestamp=true \
+        ! video/x-raw,format=BGRx \
+        ! queue \
+        ! videoconvert \
+        ! video/x-raw,format=NV12 \
+        ! nvh264enc bitrate="$bitrate" \
+        ! video/x-h264,profile=main \
+        ! h264parse \
+        ! mp4mux faststart=true \
+        ! filesink location="$location"
+      status=$?
+      ;;
+    x264)
+      timeout --signal=INT --kill-after=8s "${wall_duration}s" gst-launch-1.0 -q -e \
+        pipewiresrc target-object="$pipewire_node" do-timestamp=true \
+        ! video/x-raw,format=BGRx \
+        ! queue \
+        ! videoconvert \
+        ! video/x-raw,format=I420 \
+        ! x264enc bitrate="$bitrate" speed-preset=veryfast \
+        ! video/x-h264,profile=main \
+        ! h264parse \
+        ! mp4mux faststart=true \
+        ! filesink location="$location"
+      status=$?
+      ;;
+  esac
+  set -e
+  [[ "$status" == 0 || "$status" == 124 ]]
+}
+
+video_is_valid() {
+  local video=$1
+  local probe_duration
+  local midpoint
+  local stats
+  local ymax
+  [[ -s "$video" ]] || return 1
+  probe_duration=$(ffprobe -v error -show_entries format=duration -of csv=p=0 "$video" 2>/dev/null) || return 1
+  is_positive_number "$probe_duration" || return 1
+  midpoint=$(awk -v duration="$probe_duration" 'BEGIN { printf "%.3f", duration / 2 }')
+  stats=$(ffmpeg -v error -ss "$midpoint" -i "$video" -frames:v 1 \
+    -vf signalstats,metadata=print:file=- -f null - 2>&1) || return 1
+  ymax=$(awk -F= '/lavfi.signalstats.YMAX=/{value=$2} END{print value}' <<<"$stats")
+  [[ -n "$ymax" ]] && awk -v value="$ymax" 'BEGIN { exit !(value > 20) }'
+}
+
+candidates=()
+if [[ "$encoder" == auto ]]; then
+  if [[ "$selected_gpu" == nvidia ]]; then
+    candidates=(nvenc vaapi x264)
+  else
+    candidates=(vaapi nvenc x264)
+  fi
+else
+  candidates=("$encoder")
+fi
+
+selected_encoder=
+for candidate in "${candidates[@]}"; do
+  case "$candidate" in
+    vaapi) element=vah264enc ;;
+    nvenc) element=nvh264enc ;;
+    x264) element=x264enc ;;
+  esac
+  gst-inspect-1.0 "$element" >/dev/null 2>&1 || continue
+  test_video=$tmp_dir/encoder-test-$candidate.mp4
+  echo "Validating $candidate encoder..."
+  if run_pipeline "$candidate" "$test_video" 1 && video_is_valid "$test_video"; then
+    selected_encoder=$candidate
+    break
+  fi
+  echo "$candidate encoder validation failed; trying the next candidate" >&2
+done
+[[ -n "$selected_encoder" ]] || fail "no working H.264 encoder was found"
+echo "Encoder: $selected_encoder"
+
+partial_output=$tmp_dir/capture.mp4
+run_pipeline "$selected_encoder" "$partial_output" "$duration" || fail "recording pipeline failed"
+video_is_valid "$partial_output" || fail "recording is invalid or blank"
+
+actual_duration=$(ffprobe -v error -show_entries format=duration -of csv=p=0 "$partial_output")
+minimum_duration=$(awk -v duration="$duration" 'BEGIN { printf "%.3f", duration * 0.95 }')
+awk -v actual="$actual_duration" -v minimum="$minimum_duration" 'BEGIN { exit !(actual >= minimum) }' \
+  || fail "recording is too short: ${actual_duration}s (requested ${duration}s)"
+
+mv "$partial_output" "$output"
+echo "Captured $output"
+ffprobe -v error \
+  -show_entries format=duration,size:stream=codec_name,width,height,avg_frame_rate \
+  -of default=noprint_wrappers=1 "$output"

--- a/scripts/elodin_capture.sh
+++ b/scripts/elodin_capture.sh
@@ -303,7 +303,10 @@ run_pipeline() {
   local requested_duration=$3
   local wall_duration
   local status
-  wall_duration=$(awk -v duration="$requested_duration" 'BEGIN { printf "%.3f", duration + 0.30 }')
+  # timeout also covers plugin/device initialization. NVENC can spend roughly
+  # two seconds creating its first CUDA context, so leave enough startup slack
+  # and trim the completed capture to the requested duration below.
+  wall_duration=$(awk -v duration="$requested_duration" 'BEGIN { printf "%.3f", duration + 3.0 }')
 
   set +e
   case "$selected_encoder" in
@@ -409,7 +412,14 @@ minimum_duration=$(awk -v duration="$duration" 'BEGIN { printf "%.3f", duration 
 awk -v actual="$actual_duration" -v minimum="$minimum_duration" 'BEGIN { exit !(actual >= minimum) }' \
   || fail "recording is too short: ${actual_duration}s (requested ${duration}s)"
 
-mv "$partial_output" "$output"
+# Remove the encoder startup allowance while stream-copying the already encoded
+# H.264. A frame boundary may leave the MP4 a fraction of a second over.
+trimmed_output=$tmp_dir/capture-trimmed.mp4
+ffmpeg -v error -y -i "$partial_output" -t "$duration" -c copy -movflags +faststart "$trimmed_output" \
+  || fail "could not trim recording to the requested duration"
+video_is_valid "$trimmed_output" || fail "trimmed recording is invalid or blank"
+
+mv "$trimmed_output" "$output"
 echo "Captured $output"
 ffprobe -v error \
   -show_entries format=duration,size:stream=codec_name,width,height,avg_frame_rate \

--- a/scripts/elodin_capture.sh
+++ b/scripts/elodin_capture.sh
@@ -286,6 +286,21 @@ if [[ -x "$PWD/.venv/bin/python" ]]; then
   child_path="$PWD/.venv/bin:$child_path"
 fi
 
+# Remember every source that predates this launch. Merely choosing the highest
+# node id is racy: a stale source may be the newest match until this Gamescope
+# instance has finished publishing its own source. Node names are not unique,
+# so use the PipeWire object serial both to identify and target the new source.
+preexisting_gamescope_serials=$(pw-dump 2>/dev/null | jq -c '
+  [
+    .[]
+    | select(.type == "PipeWire:Interface:Node")
+    | select(.info.props["media.name"] == "gamescope")
+    | select(.info.props["object.serial"] != null)
+    | .info.props["object.serial"]
+    | tostring
+  ]
+')
+
 setsid gamescope --backend headless \
   -w "$width" -h "$height" -W "$width" -H "$height" -r "$refresh" \
   -- env PATH="$child_path" "$editor" editor "$simulation" \
@@ -293,24 +308,30 @@ setsid gamescope --backend headless \
 gamescope_pid=$!
 gamescope_pgid=$gamescope_pid
 
-pipewire_node=
+pipewire_target=
 for _ in $(seq 1 "$ready_timeout"); do
   kill -0 "$gamescope_pid" 2>/dev/null || fail "Gamescope/editor exited during startup"
-  pipewire_node=$(pw-dump 2>/dev/null | jq -r '
-    [
-      .[]
-      | select(.type == "PipeWire:Interface:Node")
-      | select(.info.props["media.name"] == "gamescope")
-      | {id: .id, name: .info.props["node.name"]}
-    ]
-    | sort_by(.id)
-    | last
-    | .name // empty
-  ')
-  [[ -n "$pipewire_node" ]] && break
+  pipewire_target=$(pw-dump 2>/dev/null | jq -r \
+    --argjson preexisting "$preexisting_gamescope_serials" '
+      [
+        .[]
+        | select(.type == "PipeWire:Interface:Node")
+        | select(.info.props["media.name"] == "gamescope")
+        | select(.info.props["object.serial"] != null)
+        | select(
+            (.info.props["object.serial"] | tostring) as $serial
+            | ($preexisting | index($serial)) == null
+          )
+        | {id: .id, serial: (.info.props["object.serial"] | tostring)}
+      ]
+      | sort_by(.id)
+      | last
+      | .serial // empty
+    ')
+  [[ -n "$pipewire_target" ]] && break
   sleep 1
 done
-[[ -n "$pipewire_node" ]] || fail "Gamescope did not publish a PipeWire source"
+[[ -n "$pipewire_target" ]] || fail "Gamescope did not publish a new PipeWire source"
 
 for _ in $(seq 1 "$ready_timeout"); do
   kill -0 "$gamescope_pid" 2>/dev/null || fail "Gamescope/editor exited before becoming ready"
@@ -335,7 +356,7 @@ run_pipeline() {
   case "$selected_encoder" in
     vaapi)
       timeout --signal=INT --kill-after=8s "${wall_duration}s" gst-launch-1.0 -q -e \
-        pipewiresrc target-object="$pipewire_node" do-timestamp=true \
+        pipewiresrc target-object="$pipewire_target" do-timestamp=true \
         ! video/x-raw,format=BGRx \
         ! queue \
         ! videoconvert \
@@ -349,7 +370,7 @@ run_pipeline() {
       ;;
     nvenc)
       timeout --signal=INT --kill-after=8s "${wall_duration}s" gst-launch-1.0 -q -e \
-        pipewiresrc target-object="$pipewire_node" do-timestamp=true \
+        pipewiresrc target-object="$pipewire_target" do-timestamp=true \
         ! video/x-raw,format=BGRx \
         ! queue \
         ! videoconvert \
@@ -363,7 +384,7 @@ run_pipeline() {
       ;;
     x264)
       timeout --signal=INT --kill-after=8s "${wall_duration}s" gst-launch-1.0 -q -e \
-        pipewiresrc target-object="$pipewire_node" do-timestamp=true \
+        pipewiresrc target-object="$pipewire_target" do-timestamp=true \
         ! video/x-raw,format=BGRx \
         ! queue \
         ! videoconvert \

--- a/scripts/elodin_capture.sh
+++ b/scripts/elodin_capture.sh
@@ -311,7 +311,10 @@ gamescope_pgid=$gamescope_pid
 pipewire_target=
 for _ in $(seq 1 "$ready_timeout"); do
   kill -0 "$gamescope_pid" 2>/dev/null || fail "Gamescope/editor exited during startup"
-  pipewire_target=$(pw-dump 2>/dev/null | jq -r \
+  # The PipeWire registry can change while pw-dump is serializing it. Keep
+  # polling when a transient dump or parse failure occurs instead of allowing
+  # errexit and pipefail to abort the capture.
+  if new_pipewire_target=$(pw-dump 2>/dev/null | jq -r \
     --argjson preexisting "$preexisting_gamescope_serials" '
       [
         .[]
@@ -327,7 +330,9 @@ for _ in $(seq 1 "$ready_timeout"); do
       | sort_by(.id)
       | last
       | .serial // empty
-    ')
+    '); then
+    pipewire_target=$new_pipewire_target
+  fi
   [[ -n "$pipewire_target" ]] && break
   sleep 1
 done

--- a/scripts/elodin_capture.sh
+++ b/scripts/elodin_capture.sh
@@ -155,7 +155,7 @@ case "$encoder" in
   *) fail "encoder must be auto, vaapi, nvenc, or x264" ;;
 esac
 
-for command in gamescope Xwayland pw-cli pw-dump jq gst-inspect-1.0 gst-launch-1.0 ffmpeg ffprobe timeout; do
+for command in gamescope Xwayland pw-cli pw-dump jq gst-inspect-1.0 gst-launch-1.0 ffmpeg ffprobe setsid timeout; do
   command -v "$command" >/dev/null || fail "missing required command: $command"
 done
 pw-cli info 0 >/dev/null 2>&1 || fail "PipeWire is unavailable; start the user PipeWire service"
@@ -173,17 +173,39 @@ fi
 tmp_dir=$(mktemp -d -t elodin-capture.XXXXXX)
 gamescope_log=$tmp_dir/gamescope.log
 gamescope_pid=
+gamescope_pgid=
+
+background_job_is_running() {
+  local target_pid=$1
+  local job_pid
+  while IFS= read -r job_pid; do
+    [[ "$job_pid" == "$target_pid" ]] && return 0
+  done < <(jobs -r -p)
+  return 1
+}
 
 cleanup() {
   status=$?
   trap - EXIT INT TERM
-  if [[ -n "$gamescope_pid" ]] && kill -0 "$gamescope_pid" 2>/dev/null; then
-    kill "$gamescope_pid" 2>/dev/null || true
-    for _ in $(seq 1 20); do
-      kill -0 "$gamescope_pid" 2>/dev/null || break
+  if [[ -n "$gamescope_pgid" ]]; then
+    # Gamescope, the editor, and the simulation run in a dedicated process
+    # group. Signal the whole group so cleanup does not depend on Gamescope
+    # forwarding SIGTERM to children before it exits.
+    kill -TERM -- "-$gamescope_pgid" 2>/dev/null || true
+    for _ in $(seq 1 100); do
+      # Reap the group leader as soon as it exits. Otherwise its zombie keeps
+      # kill -0 reporting that the process group exists for the full timeout.
+      if [[ -n "$gamescope_pid" ]] && ! background_job_is_running "$gamescope_pid"; then
+        wait "$gamescope_pid" 2>/dev/null || true
+        gamescope_pid=
+      fi
+      kill -0 -- "-$gamescope_pgid" 2>/dev/null || break
       sleep 0.1
     done
-    kill -KILL "$gamescope_pid" 2>/dev/null || true
+    # Sweep any group members that ignored SIGTERM or outlived Gamescope.
+    kill -KILL -- "-$gamescope_pgid" 2>/dev/null || true
+  fi
+  if [[ -n "$gamescope_pid" ]]; then
     wait "$gamescope_pid" 2>/dev/null || true
   fi
   if [[ -n "$keep_log" && -f "$gamescope_log" ]]; then
@@ -264,11 +286,12 @@ if [[ -x "$PWD/.venv/bin/python" ]]; then
   child_path="$PWD/.venv/bin:$child_path"
 fi
 
-gamescope --backend headless \
+setsid gamescope --backend headless \
   -w "$width" -h "$height" -W "$width" -H "$height" -r "$refresh" \
   -- env PATH="$child_path" "$editor" editor "$simulation" \
   >"$gamescope_log" 2>&1 &
 gamescope_pid=$!
+gamescope_pgid=$gamescope_pid
 
 pipewire_node=
 for _ in $(seq 1 "$ready_timeout"); do


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes Linux Nix graphics env and NVIDIA GPU hook behavior for all `nix develop` users; capture tooling is isolated but driver/ICD selection affects editor rendering paths.
> 
> **Overview**
> Adds **Linux headless visual capture** for the Elodin editor: a new `scripts/elodin_capture.sh` runs the release editor inside headless Gamescope, waits for sim readiness, records from PipeWire with GStreamer (VA-API/NVENC with validation, x264 fallback), rejects blank output, trims to the requested duration, and tears down the process group cleanly.
> 
> The **Nix dev shell** gains Gamescope, Nix Xwayland, PipeWire in `GST_PLUGIN_PATH`, and related capture tools. **`nix/pkgs/common.nix`** now builds Mesa Vulkan ICD paths per CPU architecture, sets `VK_DRIVER_FILES`, and broadens NVIDIA detection (flexible ICD paths, more driver lib search paths, deduplicated symlinks for NVENC/CUDA).
> 
> Documentation: new **`elodin-headless-capture`** agent skill (linked from `AGENTS.md` and `.agents/skills`), plus a **Linux headless capture** section in `docs/internal/nix.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67362bd0cfef923a522223fc196fe34493495203. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->