### PR TITLE
fix: View-cube zoom In/Out.

### DIFF
--- a/libs/elodin-editor/src/plugins/logical_key/mod.rs
+++ b/libs/elodin-editor/src/plugins/logical_key/mod.rs
@@ -1,4 +1,4 @@
-use bevy::input::keyboard::{Key, KeyboardInput};
+use bevy::input::keyboard::{Key, KeyboardFocusLost, KeyboardInput};
 use bevy::prelude::*;
 use std::collections::HashSet;
 
@@ -36,6 +36,7 @@ impl LogicalKeyState {
 fn update_logical_key_state(
     mut key_state: ResMut<LogicalKeyState>,
     mut keyboard_events: MessageReader<KeyboardInput>,
+    mut focus_lost: MessageReader<KeyboardFocusLost>,
 ) {
     key_state.just_pressed.clear();
     key_state.just_released.clear();
@@ -48,6 +49,14 @@ fn update_logical_key_state(
         } else if key_state.pressed.remove(&event.logical_key) {
             key_state.just_released.insert(event.logical_key.clone());
         }
+    }
+
+    // Leaving the window (Alt-Tab, Cmd-Tab) never delivers the key release, which
+    // would keep modifiers latched as held for the rest of the session.
+    if !focus_lost.is_empty() {
+        focus_lost.clear();
+        let released = std::mem::take(&mut key_state.pressed);
+        key_state.just_released.extend(released);
     }
 }
 

--- a/libs/elodin-editor/src/plugins/view_cube/README.md
+++ b/libs/elodin-editor/src/plugins/view_cube/README.md
@@ -31,6 +31,8 @@ It replaces the legacy navigation gizmo UX.
 - **Bottom-right button**: zoom out while preserving current orientation; holding Alt (Option on
   macOS) turns it into a zoom-in button, showing `+` instead of `−`. The mode follows the held state
   of the key, so a press or release event lost to the window manager cannot latch the wrong mode.
+  Both directions share one orbit distance ratio (`VIEWPORT_ZOOM_STEP`), so a `+` click undoes a `−`
+  click exactly.
 
 ## Quick Start
 

--- a/libs/elodin-editor/src/plugins/view_cube/README.md
+++ b/libs/elodin-editor/src/plugins/view_cube/README.md
@@ -11,7 +11,7 @@ It replaces the legacy navigation gizmo UX.
 
 - **Interactive cube**: Click on faces, edges, or corners to snap the camera to that view
 - **Rotation arrows**: top-left/top-right roll around the camera axis; left/right rotate around camera up; up/down rotate around camera right
-- **Viewport action buttons**: bottom-left reset and bottom-right zoom-out controls
+- **Viewport action buttons**: bottom-left reset and bottom-right zoom controls
 - **Hover highlighting**: Visual feedback with CAD-style grouped edge hover (4 edges for active front frame, 2-3 edges for hidden-face groups)
 - **Overlay rendering**: Dedicated ViewCube camera rendered in viewport corner
 - **Camera sync**: Cube mirrors the main camera orientation
@@ -28,7 +28,9 @@ It replaces the legacy navigation gizmo UX.
 - **Corners**: hover highlights only the targeted corner and click snaps to that corner view
 - **Front corner click**: no-op when the clicked corner is already aligned with the camera axis
 - **Bottom-left button**: reset viewport camera (`Transform::IDENTITY`, anchor depth `-2.0`)
-- **Bottom-right button**: zoom out while preserving current orientation
+- **Bottom-right button**: zoom out while preserving current orientation; holding Alt (Option on
+  macOS) turns it into a zoom-in button, showing `+` instead of `−`. The mode follows the held state
+  of the key, so a press or release event lost to the window manager cannot latch the wrong mode.
 
 ## Quick Start
 

--- a/libs/elodin-editor/src/plugins/view_cube/camera.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/camera.rs
@@ -32,8 +32,10 @@ const FACE_IN_SCREEN_PLANE_DOT_THRESHOLD: f32 = 0.999;
 const CORNER_IN_SCREEN_AXIS_DOT_THRESHOLD: f32 = 0.998;
 const ARROW_CACHE_MAX_DRIFT_RADIANS: f32 = 6.0_f32.to_radians();
 const VIEWPORT_RESET_ANCHOR_DEPTH: f64 = -2.0;
