### PR TITLE
feat: add Voyager trajectory error telemetry

### DIFF
--- a/examples/voyager/README.md
+++ b/examples/voyager/README.md
@@ -17,6 +17,19 @@ This example is a work in progress. Right now the simulated probes do
 not make it to Saturn. Future work is needed to isolate the error
 sources and improve the simulation.
 
+The editor exposes that divergence numerically as two telemetry signals
+for each simulated probe:
+
+- `position_error_km`: Euclidean distance from the matching SPICE truth
+  position, in kilometers.
+- `velocity_error_mps`: Euclidean difference from the matching SPICE truth
+  velocity, in meters per second.
+
+The default schematic graphs both signals for Voyager 1 and Voyager 2.
+These diagnostics make it possible to see when the trajectory starts
+diverging instead of relying only on the red simulated and green truth
+paths in the 3D viewport.
+
 
 ## Setup
 
@@ -42,8 +55,7 @@ cd examples/voyager
 ```
 
 This writes the kernels into `examples/voyager/nasa_spice_data/`,
-which [main.py](/mnt/share/elodin/code/elodin-agent1/examples/voyager/main.py)
-loads at startup.
+which `main.py` loads at startup.
 
 
 ## Run

--- a/examples/voyager/main.py
+++ b/examples/voyager/main.py
@@ -224,7 +224,7 @@ def pre_step(tick: int, ctx: el.StepContext):
 
 def post_step(tick: int, ctx: el.StepContext) -> None:
     """Record numerical divergence from SPICE at the completed tick epoch."""
-    current_time_et = start_time_et + tick * SIM_TIME_STEP
+    current_time_et = start_time_et + (tick + 1) * SIM_TIME_STEP
 
     for probe in PROBES:
         simulated_pos = np.asarray(

--- a/examples/voyager/main.py
+++ b/examples/voyager/main.py
@@ -1,5 +1,8 @@
 import os
+import typing as ty
+
 import elodin as el
+import jax
 from jax import numpy as jnp
 from jax.numpy import linalg as la
 import spiceypy as spice
@@ -133,6 +136,23 @@ TRUTH_PROBES = [
         "mass": 825.0,
     },
 ]
+PositionErrorKm = ty.Annotated[
+    jax.Array,
+    el.Component(
+        "position_error_km",
+        el.ComponentType(el.PrimitiveType.F64, (1,)),
+        metadata={"external_control": "true"},
+    ),
+]
+VelocityErrorMps = ty.Annotated[
+    jax.Array,
+    el.Component(
+        "velocity_error_mps",
+        el.ComponentType(el.PrimitiveType.F64, (1,)),
+        metadata={"external_control": "true"},
+    ),
+]
+
 EPHEMERIS_BODIES = PLANETS
 DISPLAY_BODIES = PLANETS + PROBES + TRUTH_PROBES
 SUN_MASS = 1.9885e30
@@ -163,14 +183,23 @@ for body in EPHEMERIS_BODIES + PROBES + TRUTH_PROBES:
     print(init_pos)
     print(init_vel)
 
+    components = [
+        el.Body(
+            world_pos=el.WorldPos(linear=init_pos),
+            world_vel=el.WorldVel(linear=init_vel),
+            inertia=el.Inertia(body["mass"]),
+        ),
+    ]
+    if body in PROBES:
+        components.extend(
+            [
+                el.C(PositionErrorKm, jnp.array([0.0], dtype=jnp.float64)),
+                el.C(VelocityErrorMps, jnp.array([0.0], dtype=jnp.float64)),
+            ]
+        )
+
     body_entity_ids[body["entity_name"]] = w.spawn(
-        [
-            el.Body(
-                world_pos=el.WorldPos(linear=init_pos),
-                world_vel=el.WorldVel(linear=init_vel),
-                inertia=el.Inertia(body["mass"]),
-            ),
-        ],
+        components,
         name=body["entity_name"],
     )
 
@@ -190,6 +219,39 @@ def pre_step(tick: int, ctx: el.StepContext):
         ctx.write_component(
             f"{body['entity_name']}.world_vel",
             np.array([0.0, 0.0, 0.0, vel_ms[0], vel_ms[1], vel_ms[2]], dtype=np.float64),
+        )
+
+
+def post_step(_tick: int, ctx: el.StepContext) -> None:
+    """Record numerical divergence from the SPICE truth trajectories."""
+    for probe, truth_probe in zip(PROBES, TRUTH_PROBES):
+        simulated_pos = np.asarray(
+            ctx.read_component(f"{probe['entity_name']}.world_pos"),
+            dtype=np.float64,
+        )[4:7]
+        truth_pos = np.asarray(
+            ctx.read_component(f"{truth_probe['entity_name']}.world_pos"),
+            dtype=np.float64,
+        )[4:7]
+        simulated_vel = np.asarray(
+            ctx.read_component(f"{probe['entity_name']}.world_vel"),
+            dtype=np.float64,
+        )[3:6]
+        truth_vel = np.asarray(
+            ctx.read_component(f"{truth_probe['entity_name']}.world_vel"),
+            dtype=np.float64,
+        )[3:6]
+
+        position_error_km = np.linalg.norm(simulated_pos - truth_pos) / 1000.0
+        velocity_error_mps = np.linalg.norm(simulated_vel - truth_vel)
+
+        ctx.write_component(
+            f"{probe['entity_name']}.position_error_km",
+            np.array([position_error_km], dtype=np.float64),
+        )
+        ctx.write_component(
+            f"{probe['entity_name']}.velocity_error_mps",
+            np.array([velocity_error_mps], dtype=np.float64),
         )
 
 
@@ -256,10 +318,13 @@ w.schematic(
             //viewport name=Viewport pos="(0,0,0,0,0,0,100)" look_at="(0,0,0,0,0,0,0)" hdr=#true
             viewport name=Viewport pos="(0,0,0,0, 0,0,2000000000000.0)" look_at="(0,0,0,0, 0,0,0)" fov=45.0 near=1000000.0
 
-            graph "sun.world_pos" name=Graph
+            graph "voyager1.position_error_km" name="Voyager 1 position error (km)"
+            graph "voyager2.position_error_km" name="Voyager 2 position error (km)"
         }}
         tabs share=0.2 {{
             inspector
+            graph "voyager1.velocity_error_mps" name="Voyager 1 velocity error (m/s)"
+            graph "voyager2.velocity_error_mps" name="Voyager 2 velocity error (m/s)"
         }}
     }}
     object_3d sun.world_pos {{
@@ -281,6 +346,7 @@ sim = w.run(
     sys,
     simulation_rate=SIMULATION_RATE_HZ,
     pre_step=pre_step,
+    post_step=post_step,
     max_ticks=max_ticks,
     start_timestamp=start_time_epoch_us,
     db_path=str(db_path),

--- a/examples/voyager/main.py
+++ b/examples/voyager/main.py
@@ -222,25 +222,25 @@ def pre_step(tick: int, ctx: el.StepContext):
         )
 
 
-def post_step(_tick: int, ctx: el.StepContext) -> None:
-    """Record numerical divergence from the SPICE truth trajectories."""
-    for probe, truth_probe in zip(PROBES, TRUTH_PROBES):
+def post_step(tick: int, ctx: el.StepContext) -> None:
+    """Record numerical divergence from SPICE at the completed tick epoch."""
+    current_time_et = start_time_et + tick * SIM_TIME_STEP
+
+    for probe in PROBES:
         simulated_pos = np.asarray(
             ctx.read_component(f"{probe['entity_name']}.world_pos"),
-            dtype=np.float64,
-        )[4:7]
-        truth_pos = np.asarray(
-            ctx.read_component(f"{truth_probe['entity_name']}.world_pos"),
             dtype=np.float64,
         )[4:7]
         simulated_vel = np.asarray(
             ctx.read_component(f"{probe['entity_name']}.world_vel"),
             dtype=np.float64,
         )[3:6]
-        truth_vel = np.asarray(
-            ctx.read_component(f"{truth_probe['entity_name']}.world_vel"),
-            dtype=np.float64,
-        )[3:6]
+
+        truth_state, _ = spice.spkezr(
+            probe["spice_name"], current_time_et, "ECLIPJ2000", "NONE", "SUN"
+        )
+        truth_pos = np.asarray(truth_state[:3], dtype=np.float64) * 1000.0
+        truth_vel = np.asarray(truth_state[3:], dtype=np.float64) * 1000.0
 
         position_error_km = np.linalg.norm(simulated_pos - truth_pos) / 1000.0
         velocity_error_mps = np.linalg.norm(simulated_vel - truth_vel)


### PR DESCRIPTION
## Demo

https://github.com/user-attachments/assets/f2d51b38-0943-48f1-bba0-229b4466c1b0

## What

Adds real-time numerical error telemetry to the Voyager example for #535:

- `position_error_km` for Voyager 1 and Voyager 2
- `velocity_error_mps` for Voyager 1 and Voyager 2
- default schematic graphs for all four signals

The metrics are computed in `post_step` from each integrated probe state and a direct SPICE lookup at the completed tick epoch. The diagnostic components are marked `external_control` so the normal world commit does not overwrite values written by `post_step`.

## Why

The example already shows simulated trajectories in red and SPICE truth trajectories in green, but the divergence is only visual. These signals make it possible to see when the trajectories begin to separate and how quickly the error grows.

This PR does not change the physics model, timestep, integrator, masses, or SPICE kernels.

## Validation

- `.venv/bin/python -m py_compile examples/voyager/main.py`
- built the editor successfully after fetching Git LFS assets
- ran `./target/release/elodin editor examples/voyager/main.py`
- re-tested with a fresh 100-tick database after fixing post-step time alignment
- Voyager 1 position error starts near 0 and reaches about 8.7 km after 4 days
- Voyager 1 velocity error starts near 0 and reaches about 0.049 m/s after 4 days
- updated 10-second runtime demo attached above

Progress on #535.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only telemetry and UI wiring; no changes to integrator, gravity model, or SPICE loading.
> 
> **Overview**
> Adds **numeric divergence diagnostics** to the Voyager example so simulated probe error vs SPICE truth is visible in the editor, not only as red/green 3D trails.
> 
> Each simulated probe gets `position_error_km` and `velocity_error_mps` components (marked `external_control`). A new **`post_step`** hook reads integrated state after each tick, looks up matching SPICE ephemeris at the completed epoch (`tick + 1`), writes Euclidean position (km) and velocity (m/s) errors, and **`world.run`** is wired to use it. The default schematic graphs all four signals for Voyager 1 and 2. **README** documents the signals; physics, timestep, and kernels are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 673484e8ea8d46cc87deb0d7639660a0bf3dd39a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->