### PR TITLE
Fix: Line_3d f32 quantization error

### DIFF
--- a/examples/f32-quant-repro/main.py
+++ b/examples/f32-quant-repro/main.py
@@ -214,5 +214,5 @@ if __name__ == "__main__":
         system(),
         simulation_rate=1.0 / SIM_TIME_STEP,
         max_ticks=MAX_TICKS,
-        db_path=db_path,
+        # db_path=db_path,
     )

--- a/examples/f32-quant-repro/main.py
+++ b/examples/f32-quant-repro/main.py
@@ -1,0 +1,218 @@
+"""Repro for f32 quantization in the editor's plot/line_3d display path (#760).
+
+A ball flies a smooth, slow climbing arc near a real launch site in ECEF
+coordinates (~6.37e6 m magnitude — the worst case for f32). The recorded
+trajectory is f64 and perfectly smooth, yet the ECEF `line_3d` trail
+staircases on screen: the display path casts each sample to f32 at ingestion,
+and at that magnitude one f32 ULP is ~0.25-0.5 m.
+
+The same motion is recorded a second time in a local ENU component (numbers of
+tens of metres) and drawn as a second `line_3d` right next to the ECEF one:
+
+    green  trail  = ball.pos_ecef  (large numbers)  -> staircases
+    magenta trail = ball.pos_enu   (small numbers)  -> stays smooth
+
+Identical f64 signal, identical rendering; only the coordinate magnitude at the
+f32 cast differs. That isolates the quantization to the display-side cast, not
+the sim, the DB, or the line's first-point subtraction (which happens after the
+cast and therefore cannot recover the lost bits).
+
+Noise is OFF by default so nothing in the data can be mistaken for the effect.
+Set DEMO_NOISE_SIGMA > 0 to overlay a realistic Ornstein-Uhlenbeck nav wander.
+
+Record then replay (from the repo root, inside `nix develop`):
+
+    uv run python examples/f32-quant-repro/main.py run     # writes ./db
+    elodin-db run 127.0.0.1:2241 examples/f32-quant-repro/db --log-level warn &
+    elodin editor 127.0.0.1:2241 --replay
+
+Zoom on the ball during the arc: the green (ECEF) trail steps; the magenta
+(ENU) trail is smooth.
+"""
+
+import math
+import os
+import typing
+
+from dataclasses import field
+
+import elodin as el
+import jax
+from jax import numpy as jnp
+from jax import random
+
+SIM_TIME_STEP = 1.0 / 100.0
+MAX_TICKS = 6000  # 60 s
+
+# Trajectory phases (seconds).
+DWELL = 15.0
+FLY = 30.0
+HELIX_RADIUS = 30.0
+HELIX_PERIOD = 60.0  # half a turn over the flight -> ~3.1 m/s
+CLIMB_RATE = 1.5
+
+# Ornstein-Uhlenbeck noise: stationary sigma and correlation time. The per-tick
+# update is n' = a*n + s*N(0,1) with a = exp(-dt/tau) and s = sigma*sqrt(1-a^2),
+# which keeps the stationary std exactly at sigma. Default sigma is 0 so the
+# recorded curve is a clean f64 ground truth: any staircase on the displayed
+# ECEF trail is then display-path f32 truncation, not data.
+NOISE_SIGMA = float(os.environ.get("DEMO_NOISE_SIGMA", "0.0"))
+NOISE_TAU = 0.15
+NOISE_A = math.exp(-SIM_TIME_STEP / NOISE_TAU)
+NOISE_STEP = NOISE_SIGMA * math.sqrt(1.0 - NOISE_A * NOISE_A)
+
+# Arbitrary surface point (WGS84 lat/lon/alt). Any location works — the repro
+# only needs a large ECEF magnitude (~6.4e6 m) to expose the f32 cast.
+LAT, LON, ALT = 35.0, -117.5, 600.0
+
+
+def _wgs84_ecef(lat_deg: float, lon_deg: float, alt: float) -> tuple:
+    a, e2 = 6378137.0, 6.69437999014e-3
+    lat, lon = math.radians(lat_deg), math.radians(lon_deg)
+    n = a / math.sqrt(1.0 - e2 * math.sin(lat) ** 2)
+    x = (n + alt) * math.cos(lat) * math.cos(lon)
+    y = (n + alt) * math.cos(lat) * math.sin(lon)
+    z = (n * (1.0 - e2) + alt) * math.sin(lat)
+    return x, y, z
+
+
+def _enu_to_ecef_matrix(lat_deg: float, lon_deg: float):
+    lat, lon = math.radians(lat_deg), math.radians(lon_deg)
+    sl, cl = math.sin(lat), math.cos(lat)
+    so, co = math.sin(lon), math.cos(lon)
+    # Columns are the ENU basis vectors expressed in ECEF.
+    return jnp.array(
+        [
+            [-so, -sl * co, cl * co],
+            [co, -sl * so, cl * so],
+            [0.0, cl, sl],
+        ]
+    )
+
+
+BASE_ECEF = jnp.array(_wgs84_ecef(LAT, LON, ALT))
+ENU2ECEF = _enu_to_ecef_matrix(LAT, LON)
+
+SimT = typing.Annotated[
+    jax.Array,
+    el.Component("sim_t", el.ComponentType(el.PrimitiveType.F64, ())),
+]
+
+PosEcef = typing.Annotated[
+    jax.Array,
+    el.Component(
+        "pos_ecef",
+        el.ComponentType(el.PrimitiveType.F64, (3,)),
+        metadata={"element_names": "x,y,z"},
+    ),
+]
+
+NavNoise = typing.Annotated[
+    jax.Array,
+    el.Component(
+        "nav_noise",
+        el.ComponentType(el.PrimitiveType.F64, (3,)),
+        metadata={"element_names": "x,y,z"},
+    ),
+]
+
+# Same motion expressed in local ENU (small numbers). Rendering it next to the
+# ECEF trail isolates the f32 magnitude effect: identical f64 signal, only the
+# coordinate magnitude at the f32 cast differs.
+PosEnu = typing.Annotated[
+    jax.Array,
+    el.Component(
+        "pos_enu",
+        el.ComponentType(el.PrimitiveType.F64, (3,)),
+        metadata={"element_names": "x,y,z"},
+    ),
+]
+
+
+@el.dataclass
+class BallData(el.Archetype):
+    sim_t: SimT = field(default_factory=lambda: jnp.float64(0.0))
+    nav_noise: NavNoise = field(default_factory=lambda: jnp.zeros(3))
+    pos_ecef: PosEcef = field(default_factory=lambda: jnp.array(BASE_ECEF))
+    pos_enu: PosEnu = field(default_factory=lambda: jnp.array([0.0, 0.0, 2.0]))
+
+
+@el.map
+def advance_time(t: SimT) -> SimT:
+    return t + SIM_TIME_STEP
+
+
+@el.map
+def wander_noise(t: SimT, n: NavNoise) -> NavNoise:
+    # OU step: correlated wander, deterministic per tick index.
+    tick = jnp.int64(jnp.round(t / SIM_TIME_STEP))
+    return NOISE_A * n + NOISE_STEP * random.normal(random.key(tick), shape=(3,))
+
+
+def _enu_pos(t: jax.Array, n: jax.Array) -> jax.Array:
+    # Dwell -> climbing arc -> dwell, defined in local ENU.
+    tt = jnp.clip(t - DWELL, 0.0, FLY)
+    ang = 2.0 * jnp.pi * tt / HELIX_PERIOD
+    enu = jnp.array(
+        [
+            HELIX_RADIUS * jnp.sin(ang),
+            HELIX_RADIUS * (1.0 - jnp.cos(ang)),
+            2.0 + CLIMB_RATE * tt,
+        ]
+    )
+    return enu + n
+
+
+@el.map
+def move_ball(t: SimT, n: NavNoise, _p: PosEcef) -> PosEcef:
+    return BASE_ECEF + ENU2ECEF @ _enu_pos(t, n)
+
+
+@el.map
+def move_ball_enu(t: SimT, n: NavNoise, _p: PosEnu) -> PosEnu:
+    return _enu_pos(t, n)
+
+
+def world() -> el.World:
+    w = el.World()
+    w.spawn(BallData(), name="ball")
+    w.schematic(
+        f"""
+        coordinate frame=ENU lat={LAT} lon={LON} alt={ALT}
+        hsplit name="f32 quantization — ECEF (green) vs ENU (magenta)" share=1.0 {{
+            viewport frame=ECEF name="RAW camera  (smoothing=0)" near=0.1 smoothing=0.0 pos="(0,0,0,0,6,6,-4) + (0,0,0,1, ball.pos_ecef[0], ball.pos_ecef[1], ball.pos_ecef[2])" look_at="(0,0,0,1, ball.pos_ecef[0], ball.pos_ecef[1], ball.pos_ecef[2])" show_grid=#true show_view_cube=#true
+            viewport frame=ECEF name="SMOOTHED camera  (smoothing=1)" near=0.1 smoothing=1.0 pos="(0,0,0,0,6,6,-4) + (0,0,0,1, ball.pos_ecef[0], ball.pos_ecef[1], ball.pos_ecef[2])" look_at="(0,0,0,1, ball.pos_ecef[0], ball.pos_ecef[1], ball.pos_ecef[2])" show_grid=#true show_view_cube=#true
+        }}
+        object_3d frame=ECEF "(0,0,0,1, ball.pos_ecef[0], ball.pos_ecef[1], ball.pos_ecef[2])" {{
+            sphere radius=0.4 {{
+                color orange
+            }}
+        }}
+        line_3d frame=ECEF "(0,0,0,1, ball.pos_ecef[0], ball.pos_ecef[1], ball.pos_ecef[2])" perspective=#false smoothing=0.0 {{
+            color 0 255 0
+            future_color 0 180 0
+        }}
+        line_3d frame=ENU "(0,0,0,1, ball.pos_enu[0] + 1.5, ball.pos_enu[1], ball.pos_enu[2])" perspective=#false smoothing=0.0 {{
+            color 255 0 255
+            future_color 160 0 160
+        }}
+    """,
+        "main.kdl",
+    )
+    return w
+
+
+def system() -> el.System:
+    return advance_time | wander_noise | move_ball | move_ball_enu
+
+
+if __name__ == "__main__":
+    db_path = os.environ.get(
+        "DEMO_DB_PATH", os.path.join(os.path.dirname(os.path.abspath(__file__)), "db")
+    )
+    world().run(
+        system(),
+        simulation_rate=1.0 / SIM_TIME_STEP,
+        max_ticks=MAX_TICKS,
+        db_path=db_path,
+    )

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -1545,6 +1545,15 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
         chunk.data.cpu().first().copied()
     }
 