-const VIEWPORT_ZOOM_OUT_MULTIPLIER: f32 = 2.2;
-const VIEWPORT_ZOOM_IN_MULTIPLIER: f32 = 1.2;
+/// Orbit distance ratio applied per zoom button click. A single factor for both
+/// directions keeps the two steps mutual inverses, so a zoom-in click undoes a
+/// zoom-out click exactly.
+const VIEWPORT_ZOOM_STEP: f32 = 2.2;
 
 #[derive(Component)]
 pub struct ViewCubeTargetCamera;
@@ -749,9 +751,9 @@ fn apply_viewport_reset(transform: &mut Transform, editor_cam: &mut EditorCam) {
 fn apply_viewport_zoom(out: bool, transform: &mut Transform, editor_cam: &mut EditorCam) {
     let current_depth = (editor_cam.last_anchor_depth.abs() as f32).max(0.25);
     let target_depth = if out {
-        (current_depth * VIEWPORT_ZOOM_OUT_MULTIPLIER).max(0.5)
+        (current_depth * VIEWPORT_ZOOM_STEP).max(0.5)
     } else {
-        (current_depth / VIEWPORT_ZOOM_IN_MULTIPLIER).max(0.5)
+        (current_depth / VIEWPORT_ZOOM_STEP).max(0.5)
     };
     let depth_delta = target_depth - current_depth;
     if depth_delta.abs() <= 1.0e-6 {
@@ -1441,7 +1443,7 @@ mod tests {
         };
 
         let initial_translation = transform.translation;
-        let expected_target_depth = 2.0 * VIEWPORT_ZOOM_OUT_MULTIPLIER;
+        let expected_target_depth = 2.0 * VIEWPORT_ZOOM_STEP;
         let expected_delta = expected_target_depth - 2.0;
         let expected_translation =
             initial_translation + (transform.rotation * Vec3::Z) * expected_delta;
@@ -1454,5 +1456,24 @@ mod tests {
             editor_cam.current_motion,
             CurrentMotion::Stationary
         ));
+    }
+
+    /// The `+` and `−` clicks have to cancel each other, otherwise zoom-in reads
+    /// as broken next to a much coarser zoom-out.
+    #[test]
+    fn viewport_zoom_in_undoes_zoom_out() {
+        let start = Transform::from_translation(Vec3::new(0.5, 1.0, -0.25))
+            .with_rotation(Quat::from_rotation_y(0.3));
+        let mut transform = start;
+        let mut editor_cam = EditorCam {
+            last_anchor_depth: -4.0,
+            ..Default::default()
+        };
+
+        apply_viewport_zoom(true, &mut transform, &mut editor_cam);
+        apply_viewport_zoom(false, &mut transform, &mut editor_cam);
+
+        assert!((transform.translation - start.translation).length() < 1.0e-5);
+        assert!((editor_cam.last_anchor_depth + 4.0).abs() < 1.0e-5);
     }
 }

--- a/libs/elodin-editor/src/plugins/view_cube/spawn.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/spawn.rs
@@ -23,7 +23,14 @@ use crate::plugins::render_layer_alloc::{
 pub(crate) fn plugin(app: &mut App) {
     app.init_resource::<ViewCubeFrames>()
         .add_systems(Startup, spawn_frame_view_cubes)
-        .add_systems(PreUpdate, swap_zoom_buttons_on_alt);
+        .add_systems(
+            PreUpdate,
+            // Reads keyboard state and is read back by the picking observers, so
+            // it has to be pinned between the two.
+            sync_zoom_button_mode
+                .after(bevy::input::InputSystems)
+                .before(bevy::picking::PickingSystems::Hover),
+        );
 }
 
 // ============================================================================
@@ -629,9 +636,10 @@ fn spawn_rotation_arrows(
     }
 }
 
