### PR TITLE
fix(editor): restore minimal terrain rendering

### DIFF
--- a/examples/terrain/main.py
+++ b/examples/terrain/main.py
@@ -1,0 +1,50 @@
+"""Minimal editor smoke test for real terrain rendering.
+
+Prepare the real Brienz elevation and imagery atlas once from the repository
+root before launching the example:
+
+    ./scripts/prepare_editor_terrain_region.sh brienz
+    elodin editor examples/terrain/main.py
+
+The viewport intentionally uses HDR while SDR terrain pipeline specialization
+remains a separate follow-up.
+"""
+
+import elodin as el
+import jax.numpy as jnp
+
+SIM_RATE = 30.0
+
+
+def world() -> el.World:
+    world = el.World()
+    world.spawn(
+        el.Body(
+            world_pos=el.SpatialTransform(linear=jnp.array([0.0, 0.0, 3_000.0])),
+            inertia=el.SpatialInertia(mass=1.0),
+        ),
+        name="reference",
+    )
+    world.schematic(
+        """
+        coordinate frame=ENU
+        world_mesh "brienz"
+
+        viewport frame=ENU name="Brienz Terrain" hdr=#true active=#true pos="(0,0,0,1, 4560,-4560,2640)" look_at="(0,0,0,1, 0,0,-120)" up="(0,0,1)" near=1.0 far=50000.0 fov=60.0 show_grid=#false show_view_cube=#true
+        """,
+        "terrain.kdl",
+    )
+    return world
+
+
+@el.map
+def no_force(force: el.Force) -> el.Force:
+    return force
+
+
+world().run(
+    el.six_dof(sys=no_force),
+    simulation_rate=SIM_RATE,
+    generate_real_time=True,
+    max_ticks=int(SIM_RATE * 120.0),
+)