+    /// Timestamp of the sample returned by [`Self::first_sample`].
+    pub fn first_timestamp(&self) -> Option<Timestamp> {
+        let (_, chunk) = self.tree.first_key_value()?;
+        if chunk.data.cpu().is_empty() {
+            return None;
+        }
+        chunk.timestamps.first().copied()
+    }
+
     pub fn chunk_count(&self) -> usize {
         self.tree.iter().count()
     }
@@ -1921,17 +1930,19 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
         written_u32s
     }
 
-    /// Collect CPU sample values for the same visible strip that
+    /// Visit `(chunk, offset)` for every sample in the visible strip that
     /// [`Self::write_to_index_buffer_with_step`] would index (same step / clip).
     ///
-    /// Does not require GPU-resident chunks — used by `line_3d` to build
-    /// floating-origin-local XYZ buffers.
-    pub fn collect_strip_values(&self, line_visible_range: Range<Timestamp>, step: usize) -> Vec<D>
-    where
-        D: Copy,
-    {
+    /// Shared by [`Self::collect_strip_values`] and
+    /// [`Self::collect_strip_timestamps`] so the two stay index-aligned: the
+    /// `line_3d` path pairs a timestamp with its value across both.
+    fn for_each_strip_sample(
+        &self,
+        line_visible_range: Range<Timestamp>,
+        step: usize,
+        mut f: impl FnMut(&Chunk<D>, usize),
+    ) {
         let step = step.max(1);
-        let mut out = Vec::new();
         for chunk in self.range_iter(line_visible_range.clone()) {
             let Some((start_offset, end_offset)) =
                 chunk_visible_offsets(&chunk.timestamps, &line_visible_range)
@@ -1942,7 +1953,6 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
             if vis_len == 0 {
                 continue;
             }
-            let values = chunk.data.cpu();
             let index_chunk = IndexChunk {
                 range: 0..u32::MAX,
                 len: vis_len,
@@ -1951,28 +1961,59 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
             let mut index_iter = index_chunk.into_index_iter();
             let mut last_written: Option<u32> = None;
             if let Some(index) = index_iter.next() {
-                let i = start_offset + index as usize;
-                if let Some(&v) = values.get(i) {
-                    out.push(v);
-                }
+                f(chunk, start_offset + index as usize);
                 last_written = Some(index);
             }
             for index in index_iter.step_by(step) {
-                let i = start_offset + index as usize;
-                if let Some(&v) = values.get(i) {
-                    out.push(v);
-                }
+                f(chunk, start_offset + index as usize);
                 last_written = Some(index);
             }
             if let Some(end) = end
                 && last_written != Some(end)
             {
-                let i = start_offset + end as usize;
-                if let Some(&v) = values.get(i) {
-                    out.push(v);
-                }
+                f(chunk, start_offset + end as usize);
             }
         }
+    }
+
+    /// Collect CPU sample values for the visible strip.
+    ///
+    /// Does not require GPU-resident chunks — used by `line_3d` to build
+    /// floating-origin-local XYZ buffers.
+    pub fn collect_strip_values(&self, line_visible_range: Range<Timestamp>, step: usize) -> Vec<D>
+    where
+        D: Copy,
+    {
+        let mut out = Vec::new();
+        self.for_each_strip_sample(line_visible_range, step, |chunk, i| {
+            if let Some(&v) = chunk.data.cpu().get(i) {
+                out.push(v);
+            }
+        });
+        out
+    }
+
+    /// Collect the timestamps of the visible strip, index-aligned with
+    /// [`Self::collect_strip_values`].
+    ///
+    /// `line_3d` uses these to re-read each sample from the f64 telemetry cache,
+    /// so ECEF-scale coordinates keep full precision until after the anchor
+    /// subtraction.
+    pub fn collect_strip_timestamps(
+        &self,
+        line_visible_range: Range<Timestamp>,
+        step: usize,
+    ) -> Vec<Timestamp> {
+        let mut out = Vec::new();
+        self.for_each_strip_sample(line_visible_range, step, |chunk, i| {
+            // Guard on `data` so a value-less index is skipped in both
+            // collectors and the two stay aligned.
+            if chunk.data.cpu().len() > i
+                && let Some(&ts) = chunk.timestamps.get(i)
+            {
+                out.push(ts);
+            }
+        });
         out
     }
 
@@ -2565,6 +2606,32 @@ mod tests {
         let step3 = tree.collect_strip_values(range, 3);
         // first, then step_by(3) on remainder, then last if needed
         assert_eq!(step3, vec![0.0, 1.0, 4.0, 7.0, 9.0]);
+    }
+
+    #[test]
+    fn collect_strip_timestamps_aligns_with_values() {
+        // `line_3d` pairs strip timestamps with cached f64 samples by index, so
+        // the two collectors must select exactly the same samples. Multiple
+        // chunks exercise the per-chunk first/last sentinel handling.
+        let mut tree = LineTree::<f32>::default();
+        let n = 40;
+        for base in [0usize, 20] {
+            let ts: Vec<Timestamp> = (base..base + 20)
+                .map(|i| Timestamp(i as i64 * 1_000))
+                .collect();
+            let vals: Vec<f32> = (base..base + 20).map(|i| i as f32).collect();
+            tree.insert(Chunk::from_iter(&ts, Timestamp(0), vals.iter().copied()).expect("chunk"));
+        }
+        let range = Timestamp(0)..Timestamp((n as i64 - 1) * 1_000);
+        for step in [1usize, 2, 3, 7, 100] {
+            let values = tree.collect_strip_values(range.clone(), step);
+            let timestamps = tree.collect_strip_timestamps(range.clone(), step);
+            assert_eq!(values.len(), timestamps.len(), "step={step}");
+            // Values are the sample index, so each timestamp must be its value.
+            for (value, ts) in values.iter().zip(&timestamps) {
+                assert_eq!(Timestamp(*value as i64 * 1_000), *ts, "step={step}");
+            }
+        }
     }
 
     #[test]

--- a/libs/elodin-editor/src/ui/plot_3d/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/gpu.rs
@@ -1185,13 +1185,59 @@ mod tests {
             .collect()
     }
 
+    /// Populate a [`TelemetryCache`] the way live/replay ingest does for a
+    /// 3-element f64 component, and return the strip timestamps a LineTree
+    /// would have selected (one per sample, step=1).
+    fn ecef_cache(samples: &[DVec3]) -> (TelemetryCache, Vec<Timestamp>, [LineAxisSource; 3]) {
+        let component_id = ComponentId::new("ball.pos_ecef");
+        let mut cache = TelemetryCache::default();
+        let timestamps: Vec<Timestamp> = (0..samples.len())
+            .map(|i| Timestamp(i as i64 * 10_000))
+            .collect();
+        for (&ts, sample) in timestamps.iter().zip(samples) {
+            cache.insert(
+                component_id,
+                ts,
+                impeller2_wkt::ComponentValue::F64(
+                    nox::array![sample.x, sample.y, sample.z].to_dyn(),
+                ),
+            );
+        }
+        let sources = [0, 1, 2].map(|element| LineAxisSource {
+            component_id,
+            element,
+            affine: ElementAffine::default(),
+        });
+        (cache, timestamps, sources)
+    }
+
+    /// Read XYZ through [`axis_strip_values_f64`] and subtract the first sample,
+    /// matching what `write_anchor_local_line_buffers` does with the fix in place.
+    fn locals_from_cache(
+        cache: &TelemetryCache,
+        sources: &[LineAxisSource; 3],
+        timestamps: &[Timestamp],
+    ) -> Vec<Vec3> {
+        let xs = axis_strip_values_f64(cache, sources[0], timestamps).expect("x");
+        let ys = axis_strip_values_f64(cache, sources[1], timestamps).expect("y");
+        let zs = axis_strip_values_f64(cache, sources[2], timestamps).expect("z");
+        assert_eq!(xs.len(), timestamps.len());
+        let anchor = DVec3::new(xs[0], ys[0], zs[0]);
+        xs.into_iter()
+            .zip(ys)
+            .zip(zs)
+            .map(|((x, y), z)| anchor_local(DVec3::new(x, y, z), anchor))
+            .collect()
+    }
+
     #[test]
     fn f64_samples_keep_ecef_trail_smooth() {
-        // The fix: sourcing samples in f64 lets the anchor subtraction recover the
-        // motion, so every step survives and the spacing stays uniform.
+        // Regression for the fix path: TelemetryCache → axis_strip_values_f64 →
+        // anchor subtraction. If axis_values went back to reading f32 from the
+        // LineTree, this would staircase and fail.
         let samples = ecef_ramp(64);
-        let anchor = samples[0];
-        let locals: Vec<Vec3> = samples.iter().map(|&s| anchor_local(s, anchor)).collect();
+        let (cache, timestamps, sources) = ecef_cache(&samples);
+        let locals = locals_from_cache(&cache, &sources, &timestamps);
         let expected_step = (samples[1] - samples[0]).length() as f32;
         for pair in locals.windows(2) {
             let step = (pair[1] - pair[0]).length();
@@ -1204,13 +1250,22 @@ mod tests {
 
     #[test]
     fn f32_samples_staircase_the_ecef_trail() {
-        // The bug this replaced: casting to f32 before the subtraction quantizes
-        // the sample to ~0.5 m, so most steps collapse to zero and the survivors
-        // jump a full ULP — the sawtooth seen on the ECEF trail.
+        // Contrast: the same ECEF ramp, but cast to f32 before the subtraction
+        // — what the LineTree path does. Most steps collapse to zero and the
+        // survivors jump a full ULP; that's the sawtooth the f64 path above
+        // avoids. Kept so a "revert to LineTree f32" can't sneak past by only
+        // exercising anchor_local.
         let samples = ecef_ramp(64);
-        let quantized: Vec<DVec3> = samples
-            .iter()
-            .map(|s| DVec3::new(s.x as f32 as f64, s.y as f32 as f64, s.z as f32 as f64))
+        let (cache, timestamps, sources) = ecef_cache(&samples);
+        // Full-fidelity strip from the cache, then the old cast.
+        let xs = axis_strip_values_f64(&cache, sources[0], &timestamps).expect("x");
+        let ys = axis_strip_values_f64(&cache, sources[1], &timestamps).expect("y");
+        let zs = axis_strip_values_f64(&cache, sources[2], &timestamps).expect("z");
+        let quantized: Vec<DVec3> = xs
+            .into_iter()
+            .zip(ys)
+            .zip(zs)
+            .map(|((x, y), z)| DVec3::new(x as f32 as f64, y as f32 as f64, z as f32 as f64))
             .collect();
         let anchor = quantized[0];
         let locals: Vec<Vec3> = quantized.iter().map(|&s| anchor_local(s, anchor)).collect();

--- a/libs/elodin-editor/src/ui/plot_3d/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/gpu.rs
@@ -1,3 +1,4 @@
+use crate::ui::schematic::ElementAffine;
 use crate::ui::widgets::SystemStateExt;
 use crate::{
     SelectedTimeRange,
@@ -24,7 +25,7 @@ use bevy::{
         },
         world::{FromWorld, Mut, World},
     },
-    math::{DVec3, Mat4, Vec4},
+    math::{DVec3, Mat4, Vec3, Vec4},
     mesh::VertexBufferLayout,
     pbr::{MeshPipeline, MeshPipelineKey, SetMeshViewBindGroup, ViewKeyCache},
     prelude::{Color, Reflect, Resource},
@@ -50,6 +51,8 @@ use bevy_render::{
     sync_world::{MainEntity, SyncToRenderWorld, TemporaryRenderEntity},
 };
 use binding_types::storage_buffer_read_only_sized;
+use impeller2::types::{ComponentId, Timestamp};
+use impeller2_bevy::TelemetryCache;
 use impeller2_wkt::{CurrentTimestamp, EarliestTimestamp, LastUpdated, Line3d};
 use std::num::NonZeroU64;
 use zerocopy::IntoBytes;
@@ -176,6 +179,53 @@ fn update_uniform_model(mut query: Query<(&mut LineUniform, &GlobalTransform)>) 
 #[derive(Component, Debug, Clone, ExtractComponent)]
 #[require(SyncToRenderWorld)]
 pub struct LineHandles(pub [Handle<Line>; 3]);
+
+/// One axis of a `line_3d`: which component element feeds it, and the affine
+/// transform its EQL expression applies.
+#[derive(Debug, Clone, Copy)]
+pub struct LineAxisSource {
+    pub component_id: ComponentId,
+    pub element: usize,
+    pub affine: ElementAffine,
+}
+
+/// The f64 sample source behind each axis of a `line_3d`.
+///
+/// [`Line`] stores `f32`, so an ECEF coordinate (~6.4e6 m, one ULP ≈ 0.5 m) is
+/// already quantized before the anchor subtraction can bring it back to a small
+/// number. Re-reading the sample from [`TelemetryCache`] keeps full precision
+/// until after that subtraction, which is what makes the trail smooth.
+#[derive(Component, Debug, Clone, Copy)]
+pub struct LineSources(pub [LineAxisSource; 3]);
+
+/// Read one axis's cached element as f64 at `ts`, with its EQL affine applied.
+///
+/// Prefers the exact sample; a strip timestamp always comes from a [`Line`] that
+/// was fed by this cache, so the fallback only matters if the cache was trimmed
+/// while the LineTree kept the sample.
+fn cached_axis_f64(cache: &TelemetryCache, source: LineAxisSource, ts: Timestamp) -> Option<f64> {
+    let value = match cache.series(&source.component_id).and_then(|s| s.get(&ts)) {
+        Some(value) => value,
+        None => cache.get_at_or_before(&source.component_id, ts)?,
+    };
+    Some(source.affine.apply(value.get(source.element)?.as_f64()))
+}
+
+/// Full-precision strip values for one axis, index-aligned with
+/// [`crate::ui::plot::data::LineTree::collect_strip_values`].
+///
+/// Returns `None` when any sample is missing from the cache so the caller can
+/// fall back to the f32 LineTree rather than render a partial trail.
+fn axis_strip_values_f64(
+    cache: &TelemetryCache,
+    source: LineAxisSource,
+    timestamps: &[Timestamp],
+) -> Option<Vec<f64>> {
+    timestamps
+        .iter()
+        .map(|&ts| cached_axis_f64(cache, source, ts))
+        .collect()
+}
 
 /// Default opacity applied to the future (not-yet-played) trail segment when a
 /// line does not set its own `future_color`, so the future reads as dimmer than
@@ -499,6 +549,7 @@ type ExtractLinesParams = (
     Res<'static, CurrentTimestamp>,
     Res<'static, TimelineSettings>,
     Res<'static, crate::ui::timeline::LatestFollow>,
+    Res<'static, TelemetryCache>,
 );
 
 #[derive(Resource)]
@@ -522,6 +573,7 @@ type LineQueryMut = (
     Option<&'static LineTrailColors>,
     Option<&'static GeoPosition>,
     Option<&'static Line3d>,
+    Option<&'static LineSources>,
     Option<&'static mut GpuLineIndexCache>,
 );
 
@@ -551,15 +603,47 @@ fn resolve_line_frame(geo_pos: Option<&GeoPosition>, line: Option<&Line3d>) -> G
 }
 
 /// First sample currently in the LineTree (visible window), in frame coords.
-/// Must match the entity `GeoPosition` written by `sync_line_3d_anchor`.
-fn line_first_point_frame(
+///
+/// Read back from [`TelemetryCache`] in f64 when the line's sources are known, so
+/// the anchor carries the same precision as the vertices subtracted from it.
+/// Falls back to the f32 LineTree sample when the cache has no entry.
+///
+/// Shared by `extract_lines` and `sync_line_3d_anchor` (which writes the entity
+/// `GeoPosition`): the two must agree or the trail lands away from the craft.
+pub(super) fn line_first_point_frame(
+    cache: &TelemetryCache,
+    sources: Option<&LineSources>,
     line_assets: &Assets<Line>,
     handles: &[Handle<Line>; 3],
 ) -> Option<DVec3> {
-    let x = line_assets.get(&handles[0])?.data.first_sample()?;
-    let y = line_assets.get(&handles[1])?.data.first_sample()?;
-    let z = line_assets.get(&handles[2])?.data.first_sample()?;
-    Some(DVec3::new(x as f64, y as f64, z as f64))
+    let mut point = [0.0f64; 3];
+    for (axis, value) in point.iter_mut().enumerate() {
+        let line = line_assets.get(&handles[axis])?;
+        let source = sources.map(|s| s.0[axis]);
+        *value = source
+            .and_then(|source| {
+                let ts = line.data.first_timestamp()?;
+                cached_axis_f64(cache, source, ts)
+            })
+            .or_else(|| {
+                let sample = line.data.first_sample()? as f64;
+                Some(match source {
+                    Some(source) => source.affine.apply(sample),
+                    None => sample,
+                })
+            })?;
+    }
+    Some(DVec3::from_array(point))
+}
+
+/// Vertex position for one sample: its frame-space offset from the line's anchor.
+///
+/// The subtraction stays in f64 and only the small residual is cast, so an ECEF
+/// sample keeps sub-millimetre resolution instead of the ~0.5 m f32 ULP it would
+/// have at 6.4e6 m. This only holds if `sample` itself arrived in f64 — see
+/// [`LineSources`].
+fn anchor_local(sample: DVec3, anchor: DVec3) -> Vec3 {
+    (sample - anchor).as_vec3()
 }
 
 /// Build dense first-point-relative XYZ value buffers + remapped strip indices.
@@ -570,9 +654,9 @@ fn line_first_point_frame(
 /// Index layout matches the historical NaN-sentinel strip: leading/trailing
 /// `0` (NaN slot), samples at `1..n`.
 fn write_anchor_local_line_buffers(
-    xs: &[f32],
-    ys: &[f32],
-    zs: &[f32],
+    xs: &[f64],
+    ys: &[f64],
+    zs: &[f64],
     anchor: DVec3,
     render_device: &RenderDevice,
     render_queue: &RenderQueue,
@@ -588,10 +672,10 @@ fn write_anchor_local_line_buffers(
     let mut y_local = vec![f32::NAN; n + 1];
     let mut z_local = vec![f32::NAN; n + 1];
     for i in 0..n {
-        let local = DVec3::new(xs[i] as f64, ys[i] as f64, zs[i] as f64) - anchor;
-        x_local[i + 1] = local.x as f32;
-        y_local[i + 1] = local.y as f32;
-        z_local[i + 1] = local.z as f32;
+        let local = anchor_local(DVec3::new(xs[i], ys[i], zs[i]), anchor);
+        x_local[i + 1] = local.x;
+        y_local[i + 1] = local.y;
+        z_local[i + 1] = local.z;
     }
 
     // Single contiguous strip with NaN sentinels (one logical chunk).
@@ -656,6 +740,7 @@ fn extract_lines(
             current_timestamp,
             timeline_settings,
             latest_follow,
+            telemetry_cache,
         ) = cached_state.state.params_mut(world);
         let selected_range = if crate::is_short_accuracy_window(&selected_time_range.0) {
             selected_time_range.0.clone()
@@ -713,6 +798,7 @@ fn extract_lines(
             trail_colors,
             geo_pos,
             line_3d,
+            line_sources,
             mut index_cache,
         ) in lines.iter_mut()
         {
@@ -730,7 +816,12 @@ fn extract_lines(
 
             // Frame-space first sample. Entity GeoPosition is synced to this;
             // GeoRotation carries the frame→Bevy basis into GlobalTransform.
-            let Some(line_anchor) = line_first_point_frame(&line_assets, &line_handles.0) else {
+            let Some(line_anchor) = line_first_point_frame(
+                &telemetry_cache,
+                line_sources,
+                &line_assets,
+                &line_handles.0,
+            ) else {
                 continue 'outer;
             };
             let anchor_key = anchor_cache_key(frame, line_anchor);
@@ -806,18 +897,32 @@ fn extract_lines(
                     step = step.saturating_mul(2).max(2);
                 }
 
-                let xs = line_assets
-                    .get(&line_handles.0[0])
-                    .map(|l| l.data.collect_strip_values(range.clone(), step))
-                    .unwrap_or_default();
-                let ys = line_assets
-                    .get(&line_handles.0[1])
-                    .map(|l| l.data.collect_strip_values(range.clone(), step))
-                    .unwrap_or_default();
-                let zs = line_assets
-                    .get(&line_handles.0[2])
-                    .map(|l| l.data.collect_strip_values(range.clone(), step))
-                    .unwrap_or_default();
+                // Prefer the f64 cache so the anchor subtraction happens before
+                // any f32 cast; fall back to the LineTree's own f32 samples when
+                // the sources or cached values are unavailable.
+                let axis_values = |axis: usize| -> Vec<f64> {
+                    let Some(line) = line_assets.get(&line_handles.0[axis]) else {
+                        return Vec::new();
+                    };
+                    let source = line_sources.map(|s| s.0[axis]);
+                    if let Some(source) = source {
+                        let timestamps = line.data.collect_strip_timestamps(range.clone(), step);
+                        if let Some(values) =
+                            axis_strip_values_f64(&telemetry_cache, source, &timestamps)
+                        {
+                            return values;
+                        }
+                    }
+                    let affine = source.map(|s| s.affine).unwrap_or_default();
+                    line.data
+                        .collect_strip_values(range.clone(), step)
+                        .into_iter()
+                        .map(|v| affine.apply(f64::from(v)))
+                        .collect()
+                };
+                let xs = axis_values(0);
+                let ys = axis_values(1);
+                let zs = axis_values(2);
 
                 let (value_buffers, index_buffers, count) = write_anchor_local_line_buffers(
                     &xs,
@@ -1069,6 +1174,57 @@ mod tests {
         assert!((placed_tip.as_dvec3() - expected_tip).length() < 1e-3);
         let placed_start = model.transform_point3(bevy::math::Vec3::ZERO);
         assert!((placed_start.as_dvec3() - translation).length() < 1e-3);
+    }
+
+    /// A smooth ECEF trajectory: ~6.37e6 m from the geocentre, advancing 5 cm per
+    /// sample. That step is well under the ~0.5 m f32 ULP at this magnitude.
+    fn ecef_ramp(samples: usize) -> Vec<DVec3> {
+        let base = DVec3::new(-2_430_601.8, -4_702_442.7, 3_546_587.4);
+        (0..samples)
+            .map(|i| base + DVec3::new(0.05, 0.03, 0.04) * i as f64)
+            .collect()
+    }
+
+    #[test]
+    fn f64_samples_keep_ecef_trail_smooth() {
+        // The fix: sourcing samples in f64 lets the anchor subtraction recover the
+        // motion, so every step survives and the spacing stays uniform.
+        let samples = ecef_ramp(64);
+        let anchor = samples[0];
+        let locals: Vec<Vec3> = samples.iter().map(|&s| anchor_local(s, anchor)).collect();
+        let expected_step = (samples[1] - samples[0]).length() as f32;
+        for pair in locals.windows(2) {
+            let step = (pair[1] - pair[0]).length();
+            assert!(
+                (step - expected_step).abs() < expected_step * 1e-3,
+                "step={step} expected={expected_step}"
+            );
+        }
+    }
+
+    #[test]
+    fn f32_samples_staircase_the_ecef_trail() {
+        // The bug this replaced: casting to f32 before the subtraction quantizes
+        // the sample to ~0.5 m, so most steps collapse to zero and the survivors
+        // jump a full ULP — the sawtooth seen on the ECEF trail.
+        let samples = ecef_ramp(64);
+        let quantized: Vec<DVec3> = samples
+            .iter()
+            .map(|s| DVec3::new(s.x as f32 as f64, s.y as f32 as f64, s.z as f32 as f64))
+            .collect();
+        let anchor = quantized[0];
+        let locals: Vec<Vec3> = quantized.iter().map(|&s| anchor_local(s, anchor)).collect();
+        let expected_step = (samples[1] - samples[0]).length() as f32;
+        let stalled = locals
+            .windows(2)
+            .filter(|pair| (pair[1] - pair[0]).length() == 0.0)
+            .count();
+        let overshoot = locals
+            .windows(2)
+            .filter(|pair| (pair[1] - pair[0]).length() > expected_step * 2.0)
+            .count();
+        assert!(stalled > 0, "expected repeated samples, stalled={stalled}");
+        assert!(overshoot > 0, "expected ULP jumps, overshoot={overshoot}");
     }
 
     #[test]

--- a/libs/elodin-editor/src/ui/plot_3d/mod.rs
+++ b/libs/elodin-editor/src/ui/plot_3d/mod.rs
@@ -7,12 +7,12 @@ use bevy::{
         query::{With, Without},
         system::{Commands, Query, Res, ResMut},
     },
-    math::{DVec3, Vec4},
+    math::Vec4,
     prelude::{Color, GlobalTransform, IntoScheduleConfigs, Transform, warn_once},
     transform::TransformSystems,
 };
 use bevy_geo_frames::GeoPosition;
-use impeller2_bevy::ComponentMetadataRegistry;
+use impeller2_bevy::{ComponentMetadataRegistry, TelemetryCache};
 use impeller2_wkt::Line3d;
 
 use gpu::{LineConfig, LineUniform};
@@ -56,29 +56,23 @@ fn line_trail_colors(line_plot: &Line3d) -> gpu::LineTrailColors {
 /// Scheduled after [`queue_timestamp_read`] so a rolling-window rebuild and the
 /// pose update land in the same frame (before PostUpdate geo→Transform).
 fn sync_line_3d_anchor(
-    mut lines: Query<(&gpu::LineHandles, &mut GeoPosition), With<Line3d>>,
+    mut lines: Query<
+        (
+            &gpu::LineHandles,
+            Option<&gpu::LineSources>,
+            &mut GeoPosition,
+        ),
+        With<Line3d>,
+    >,
     line_assets: Res<Assets<Line>>,
+    telemetry_cache: Res<TelemetryCache>,
 ) {
-    for (handles, mut geo) in &mut lines {
-        let Some(x) = line_assets
-            .get(&handles.0[0])
-            .and_then(|l| l.data.first_sample())
+    for (handles, sources, mut geo) in &mut lines {
+        let Some(first) =
+            gpu::line_first_point_frame(&telemetry_cache, sources, &line_assets, &handles.0)
         else {
             continue;
         };
-        let Some(y) = line_assets
-            .get(&handles.0[1])
-            .and_then(|l| l.data.first_sample())
-        else {
-            continue;
-        };
-        let Some(z) = line_assets
-            .get(&handles.0[2])
-            .and_then(|l| l.data.first_sample())
-        else {
-            continue;
-        };
-        let first = DVec3::new(x as f64, y as f64, z as f64);
         if geo.1 != first {
             geo.1 = first;
         }
@@ -116,10 +110,11 @@ pub fn sync_line_plot_3d(
                 continue;
             }
         };
-        let graph_components = parsed.to_graph_components();
+        let graph_components = parsed.to_graph_component_affines();
         let skip = if graph_components.len() == 7 { 4 } else { 0 };
         let mut handles: [Option<Handle<Line>>; 3] = [None, None, None];
-        for (i, (c, index)) in graph_components.iter().skip(skip).take(3).enumerate() {
+        let mut sources: [Option<gpu::LineAxisSource>; 3] = [None, None, None];
+        for (i, (c, index, affine)) in graph_components.iter().skip(skip).take(3).enumerate() {
             let Some(metadata) = metadata_store.get_metadata(&c.id) else {
                 continue;
             };
@@ -138,6 +133,11 @@ pub fn sync_line_plot_3d(
                     )
                 });
             handles[i] = data.lines.get(index).cloned();
+            sources[i] = Some(gpu::LineAxisSource {
+                component_id: c.id,
+                element: *index,
+                affine: *affine,
+            });
         }
         let [Some(x), Some(y), Some(z)] = handles else {
             continue;
@@ -145,6 +145,9 @@ pub fn sync_line_plot_3d(
 
         let trail = line_trail_colors(line_plot);
         if let Ok(mut entity) = commands.get_entity(entity) {
+            if let [Some(sx), Some(sy), Some(sz)] = sources {
+                entity.try_insert(gpu::LineSources([sx, sy, sz]));
+            }
             // Pose comes from GeoPosition(first sample) + GeoRotation::absolute;
             // vertices are frame-relative to that first point.
             entity.try_insert((
@@ -225,6 +228,7 @@ impl bevy::app::Plugin for LinePlot3dPlugin {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bevy::math::DVec3;
 
     #[test]
     fn line_color_linear_preserves_alpha() {

--- a/libs/elodin-editor/src/ui/schematic/mod.rs
+++ b/libs/elodin-editor/src/ui/schematic/mod.rs
@@ -762,47 +762,337 @@ fn component_expr(
     format!("{base}[{index}]")
 }
 
+/// The `value * scale + offset` an expression applies to a component element.
+///
+/// Consumers that plot a bare element (2D graphs, monitors) ignore this;
+/// `line_3d` applies it so `ball.pos[0] + 1.5` offsets the trail rather than
+/// silently rendering the unshifted component.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ElementAffine {
+    pub scale: f64,
+    pub offset: f64,
+}
+
+impl Default for ElementAffine {
+    fn default() -> Self {
+        Self {
+            scale: 1.0,
+            offset: 0.0,
+        }
+    }
+}
+
+impl ElementAffine {
+    pub fn apply(self, value: f64) -> f64 {
+        value * self.scale + self.offset
+    }
+
+    pub fn is_identity(self) -> bool {
+        self == Self::default()
+    }
+
+    fn scaled(self, k: f64) -> Self {
+        Self {
+            scale: self.scale * k,
+            offset: self.offset * k,
+        }
+    }
+
+    fn shifted(self, k: f64) -> Self {
+        Self {
+            scale: self.scale,
+            offset: self.offset + k,
+        }
+    }
+}
+
+/// Fold an expression made only of float literals into its value.
+fn const_value(expr: &eql::Expr) -> Option<f64> {
+    match expr {
+        eql::Expr::FloatLiteral(f) => Some(*f),
+        eql::Expr::BinaryOp(left, right, op) => {
+            let (left, right) = (const_value(left)?, const_value(right)?);
+            Some(match op {
+                eql::BinaryOp::Add => left + right,
+                eql::BinaryOp::Sub => left - right,
+                eql::BinaryOp::Mul => left * right,
+                eql::BinaryOp::Div => left / right,
+            })
+        }
+        _ => None,
+    }
+}
+
 pub trait EqlExt {
     fn to_graph_components(&self) -> Vec<(ComponentPath, usize)>;
+    fn to_graph_component_affines(&self) -> Vec<(ComponentPath, usize, ElementAffine)>;
 }
 
 impl EqlExt for eql::Expr {
     fn to_graph_components(&self) -> Vec<(ComponentPath, usize)> {
+        self.to_graph_component_affines()
+            .into_iter()
+            .map(|(path, index, _)| (path, index))
+            .collect()
+    }
+
+    fn to_graph_component_affines(&self) -> Vec<(ComponentPath, usize, ElementAffine)> {
         match self {
             eql::Expr::ComponentPart(component_part) => {
                 let Some(component) = &component_part.component else {
                     return vec![];
                 };
                 (0..component.element_names.len())
-                    .map(|i| (ComponentPath::from_name(&component_part.name), i))
+                    .map(|i| {
+                        (
+                            ComponentPath::from_name(&component_part.name),
+                            i,
+                            ElementAffine::default(),
+                        )
+                    })
                     .collect()
             }
             eql::Expr::ArrayAccess(expr, i) => {
                 // Handle array access - recursively get components from the inner expression
                 match &**expr {
                     eql::Expr::ComponentPart(component_part) => {
-                        vec![(ComponentPath::from_name(&component_part.name), *i)]
+                        vec![(
+                            ComponentPath::from_name(&component_part.name),
+                            *i,
+                            ElementAffine::default(),
+                        )]
                     }
                     // For formulas or binary ops, extract components recursively
-                    _ => expr.to_graph_components(),
+                    _ => expr.to_graph_component_affines(),
                 }
             }
             eql::Expr::Tuple(exprs) => exprs
                 .iter()
-                .flat_map(|expr| expr.to_graph_components().into_iter())
+                .flat_map(|expr| expr.to_graph_component_affines().into_iter())
                 .collect(),
-            eql::Expr::BinaryOp(left, right, _) => {
-                // Extract components from both operands
-                let mut components = left.to_graph_components();
-                components.extend(right.to_graph_components());
+            eql::Expr::BinaryOp(left, right, op) => {
+                // Arithmetic against a constant stays exactly representable, so
+                // fold it into the affine. Anything else (component against
+                // component, non-affine ops) falls back to listing both sides'
+                // components untransformed.
+                if let Some(k) = const_value(right) {
+                    let folded = match op {
+                        eql::BinaryOp::Add => Some(Folded::Shift(k)),
+                        eql::BinaryOp::Sub => Some(Folded::Shift(-k)),
+                        eql::BinaryOp::Mul => Some(Folded::Scale(k)),
+                        eql::BinaryOp::Div if k != 0.0 => Some(Folded::Scale(1.0 / k)),
+                        eql::BinaryOp::Div => None,
+                    };
+                    if let Some(folded) = folded {
+                        return folded.apply_to(left.to_graph_component_affines());
+                    }
+                } else if let Some(k) = const_value(left) {
+                    // `k - expr` is `-expr + k`; `k / expr` is not affine.
+                    let folded = match op {
+                        eql::BinaryOp::Add => Some(vec![Folded::Shift(k)]),
+                        eql::BinaryOp::Sub => Some(vec![Folded::Scale(-1.0), Folded::Shift(k)]),
+                        eql::BinaryOp::Mul => Some(vec![Folded::Scale(k)]),
+                        eql::BinaryOp::Div => None,
+                    };
+                    if let Some(folded) = folded {
+                        let mut components = right.to_graph_component_affines();
+                        for step in folded {
+                            components = step.apply_to(components);
+                        }
+                        return components;
+                    }
+                }
+                let mut components = left.to_graph_component_affines();
+                components.extend(right.to_graph_component_affines());
                 components
             }
             eql::Expr::Formula(_, expr) => {
-                // Extract components from the formula's receiver/operand
-                expr.to_graph_components()
+                // Extract components from the formula's receiver/operand. The
+                // formula itself is not affine, so the transform is dropped.
+                expr.to_graph_component_affines()
+                    .into_iter()
+                    .map(|(path, index, _)| (path, index, ElementAffine::default()))
+                    .collect()
             }
             _ => vec![],
         }
+    }
+}
+
+/// A constant folded out of a [`eql::Expr::BinaryOp`], ready to compose onto the
+/// other operand's affines.
+enum Folded {
+    Scale(f64),
+    Shift(f64),
+}
+
+impl Folded {
+    fn apply_to(
+        &self,
+        components: Vec<(ComponentPath, usize, ElementAffine)>,
+    ) -> Vec<(ComponentPath, usize, ElementAffine)> {
+        components
+            .into_iter()
+            .map(|(path, index, affine)| {
+                let affine = match self {
+                    Folded::Scale(k) => affine.scaled(*k),
+                    Folded::Shift(k) => affine.shifted(*k),
+                };
+                (path, index, affine)
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod element_affine_tests {
+    use super::*;
+    use std::sync::Arc;
+
+    /// `<name>[<index>]`, the shape `line_3d` axes come in.
+    fn element(name: &str, index: usize) -> eql::Expr {
+        eql::Expr::ArrayAccess(
+            Box::new(eql::Expr::ComponentPart(Arc::new(eql::ComponentPart {
+                name: name.to_string(),
+                id: impeller2::types::ComponentId::new(name),
+                component: None,
+                children: Default::default(),
+            }))),
+            index,
+        )
+    }
+
+    fn binary(left: eql::Expr, right: eql::Expr, op: eql::BinaryOp) -> eql::Expr {
+        eql::Expr::BinaryOp(Box::new(left), Box::new(right), op)
+    }
+
+    fn affines(expr: &eql::Expr) -> Vec<ElementAffine> {
+        expr.to_graph_component_affines()
+            .into_iter()
+            .map(|(_, _, affine)| affine)
+            .collect()
+    }
+
+    fn only_affine(expr: &eql::Expr) -> ElementAffine {
+        let affines = affines(expr);
+        assert_eq!(affines.len(), 1, "{affines:?}");
+        affines[0]
+    }
+
+    #[test]
+    fn bare_element_is_identity() {
+        assert!(only_affine(&element("ball.pos", 0)).is_identity());
+    }
+
+    #[test]
+    fn constant_offsets_fold_in() {
+        // `pos[0] + 1.5` is what separates two otherwise-coincident trails.
+        let shifted = binary(
+            element("ball.pos", 0),
+            eql::Expr::FloatLiteral(1.5),
+            eql::BinaryOp::Add,
+        );
+        assert_eq!(only_affine(&shifted).apply(10.0), 11.5);
+
+        // Addition commutes.
+        let flipped = binary(
+            eql::Expr::FloatLiteral(1.5),
+            element("ball.pos", 0),
+            eql::BinaryOp::Add,
+        );
+        assert_eq!(only_affine(&flipped).apply(10.0), 11.5);
+
+        let subtracted = binary(
+            element("ball.pos", 0),
+            eql::Expr::FloatLiteral(1.5),
+            eql::BinaryOp::Sub,
+        );
+        assert_eq!(only_affine(&subtracted).apply(10.0), 8.5);
+
+        // `k - expr` negates the element.
+        let negated = binary(
+            eql::Expr::FloatLiteral(1.5),
+            element("ball.pos", 0),
+            eql::BinaryOp::Sub,
+        );
+        assert_eq!(only_affine(&negated).apply(10.0), -8.5);
+    }
+
+    #[test]
+    fn constant_scales_fold_in() {
+        let scaled = binary(
+            element("ball.pos", 0),
+            eql::Expr::FloatLiteral(3.0),
+            eql::BinaryOp::Mul,
+        );
+        assert_eq!(only_affine(&scaled).apply(10.0), 30.0);
+
+        let divided = binary(
+            element("ball.pos", 0),
+            eql::Expr::FloatLiteral(4.0),
+            eql::BinaryOp::Div,
+        );
+        assert_eq!(only_affine(&divided).apply(10.0), 2.5);
+    }
+
+    #[test]
+    fn nested_constants_compose_in_order() {
+        // `(pos[0] + 1) * 2` scales the existing offset too.
+        let expr = binary(
+            binary(
+                element("ball.pos", 0),
+                eql::Expr::FloatLiteral(1.0),
+                eql::BinaryOp::Add,
+            ),
+            eql::Expr::FloatLiteral(2.0),
+            eql::BinaryOp::Mul,
+        );
+        assert_eq!(only_affine(&expr).apply(10.0), 22.0);
+    }
+
+    #[test]
+    fn division_by_zero_is_not_folded() {
+        let expr = binary(
+            element("ball.pos", 0),
+            eql::Expr::FloatLiteral(0.0),
+            eql::BinaryOp::Div,
+        );
+        assert!(only_affine(&expr).is_identity());
+    }
+
+    #[test]
+    fn component_arithmetic_stays_untransformed() {
+        // Two components can't collapse to one affine, so both are listed as-is
+        // (the pre-existing behavior).
+        let expr = binary(element("a.pos", 0), element("b.pos", 1), eql::BinaryOp::Add);
+        let affines = affines(&expr);
+        assert_eq!(affines.len(), 2);
+        assert!(affines.iter().all(|a| a.is_identity()));
+    }
+
+    #[test]
+    fn to_graph_components_matches_the_affine_traversal() {
+        // The plain accessor must stay a projection of the affine one; graphs and
+        // monitors rely on its exact ordering.
+        let expr = eql::Expr::Tuple(vec![
+            eql::Expr::FloatLiteral(0.0),
+            binary(
+                element("ball.pos", 0),
+                eql::Expr::FloatLiteral(1.5),
+                eql::BinaryOp::Add,
+            ),
+            element("ball.pos", 1),
+        ]);
+        let plain = expr.to_graph_components();
+        let with_affine = expr.to_graph_component_affines();
+        assert_eq!(plain.len(), 2);
+        assert_eq!(
+            plain,
+            with_affine
+                .iter()
+                .map(|(path, index, _)| (path.clone(), *index))
+                .collect::<Vec<_>>()
+        );
     }
 }
 


### PR DESCRIPTION
# Problem

We had quantization error in line_3d still. @zxq82lm noticed it and created an example to reproduce it. It looks like this:

<img width="1322" height="1258" alt="Screenshot 2026-08-07 at 5 02 10 AM" src="https://github.com/user-attachments/assets/3189bd56-beba-4ae2-8f5e-28dc4e65a4fb" />

# Solution

Turns out my scheme of subtracting the first from the following points in the line was happening after the data had already gone through a f32 conversion. But it's now fixed and looks correct in ENU or ECEF:

<img width="927" height="898" alt="Screenshot from 2026-08-07 02-08-57" src="https://github.com/user-attachments/assets/86e3f882-fed4-434b-a96d-afc5ffeb2042" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the 3D line extraction/render data path and depends on TelemetryCache coverage; falls back to f32 LineTree when cache misses, which could still show quantization in edge cases.
> 
> **Overview**
> Fixes **staircased `line_3d` trails** at ECEF-scale coordinates (~6.4e6 m), where the display path had already quantized samples to **f32** before the floating-origin anchor subtraction, so subtracting the first point could not recover sub-metre motion.
> 
> The render path now keeps **`LineSources`** (component, element, and EQL **`ElementAffine`**) on each line, uses **`collect_strip_timestamps`** aligned with strip decimation, and **re-reads f64 samples from `TelemetryCache`** for anchor and vertices. Subtraction stays in **f64** via **`anchor_local`**; only the small residual is cast to f32 for GPU buffers. **`sync_line_3d_anchor`** uses the same **`line_first_point_frame`** helper so entity pose matches the trail.
> 
> EQL parsing gains **`to_graph_component_affines`** so constant shifts/scales (e.g. `ball.pos_enu[0] + 1.5`) apply to trails, not only bare elements. Adds **`examples/f32-quant-repro`** (ECEF vs ENU side-by-side) and unit tests for timestamp alignment and ECEF smoothness vs pre-fix f32 behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c83314e9bdc0e2570366f0e3c8cbdc9451d0e24e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->