-#[derive(Debug, Resource)]
-struct ZoomIconMaterials {
-    icon_material: Handle<StandardMaterial>,
+/// Icon textures of a zoom button, kept on the icon entity: every viewport
+/// overlay spawns its own material, so this state cannot be shared globally.
+#[derive(Debug, Component)]
+struct ZoomButtonIcon {
     zoom_in: Handle<Image>,
     zoom_out: Handle<Image>,
 }
@@ -714,7 +722,7 @@ fn spawn_viewport_action_buttons(
             Transform::from_translation(Vec3::new(0.40, -0.39, depth)),
             Pickable::IGNORE,
             ViewportActionButton::ZoomOut,
-            Name::new("viewport_action_button_ZoomOut"),
+            Name::new("viewport_action_button_zoom"),
         ))
         .id();
     let mut zoom_button_cmd = commands.entity(zoom_button);
@@ -731,18 +739,17 @@ fn spawn_viewport_action_buttons(
         cull_mode: None,
         ..default()
     });
-    commands.insert_resource(ZoomIconMaterials {
-        icon_material: zoom_icon_material.clone(),
-        zoom_out: zoom_out_icon,
-        zoom_in: zoom_in_icon,
-    });
     let mut zoom_icon_cmd = commands.spawn((
         Mesh3d(zoom_icon_mesh),
         MeshMaterial3d(zoom_icon_material),
         Transform::from_translation(Vec3::new(0.0, 0.0, 0.002)),
         Pickable::IGNORE,
         ChildOf(zoom_button),
-        Name::new("viewport_action_button_ZoomOut_icon"),
+        ZoomButtonIcon {
+            zoom_in: zoom_in_icon,
+            zoom_out: zoom_out_icon,
+        },
+        Name::new("viewport_action_button_zoom_icon"),
     ));
     if let Some(layers) = render_layers {
         zoom_icon_cmd.insert(layers.clone());
@@ -754,51 +761,201 @@ fn spawn_viewport_action_buttons(
         Transform::from_translation(Vec3::ZERO),
         ChildOf(zoom_button),
         Pickable::default(),
-        Name::new("viewport_action_button_ZoomOut_hitbox"),
+        Name::new("viewport_action_button_zoom_hitbox"),
     ));
     if let Some(layers) = render_layers {
         zoom_hitbox_cmd.insert(layers.clone());
     }
 }
 
