### PR TITLE
fix: Capture headless video on hybrid Intel + NVIDIA hosts.

### DIFF
--- a/.cursor/skills/elodin-headless-capture/SKILL.md
+++ b/.cursor/skills/elodin-headless-capture/SKILL.md
@@ -65,8 +65,10 @@ simulation database server and then allows a two-second warmup. Use
 `--encoder x264` to force the portable fallback, or `--encoder vaapi` /
 `--encoder nvenc` when testing a specific hardware path. Set
 `ELODIN_GPU=mesa` or `ELODIN_GPU=nvidia` before entering the development shell
-to override automatic GPU selection. An explicitly set `GBM_BACKENDS_PATH` is
-always preserved.
+to override automatic GPU selection; `ELODIN_GPU=nvk` instead drives an NVIDIA
+GPU through Mesa's NVK driver and needs no proprietary driver, which is the
+working path on a hybrid Intel + NVIDIA host. An explicitly set
+`GBM_BACKENDS_PATH` is always preserved.
 
 The manual workflow below remains useful for debugging capture infrastructure.
 
@@ -207,3 +209,7 @@ buffers.
   a lighter example and lower resolution.
 - **Stale editor process or DB/assets port conflict:** stop the previous
   Gamescope child or choose another free DB/assets pair with `--port`.
+- **Gamescope dies as soon as recording starts, and the script then reports
+  that no encoder works:** on an Intel iGPU, Gamescope can segfault inside
+  Mesa's ANV driver while allocating the PipeWire capture buffers. Confirm it
+  with `gdb`, then capture through the discrete GPU using `ELODIN_GPU=nvk`.

--- a/scripts/elodin_capture.sh
+++ b/scripts/elodin_capture.sh
@@ -26,8 +26,9 @@ Options:
   -h, --help               Show this help
 
 Environment:
-  GPU selection comes from the Nix development shell. Set ELODIN_GPU before
-  entering the shell to override automatic selection. An explicitly set
+  GPU selection comes from the Nix development shell. Set ELODIN_GPU to mesa,
+  nvk, or nvidia to override automatic selection; nvk drives an NVIDIA GPU
+  through Mesa and needs no proprietary driver. An explicitly set
   GBM_BACKENDS_PATH is always preserved.
 EOF
 }
@@ -247,16 +248,25 @@ fi
 case "${ELODIN_GPU:-auto}" in
   auto) ;;
   mesa) selected_gpu=mesa ;;
+  nvk) selected_gpu=nvk ;;
   nvidia)
     [[ "$selected_gpu" == nvidia ]] \
       || fail "NVIDIA is not configured; set ELODIN_GPU=nvidia before entering nix develop"
     ;;
-  *) fail "ELODIN_GPU must be auto, mesa, or nvidia" ;;
+  *) fail "ELODIN_GPU must be auto, mesa, nvk, or nvidia" ;;
 esac
 
-if [[ "$selected_gpu" == mesa ]]; then
+if [[ "$selected_gpu" == mesa || "$selected_gpu" == nvk ]]; then
+  # Intel's ANV driver segfaults gamescope while it allocates PipeWire capture
+  # buffers, so a hybrid Intel+NVIDIA host needs NVK to reach its discrete GPU
+  # without the proprietary driver.
+  if [[ "$selected_gpu" == nvk ]]; then
+    mesa_drivers=(nouveau)
+  else
+    mesa_drivers=(radeon intel)
+  fi
   mesa_manifests=()
-  for manifest in radeon intel; do
+  for manifest in "${mesa_drivers[@]}"; do
     path="$mesa_prefix/share/vulkan/icd.d/${manifest}_icd.$(uname -m).json"
     [[ -e "$path" ]] && mesa_manifests+=("$path")
   done
@@ -270,7 +280,7 @@ if [[ "$selected_gpu" == mesa ]]; then
 fi
 
 if [[ -z "${GBM_BACKENDS_PATH+x}" ]]; then
-  if [[ "$selected_gpu" == mesa ]]; then
+  if [[ "$selected_gpu" == mesa || "$selected_gpu" == nvk ]]; then
     export GBM_BACKENDS_PATH="$mesa_prefix/lib/gbm"
   else
     for candidate in \


### PR DESCRIPTION
Gamescope segfaults inside Mesa's ANV driver while it allocates the PipeWire capture buffers, so no capture is possible through an Intel iGPU. The script only built its Vulkan ICD list from radeon and intel, leaving the discrete NVIDIA GPU unreachable even though Mesa ships NVK next to them.

Add ELODIN_GPU=nvk to select that driver, which captures without the proprietary NVIDIA driver and without patching gamescope.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to capture script GPU/env selection and docs; no auth, data, or core simulation paths.
> 
> **Overview**
> Adds **`ELODIN_GPU=nvk`** so headless capture can use an NVIDIA GPU through Mesa’s NVK stack (no proprietary driver), aimed at **hybrid Intel iGPU + discrete NVIDIA** machines where Gamescope can crash in Mesa ANV during PipeWire buffer allocation.
> 
> In **`scripts/elodin_capture.sh`**, `nvk` is a valid override alongside `mesa` and `nvidia`. For `nvk`, Vulkan ICD discovery uses the **`nouveau`** manifest instead of **`radeon`/`intel`**; Mesa driver/GBM exports match the existing Mesa path. Help text documents the new option.
> 
> The **elodin-headless-capture** skill documents `ELODIN_GPU=nvk` as the recommended hybrid-host path and adds troubleshooting: Gamescope dying when recording starts → confirm with `gdb`, then retry with **`ELODIN_GPU=nvk`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c93ea4d6c17c3de17c2af0efc5d4da3e32f581e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->