### PR TITLE
fix: Refine the second patch to its minimal essential elements.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3479,6 +3479,18 @@ dependencies = [
 
 [[package]]
 name = "calloop-wayland-source"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
+dependencies = [
+ "calloop 0.13.0",
+ "rustix 0.38.44",
+ "wayland-backend",
+ "wayland-client",
+]
+
+[[package]]
+name = "calloop-wayland-source"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138efcf0940a02ebf0cc8d1eff41a1682a46b431630f4c52450d6265876021fa"
@@ -12978,6 +12990,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sctk-adwaita"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec"
+dependencies = [
+ "ab_glyph",
+ "log",
+ "memmap2",
+ "smithay-client-toolkit 0.19.2",
+ "tiny-skia",
+]
+
+[[package]]
 name = "scuffle-bytes-util"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13400,13 +13425,38 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "smithay-client-toolkit"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
+dependencies = [
+ "bitflags 2.11.1",
+ "calloop 0.13.0",
+ "calloop-wayland-source 0.3.0",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix 0.38.44",
+ "thiserror 1.0.69",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
+name = "smithay-client-toolkit"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
 dependencies = [
  "bitflags 2.11.1",
  "calloop 0.14.4",
- "calloop-wayland-source",
+ "calloop-wayland-source 0.4.1",
  "cursor-icon",
  "libc",
  "log",
@@ -13432,7 +13482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71704c03f739f7745053bde45fa203a46c58d25bc5c4efba1d9a60e9dba81226"
 dependencies = [
  "libc",
- "smithay-client-toolkit",
+ "smithay-client-toolkit 0.20.0",
  "wayland-backend",
 ]
 
@@ -13658,6 +13708,12 @@ name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
 name = "strsim"
@@ -14313,6 +14369,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
 ]
 
 [[package]]
@@ -15488,6 +15569,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-protocols-plasma"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
 name = "wayland-protocols-wlr"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16341,6 +16435,7 @@ version = "0.30.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6755fa58a9f8350bd1e472d4c3fcc25f824ec358933bba33306d0b63df5978d"
 dependencies = [
+ "ahash",
  "android-activity",
  "atomic-waker",
  "bitflags 2.11.1",
@@ -16355,6 +16450,7 @@ dependencies = [
  "dpi",
  "js-sys",
  "libc",
+ "memmap2",
  "ndk",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
@@ -16367,11 +16463,17 @@ dependencies = [
  "raw-window-handle 0.6.2",
  "redox_syscall 0.4.1",
  "rustix 0.38.44",
+ "sctk-adwaita",
+ "smithay-client-toolkit 0.19.2",
  "smol_str",
  "tracing",
  "unicode-segmentation",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-plasma",
  "web-sys",
  "web-time",
  "windows-sys 0.52.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,6 +168,7 @@ features = [
   "ui_picking",
   "webgl2",
   "x11",
+  "wayland",
   "debug",
   "zstd_rust",
 ]

--- a/scripts/elodin_capture.sh
+++ b/scripts/elodin_capture.sh
@@ -312,9 +312,22 @@ preexisting_gamescope_serials=$(pw-dump 2>/dev/null | jq -c '
   ]
 ')
 
+# NVIDIA's proprietary Vulkan WSI cannot present to Gamescope's nested Xwayland
+# (X11) surface, but its Wayland WSI can. Render the editor as a native Wayland
+# client of Gamescope's compositor: override the dev-shell's forced
+# WINIT_UNIX_BACKEND=x11, and expose xdg-shell in that compositor with
+# --expose-wayland. Mesa keeps the default X11/Xwayland path. Requires the
+# editor to be built with Bevy's `wayland` feature.
+child_env=(PATH="$child_path")
+gamescope_extra=()
+if [[ "$selected_gpu" == nvidia ]]; then
+  child_env+=(WINIT_UNIX_BACKEND=wayland)
+  gamescope_extra+=(--expose-wayland)
+fi
+
 setsid gamescope --backend headless \
-  -w "$width" -h "$height" -W "$width" -H "$height" -r "$refresh" \
-  -- env PATH="$child_path" "$editor" editor --addr "127.0.0.1:$port" "$simulation" \
+  -w "$width" -h "$height" -W "$width" -H "$height" -r "$refresh" "${gamescope_extra[@]}" \
+  -- env "${child_env[@]}" "$editor" editor --addr "127.0.0.1:$port" "$simulation" \
   >"$gamescope_log" 2>&1 &
 gamescope_pid=$!
 gamescope_pgid=$gamescope_pid


### PR DESCRIPTION
This is a fix for issue #765. This is the second patch mentioned in the issue, but it is much more limited. The biggest change is adding wayland to bevy's imports.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the display/WSI path for NVIDIA-only capture and expands Bevy’s default Linux windowing features workspace-wide; Mesa behavior is unchanged but graphics regressions on NVIDIA are the main concern.
> 
> **Overview**
> Fixes headless **Gamescope** capture when the dev shell uses **NVIDIA** Vulkan: proprietary NVIDIA WSI cannot present to Gamescope’s nested **Xwayland** surface, but it can present as a **Wayland** client.
> 
> **Bevy** workspace features now include **`wayland`** so the editor can use winit’s Wayland backend (`Cargo.lock` picks up the usual winit/Smithay stack). In **`elodin_capture.sh`**, when `selected_gpu` is **nvidia**, the script passes **`--expose-wayland`** to Gamescope and sets **`WINIT_UNIX_BACKEND=wayland`** for the editor child (overriding the shell’s typical X11 default); **Mesa** keeps the existing X11/Xwayland launch path unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e8698f1b70a7b459eec780e3975591b56bc2542. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->