### PR TITLE
fix: Ctrl-P was panicking.

### DIFF
--- a/libs/elodin-editor/src/ui/command_palette/palette_items.rs
+++ b/libs/elodin-editor/src/ui/command_palette/palette_items.rs
@@ -1440,10 +1440,9 @@ pub fn clear_schematic() -> PaletteItem {
          mut skyboxes: MessageWriter<SetActiveSkybox>,
          mut skybox_cache: ResMut<SkyboxCache>,
          mut skybox_mirror: ResMut<crate::skybox_db_assets::DbSkyboxAssetMirror>,
-         mut initial_kdl: ResMut<InitialKdlPath>,
          config: Res<DbConfig>| {
             // Leave the CLI `--kdl` pin so Clear isn't undone by sticky sync.
-            initial_kdl.0 = None;
+            params.clear_initial_kdl_pin();
             params.current_document.clear();
             params.load_schematic(&impeller2_wkt::Schematic::default(), None, None);
             // `load_schematic` despawns every schematic entity and zeroes
@@ -2301,6 +2300,15 @@ mod tests {
 
     fn parse_saved_schematic(kdl: &str) -> Schematic {
         Schematic::from_kdl(kdl).expect("saved KDL should parse")
+    }
+
+    /// Initializing an item's system is where Bevy validates its params, so a
+    /// duplicate resource access (e.g. `ResMut<T>` alongside a `SystemParam`
+    /// that already borrows `T`) panics the first time the palette opens.
+    #[test]
+    fn root_palette_items_have_no_conflicting_params() {
+        let mut world = bevy::prelude::World::new();
+        PalettePage::default().initialize(&mut world);
     }
 
     #[test]

--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -274,7 +274,7 @@ pub struct LoadSchematicParams<'w, 's> {
     pub eql: Res<'w, EqlContext>,
     connection_addr: Option<Res<'w, ConnectionAddr>>,
     /// Optional: absent in minimal test apps (no kdl_document plugin).
-    initial_kdl: Option<Res<'w, crate::plugins::kdl_document::InitialKdlPath>>,
+    initial_kdl: Option<ResMut<'w, crate::plugins::kdl_document::InitialKdlPath>>,
     pub geo_context: ResMut<'w, GeoContext>,
     pub sensor_camera_configs: Res<'w, crate::sensor_camera::SensorCameraConfigs>,
     pub coordinate: ResMut<'w, crate::Coordinate>,
@@ -422,6 +422,14 @@ pub fn render_diag(diagnostic: &dyn Diagnostic) -> String {
 }
 
 impl LoadSchematicParams<'_, '_> {
+    /// Drops the CLI `--kdl` pin so a local clear/open is not re-forced by
+    /// sticky config sync.
+    pub fn clear_initial_kdl_pin(&mut self) {
+        if let Some(pin) = self.initial_kdl.as_deref_mut() {
+            pin.0 = None;
+        }
+    }
+
     pub fn load_schematic(
         &mut self,
         schematic: &Schematic,
@@ -1992,6 +2000,33 @@ mod tests {
 
         load_schematic(&mut app, &Schematic::default());
         assert_eq!(app.world().resource::<crate::Coordinate>().0, None);
+    }
+
+    /// "Clear Schematic" drops the CLI `--kdl` pin through these params: a
+    /// second `ResMut<InitialKdlPath>` in the same system is a conflicting
+    /// param and panics when the palette item is initialized.
+    #[test]
+    fn clear_initial_kdl_pin_drops_the_cli_path() {
+        use crate::plugins::kdl_document::InitialKdlPath;
+
+        let mut app = test_app();
+        // Absent in minimal apps (no kdl_document plugin): a no-op, not a panic.
+        clear_pin(&mut app);
+        assert!(app.world().get_resource::<InitialKdlPath>().is_none());
+
+        app.insert_resource(InitialKdlPath(Some(std::path::PathBuf::from(
+            "/tmp/sim.kdl",
+        ))));
+        clear_pin(&mut app);
+        assert!(app.world().resource::<InitialKdlPath>().0.is_none());
+    }
+
+    fn clear_pin(app: &mut App) {
+        let mut system_state: SystemState<LoadSchematicParams> = SystemState::new(app.world_mut());
+        system_state
+            .params_mut(app.world_mut())
+            .clear_initial_kdl_pin();
+        system_state.apply(app.world_mut());
     }
 
     #[test]


### PR DESCRIPTION
# Problem

Ctrl-P causes a panic.

# Solution

Don't panic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized Bevy system-param fix with new regression tests; no auth, data, or architectural changes.
> 
> **Overview**
> Fixes a panic when opening the command palette (Ctrl-P) caused by **Clear Schematic** borrowing `InitialKdlPath` twice: once via `LoadSchematicParams` and again as a direct `ResMut`.
> 
> Routes CLI `--kdl` pin clearing through a new `LoadSchematicParams::clear_initial_kdl_pin()` helper (with `initial_kdl` upgraded to `ResMut`), and adds regression tests that initialize root palette items and verify the pin drop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3073af7e21eabd43b18f465a827f4c8443346748. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->