-fn swap_zoom_buttons_on_alt(
-    mut buttons: Query<&mut ViewportActionButton>,
+/// Track whether the zoom button acts as zoom-in (Alt/Option held) or zoom-out.
+///
+/// Derived from the held state rather than press/release edges: a dropped edge
+/// (window focus change, compositor grabbing Alt on Linux, Alt-Tab) would
+/// otherwise latch the button in the wrong mode for the rest of the session.
+fn sync_zoom_button_mode(
     keys: Res<ButtonInput<KeyCode>>,
-    zoom_icon_materials: Option<Res<ZoomIconMaterials>>,
+    mut buttons: Query<&mut ViewportActionButton>,
+    icons: Query<(&ZoomButtonIcon, &MeshMaterial3d<StandardMaterial>)>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    let pressed = if keys.just_pressed(KeyCode::AltLeft) || keys.just_pressed(KeyCode::AltRight) {
-        Some(true)
-    } else if keys.just_released(KeyCode::AltLeft) || keys.just_released(KeyCode::AltRight) {
-        Some(false)
+    let zoom_in = keys.any_pressed([KeyCode::AltLeft, KeyCode::AltRight]);
+    let mode = if zoom_in {
+        ViewportActionButton::ZoomIn
     } else {
-        None
+        ViewportActionButton::ZoomOut
     };
-    if let Some(pressed) = pressed {
-        for mut action in &mut buttons {
-            match *action {
-                ViewportActionButton::ZoomIn | ViewportActionButton::ZoomOut => {
-                    if pressed {
-                        *action = ViewportActionButton::ZoomIn;
-                    } else {
-                        *action = ViewportActionButton::ZoomOut;
-                    }
-                }
-                _ => (),
+
+    for mut action in &mut buttons {
+        let is_zoom = matches!(
+            *action,
+            ViewportActionButton::ZoomIn | ViewportActionButton::ZoomOut
+        );
+        if is_zoom && *action != mode {
+            *action = mode;
+        }
+    }
+
+    for (icon, handle) in icons.iter() {
+        let texture = if zoom_in {
+            &icon.zoom_in
+        } else {
+            &icon.zoom_out
+        };
+        // Only reach for `get_mut` on a real change, otherwise every frame would
+        // flag the material as modified and force a GPU re-upload.
+        let stale = materials
+            .get(&handle.0)
+            .is_some_and(|material| material.base_color_texture.as_ref() != Some(texture));
+        if stale && let Some(mut material) = materials.get_mut(&handle.0) {
+            material.base_color_texture = Some(texture.clone());
+        }
+    }
+}
+
+#[cfg(test)]
+mod zoom_button_tests {
+    use super::*;
+
+    struct ZoomButton {
+        button: Entity,
+        material: Handle<StandardMaterial>,
+        zoom_in: Handle<Image>,
+        zoom_out: Handle<Image>,
+    }
+
+    impl ZoomButton {
+        fn spawn(app: &mut App) -> Self {
+            let images = app.world().resource::<Assets<Image>>();
+            let zoom_in = images.reserve_handle();
+            let zoom_out = images.reserve_handle();
+            let material = app
+                .world_mut()
+                .resource_mut::<Assets<StandardMaterial>>()
+                .add(StandardMaterial {
+                    base_color_texture: Some(zoom_out.clone()),
+                    ..default()
+                });
+
+            let button = app.world_mut().spawn(ViewportActionButton::ZoomOut).id();
+            app.world_mut().spawn((
+                MeshMaterial3d(material.clone()),
+                ZoomButtonIcon {
+                    zoom_in: zoom_in.clone(),
+                    zoom_out: zoom_out.clone(),
+                },
+                ChildOf(button),
+            ));
+
+            Self {
+                button,
+                material,
+                zoom_in,
+                zoom_out,
             }
         }
-        let Some(zoom_icon_materials) = zoom_icon_materials else {
-            return;
-        };
 
-        let Some(mut zoom_material) = materials.get_mut(&zoom_icon_materials.icon_material) else {
-            return;
-        };
-        let zoom_icon: Handle<Image> = if pressed {
-            zoom_icon_materials.zoom_in.clone()
+        fn action(&self, app: &App) -> ViewportActionButton {
+            *app.world()
+                .entity(self.button)
+                .get::<ViewportActionButton>()
+                .unwrap()
+        }
+
+        fn icon(&self, app: &App) -> Handle<Image> {
+            app.world()
+                .resource::<Assets<StandardMaterial>>()
+                .get(&self.material)
+                .unwrap()
+                .base_color_texture
+                .clone()
+                .unwrap()
+        }
+    }
+
+    fn app() -> App {
+        let mut app = App::new();
+        app.init_resource::<Assets<StandardMaterial>>()
+            .init_resource::<Assets<Image>>()
+            .init_resource::<ButtonInput<KeyCode>>()
+            .add_systems(Update, sync_zoom_button_mode);
+        app
+    }
+
+    fn set_alt(app: &mut App, held: bool) {
+        let mut keys = app.world_mut().resource_mut::<ButtonInput<KeyCode>>();
+        if held {
+            keys.press(KeyCode::AltLeft);
         } else {
-            zoom_icon_materials.zoom_out.clone()
-        };
-        zoom_material.base_color_texture = Some(zoom_icon);
+            keys.release(KeyCode::AltLeft);
+        }
+    }
+
+    /// Each viewport overlay owns its icon material, so all of them have to
+    /// follow the modifier, not just the last one spawned.
+    #[test]
+    fn every_zoom_button_follows_alt() {
+        let mut app = app();
+        let first = ZoomButton::spawn(&mut app);
+        let second = ZoomButton::spawn(&mut app);
+
+        set_alt(&mut app, true);
+        app.update();
+
+        for button in [&first, &second] {
+            assert_eq!(button.action(&app), ViewportActionButton::ZoomIn);
+            assert_eq!(button.icon(&app), button.zoom_in);
+        }
+
+        set_alt(&mut app, false);
+        app.update();
+
+        for button in [&first, &second] {
+            assert_eq!(button.action(&app), ViewportActionButton::ZoomOut);
+            assert_eq!(button.icon(&app), button.zoom_out);
+        }
+    }
+
+    /// A press edge consumed elsewhere (focus change, window manager) must not
+    /// leave the button stuck in the wrong mode.
+    #[test]
+    fn zoom_mode_recovers_from_missed_key_edges() {
+        let mut app = app();
+        let button = ZoomButton::spawn(&mut app);
+
+        set_alt(&mut app, true);
+        // Clearing drops `just_pressed`/`just_released` while Alt stays held.
+        app.world_mut()
+            .resource_mut::<ButtonInput<KeyCode>>()
+            .clear();
+        app.update();
+
+        assert_eq!(button.action(&app), ViewportActionButton::ZoomIn);
+        assert_eq!(button.icon(&app), button.zoom_in);
+
+        app.world_mut()
+            .resource_mut::<ButtonInput<KeyCode>>()
+            .reset_all();
+        app.update();
+
+        assert_eq!(button.action(&app), ViewportActionButton::ZoomOut);
+        assert_eq!(button.icon(&app), button.zoom_out);
+    }
+
+    #[test]
+    fn reset_button_is_not_affected_by_alt() {
+        let mut app = app();
+        let reset = app.world_mut().spawn(ViewportActionButton::Reset).id();
+
+        set_alt(&mut app, true);
+        app.update();
+
+        assert_eq!(
+            *app.world()
+                .entity(reset)
+                .get::<ViewportActionButton>()
+                .unwrap(),
+            ViewportActionButton::Reset
+        );
     }
 }


### PR DESCRIPTION
> This branch only fixes the issue with triggering the + button (Zoom In) in the cube viewer. It has been tested on macOS and Linux.
> Mouse-wheel zoom possible bug is not included.

## 2 root causes

- 1 **The icon belonged to the wrong viewport.** Each overlay creates its own icon material, but `spawn_viewport_action_buttons` published the handle in a global `ZoomIconMaterials` resource that was overwritten on every call. Since `spawn_view_cube_overlay` runs once per 3D tile, only the last created viewport could swap its icon, and none could once that tile was closed. The observed behaviour therefore depended on the tile layout and on the order in which tiles were opened, not on the operating system.

- 2 **The modifier was read on edges.** The system used `just_pressed` / `just_released` on `KeyCode::AltLeft` / `AltRight`. Any lost edge latched the button in the wrong mode until restart, and Alt is precisely the key window managers intercept on Linux for window dragging and Alt-Tab. The system was also registered in `PreUpdate` without any ordering against Bevy's `keyboard_input_system`, which clears `just_pressed` at the start of each frame.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Editor viewport UX and input state only; behavior is covered by new unit tests with no auth, persistence, or network impact.
> 
> **Overview**
> Fixes view-cube viewport zoom so **Alt/Option** toggles zoom-in (`+`) vs zoom-out (`−`) from **held** modifier state instead of press/release edges, avoiding a latched wrong mode when the OS drops key events (Alt-Tab, focus loss, Linux compositor).
> 
> Zoom icons and action mode are **per overlay** via a `ZoomButtonIcon` component (replacing a single shared material resource), and `sync_zoom_button_mode` runs between input and picking so hover/click see the current mode. **Zoom in and out now share one ratio** (`VIEWPORT_ZOOM_STEP`), so consecutive `+` and `−` clicks cancel exactly; tests cover that and multi-viewport Alt sync.
> 
> **LogicalKeyState** clears all pressed keys on `KeyboardFocusLost` so modifiers cannot stay stuck after leaving the window without release events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ee743bf5fb0634f4fab890777b150b738698c4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->