### PR TITLE
Allow for local kdl and asset development

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2054,8 +2054,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_hanabi"
-version = "0.19.0"
-source = "git+https://github.com/elodin-sys/bevy_hanabi?rev=1b46c8cb2bd9655cea25943c51ba0502055ce2ae#1b46c8cb2bd9655cea25943c51ba0502055ce2ae"
+version = "0.19.1-dev"
+source = "git+https://github.com/elodin-sys/bevy_hanabi?rev=e721a3c5f8c730baa6bb9885f08d55237404640b#e721a3c5f8c730baa6bb9885f08d55237404640b"
 dependencies = [
  "anyhow",
  "bevy",
@@ -3739,7 +3739,7 @@ checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -3750,7 +3750,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -3787,7 +3787,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6886,7 +6886,7 @@ dependencies = [
  "vec_map",
  "wasm-bindgen",
  "web-sys",
- "windows 0.48.0",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -13478,7 +13478,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -13779,7 +13779,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "842f3cd369c2ba38966204f983eaa5e54a8e84a7d7159ed36ade2b6c335aae64"
 dependencies = [
- "skrifa 0.39.0",
+ "skrifa 0.40.0",
  "yazi",
  "zeno",
 ]
@@ -14811,7 +14811,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f7c95348f20c1c913d72157b3c6dee6ea3e30b3d19502c5a7f6d3f160dacbf"
 dependencies = [
  "cc",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -15846,7 +15846,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ version = "0.2.5"
 map_3d = { git = "https://github.com/shanecelis/map_3d.git", branch = "feat/sphere" }
 # Local-space FaceCamera/AlongVelocity: full inverse affine for camera
 # position in effect space (elodin-sys fork; upstream candidate).
-bevy_hanabi = { git = "https://github.com/elodin-sys/bevy_hanabi", rev = "1b46c8cb2bd9655cea25943c51ba0502055ce2ae" }
+bevy_hanabi = { git = "https://github.com/elodin-sys/bevy_hanabi", rev = "e721a3c5f8c730baa6bb9885f08d55237404640b" }
 
 # bevy_editor_cam's bevy-0.19 branch depends on bevy_framepace from this
 # personal git branch; redirect it to the official v0.22.0 tag so the whole

--- a/libs/elodin-editor/Cargo.toml
+++ b/libs/elodin-editor/Cargo.toml
@@ -135,7 +135,7 @@ impeller2-bevy.path = "../../libs/impeller2/bevy"
 impeller2-bevy.default-features = false
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-bevy_hanabi = { version = "0.19", default-features = false, features = ["3d"] }
+bevy_hanabi = { version = "0.19.1-dev", default-features = false, features = ["3d"] }
 tokio = { version = "1.34", features = ["rt-multi-thread", "net"] }
 # os
 directories = "5.0"

--- a/libs/elodin-editor/src/headless.rs
+++ b/libs/elodin-editor/src/headless.rs
@@ -329,6 +329,9 @@ fn load_headless_scene(
                     &asset_server,
                     &geo_context,
                     connection_addr,
+                    // Headless render server is always DB-driven; no --kdl
+                    // local-iteration override.
+                    None,
                 ) {
                     entities.push(entity);
                 }

--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -1244,8 +1244,10 @@ pub fn sync_object_3d(
     assets: Res<AssetServer>,
     geo_context: Res<GeoContext>,
     connection_addr: Option<Res<impeller2_bevy::ConnectionAddr>>,
+    initial_kdl: Option<Res<plugins::kdl_document::InitialKdlPath>>,
 ) {
     let connection_addr = connection_addr.as_ref().map(|addr| addr.0);
+    let local_root = object_3d::local_assets_root(initial_kdl.as_deref());
     for (entity, id) in &query {
         if synced_object_3d.0.contains_key(&entity) {
             continue;
@@ -1303,6 +1305,7 @@ pub fn sync_object_3d(
             &assets,
             &geo_context,
             connection_addr,
+            local_root.as_deref(),
         ) {
             synced_object_3d.0.insert(entity, object_entity);
         }

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -46,13 +46,22 @@ fn client_asset_ip(ip: IpAddr) -> IpAddr {
     }
 }
 
+/// Socket address of the DB assets HTTP server for a DB TCP address
+/// (TCP port + offset; unspecified bind IPs mapped to loopback).
+pub fn assets_http_addr(connection_addr: SocketAddr) -> SocketAddr {
+    SocketAddr::new(
+        client_asset_ip(connection_addr.ip()),
+        connection_addr
+            .port()
+            .saturating_add(impeller2::ASSETS_HTTP_PORT_OFFSET),
+    )
+}
+
 pub fn assets_http_base(connection_addr: SocketAddr) -> String {
-    let port = connection_addr
-        .port()
-        .saturating_add(impeller2::ASSETS_HTTP_PORT_OFFSET);
-    match client_asset_ip(connection_addr.ip()) {
-        IpAddr::V4(v4) => format!("http://{v4}:{port}"),
-        IpAddr::V6(v6) => format!("http://[{v6}]:{port}"),
+    let addr = assets_http_addr(connection_addr);
+    match addr.ip() {
+        IpAddr::V4(v4) => format!("http://{v4}:{}", addr.port()),
+        IpAddr::V6(v6) => format!("http://[{v6}]:{}", addr.port()),
     }
 }
 
@@ -67,8 +76,41 @@ pub fn resolve_db_asset_url(path: &str, connection_addr: Option<SocketAddr>) -> 
     }
 }
 
-pub fn resolve_glb_asset_url(path: &str, connection_addr: Option<SocketAddr>) -> String {
+/// Like [`resolve_db_asset_url`], but when `local_root` is set (local
+/// iteration via CLI `--kdl`) a `db:` key that exists under the local assets
+/// root resolves to the bare relative path instead, so it loads — and
+/// hot-reloads — from disk rather than the DB.
+pub fn resolve_db_asset_url_prefer_local(
+    path: &str,
+    connection_addr: Option<SocketAddr>,
+    local_root: Option<&std::path::Path>,
+) -> String {
+    if let Some(root) = local_root
+        && let Some(key) = path.strip_prefix("db:")
+    {
+        let key = key.trim_start_matches('/');
+        if root.join(key).is_file() {
+            bevy::log::info!(
+                key = %key,
+                root = %root.display(),
+                "db asset shadowed by local file (--kdl session)"
+            );
+            return key.to_string();
+        }
+    }
     resolve_db_asset_url(path, connection_addr)
+}
+
+/// Local assets root override for `db:` keys: set when the session was opened
+/// with a CLI `--kdl` schematic (local iteration), `None` otherwise.
+pub fn local_assets_root(
+    initial_kdl: Option<&crate::plugins::kdl_document::InitialKdlPath>,
+) -> Option<std::path::PathBuf> {
+    if initial_kdl?.0.is_some() {
+        crate::plugins::env_asset_source::resolve_assets_dir()
+    } else {
+        None
+    }
 }
 
 /// ExprObject3D component that holds an EQL expression for dynamic positioning
@@ -1696,6 +1738,7 @@ pub fn create_object_3d_entity(
     assets: &AssetServer,
     geo_context: &GeoContext,
     connection_addr: Option<SocketAddr>,
+    local_root: Option<&std::path::Path>,
 ) -> Result<Entity, CompileError> {
     // Compile only the field-selected driver. Failed Cholesky/covariance compiles leave the
     // expr as None but keep Mat3 spawning (spawn_mesh keys off field presence); update must
@@ -1797,6 +1840,7 @@ pub fn create_object_3d_entity(
         mat3_material_assets,
         assets,
         connection_addr,
+        local_root,
     );
     Ok(entity_id)
 }
@@ -1813,10 +1857,11 @@ pub fn spawn_billboard_icon(
     asset_server: &Res<AssetServer>,
     icon_cache: &mut ResMut<IconTextureCache>,
     connection_addr: Option<SocketAddr>,
+    local_root: Option<&std::path::Path>,
 ) {
     let texture_handle: Handle<Image> = match &icon.source {
         Object3DIconSource::Path(path) => {
-            let url = resolve_db_asset_url(path, connection_addr);
+            let url = resolve_db_asset_url_prefer_local(path, connection_addr, local_root);
             asset_server.load(url)
         }
         Object3DIconSource::Builtin(name) => {
@@ -1875,6 +1920,7 @@ pub fn spawn_mesh(
     mat3_material_assets: &mut Assets<Mat3Material>,
     assets: &AssetServer,
     connection_addr: Option<SocketAddr>,
+    local_root: Option<&std::path::Path>,
 ) {
     match mesh {
         impeller2_wkt::Object3DMesh::Glb {
@@ -1887,7 +1933,7 @@ pub fn spawn_mesh(
             glow: _,
             glow_color: _,
         } => {
-            let resolved = resolve_glb_asset_url(path, connection_addr);
+            let resolved = resolve_db_asset_url_prefer_local(path, connection_addr, local_root);
             let url = format!("{resolved}#Scene0");
             let scene = assets.load(&url);
 
@@ -2752,5 +2798,60 @@ mod db_asset_url_tests {
             resolve_db_asset_url("db:icons/marker.png", Some(conn)),
             "http://127.0.0.1:2241/icons/marker.png"
         );
+    }
+
+    #[test]
+    fn assets_http_addr_offsets_port_and_maps_unspecified_to_loopback() {
+        let conn: SocketAddr = "0.0.0.0:2240".parse().unwrap();
+        assert_eq!(
+            super::assets_http_addr(conn),
+            "127.0.0.1:2241".parse::<SocketAddr>().unwrap()
+        );
+    }
+
+    #[test]
+    fn prefer_local_resolves_existing_file_to_bare_path() {
+        let root = std::env::temp_dir().join(format!(
+            "elodin-prefer-local-{}-{}",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::create_dir_all(root.join("textures")).unwrap();
+        std::fs::write(root.join("textures/soft_circle.png"), b"png").unwrap();
+        let conn: SocketAddr = "10.0.0.5:2240".parse().unwrap();
+
+        assert_eq!(
+            super::resolve_db_asset_url_prefer_local(
+                "db:textures/soft_circle.png",
+                Some(conn),
+                Some(&root)
+            ),
+            "textures/soft_circle.png"
+        );
+        // Missing locally: falls through to the DB URL.
+        assert_eq!(
+            super::resolve_db_asset_url_prefer_local(
+                "db:textures/missing.png",
+                Some(conn),
+                Some(&root)
+            ),
+            "http://10.0.0.5:2241/textures/missing.png"
+        );
+        // Bare (non-db:) paths pass through untouched.
+        assert_eq!(
+            super::resolve_db_asset_url_prefer_local("models/x.glb", Some(conn), Some(&root)),
+            "models/x.glb"
+        );
+        // No local root (no --kdl): DB URL as before.
+        assert_eq!(
+            super::resolve_db_asset_url_prefer_local(
+                "db:textures/soft_circle.png",
+                Some(conn),
+                None
+            ),
+            "http://10.0.0.5:2241/textures/soft_circle.png"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
     }
 }

--- a/libs/elodin-editor/src/plugins/thruster_particles/mod.rs
+++ b/libs/elodin-editor/src/plugins/thruster_particles/mod.rs
@@ -55,8 +55,10 @@ use impeller2_wkt::{ComponentValue as WktComponentValue, CurrentTimestamp, Thrus
 use crate::EqlContext;
 use crate::WorldPosExt;
 use crate::object_3d::{
-    CompiledExpr, Object3DState, WorldPosReceived, compile_eql_expr, resolve_db_asset_url,
+    CompiledExpr, Object3DState, WorldPosReceived, compile_eql_expr, local_assets_root,
+    resolve_db_asset_url_prefer_local,
 };
+use crate::plugins::kdl_document::InitialKdlPath;
 use crate::plugins::render_layer_alloc::THRUSTER_PARTICLES_RENDER_LAYER;
 use crate::ui::Paused;
 use crate::vector_arrow::component_value_tail_to_vec3;
@@ -505,6 +507,7 @@ fn sweep_trail_anchors(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn ensure_kdl_thrusters(
     mut commands: Commands,
     objects: Query<(Entity, &Object3DState), Without<KdlThrusterRig>>,
@@ -512,9 +515,11 @@ fn ensure_kdl_thrusters(
     mut file_effects: ResMut<FileEffectAssets>,
     asset_server: Res<AssetServer>,
     connection_addr: Option<Res<ConnectionAddr>>,
+    initial_kdl: Option<Res<InitialKdlPath>>,
     eql: Res<EqlContext>,
 ) {
     let connection_addr = connection_addr.as_ref().map(|addr| addr.0);
+    let local_root = local_assets_root(initial_kdl.as_deref());
     for (object, state) in &objects {
         if state.data.thrusters.is_empty() {
             continue;
@@ -549,7 +554,11 @@ fn ensure_kdl_thrusters(
                     // bare paths fall back to the Bevy asset root (offline
                     // --kdl dev). Retained in FileEffectAssets so seek/schematic
                     // rebuilds clone the same strong handle instead of unloading.
-                    let url = resolve_db_asset_url(effect, connection_addr);
+                    let url = resolve_db_asset_url_prefer_local(
+                        effect,
+                        connection_addr,
+                        local_root.as_deref(),
+                    );
                     jet.pending_effect = Some(file_effects.get_or_load(url, &asset_server));
                 }
                 let base_name = config
@@ -658,16 +667,19 @@ fn slot_image(
     assets: &ThrusterEffectAssets,
     asset_server: &AssetServer,
     connection_addr: Option<std::net::SocketAddr>,
+    local_root: Option<&std::path::Path>,
 ) -> Handle<Image> {
     match slot {
         "mask" => assets.mask.clone(),
-        "smoke" => asset_server.load(resolve_db_asset_url(
+        "smoke" => asset_server.load(resolve_db_asset_url_prefer_local(
             "db:textures/smoke_puff.png",
             connection_addr,
+            local_root,
         )),
-        _ => asset_server.load(resolve_db_asset_url(
+        _ => asset_server.load(resolve_db_asset_url_prefer_local(
             "db:textures/soft_circle.png",
             connection_addr,
+            local_root,
         )),
     }
 }
@@ -732,6 +744,7 @@ fn spawn_trail_anchor(
 /// anchor entity — but only once the owner has a telemetry `WorldPos`
 /// (`WorldPosReceived`), so the freeze does not capture the spawn default
 /// at ECEF origin.
+#[allow(clippy::too_many_arguments)]
 fn bind_file_effect_assets(
     mut commands: Commands,
     mut jets: Query<(Entity, &mut KdlThrusterJet, &KdlThrusterJetOf)>,
@@ -740,8 +753,10 @@ fn bind_file_effect_assets(
     assets: Res<ThrusterEffectAssets>,
     asset_server: Res<AssetServer>,
     connection_addr: Option<Res<ConnectionAddr>>,
+    initial_kdl: Option<Res<InitialKdlPath>>,
 ) {
     let connection_addr = connection_addr.as_ref().map(|addr| addr.0);
+    let local_root = local_assets_root(initial_kdl.as_deref());
     for (entity, mut jet, owner) in &mut jets {
         let Some(handle) = jet.pending_effect.clone() else {
             continue;
@@ -766,7 +781,15 @@ fn bind_file_effect_assets(
             .texture_layout()
             .layout
             .iter()
-            .map(|slot| slot_image(&slot.name, &assets, &asset_server, connection_addr))
+            .map(|slot| {
+                slot_image(
+                    &slot.name,
+                    &assets,
+                    &asset_server,
+                    connection_addr,
+                    local_root.as_deref(),
+                )
+            })
             .collect();
         jet.has_intensity_property = asset
             .properties()
@@ -1213,8 +1236,8 @@ fn apply_kdl_spawner(
     jet: &KdlThrusterJet,
 ) {
     if intensity <= jet.cutoff {
+        // Stop spawning only — keep Visible so trails/smoke already emitted can age out.
         spawner.active = false;
-        *visibility = Visibility::Hidden;
         return;
     }
     let settings = match (jet.base_rate, jet.authored_settings) {

--- a/libs/elodin-editor/src/plugins/web_asset/mod.rs
+++ b/libs/elodin-editor/src/plugins/web_asset/mod.rs
@@ -2,22 +2,58 @@ use std::collections::hash_map::DefaultHasher;
 use std::future::Future;
 use std::hash::{Hash, Hasher};
 use std::io;
-use std::path::Path;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
 
 use bevy::asset::io::*;
 use bevy::prelude::*;
+use impeller2_bevy::ConnectionAddr;
 use reqwest::StatusCode;
 
 use super::asset_cache::{self, CachedAsset};
+use crate::object_3d::assets_http_addr;
 
 #[derive(Default)]
 pub struct WebAssetPlugin;
+
+/// Live `ip:port` of the DB assets HTTP server, shared with the `http` asset
+/// reader so failed fetches of DB assets can fall back to local files.
+#[derive(Resource, Clone)]
+pub struct DbAssetsEndpoint(Arc<RwLock<SocketAddr>>);
+
+impl Default for DbAssetsEndpoint {
+    fn default() -> Self {
+        let default_db: SocketAddr = "127.0.0.1:2240".parse().expect("valid addr");
+        Self(Arc::new(RwLock::new(assets_http_addr(default_db))))
+    }
+}
+
+/// Keeps the fallback endpoint in sync with the live DB connection.
+fn sync_db_assets_endpoint(
+    endpoint: Res<DbAssetsEndpoint>,
+    connection: Option<Res<ConnectionAddr>>,
+) {
+    let Some(connection) = connection else {
+        return;
+    };
+    if !connection.is_changed() {
+        return;
+    }
+    if let Ok(mut current) = endpoint.0.write() {
+        *current = assets_http_addr(connection.0);
+    }
+}
 
 struct Client {
     #[allow(dead_code)]
     rt: Runtime,
     source: Source,
     cache: Box<dyn asset_cache::AssetCache>,
+    /// URLs under this endpoint are DB assets eligible for local fallback.
+    db_endpoint: Option<Arc<RwLock<SocketAddr>>>,
+    /// Local assets root searched when a DB asset fetch fails.
+    local_root: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -74,8 +110,23 @@ impl Runtime {
 impl Plugin for WebAssetPlugin {
     fn build(&self, app: &mut App) {
         let rt = Runtime::new();
-        app.register_asset_source("http", Client::asset_source(rt.clone(), Source::Http));
-        app.register_asset_source("https", Client::asset_source(rt.clone(), Source::Https));
+        let endpoint = DbAssetsEndpoint::default();
+        let local_root = super::env_asset_source::resolve_assets_dir();
+        app.insert_resource(endpoint.clone());
+        app.add_systems(Update, sync_db_assets_endpoint);
+        app.register_asset_source(
+            "http",
+            Client::asset_source(
+                rt.clone(),
+                Source::Http,
+                Some(endpoint.0.clone()),
+                local_root,
+            ),
+        );
+        app.register_asset_source(
+            "https",
+            Client::asset_source(rt.clone(), Source::Https, None, None),
+        );
     }
 }
 
@@ -113,6 +164,12 @@ impl Client {
                 {
                     return Ok((data, None));
                 }
+                // Error statuses must not flow into asset loaders as bytes
+                // (a 404 body is not a GLB) and must not be cached.
+                let status = response.status();
+                if !status.is_success() {
+                    return Err(AssetReaderError::HttpError(status.as_u16()));
+                }
                 let etag = response
                     .headers()
                     .get("ETag")
@@ -129,13 +186,51 @@ impl Client {
             .await
     }
 
-    fn asset_source(rt: Runtime, source: Source) -> AssetSourceBuilder {
+    fn asset_source(
+        rt: Runtime,
+        source: Source,
+        db_endpoint: Option<Arc<RwLock<SocketAddr>>>,
+        local_root: Option<PathBuf>,
+    ) -> AssetSourceBuilder {
         AssetSourceBuilder::new(move || {
-            let rt = rt.clone();
-            let cache = Box::new(asset_cache::cache());
-            Box::new(Client { rt, source, cache })
+            Box::new(Client {
+                rt: rt.clone(),
+                source,
+                cache: Box::new(asset_cache::cache()),
+                db_endpoint: db_endpoint.clone(),
+                local_root: local_root.clone(),
+            })
         })
     }
+
+    /// Serves `<local_root>/<key>` for DB-asset URLs that failed to fetch, so
+    /// local iteration (`--kdl`) works without injecting every asset into the
+    /// DB. Only URLs under the DB assets endpoint are eligible.
+    fn local_fallback(&self, path: &Path, url: &str) -> Option<Box<dyn Reader>> {
+        let endpoint = *self.db_endpoint.as_ref()?.read().ok()?;
+        let key = db_asset_key(path.to_str()?, endpoint)?;
+        let file = self.local_root.as_ref()?.join(key);
+        let bytes = std::fs::read(&file).ok()?;
+        tracing::info!(
+            url = %url,
+            file = %file.display(),
+            "db asset unavailable; serving local file"
+        );
+        Some(Box::new(VecReader::new(bytes)) as Box<dyn Reader>)
+    }
+}
+
+/// `host:port/key` reader path -> `key`, when `host:port` is the DB assets
+/// endpoint. Rejects parent-dir components so a malformed key cannot escape
+/// the assets root.
+fn db_asset_key(path: &str, endpoint: SocketAddr) -> Option<&str> {
+    let key = path
+        .strip_prefix(&endpoint.to_string())?
+        .strip_prefix('/')?;
+    if key.is_empty() || key.split('/').any(|part| part == "..") {
+        return None;
+    }
+    Some(key)
 }
 
 /// Content fingerprint used when the HTTP server omits `ETag` (historically
@@ -168,6 +263,14 @@ impl AssetReader for Client {
                 Ok(Box::new(reader) as Box<dyn Reader>)
             }
             Err(err) => {
+                // 404: the DB genuinely lacks the key. Don't resurrect a stale
+                // cached copy; do try the local assets tree (--kdl iteration).
+                if matches!(err, AssetReaderError::HttpError(404)) {
+                    if let Some(reader) = self.local_fallback(path, &url) {
+                        return Ok(reader);
+                    }
+                    return Err(err);
+                }
                 // Stale-while-error: if the DB asset HTTP port is already down
                 // (sim teardown) or briefly unreachable, keep using the last
                 // good copy instead of spamming failed fetches.
@@ -179,6 +282,9 @@ impl AssetReader for Client {
                     );
                     let reader = VecReader::new(data);
                     return Ok(Box::new(reader) as Box<dyn Reader>);
+                }
+                if let Some(reader) = self.local_fallback(path, &url) {
+                    return Ok(reader);
                 }
                 Err(err)
             }
@@ -222,5 +328,78 @@ mod tests {
         assert_eq!(a, b);
         assert_ne!(a, c);
         assert!(a.starts_with("W/\""));
+    }
+
+    #[test]
+    fn db_asset_key_extracts_key_only_for_matching_endpoint() {
+        let endpoint: SocketAddr = "127.0.0.1:2241".parse().unwrap();
+        assert_eq!(
+            db_asset_key("127.0.0.1:2241/textures/x.png", endpoint),
+            Some("textures/x.png")
+        );
+        // Different host or port: not a DB asset.
+        assert_eq!(db_asset_key("10.0.0.5:2241/textures/x.png", endpoint), None);
+        assert_eq!(db_asset_key("127.0.0.1:8080/textures/x.png", endpoint), None);
+        // Parent-dir escapes rejected.
+        assert_eq!(db_asset_key("127.0.0.1:2241/../secrets", endpoint), None);
+        // Empty key rejected.
+        assert_eq!(db_asset_key("127.0.0.1:2241/", endpoint), None);
+    }
+
+    #[test]
+    fn db_asset_key_handles_ipv6_endpoints() {
+        let endpoint: SocketAddr = "[::1]:2241".parse().unwrap();
+        assert_eq!(
+            db_asset_key("[::1]:2241/models/a.glb", endpoint),
+            Some("models/a.glb")
+        );
+    }
+
+    struct NoopCache;
+
+    impl asset_cache::AssetCache for NoopCache {
+        fn get(&self, _url: &str) -> Option<CachedAsset> {
+            None
+        }
+
+        fn put(&self, _url: &str, _asset: CachedAsset) {}
+    }
+
+    #[test]
+    fn read_serves_local_file_when_db_endpoint_is_unreachable() {
+        let root = std::env::temp_dir().join(format!(
+            "elodin-web-asset-fallback-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(root.join("textures")).unwrap();
+        std::fs::write(root.join("textures/x.png"), b"png-bytes").unwrap();
+
+        // Port 1 on loopback: connection refused, deterministic transport error.
+        let endpoint: SocketAddr = "127.0.0.1:1".parse().unwrap();
+        let client = Client {
+            rt: Runtime::new(),
+            source: Source::Http,
+            cache: Box::new(NoopCache),
+            db_endpoint: Some(Arc::new(RwLock::new(endpoint))),
+            local_root: Some(root.clone()),
+        };
+
+        let mut buf = Vec::new();
+        bevy::tasks::block_on(async {
+            let mut reader = AssetReader::read(&client, Path::new("127.0.0.1:1/textures/x.png"))
+                .await
+                .expect("local fallback should serve the file");
+            reader.read_to_end(&mut buf).await.unwrap();
+        });
+        assert_eq!(buf, b"png-bytes");
+
+        // A URL outside the DB endpoint must not fall back.
+        bevy::tasks::block_on(async {
+            let result =
+                AssetReader::read(&client, Path::new("127.0.0.1:2/textures/x.png")).await;
+            assert!(result.is_err(), "non-DB URLs must not serve local files");
+        });
+
+        std::fs::remove_dir_all(&root).ok();
     }
 }

--- a/libs/elodin-editor/src/plugins/web_asset/mod.rs
+++ b/libs/elodin-editor/src/plugins/web_asset/mod.rs
@@ -339,7 +339,10 @@ mod tests {
         );
         // Different host or port: not a DB asset.
         assert_eq!(db_asset_key("10.0.0.5:2241/textures/x.png", endpoint), None);
-        assert_eq!(db_asset_key("127.0.0.1:8080/textures/x.png", endpoint), None);
+        assert_eq!(
+            db_asset_key("127.0.0.1:8080/textures/x.png", endpoint),
+            None
+        );
         // Parent-dir escapes rejected.
         assert_eq!(db_asset_key("127.0.0.1:2241/../secrets", endpoint), None);
         // Empty key rejected.
@@ -367,10 +370,8 @@ mod tests {
 
     #[test]
     fn read_serves_local_file_when_db_endpoint_is_unreachable() {
-        let root = std::env::temp_dir().join(format!(
-            "elodin-web-asset-fallback-{}",
-            std::process::id()
-        ));
+        let root =
+            std::env::temp_dir().join(format!("elodin-web-asset-fallback-{}", std::process::id()));
         std::fs::create_dir_all(root.join("textures")).unwrap();
         std::fs::write(root.join("textures/x.png"), b"png-bytes").unwrap();
 
@@ -395,8 +396,7 @@ mod tests {
 
         // A URL outside the DB endpoint must not fall back.
         bevy::tasks::block_on(async {
-            let result =
-                AssetReader::read(&client, Path::new("127.0.0.1:2/textures/x.png")).await;
+            let result = AssetReader::read(&client, Path::new("127.0.0.1:2/textures/x.png")).await;
             assert!(result.is_err(), "non-DB URLs must not serve local files");
         });
 

--- a/libs/elodin-editor/src/ui/command_palette/palette_items.rs
+++ b/libs/elodin-editor/src/ui/command_palette/palette_items.rs
@@ -1928,6 +1928,8 @@ fn create_object_3d_with_color(eql: String, expr: eql::Expr, mesh: Mesh) -> Pale
                     &assets,
                     &geo_context,
                     connection_addr,
+                    // Color-mesh source: no asset URL to resolve.
+                    None,
                 );
 
                 PaletteEvent::Exit
@@ -1994,10 +1996,12 @@ pub fn create_3d_object() -> PaletteItem {
                                                   mut mat3_material_assets: ResMut<Assets<bevy_mat3_material::Mat3Material>>,
                                                   assets: Res<AssetServer>,
                                                   geo_context: Res<GeoContext>,
-                                                  connection_addr: Option<Res<ConnectionAddr>>
+                                                  connection_addr: Option<Res<ConnectionAddr>>,
+                                                  initial_kdl: Option<Res<crate::plugins::kdl_document::InitialKdlPath>>
                                                 | {
                                                 let obj = impeller2_wkt::Object3DMesh::glb(gltf_path.trim());
                                                 let connection_addr = connection_addr.as_ref().map(|addr| addr.0);
+                                                let local_root = crate::object_3d::local_assets_root(initial_kdl.as_deref());
 
                                                 let _ = crate::object_3d::create_object_3d_entity(
                                                     &mut commands,
@@ -2010,6 +2014,7 @@ pub fn create_3d_object() -> PaletteItem {
                     &assets,
                     &geo_context,
                     connection_addr,
+                    local_root.as_deref(),
                 );
 
                                                 PaletteEvent::Exit

--- a/libs/elodin-editor/src/ui/inspector/object3d.rs
+++ b/libs/elodin-editor/src/ui/inspector/object3d.rs
@@ -63,6 +63,10 @@ impl WidgetSystem for InspectorObject3D<'_, '_> {
         let connection_addr = world
             .get_resource::<impeller2_bevy::ConnectionAddr>()
             .map(|addr| addr.0);
+        let local_root = crate::object_3d::local_assets_root(
+            world
+                .get_resource::<crate::plugins::kdl_document::InitialKdlPath>(),
+        );
         let InspectorObject3D {
             mut object_3d,
             metadata_query,
@@ -664,6 +668,7 @@ impl WidgetSystem for InspectorObject3D<'_, '_> {
                     &mut mat3_material_assets,
                     &assets,
                     connection_addr,
+                    local_root.as_deref(),
                 );
             }
         });

--- a/libs/elodin-editor/src/ui/inspector/object3d.rs
+++ b/libs/elodin-editor/src/ui/inspector/object3d.rs
@@ -64,8 +64,7 @@ impl WidgetSystem for InspectorObject3D<'_, '_> {
             .get_resource::<impeller2_bevy::ConnectionAddr>()
             .map(|addr| addr.0);
         let local_root = crate::object_3d::local_assets_root(
-            world
-                .get_resource::<crate::plugins::kdl_document::InitialKdlPath>(),
+            world.get_resource::<crate::plugins::kdl_document::InitialKdlPath>(),
         );
         let InspectorObject3D {
             mut object_3d,

--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -947,8 +947,7 @@ impl LoadSchematicParams<'_, '_> {
         let icon = object_3d.icon.clone();
         let mesh_vr = object_3d.mesh_visibility_range.clone();
         let connection_addr = self.connection_addr.as_ref().map(|addr| addr.0);
-        let local_root =
-            crate::object_3d::local_assets_root(self.initial_kdl.as_deref());
+        let local_root = crate::object_3d::local_assets_root(self.initial_kdl.as_deref());
         let result = crate::object_3d::create_object_3d_entity(
             &mut self.commands,
             object_3d.clone(),

--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -273,6 +273,8 @@ pub struct LoadSchematicParams<'w, 's> {
     pub schema_reg: Res<'w, ComponentSchemaRegistry>,
     pub eql: Res<'w, EqlContext>,
     connection_addr: Option<Res<'w, ConnectionAddr>>,
+    /// Optional: absent in minimal test apps (no kdl_document plugin).
+    initial_kdl: Option<Res<'w, crate::plugins::kdl_document::InitialKdlPath>>,
     pub geo_context: ResMut<'w, GeoContext>,
     pub sensor_camera_configs: Res<'w, crate::sensor_camera::SensorCameraConfigs>,
     pub coordinate: ResMut<'w, crate::Coordinate>,
@@ -945,6 +947,8 @@ impl LoadSchematicParams<'_, '_> {
         let icon = object_3d.icon.clone();
         let mesh_vr = object_3d.mesh_visibility_range.clone();
         let connection_addr = self.connection_addr.as_ref().map(|addr| addr.0);
+        let local_root =
+            crate::object_3d::local_assets_root(self.initial_kdl.as_deref());
         let result = crate::object_3d::create_object_3d_entity(
             &mut self.commands,
             object_3d.clone(),
@@ -956,6 +960,7 @@ impl LoadSchematicParams<'_, '_> {
             &self.asset_server,
             &self.geo_context,
             connection_addr,
+            local_root.as_deref(),
         );
         match result {
             Ok(entity) => {
@@ -977,6 +982,7 @@ impl LoadSchematicParams<'_, '_> {
                         &self.asset_server,
                         &mut self.icon_cache,
                         connection_addr,
+                        local_root.as_deref(),
                     );
                 }
             }


### PR DESCRIPTION
While developing on a schematic, I found that while I could specify the local kdl file, I couldn't also iterate on the other assets with it. This change allows using the --kdl as a hook to also allow loading local assets first, purely for development.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which bytes asset loaders receive (HTTP errors, 404 fallback, local shadowing) across GLBs, icons, and particle effects; scoped to dev via --kdl for URL resolution but HTTP fallback is always wired to the assets dir.
> 
> **Overview**
> **Local schematic iteration (`--kdl`)** now shadows DB-backed assets: when a session was opened with a CLI KDL path, `db:…` keys that exist under the resolved local assets tree load as bare relative paths (disk + hot reload) instead of the DB HTTP URL. That preference is threaded through Object3D spawn/sync, schematic load, inspector, command palette, and thruster `.effect`/texture resolution; the headless render server keeps passing no override so it stays DB-only.
> 
> **HTTP asset loading** is tightened and given a dev fallback: non-success HTTP responses are errors (not fed to loaders or cached), the DB assets endpoint tracks the live connection, and failed fetches for URLs under that endpoint can serve matching files from the local assets root (with `..` rejected). **`bevy_hanabi`** is bumped to a newer elodin-sys git rev (`0.19.1-dev`).
> 
> **Thruster VFX:** cutting intensity below cutoff stops emission but leaves effects **visible** so existing trails/smoke can finish instead of hiding immediately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0cfcd1afd9db97761858e3394c2dd2ecc2d6eb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->