--- a/libs/bevy_world_mesh/src/terrain/plugin.rs
+++ b/libs/bevy_world_mesh/src/terrain/plugin.rs
@@ -51,11 +51,9 @@ pub struct TerrainPlugin;
 impl Plugin for TerrainPlugin {
     fn build(&self, app: &mut App) {
         #[cfg(feature = "high_precision")]
-        app.add_plugins(
-            big_space::prelude::BigSpaceDefaultPlugins
-                .build()
-                .disable::<big_space::debug::BigSpaceDebugPlugin>(),
-        );
+        // BigSpaceDebugPlugin is no longer part of BigSpaceDefaultPlugins;
+        // trying to disable the absent plugin panics during preprocessing.
+        app.add_plugins(big_space::prelude::BigSpaceDefaultPlugins);
 
         // `check_visibility` became non-generic in Bevy 0.16. Our terrain
         // entity carries `NoFrustumCulling` on the bundle, so it is always

--- a/libs/elodin-editor/src/plugins/world_mesh/mod.rs
+++ b/libs/elodin-editor/src/plugins/world_mesh/mod.rs
@@ -89,6 +89,12 @@ pub(crate) fn spawn_world_mesh_terrain(
 
     match config {
         WorldMeshConfig::Terrain(config) => {
+            if has_nonzero_translation(world_mesh.translate) {
+                bevy::log::warn!(
+                    "schematic world_mesh region={region:?} has a non-zero translation; the translation is rendered via the geo anchor, but terrain tile LOD selection remains origin-relative, so detail selection may be incorrect"
+                );
+            }
+
             let tile_atlas = TileAtlas::new(&config);
             let mut terrain_bundle = TerrainBundle::new(tile_atlas);
             terrain_bundle.visibility = world_mesh_visibility(world_mesh);
@@ -141,6 +147,10 @@ fn spawn_world_mesh_terrain_bundle(
     insert_geo_components(commands, anchor, world_mesh);
     insert_big_space_cell(commands, anchor);
     anchor
+}
+
+fn has_nonzero_translation(translate: Option<(f64, f64, f64)>) -> bool {
+    matches!(translate, Some((x, y, z)) if x != 0.0 || y != 0.0 || z != 0.0)
 }
 
 fn world_mesh_transform(world_mesh: &impeller2_wkt::WorldMesh) -> Transform {
@@ -525,6 +535,13 @@ mod tests {
     use bevy::ecs::system::RunSystemOnce;
     use bevy_geo_frames::{GeoContext, GeoFrame};
     use impeller2_wkt::{NodeId, WorldMesh};
+
+    #[test]
+    fn translation_warning_requires_a_nonzero_component() {
+        assert!(!has_nonzero_translation(None));
+        assert!(!has_nonzero_translation(Some((0.0, 0.0, 0.0))));
+        assert!(has_nonzero_translation(Some((0.0, -1.0, 0.0))));
+    }
 
     #[test]
     fn planar_lod_count_defaults_to_preprocessed_depth() {

--- a/libs/elodin-editor/src/plugins/world_mesh/mod.rs
+++ b/libs/elodin-editor/src/plugins/world_mesh/mod.rs
@@ -47,9 +47,16 @@ const SPHERICAL_MAX_HEIGHT_M: f32 = 9_000.0;
 const SPHERICAL_FALLBACK_GRID_SECTORS: u32 = 64;
 const SPHERICAL_FALLBACK_GRID_STACKS: u32 = 32;
 
-/// Marker for terrain entities spawned from a schematic `world_mesh` element.
+/// Marker for terrain renderer entities spawned from a schematic `world_mesh` element.
 #[derive(Component)]
 pub struct WorldMeshTerrain;
+
+/// Spatial anchor for a real terrain renderer.
+///
+/// Geo-frame and big-space systems own this entity's transform. The renderer
+/// stays below it so its [`TerrainBundle`] model-local transform is preserved.
+#[derive(Component)]
+struct WorldMeshTerrainAnchor;
 
 /// Editor integration layer for the real `bevy_world_mesh` terrain renderer.
 ///
@@ -84,23 +91,12 @@ pub(crate) fn spawn_world_mesh_terrain(
         WorldMeshConfig::Terrain(config) => {
             let tile_atlas = TileAtlas::new(&config);
             let mut terrain_bundle = TerrainBundle::new(tile_atlas);
-            apply_world_mesh_transform_and_visibility(&mut terrain_bundle, world_mesh);
+            terrain_bundle.visibility = world_mesh_visibility(world_mesh);
 
             let material =
                 world_mesh_materials.add(bevy_world_mesh::prelude::WorldMeshMaterial::default());
 
-            let entity = commands
-                .spawn((
-                    terrain_bundle,
-                    MeshMaterial3d(material),
-                    WorldMeshTerrain,
-                    Name::new(format!("world_mesh terrain ({region})")),
-                ))
-                .id();
-
-            insert_geo_components(commands, entity, world_mesh);
-            insert_big_space_cell(commands, entity);
-            entity
+            spawn_world_mesh_terrain_bundle(commands, terrain_bundle, material, world_mesh, &region)
         }
         WorldMeshConfig::Fallback(fallback) => {
             spawn_world_mesh_fallback(commands, meshes, materials, world_mesh, &region, fallback)
@@ -118,12 +114,33 @@ enum WorldMeshFallback {
     Globe,
 }
 
-fn apply_world_mesh_transform_and_visibility(
-    terrain_bundle: &mut TerrainBundle,
+fn spawn_world_mesh_terrain_bundle(
+    commands: &mut Commands,
+    terrain_bundle: TerrainBundle,
+    material: Handle<bevy_world_mesh::prelude::WorldMeshMaterial>,
     world_mesh: &impeller2_wkt::WorldMesh,
-) {
-    terrain_bundle.transform = world_mesh_transform(world_mesh);
-    terrain_bundle.visibility = world_mesh_visibility(world_mesh);
+    region: &str,
+) -> Entity {
+    let anchor = commands
+        .spawn((
+            WorldMeshTerrainAnchor,
+            world_mesh_transform(world_mesh),
+            Visibility::Visible,
+            Name::new(format!("world_mesh terrain ({region})")),
+        ))
+        .id();
+
+    commands.spawn((
+        terrain_bundle,
+        MeshMaterial3d(material),
+        WorldMeshTerrain,
+        ChildOf(anchor),
+        Name::new(format!("world_mesh terrain renderer ({region})")),
+    ));
+
+    insert_geo_components(commands, anchor, world_mesh);
+    insert_big_space_cell(commands, anchor);
+    anchor
 }
 
 fn world_mesh_transform(world_mesh: &impeller2_wkt::WorldMesh) -> Transform {
@@ -505,7 +522,8 @@ fn sync_terrain_view_positions(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bevy_geo_frames::GeoFrame;
+    use bevy::ecs::system::RunSystemOnce;
+    use bevy_geo_frames::{GeoContext, GeoFrame};
     use impeller2_wkt::{NodeId, WorldMesh};
 
     #[test]
@@ -524,17 +542,125 @@ mod tests {
     }
 
     #[test]
-    fn framed_world_mesh_transform_stays_at_origin_for_geo_pipeline() {
+    fn planar_model_transform_survives_geo_and_big_space_integration() {
+        let model_translation = Vec3::new(0.0, -40.0, 0.0);
+        let model_scale = Vec3::splat(250.0);
+        let (mut app, anchor, renderer) = spawn_model_terrain(
+            TerrainModel::planar(model_translation.as_dvec3(), 250.0, 0.0, 100.0),
+            world_mesh(Some(GeoFrame::NED), Some((1.0, 2.0, 3.0))),
+        );
+
+        apply_geo_transforms(&mut app);
+
+        let transform = app.world().get::<Transform>(renderer).unwrap();
+        assert_eq!(transform.translation, model_translation);
+        assert_eq!(transform.scale, model_scale);
+        assert_eq!(
+            app.world().get::<ChildOf>(renderer).unwrap().parent(),
+            anchor
+        );
+        assert!(app.world().get::<GeoPosition>(renderer).is_none());
+        assert!(app.world().get::<GeoRotation>(renderer).is_none());
+        assert!(app.world().get::<GeoPosition>(anchor).is_some());
+        assert!(app.world().get::<TileAtlas>(renderer).is_some());
+        #[cfg(feature = "big_space")]
+        {
+            assert!(
+                app.world()
+                    .get::<crate::spatial::GridCell>(anchor)
+                    .is_some()
+            );
+            assert!(
+                app.world()
+                    .get::<crate::spatial::GridCell>(renderer)
+                    .is_none()
+            );
+        }
+
+        assert!(app.world_mut().despawn(anchor));
+        assert!(
+            app.world().get_entity(renderer).is_err(),
+            "despawning the schematic root must clean up its renderer child"
+        );
+    }
+
+    #[test]
+    fn globe_ellipsoid_scale_survives_geo_and_big_space_integration() {
+        let major_axis = 6_378_137.0;
+        let minor_axis = 6_356_752.0;
+        let (mut app, _, renderer) = spawn_model_terrain(
+            TerrainModel::ellipsoid(
+                DVec3::ZERO,
+                major_axis,
+                minor_axis,
+                SPHERICAL_MIN_HEIGHT_M,
+                SPHERICAL_MAX_HEIGHT_M,
+            ),
+            world_mesh(Some(GeoFrame::ECEF), Some((10.0, 20.0, 30.0))),
+        );
+
+        apply_geo_transforms(&mut app);
+
+        let transform = app.world().get::<Transform>(renderer).unwrap();
+        assert_eq!(transform.translation, Vec3::ZERO);
+        assert_eq!(
+            transform.scale,
+            Vec3::new(major_axis as f32, minor_axis as f32, major_axis as f32)
+        );
+    }
+
+    #[test]
+    fn framed_world_mesh_anchor_stays_at_origin_for_geo_pipeline() {
         let world_mesh = world_mesh(Some(GeoFrame::NED), Some((1.0, 2.0, 3.0)));
 
         assert_eq!(world_mesh_transform(&world_mesh).translation, Vec3::ZERO);
     }
 
     #[test]
-    fn unframed_world_mesh_transform_uses_default_geo_frame() {
+    fn unframed_world_mesh_anchor_uses_default_geo_frame() {
         let world_mesh = world_mesh(None, Some((1.0, 2.0, 3.0)));
 
         assert_eq!(world_mesh_transform(&world_mesh).translation, Vec3::ZERO);
+    }
+
+    fn spawn_model_terrain(model: TerrainModel, world_mesh: WorldMesh) -> (App, Entity, Entity) {
+        let config = TerrainConfig {
+            model,
+            path: "terrain-transform-regression-test".to_string(),
+            ..default()
+        };
+        let terrain_bundle = TerrainBundle::new(TileAtlas::new(&config));
+        let mut app = App::new();
+        app.insert_resource(GeoContext::default());
+
+        let anchor = {
+            let mut commands = app.world_mut().commands();
+            spawn_world_mesh_terrain_bundle(
+                &mut commands,
+                terrain_bundle,
+                Handle::default(),
+                &world_mesh,
+                &world_mesh.region,
+            )
+        };
+        app.world_mut().flush();
+
+        let renderer = {
+            let world = app.world_mut();
+            let mut renderers =
+                world.query_filtered::<Entity, (With<WorldMeshTerrain>, With<TileAtlas>)>();
+            renderers.single(world).expect("one terrain renderer")
+        };
+        (app, anchor, renderer)
+    }
+
+    fn apply_geo_transforms(app: &mut App) {
+        app.world_mut()
+            .run_system_once(bevy_geo_frames::apply_transforms)
+            .unwrap();
+        app.world_mut()
+            .run_system_once(bevy_geo_frames::apply_geo_rotation)
+            .unwrap();
     }
 
     fn world_mesh(frame: Option<GeoFrame>, translate: Option<(f64, f64, f64)>) -> WorldMesh {


### PR DESCRIPTION
This PR is a minimal fix to get some level of terrain rendering working in the editor again. The goal is to avoid main from diverging too much so that it's easier to fully integrate everything later.

Adds a few units tests and a minimal example.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes terrain entity hierarchy and geo-frame integration paths that affect how terrain is positioned and torn down; mitigated by focused unit tests but still touches viewport rendering behavior.
> 
> **Overview**
> Restores editor terrain rendering with a **parent/child spawn model**: geo-frame and big-space components sit on a `WorldMeshTerrainAnchor`, while the `TerrainBundle` renderer stays a child so **model-local scale/translation** (planar offset, globe ellipsoid) are not overwritten by geo transforms. Schematic spawns now return the anchor as the schematic root; despawn tests cover child cleanup.
> 
> **`bevy_world_mesh`**: registers `BigSpaceDefaultPlugins` without disabling `BigSpaceDebugPlugin`, which is no longer in that set and previously caused a **startup panic**.
> 
> Adds a **log warning** when `world_mesh` has non-zero `translate` (position still applied via geo anchor, but tile LOD stays origin-relative). New **`examples/terrain/main.py`** smoke test for prepared Brienz `world_mesh` + HDR viewport.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1faf0ea0de9f348ad1e6abd40f998e012867c763. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->