### PR TITLE
Add the ability to select port for editor CLI and headless video capture

### DIFF
--- a/.cursor/skills/elodin-headless-capture/SKILL.md
+++ b/.cursor/skills/elodin-headless-capture/SKILL.md
@@ -51,6 +51,14 @@ processes:
 ./scripts/elodin_capture.sh --duration 10 --output /tmp/elodin.mp4 examples/cube-sat/main.py
 ```
 
+Use `--port PORT` to isolate the capture from another editor/simulation. The
+simulation DB uses `PORT` and its asset server uses `PORT + 1`, so both must be
+available:
+
+```bash
+./scripts/elodin_capture.sh --port 32400 --output /tmp/elodin.mp4 examples/cube-sat/main.py
+```
+
 Run it inside `nix develop`. The default readiness check waits for the
 simulation database server and then allows a two-second warmup. Use
 `--ready-regex` or `--warmup` for examples with unusual startup behavior. Use
@@ -197,5 +205,5 @@ buffers.
   the source format directly.
 - **Partially loaded recording:** wait longer before starting GStreamer, or use
   a lighter example and lower resolution.
-- **Stale editor process or port 2240 conflict:** stop the previous Gamescope
-  child before starting another editor.
+- **Stale editor process or DB/assets port conflict:** stop the previous
+  Gamescope child or choose another free DB/assets pair with `--port`.

--- a/VIDEOS.md
+++ b/VIDEOS.md
@@ -17,6 +17,16 @@ Each entry should be a clickable thumbnail followed by a short description. For 
 **[Elodin Dev Intro](https://www.youtube.com/watch?v=p8tyteJksas)** — Quick introduction to local development with Elodin. By Dan Driscoll. See also [`README.md`](README.md).
 
 
+## Headless Capture
+
+[![Elodin Editor - Headless Video Capture with Agent and Manual Capture](https://img.youtube.com/vi/z7V1lSHIVqA/hqdefault.jpg)](https://www.youtube.com/watch?v=z7V1lSHIVqA)
+
+**[Elodin Editor - Headless Video Capture with Agent and Manual Capture](https://www.youtube.com/watch?v=z7V1lSHIVqA)** — Demonstrates a headless video capture of an Elodin example while an agent also captures. By Anders Pitman. See also [`.cursor/skills/elodin-headless-capture/SKILL.md`](.cursor/skills/elodin-headless-capture/SKILL.md).
+
+[![Elodin Editor - Headless Video Capture with Agent and Live Editor](https://img.youtube.com/vi/vyoQbBBw-m8/hqdefault.jpg)](https://www.youtube.com/watch?v=vyoQbBBw-m8)
+
+**[Elodin Editor - Headless Video Capture with Agent and Live Editor](https://www.youtube.com/watch?v=vyoQbBBw-m8)** — Demonstrates a headless video capture of an Elodin example while the live editor is running. By Anders Pitman. See also [`.cursor/skills/elodin-headless-capture/SKILL.md`](.cursor/skills/elodin-headless-capture/SKILL.md).
+
 ## Profiling & Performance
 
 [![Tracy - Elodin Editor](https://img.youtube.com/vi/-jW672rMV2s/hqdefault.jpg)](https://www.youtube.com/watch?v=-jW672rMV2s)

--- a/apps/elodin/src/cli/editor.rs
+++ b/apps/elodin/src/cli/editor.rs
@@ -16,13 +16,21 @@ use super::Cli;
 
 const DEFAULT_SIM: Simulator = Simulator::None;
 
-#[derive(clap::Args, Clone, Default)]
+fn default_sim_addr() -> SocketAddr {
+    SocketAddr::new(Ipv6Addr::UNSPECIFIED.into(), 2240)
+}
+
+#[derive(clap::Args, Clone)]
 #[command(
     after_help = "Environment:\n  BLOCKADE_API_KEY    Optional. Enables Skybox AI generation from the command palette. Get one from https://skybox.blockadelabs.com/api and keep it out of source control."
 )]
 pub struct Args {
     #[clap(name = "addr/path", default_value_t = DEFAULT_SIM)]
     sim: Simulator,
+
+    /// Address to use when launching a simulation file. Assets use its port + 1.
+    #[clap(long, default_value = "[::]:2240")]
+    addr: SocketAddr,
 
     /// Open this KDL schematic file after connecting to the database.
     #[clap(long)]
@@ -52,6 +60,17 @@ enum Simulator {
 
 #[derive(Resource)]
 struct WindowStateFile(std::fs::File);
+
+impl Default for Args {
+    fn default() -> Self {
+        Self {
+            sim: DEFAULT_SIM,
+            addr: default_sim_addr(),
+            kdl: None,
+            replay: false,
+        }
+    }
+}
 
 impl Default for Simulator {
     fn default() -> Self {
@@ -98,6 +117,7 @@ impl Cli {
         cancel_token: CancelToken,
     ) -> miette::Result<JoinHandle<miette::Result<()>>> {
         let sim = args.sim.clone();
+        let sim_addr = args.addr;
         let dirs = self.dirs().into_diagnostic()?;
         let cache_dir = dirs.cache_dir().to_owned();
         let thread = std::thread::spawn(move || {
@@ -122,10 +142,11 @@ impl Cli {
                 match &sim {
                     Simulator::File(path) => {
                         let mut res = None;
-                        let mut recipe_fut = Box::pin(elodin_editor::run::run_recipe(
+                        let mut recipe_fut = Box::pin(elodin_editor::run::run_recipe_at(
                             cache_dir,
                             path.clone(),
                             cancel_token.clone(),
+                            sim_addr,
                         ));
                         tokio::select! {
                             r = &mut recipe_fut => res = Some(r),
@@ -181,9 +202,7 @@ impl Cli {
                 app.add_plugins(impeller2_bevy::TcpImpellerPlugin::new(Some(addr)));
             }
             Simulator::File(_) => {
-                app.add_plugins(impeller2_bevy::TcpImpellerPlugin::new(Some(
-                    SocketAddr::new(Ipv6Addr::UNSPECIFIED.into(), 2240),
-                )));
+                app.add_plugins(impeller2_bevy::TcpImpellerPlugin::new(Some(args.addr)));
             }
             Simulator::ReplayDir(_) => {
                 // TODO

--- a/apps/elodin/src/cli/editor.rs
+++ b/apps/elodin/src/cli/editor.rs
@@ -28,7 +28,8 @@ pub struct Args {
     #[clap(name = "addr/path", default_value_t = DEFAULT_SIM)]
     sim: Simulator,
 
-    /// Address to use when launching a simulation file. Assets use its port + 1.
+    /// Address to use when launching a Python simulation file. Assets use its port + 1.
+    /// Existing s10.toml plans control their own addresses.
     #[clap(long, default_value = "[::]:2240")]
     addr: SocketAddr,
 
@@ -76,6 +77,37 @@ impl Default for Simulator {
     fn default() -> Self {
         DEFAULT_SIM
     }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn recipe_sim_addr(recipe: &s10::Recipe) -> Option<SocketAddr> {
+    match recipe {
+        s10::Recipe::Sim(sim) => Some(sim.addr),
+        s10::Recipe::Group(group) => group.recipes.values().find_map(recipe_sim_addr),
+        _ => None,
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn use_plan_addr(args: &mut Args) -> miette::Result<()> {
+    let Simulator::File(path) = &args.sim else {
+        return Ok(());
+    };
+    if path.extension().and_then(|ext| ext.to_str()) != Some("toml") {
+        return Ok(());
+    }
+    if args.addr != default_sim_addr() {
+        return Err(miette!(
+            "--addr cannot override an existing s10.toml plan; edit the plan instead"
+        ));
+    }
+
+    let contents = std::fs::read_to_string(path).into_diagnostic()?;
+    let recipe: s10::Recipe = toml::from_str(&contents).into_diagnostic()?;
+    if let Some(addr) = recipe_sim_addr(&recipe) {
+        args.addr = addr;
+    }
+    Ok(())
 }
 
 impl fmt::Display for Simulator {
@@ -190,7 +222,10 @@ impl Cli {
         }))
     }
 
-    pub fn editor(self, args: Args, rt: Runtime) -> miette::Result<()> {
+    pub fn editor(self, mut args: Args, rt: Runtime) -> miette::Result<()> {
+        #[cfg(not(target_os = "windows"))]
+        use_plan_addr(&mut args)?;
+
         let cancel_token = CancelToken::new();
         let thread = self.run_sim(&args, rt, cancel_token.clone())?;
         let mut app = self.editor_app()?;
@@ -227,7 +262,9 @@ impl Cli {
     /// are configured) is started as a separate s10-managed process — see the
     /// auto-registered recipe in `world_builder.rs`.
     #[cfg(not(target_os = "windows"))]
-    pub fn run_headless(self, args: Args, rt: Runtime) -> miette::Result<()> {
+    pub fn run_headless(self, mut args: Args, rt: Runtime) -> miette::Result<()> {
+        use_plan_addr(&mut args)?;
+
         let cancel_token = CancelToken::new();
         let thread = self.run_sim(&args, rt, cancel_token.clone())?;
         let result = thread.join().map_err(|_| miette!("join error"));

--- a/libs/elodin-editor/src/run.rs
+++ b/libs/elodin-editor/src/run.rs
@@ -3,7 +3,10 @@ use bevy::prelude::*;
 #[cfg(not(target_os = "windows"))]
 use miette::{Context, IntoDiagnostic, miette};
 #[cfg(not(target_os = "windows"))]
-use std::path::{Path, PathBuf};
+use std::{
+    net::{Ipv6Addr, SocketAddr},
+    path::{Path, PathBuf},
+};
 #[cfg(not(target_os = "windows"))]
 use stellarator::util::CancelToken;
 
@@ -12,6 +15,22 @@ pub async fn run_recipe(
     cache_dir: PathBuf,
     path: PathBuf,
     cancel_token: CancelToken,
+) -> miette::Result<()> {
+    run_recipe_at(
+        cache_dir,
+        path,
+        cancel_token,
+        SocketAddr::new(Ipv6Addr::UNSPECIFIED.into(), 2240),
+    )
+    .await
+}
+
+#[cfg(not(target_os = "windows"))]
+pub async fn run_recipe_at(
+    cache_dir: PathBuf,
+    path: PathBuf,
+    cancel_token: CancelToken,
+    addr: SocketAddr,
 ) -> miette::Result<()> {
     let mut path = if path.is_dir() {
         let toml = path.join("s10.toml");
@@ -38,6 +57,7 @@ pub async fn run_recipe(
             .arg(path.clone())
             .arg("plan")
             .arg(&out_dir)
+            .arg(addr.to_string())
             .stdout(std::process::Stdio::inherit())
             .stderr(std::process::Stdio::inherit())
             .output()

--- a/scripts/elodin_capture.sh
+++ b/scripts/elodin_capture.sh
@@ -150,6 +150,8 @@ done
   exit 2
 }
 [[ -f "$simulation" ]] || fail "simulation not found: $simulation"
+[[ "$simulation" == *.py ]] \
+  || fail "headless capture requires a Python simulation file; existing s10.toml plans control their own ports"
 [[ -x "$editor" ]] || fail "editor not found at $editor; run 'cargo build --release -p elodin' or pass --editor"
 is_positive_number "$duration" || fail "duration must be positive"
 is_positive_number "$warmup" || [[ "$warmup" == 0 ]] || fail "warmup must be non-negative"

--- a/scripts/elodin_capture.sh
+++ b/scripts/elodin_capture.sh
@@ -16,6 +16,7 @@ Options:
       --height PIXELS      Capture height (default: 720)
       --refresh HZ         Gamescope refresh rate (default: 30)
       --bitrate KBIT       H.264 bitrate (default: 8000)
+      --port PORT           Simulation DB port (default: 2240; assets use PORT+1)
       --encoder NAME       auto, vaapi, nvenc, or x264 (default: auto)
       --editor PATH        Editor executable (default: target/release/elodin)
       --ready-regex REGEX  Editor-log readiness expression
@@ -46,6 +47,7 @@ width=1280
 height=720
 refresh=30
 bitrate=8000
+port=2240
 encoder=auto
 editor="${ELODIN_EDITOR_BIN:-$PWD/target/release/elodin}"
 ready_regex='running server with cancellation'
@@ -84,6 +86,11 @@ while (($#)); do
     --bitrate)
       (($# >= 2)) || fail "$1 requires a value"
       bitrate=$2
+      shift 2
+      ;;
+    --port)
+      (($# >= 2)) || fail "$1 requires a value"
+      port=$2
       shift 2
       ;;
     --encoder)
@@ -146,10 +153,11 @@ done
 [[ -x "$editor" ]] || fail "editor not found at $editor; run 'cargo build --release -p elodin' or pass --editor"
 is_positive_number "$duration" || fail "duration must be positive"
 is_positive_number "$warmup" || [[ "$warmup" == 0 ]] || fail "warmup must be non-negative"
-for value_name in width height refresh bitrate ready_timeout; do
+for value_name in width height refresh bitrate ready_timeout port; do
   value=${!value_name}
   [[ "$value" =~ ^[1-9][0-9]*$ ]] || fail "$value_name must be a positive integer"
 done
+((port <= 65534)) || fail "port must be between 1 and 65534 (assets use port + 1)"
 case "$encoder" in
   auto | vaapi | nvenc | x264) ;;
   *) fail "encoder must be auto, vaapi, nvenc, or x264" ;;
@@ -280,6 +288,7 @@ echo "GPU path: $selected_gpu"
 echo "Gamescope: $(command -v gamescope)"
 echo "Xwayland: $(command -v Xwayland)"
 echo "GBM backends: ${GBM_BACKENDS_PATH:-driver default}"
+echo "Simulation DB address: 127.0.0.1:$port (assets: 127.0.0.1:$((port + 1)))"
 
 child_path=$PATH
 if [[ -x "$PWD/.venv/bin/python" ]]; then
@@ -303,7 +312,7 @@ preexisting_gamescope_serials=$(pw-dump 2>/dev/null | jq -c '
 
 setsid gamescope --backend headless \
   -w "$width" -h "$height" -W "$width" -H "$height" -r "$refresh" \
-  -- env PATH="$child_path" "$editor" editor "$simulation" \
+  -- env PATH="$child_path" "$editor" editor --addr "127.0.0.1:$port" "$simulation" \
   >"$gamescope_log" 2>&1 &
 gamescope_pid=$!
 gamescope_pgid=$gamescope_pid


### PR DESCRIPTION
Also added a couple demo videos of headless video capture

bugbot identified an issue, partially pre-existing, partially triggered by adding `--addr` functionality to the editor:                                                                                                                         
                                                                                                                                                                                                                          
 Previously, an existing s10.toml retained its configured address, but the editor always connected to the CLI default ([::]:2240). This meant a plan configured for another port could launch correctly while the editor  
 connected to the wrong database.                                                                                                                                                                                         
                                                                                                                                                                                                                          
 We resolved the issues by making the address semantics explicit:                                                                                                                                                         
                                                                                                                                                                                                                          
 - Existing S10 plans are authoritative for their addresses.                                                                                                                                                              
 - The editor now parses an existing plan before startup, recursively finds its Recipe::Sim, and connects to that simulation’s configured address.                                                                        
 - A non-default --addr is rejected when launching an existing plan, avoiding a partial override where the simulation changes ports but render servers or arbitrary sidecars remain on their plan-configured addresses.   
 - --addr is now documented as applying to Python simulation files, where Elodin generates the plan and can consistently set the simulation and generated render-server addresses.                                        
                                                                                                                                                                                                                          
 The Python/custom-port workflow used by headless capture remains unchanged and was manually verified with a capture on DB port 24100 and asset port 24101. Clippy and the editor test suite also pass. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches simulation networking and editor connection binding; default port 2240 is unchanged, but wrong port pairs could cause confusing connection failures when running multiple instances.
> 
> **Overview**
> Adds **`--addr`** on `elodin editor` (and headless runs) so Python simulations can bind the DB on a chosen port; the asset server still uses **port + 1**. The editor and sim runner thread use that address for `TcpImpellerPlugin` and for `run_recipe_at`, which now passes the address into Python **`plan`** when generating `s10.toml` from a `.py` file.
> 
> For **`s10.toml`** inputs, the CLI loads the sim address from the plan and **rejects** a non-default `--addr` override. **`scripts/elodin_capture.sh`** gains **`--port`**, forwards **`editor --addr 127.0.0.1:$port`**, restricts capture to **`.py`** sims, and documents port conflicts in the headless-capture skill. **`VIDEOS.md`** adds a Headless Capture section with two demo links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dd6afd94a2eee0437fc5a3b56a0f8e8c4563b6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->