### PR TITLE
perf: editor fps on db.

### DIFF
--- a/.cursor/skills/elodin-editor-dev/SKILL.md
+++ b/.cursor/skills/elodin-editor-dev/SKILL.md
@@ -27,6 +27,8 @@ cargo run --bin elodin editor 127.0.0.1:2240
 |----------|---------|---------|
 | `ELODIN_ASSETS` | `./assets` | Directory for meshes, images, GLB files |
 | `ELODIN_KDL_DIR` | `.` (cwd) | Directory for `.kdl` schematic files |
+| `ELODIN_GPU` | `auto` | Nix shell GPU path (`nvidia` / `mesa` / `nvk`). Set **before** `nix develop`. |
+| `ELODIN_GPU_PANIC` | unset | Set to `true` to force the GPU-not-found panic and print the `ELODIN_GPU=… nix develop` help. |
 
 ## Cargo features
 

--- a/docs/internal/nix.md
+++ b/docs/internal/nix.md
@@ -11,7 +11,17 @@ Elodin provides a unified development shell that includes all necessary tools fo
 - This single shell includes tools for Rust, Python, C/C++, cloud operations, documentation, and git-lfs
 - No need to switch between different shells for different tasks
 - git-lfs is included to handle large files in the repository
-- On Linux the shell and the packaged binaries render on the discrete NVIDIA GPU whenever its driver is usable; set `ELODIN_GPU=mesa` to stay on Mesa, or `ELODIN_GPU=nvk` to reach an NVIDIA GPU through Mesa's own driver
+- On Linux the shell and the packaged binaries render on the discrete NVIDIA GPU whenever its driver is usable; set `ELODIN_GPU=mesa` to stay on Mesa, or `ELODIN_GPU=nvk` to reach an NVIDIA GPU through Mesa's own driver. `ELODIN_GPU` is a Nix shell setting: export it **before** `nix develop`.
+
+### GPU-not-found help
+
+If the editor panics with `Unable to find a GPU`, it prints how to pick a path (`ELODIN_GPU=nvidia|mesa|nvk nix develop`). To preview that message without unplugging a GPU:
+
+```bash
+ELODIN_GPU_PANIC=true elodin editor
+```
+
+Only the exact value `true` triggers it (`1` / `false` are ignored). The process exits immediately with status 101.
 
 ## Linux headless capture
 

--- a/docs/internal/nix.md
+++ b/docs/internal/nix.md
@@ -11,6 +11,7 @@ Elodin provides a unified development shell that includes all necessary tools fo
 - This single shell includes tools for Rust, Python, C/C++, cloud operations, documentation, and git-lfs
 - No need to switch between different shells for different tasks
 - git-lfs is included to handle large files in the repository
+- On Linux the shell and the packaged binaries render on the discrete NVIDIA GPU whenever its driver is usable; set `ELODIN_GPU=mesa` to stay on Mesa, or `ELODIN_GPU=nvk` to reach an NVIDIA GPU through Mesa's own driver
 
 ## Linux headless capture
 

--- a/libs/elodin-editor/src/headless.rs
+++ b/libs/elodin-editor/src/headless.rs
@@ -61,6 +61,7 @@ impl Plugin for HeadlessEditorPlugin {
     fn build(&self, app: &mut App) {
         // Must run before anything can spawn a `WorldPos` entity.
         crate::register_world_pos_components(app);
+        crate::plugins::gpu_info::install_gpu_panic_handler();
         app.add_plugins(crate::plugins::WebAssetPlugin)
             .add_plugins(crate::plugins::env_asset_source::plugin)
             .add_plugins(

--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -218,6 +218,7 @@ impl Plugin for EditorPlugin {
         } else {
             WinitSettings::game()
         };
+        plugins::gpu_info::install_gpu_panic_handler();
         app
             // .insert_resource(AssetMetaCheck::Never)
             .add_plugins(plugins::WebAssetPlugin)

--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -260,6 +260,7 @@ impl Plugin for EditorPlugin {
                     .disable::<bevy::dev_tools::render_debug::RenderDebugOverlayPlugin>()
                     .build(),
             )
+            .add_plugins(plugins::gpu_info::GpuInfoPlugin)
             .add_plugins(plugins::kdl_document::plugin)
             .add_plugins(skybox_asset_plugin())
             .add_plugins(skybox_generation_plugin())

--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -48,7 +48,7 @@ use plugins::view_cube::{ViewCubeConfig, ViewCubePlugin};
 use ui::{
     UI_ORDER_BASE,
     colors::{ColorExt, get_scheme},
-    create_egui_context, default_present_mode,
+    create_egui_context,
     inspector::viewport::{
         retry_viewport_eql_compile, set_viewport_pos, sync_viewport_focus_pick_targets,
     },
@@ -196,16 +196,18 @@ impl Plugin for EditorPlugin {
         } else {
             bevy::window::CompositeAlphaMode::Opaque
         };
-        let winit_settings = if cfg!(feature = "tracy") {
+        // `ELODIN_WINIT_MODE=continuous` forces Continuous regardless of focus;
+        // used to benchmark without focus-dependent Reactive throttling.
+        let winit_settings = if cfg!(feature = "tracy")
+            || std::env::var("ELODIN_WINIT_MODE").as_deref() == Ok("continuous")
+        {
             WinitSettings::continuous()
         } else if cfg!(target_os = "macos") {
             WinitSettings {
-                focused_mode: bevy::winit::UpdateMode::Reactive {
-                    wait: Duration::from_millis(16),
-                    react_to_device_events: true,
-                    react_to_user_events: true,
-                    react_to_window_events: true,
-                },
+                // Continuous + Fifo vsync paces to the display refresh. A
+                // `Reactive { wait: 16ms }` mode adds the wait *after* frame
+                // work, capping a vsynced editor at ~50 FPS regardless of load.
+                focused_mode: bevy::winit::UpdateMode::Continuous,
                 unfocused_mode: bevy::winit::UpdateMode::Reactive {
                     wait: Duration::from_millis(32),
                     react_to_device_events: false,
@@ -226,7 +228,7 @@ impl Plugin for EditorPlugin {
                     .set(WindowPlugin {
                         primary_window: Some(Window {
                             title: "Elodin".into(),
-                            present_mode: default_present_mode(),
+                            present_mode: ui::window::present_mode_from_env(),
                             canvas: Some("#editor".to_string()),
                             resolution: self.window_resolution.clone(),
                             resize_constraints: WindowResizeConstraints {

--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -300,6 +300,8 @@ impl Plugin for EditorPlugin {
         app.add_plugins(plugins::scene_environment::SceneEnvironmentPlugin);
         #[cfg(not(target_family = "wasm"))]
         app.add_plugins(plugins::screenshot::EnvScreenshotPlugin);
+        #[cfg(not(target_family = "wasm"))]
+        app.add_plugins(plugins::fps_log::EnvFpsLogPlugin);
         app.add_plugins(ui::UiPlugin)
             .add_plugins(FrameTimeDiagnosticsPlugin::default())
             .add_plugins(WireframePlugin::default())

--- a/libs/elodin-editor/src/plugins/fps_log.rs
+++ b/libs/elodin-editor/src/plugins/fps_log.rs
@@ -1,0 +1,52 @@
+//! Env-var-gated FPS logger for headless perf measurement, mirroring
+//! `screenshot.rs`. When `ELODIN_FPS_LOG=path/to/out.csv` is set, appends one
+//! `elapsed_s,fps,frame_time_ms` line per second from the smoothed Bevy frame
+//! diagnostics, so scripted runs can compare scenarios without reading the
+//! status bar from screenshots.
+
+use bevy::diagnostic::{DiagnosticsStore, FrameTimeDiagnosticsPlugin};
+use bevy::prelude::*;
+use std::io::Write;
+
+pub struct EnvFpsLogPlugin;
+
+impl Plugin for EnvFpsLogPlugin {
+    fn build(&self, app: &mut App) {
+        if std::env::var("ELODIN_FPS_LOG").is_ok() {
+            app.add_systems(Update, log_fps);
+        }
+    }
+}
+
+fn log_fps(
+    time: Res<Time>,
+    diagnostics: Res<DiagnosticsStore>,
+    mut file: Local<Option<std::fs::File>>,
+    mut last_logged_s: Local<f64>,
+) {
+    let elapsed = time.elapsed_secs_f64();
+    if elapsed - *last_logged_s < 1.0 {
+        return;
+    }
+    *last_logged_s = elapsed;
+
+    let file = file.get_or_insert_with(|| {
+        let path = std::env::var("ELODIN_FPS_LOG").expect("checked in plugin build");
+        if let Some(parent) = std::path::Path::new(&path).parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let mut f = std::fs::File::create(&path).expect("create ELODIN_FPS_LOG file");
+        let _ = writeln!(f, "elapsed_s,fps,frame_time_ms");
+        f
+    });
+
+    let fps = diagnostics
+        .get(&FrameTimeDiagnosticsPlugin::FPS)
+        .and_then(|d| d.smoothed());
+    let frame_time = diagnostics
+        .get(&FrameTimeDiagnosticsPlugin::FRAME_TIME)
+        .and_then(|d| d.smoothed());
+    if let (Some(fps), Some(frame_time)) = (fps, frame_time) {
+        let _ = writeln!(file, "{elapsed:.1},{fps:.2},{frame_time:.3}");
+    }
+}

--- a/libs/elodin-editor/src/plugins/gpu_info.rs
+++ b/libs/elodin-editor/src/plugins/gpu_info.rs
@@ -1,8 +1,17 @@
+use std::{env, ffi::OsStr, sync::Once};
+
 use bevy::{
     app::Plugin,
     prelude::{App, Local, Res},
     render::{Render, RenderApp, renderer::RenderAdapterInfo},
 };
+
+const GPU_FAILURE_HELP: &str = "\
+elodin: unable to initialize graphics because no GPU was found.
+elodin: select a graphics path before entering the development shell:
+  ELODIN_GPU=nvidia nix develop
+  ELODIN_GPU=mesa nix develop
+  ELODIN_GPU=nvk nix develop";
 
 pub struct GpuInfoPlugin;
 
@@ -10,6 +19,38 @@ impl Plugin for GpuInfoPlugin {
     fn build(&self, app: &mut App) {
         app.sub_app_mut(RenderApp).add_systems(Render, log_gpu_info);
     }
+}
+
+pub fn install_gpu_panic_handler() {
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            if panic_message(info).is_some_and(is_gpu_init_panic) {
+                eprintln!("{GPU_FAILURE_HELP}");
+            }
+            previous(info);
+        }));
+    });
+
+    if should_force_gpu_panic(env::var_os("ELODIN_GPU_PANIC").as_deref()) {
+        panic!("Unable to find a GPU! Make sure you have installed required drivers!");
+    }
+}
+
+fn panic_message<'a>(info: &'a std::panic::PanicHookInfo<'_>) -> Option<&'a str> {
+    info.payload()
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| info.payload().downcast_ref::<String>().map(String::as_str))
+}
+
+fn is_gpu_init_panic(message: &str) -> bool {
+    message.contains("Unable to find a GPU")
+}
+
+fn should_force_gpu_panic(value: Option<&OsStr>) -> bool {
+    value == Some(OsStr::new("true"))
 }
 
 fn log_gpu_info(adapter: Res<RenderAdapterInfo>, mut logged: Local<bool>) {
@@ -28,4 +69,25 @@ fn log_gpu_info(adapter: Res<RenderAdapterInfo>, mut logged: Local<bool>) {
         "Graphics adapter initialized"
     );
     *logged = true;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identifies_gpu_initialization_panic() {
+        assert!(is_gpu_init_panic(
+            "Unable to find a GPU! Make sure you have installed required drivers!"
+        ));
+        assert!(!is_gpu_init_panic("another panic"));
+    }
+
+    #[test]
+    fn force_panic_requires_true() {
+        assert!(should_force_gpu_panic(Some(OsStr::new("true"))));
+        assert!(!should_force_gpu_panic(Some(OsStr::new("1"))));
+        assert!(!should_force_gpu_panic(Some(OsStr::new("false"))));
+        assert!(!should_force_gpu_panic(None));
+    }
 }

--- a/libs/elodin-editor/src/plugins/gpu_info.rs
+++ b/libs/elodin-editor/src/plugins/gpu_info.rs
@@ -1,0 +1,31 @@
+use bevy::{
+    app::Plugin,
+    prelude::{App, Local, Res},
+    render::{Render, RenderApp, renderer::RenderAdapterInfo},
+};
+
+pub struct GpuInfoPlugin;
+
+impl Plugin for GpuInfoPlugin {
+    fn build(&self, app: &mut App) {
+        app.sub_app_mut(RenderApp).add_systems(Render, log_gpu_info);
+    }
+}
+
+fn log_gpu_info(adapter: Res<RenderAdapterInfo>, mut logged: Local<bool>) {
+    if *logged {
+        return;
+    }
+    tracing::info!(
+        name = %adapter.name,
+        device_type = ?adapter.device_type,
+        backend = ?adapter.backend,
+        driver = %adapter.driver,
+        driver_info = %adapter.driver_info,
+        vendor_id = %format_args!("{:#06x}", adapter.vendor),
+        device_id = %format_args!("{:#06x}", adapter.device),
+        pci_bus = %adapter.device_pci_bus_id,
+        "Graphics adapter initialized"
+    );
+    *logged = true;
+}

--- a/libs/elodin-editor/src/plugins/mod.rs
+++ b/libs/elodin-editor/src/plugins/mod.rs
@@ -3,6 +3,8 @@ pub(crate) mod camera_anchor;
 pub mod editor_cam_input;
 pub mod editor_cam_touch;
 pub(crate) mod env_asset_source;
+#[cfg(not(target_family = "wasm"))]
+pub(crate) mod fps_log;
 pub mod frustum;
 pub(crate) mod frustum_common;
 pub mod frustum_intersection;

--- a/libs/elodin-editor/src/plugins/mod.rs
+++ b/libs/elodin-editor/src/plugins/mod.rs
@@ -9,6 +9,7 @@ pub mod frustum;
 pub(crate) mod frustum_common;
 pub mod frustum_intersection;
 pub mod gizmos;
+pub(crate) mod gpu_info;
 pub(crate) mod kdl_asset_source;
 pub(crate) mod kdl_document;
 mod logical_key;

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -1479,8 +1479,10 @@ pub struct LineTree<D: Clone + BoundOrd> {
     last_hc_archive_len: usize,
     /// Wall-clock instant of the last HC pass, for time-based throttling.
     last_hc_instant: Option<std::time::Instant>,
-    /// Bumped on [`Self::clear`] / view rebuild so GPU index caches can invalidate
-    /// when LineTree contents change without a visible-range change.
+    /// Bumped on any view-content mutation ([`Self::insert`] — including live
+    /// appends via [`Self::update_last`] — [`Self::clear`], and view rebuild)
+    /// so GPU index caches invalidate when LineTree contents change without a
+    /// visible-range change.
     content_gen: u64,
 }
 
@@ -1518,6 +1520,10 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
     }
 
     pub fn insert(&mut self, chunk: Chunk<D>) {
+        // Covers live appends too (`update_last` re-inserts the tail chunk):
+        // the GPU index strip must be rewritten for the live tip to advance
+        // even when the visible-range cache key is unchanged.
+        self.content_gen = self.content_gen.wrapping_add(1);
         let _ = self.tree.insert_overwrite(
             ii(
                 chunk.summary.start_timestamp.0,
@@ -2503,16 +2509,17 @@ mod tests {
     }
 
     #[test]
-    fn line_tree_content_gen_bumps_on_clear() {
+    fn line_tree_content_gen_bumps_on_insert_and_clear() {
         let mut tree = LineTree::<f32>::default();
         assert_eq!(tree.content_gen(), 0);
         let chunk =
             Chunk::from_iter(&[Timestamp(1)], Timestamp(0), [1.0f32].into_iter()).expect("chunk");
         tree.insert(chunk);
-        tree.clear();
         assert_eq!(tree.content_gen(), 1);
         tree.clear();
         assert_eq!(tree.content_gen(), 2);
+        tree.clear();
+        assert_eq!(tree.content_gen(), 3);
     }
 
     #[test]

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -1667,15 +1667,21 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
             return None;
         }
 
-        // Sort for percentile calculation
-        values.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-
+        // Two quickselect passes (O(n) each) instead of a full O(n log n) sort.
+        // On long historical windows this is the dominant frame cost: sorting
+        // hundreds of thousands of samples per graph per refresh.
         let len = values.len();
         let low_idx = ((p_low / 100.0) * len as f32) as usize;
         let high_idx = ((p_high / 100.0) * len as f32) as usize;
         let high_idx = high_idx.min(len - 1);
 
-        Some((values[low_idx], values[high_idx]))
+        let cmp = |a: &D, b: &D| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal);
+        // Select the high percentile first, then the low within the partition
+        // below it (low_idx <= high_idx always, since p_low < p_high).
+        let (_, &mut high, _) = values.select_nth_unstable_by(high_idx, cmp);
+        let (_, &mut low, _) = values[..=high_idx].select_nth_unstable_by(low_idx, cmp);
+
+        Some((low, high))
     }
 
     pub fn last(&self) -> Option<&Chunk<D>> {

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -551,7 +551,7 @@ fn prefetch_visible_window(
         if !schema_reg.0.contains_key(&component_id) {
             continue;
         }
-        if series_store.sample_count_in_range(&component_id, sync_range) > 0 {
+        if series_store.has_samples_in_range(&component_id, sync_range) {
             prefetch
                 .in_flight
                 .remove(&(component_id, range_key.0, range_key.1));
@@ -744,7 +744,7 @@ pub fn sync_plot_lines_from_series_store(
         if !fetch_ids.contains(&component_id) {
             continue;
         }
-        let samples_in_window = series_store.sample_count_in_range(&component_id, sync_range);
+        let has_samples_in_window = series_store.has_samples_in_range(&component_id, sync_range);
         let num_elements = component.element_names.len().max(1);
         for element_index in 0..num_elements {
             let handle = component.lines.entry(element_index).or_insert_with(|| {
@@ -762,7 +762,7 @@ pub fn sync_plot_lines_from_series_store(
             let Some(mut line) = lines.get_mut(handle) else {
                 continue;
             };
-            if samples_in_window == 0 {
+            if !has_samples_in_window {
                 // Don't wipe live tip / prior draw when the store hasn't caught
                 // up to this window yet — unless the camera moved (show empty).
                 if range_changed {

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -48,6 +48,10 @@ use super::PlotBounds;
 /// Must be <= CHUNK_LEN to fit within a single GPU buffer shard
 pub const OVERVIEW_MAX_POINTS: usize = CHUNK_LEN;
 
+/// Cap for [`LineTree::percentile_bounds`]. Uniform stride keeps P1/P99
+/// stable while avoiding a full-window `Vec` (the remaining FULL RANGE cost).
+pub const MAX_PERCENTILE_SAMPLES: usize = 8192;
+
 /// Tuning for **Hamann–Chen** downsampling of live [`LineTree`] telemetry.
 ///
 /// The simplifier lives in the `hamann-chen-line` workspace crate; its steps follow Shane Celis’s
@@ -1636,6 +1640,10 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
 
     /// Compute robust percentile-based bounds that filter out extreme outliers.
     /// Returns (p1, p99) percentile values from the data, which excludes the most extreme 1% on each end.
+    ///
+    /// Values are taken at a uniform stride so the working set stays at
+    /// [`MAX_PERCENTILE_SAMPLES`]. Full-window collect + quickselect was the
+    /// remaining ~12 FPS cost on graph-heavy FULL RANGE views.
     pub fn percentile_bounds(
         &self,
         range: Range<Timestamp>,
@@ -1645,39 +1653,47 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
     where
         D: PartialOrd + Copy,
     {
-        // Collect all values from chunks in range
-        let mut values: Vec<D> = self
-            .range_iter(range)
-            .flat_map(|chunk| chunk.data.cpu().iter().copied())
-            .filter(|v| {
-                // Filter out non-finite f32 values if D is f32
-                // This is a bit of a hack but works for our use case
-                let bytes = std::mem::size_of::<D>();
-                if bytes == 4 {
-                    // Likely f32
-                    let v_f32: f32 = unsafe { std::mem::transmute_copy(v) };
-                    v_f32.is_finite()
-                } else {
-                    true
+        let mut slices: Vec<&[D]> = Vec::new();
+        let mut total = 0usize;
+        for chunk in self.range_iter(range.clone()) {
+            let Some((start, end)) = chunk_visible_offsets(&chunk.timestamps, &range) else {
+                continue;
+            };
+            let data = chunk.data.cpu();
+            let end = end.min(data.len());
+            if start >= end {
+                continue;
+            }
+            let slice = &data[start..end];
+            total += slice.len();
+            slices.push(slice);
+        }
+        if total == 0 {
+            return None;
+        }
+
+        let step = total.div_ceil(MAX_PERCENTILE_SAMPLES).max(1);
+        let mut values: Vec<D> = Vec::with_capacity(total.div_ceil(step));
+        let mut i = 0usize;
+        for slice in slices {
+            for &v in slice {
+                if i.is_multiple_of(step) && value_is_finite(&v) {
+                    values.push(v);
                 }
-            })
-            .collect();
+                i += 1;
+            }
+        }
 
         if values.is_empty() {
             return None;
         }
 
-        // Two quickselect passes (O(n) each) instead of a full O(n log n) sort.
-        // On long historical windows this is the dominant frame cost: sorting
-        // hundreds of thousands of samples per graph per refresh.
         let len = values.len();
         let low_idx = ((p_low / 100.0) * len as f32) as usize;
         let high_idx = ((p_high / 100.0) * len as f32) as usize;
         let high_idx = high_idx.min(len - 1);
 
         let cmp = |a: &D, b: &D| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal);
-        // Select the high percentile first, then the low within the partition
-        // below it (low_idx <= high_idx always, since p_low < p_high).
         let (_, &mut high, _) = values.select_nth_unstable_by(high_idx, cmp);
         let (_, &mut low, _) = values[..=high_idx].select_nth_unstable_by(low_idx, cmp);
 
@@ -2256,6 +2272,15 @@ pub(crate) fn chunk_visible_offsets(
     (end_offset > start_offset).then_some((start_offset, end_offset))
 }
 
+fn value_is_finite<D: Copy>(v: &D) -> bool {
+    if std::mem::size_of::<D>() == 4 {
+        let v_f32: f32 = unsafe { std::mem::transmute_copy(v) };
+        v_f32.is_finite()
+    } else {
+        true
+    }
+}
+
 pub fn index_sampling_step(chunk_count: usize, index_count: usize, pixel_width: usize) -> usize {
     let desired_index_len = INDEX_BUFFER_LEN.min(pixel_width.max(1) * 4);
     // Per-chunk index overhead: leading sentinel, first point, strided interior, last point,
@@ -2526,6 +2551,25 @@ mod tests {
         assert_eq!(tree.content_gen(), 2);
         tree.clear();
         assert_eq!(tree.content_gen(), 3);
+    }
+
+    #[test]
+    fn percentile_bounds_filters_sparse_outliers_on_large_series() {
+        let mut tree = LineTree::<f32>::default();
+        let n = MAX_PERCENTILE_SAMPLES * 4;
+        let timestamps: Vec<Timestamp> = (0..n).map(|i| Timestamp(i as i64)).collect();
+        let mut values = vec![1.0f32; n];
+        let outlier_count = n / 200;
+        for v in values.iter_mut().rev().take(outlier_count) {
+            *v = 1.0e9;
+        }
+        let chunk = Chunk::from_iter(&timestamps, Timestamp(0), values.into_iter()).expect("chunk");
+        tree.insert(chunk);
+        let (low, high) = tree
+            .percentile_bounds(Timestamp(0)..Timestamp(n as i64), 1.0, 99.0)
+            .expect("bounds");
+        assert!((low - 1.0).abs() < 1e-3, "low={low}");
+        assert!((high - 1.0).abs() < 1e-3, "high={high}");
     }
 
     #[test]

--- a/libs/elodin-editor/src/ui/plot/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot/gpu.rs
@@ -228,8 +228,9 @@ impl LineMut<'_> {
         }
     }
 
-    /// Content generation for index-cache invalidation: bumps whenever the
-    /// tree is cleared/rebuilt (shard offsets move within the same buffers).
+    /// Content generation for index-cache invalidation: bumps on any tree
+    /// content change — live appends, clear, rebuild (shard offsets can move
+    /// within the same buffers, and the live tip must keep advancing).
     /// XY lines are append-only, so the point count serves as their gen.
     pub fn content_gen(&self) -> u64 {
         match self {

--- a/libs/elodin-editor/src/ui/plot/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot/gpu.rs
@@ -74,6 +74,7 @@ pub struct PlotGpuPlugin;
 impl Plugin for PlotGpuPlugin {
     fn build(&self, app: &mut bevy::prelude::App) {
         app.add_plugins(UniformComponentPlugin::<LineUniform>::default())
+            .init_resource::<ExtractLinesState>()
             .init_asset::<Line>()
             .init_asset::<XYLine>();
 
@@ -463,7 +464,18 @@ pub struct GpuLine {
     last_index_range: Option<(i64, i64)>,
     /// Cache key part B: `(clip_end, pixel_width)`.
     last_clip_range: Option<(i64, i64)>,
+    /// Identity of the x/y value buffers the bind group references; the bind
+    /// group must be rebuilt if the underlying `BufferShardAlloc` changes.
+    value_buffer_ids: (BufferId, BufferId),
 }
+
+/// Main-world cache of the per-line GPU resources, written back by
+/// `extract_lines` — same pattern as `plot_3d::gpu::GpuLineIndexCache`.
+/// Without it, every frame allocated a fresh 512 KB index buffer, created a
+/// new bind group and rewrote the full index strip for every line, which
+/// dominates frame time on graph-heavy schematics.
+#[derive(Component, Default)]
+pub struct GpuLineCache(Option<GpuLine>);
 
 pub struct SetLineBindGroup;
 
@@ -532,8 +544,31 @@ type LineQueryMut = (
     &'static mut LineVisibleRange,
     &'static mut LineWidgetWidth,
     &'static mut GraphType,
-    Option<&'static mut GpuLine>,
+    Option<&'static mut GpuLineCache>,
 );
+
+type ExtractLinesParams = (
+    Query<'static, 'static, LineQueryMut>,
+    ResMut<'static, Assets<Line>>,
+    ResMut<'static, Assets<XYLine>>,
+    Res<'static, crate::SelectedTimeRange>,
+    Commands<'static, 'static>,
+);
+
+/// Main-world `SystemState` kept across frames; rebuilding it every extract
+/// re-runs query archetype matching.
+#[derive(Resource)]
+struct ExtractLinesState {
+    state: SystemState<ExtractLinesParams>,
+}
+
+impl bevy::prelude::FromWorld for ExtractLinesState {
+    fn from_world(world: &mut bevy::prelude::World) -> Self {
+        Self {
+            state: SystemState::new(world),
+        }
+    }
+}
 
 fn extract_lines(
     mut main_world: ResMut<MainWorld>,
@@ -542,124 +577,160 @@ fn extract_lines(
     render_queue: Res<RenderQueue>,
     values_layout: Res<LineValuesLayout>,
 ) {
-    let mut state = SystemState::<(
-        Query<'static, 'static, LineQueryMut>,
-        ResMut<'static, Assets<Line>>,
-        ResMut<'static, Assets<XYLine>>,
-        Res<'static, crate::SelectedTimeRange>,
-    )>::new(&mut main_world);
-    let (mut lines, mut line_assets, mut xy_lines, selected_range) =
-        state.params_mut(&mut main_world);
-    let selected = selected_range.0.clone();
-    let selected_span_micros = selected.end.0.saturating_sub(selected.start.0);
-    let short_window = crate::is_short_accuracy_window(&selected);
-    for (entity, line_handle, config, uniform, line_visible_range, width, graph_type, gpu_line) in
-        lines.iter_mut()
-    {
-        let Some(mut line) = line_handle.get(&mut line_assets, &mut xy_lines) else {
-            continue;
-        };
-        // Camera / clip: continuous visible range for short windows (silky scrub);
-        // long windows keep 100 ms quantum to limit index rewrite churn.
-        let visible = line_visible_range.0.clone();
-        let clip_range = if short_window {
-            visible.clone()
-        } else {
-            crate::quantize_visible_range(visible.clone(), crate::TRAILING_RANGE_QUANTUM_MICROS)
-        };
-        // Short windows: step = 1 on clip (truth). Long windows: pixel stride on clip.
-        line.queue_load_range(clip_range.clone(), &render_queue, &render_device);
-        let index_buffer = if let Some(ref gpu_line) = gpu_line {
-            gpu_line.index_buffer.clone()
-        } else {
-            render_device.create_buffer(
-                &(BufferDescriptor {
-                    label: Some("Line index Buffer"),
-                    size: (INDEX_BUFFER_LEN * size_of::<u32>()) as u64,
-                    usage: BufferUsages::STORAGE | BufferUsages::COPY_DST,
-                    mapped_at_creation: false,
-                }),
-            )
-        };
+    main_world.resource_scope(
+        |world, mut cached_state: bevy::prelude::Mut<ExtractLinesState>| {
+            let (mut lines, mut line_assets, mut xy_lines, selected_range, mut main_commands) =
+                cached_state.state.params_mut(world);
+            let selected = selected_range.0.clone();
+            let selected_span_micros = selected.end.0.saturating_sub(selected.start.0);
+            let short_window = crate::is_short_accuracy_window(&selected);
+            for (
+                entity,
+                line_handle,
+                config,
+                uniform,
+                line_visible_range,
+                width,
+                graph_type,
+                mut cache,
+            ) in lines.iter_mut()
+            {
+                let Some(mut line) = line_handle.get(&mut line_assets, &mut xy_lines) else {
+                    continue;
+                };
+                // Camera / clip: continuous visible range for short windows (silky scrub);
+                // long windows keep 100 ms quantum to limit index rewrite churn.
+                let visible = line_visible_range.0.clone();
+                let clip_range = if short_window {
+                    visible.clone()
+                } else {
+                    crate::quantize_visible_range(
+                        visible.clone(),
+                        crate::TRAILING_RANGE_QUANTUM_MICROS,
+                    )
+                };
+                // Short windows: step = 1 on clip (truth). Long windows: pixel stride on clip.
+                line.queue_load_range(clip_range.clone(), &render_queue, &render_device);
+                let x_buffer = line
+                    .x_buffer_shard_alloc()
+                    .expect("no x buf")
+                    .buffer()
+                    .clone();
+                let y_buffer = line
+                    .y_buffer_shard_alloc()
+                    .expect("no y buf")
+                    .buffer()
+                    .clone();
+                let value_buffer_ids = (x_buffer.id(), y_buffer.id());
+                // Reuse the cached buffers/bind group unless the value buffers were
+                // reallocated (new `BufferShardAlloc`).
+                let cached = cache
+                    .as_ref()
+                    .and_then(|c| c.0.as_ref())
+                    .filter(|g| g.value_buffer_ids == value_buffer_ids);
+                let (index_buffer, values_bind_group) = if let Some(gpu_line) = cached {
+                    (
+                        gpu_line.index_buffer.clone(),
+                        gpu_line.values_bind_group.clone(),
+                    )
+                } else {
+                    let index_buffer = render_device.create_buffer(
+                        &(BufferDescriptor {
+                            label: Some("Line index Buffer"),
+                            size: (INDEX_BUFFER_LEN * size_of::<u32>()) as u64,
+                            usage: BufferUsages::STORAGE | BufferUsages::COPY_DST,
+                            mapped_at_creation: false,
+                        }),
+                    );
+                    let size = Some(VALUE_BUFFER_SIZE);
+                    let values_bind_group = render_device.create_bind_group(
+                        "line values",
+                        &values_layout.layout,
+                        &[
+                            BindGroupEntry {
+                                binding: 0,
+                                resource: BindingResource::Buffer(BufferBinding {
+                                    buffer: &x_buffer,
+                                    offset: 0,
+                                    size,
+                                }),
+                            },
+                            BindGroupEntry {
+                                binding: 1,
+                                resource: BindingResource::Buffer(BufferBinding {
+                                    buffer: &y_buffer,
+                                    offset: 0,
+                                    size,
+                                }),
+                            },
+                            BindGroupEntry {
+                                binding: 2,
+                                resource: BindingResource::Buffer(BufferBinding {
+                                    buffer: &index_buffer,
+                                    offset: 0,
+                                    size: Some(INDEX_BUFFER_SIZE),
+                                }),
+                            },
+                        ],
+                    );
+                    (index_buffer, values_bind_group)
+                };
+                let range_key = (
+                    selected_span_micros,
+                    clip_range.start.0,
+                    clip_range.end.0,
+                    width.0 as i64,
+                );
+                let prev_key = cached.and_then(|g| {
+                    let (sa, sb) = g.last_index_range?;
+                    let (ca, cb) = g.last_clip_range?;
+                    Some((sa, sb, ca, cb))
+                });
+                let count = if prev_key == Some(range_key) {
+                    cached.map(|g| g.count).unwrap_or(0)
+                } else {
+                    line.write_to_index_buffer_sampled(
+                        &index_buffer,
+                        &render_queue,
+                        clip_range.clone(),
+                        selected_span_micros,
+                        width.0,
+                    )
+                };
+                let gpu_line = GpuLine {
+                    values_bind_group,
+                    index_buffer,
+                    count,
+                    last_index_range: Some((range_key.0, range_key.1)),
+                    last_clip_range: Some((range_key.2, range_key.3)),
+                    value_buffer_ids,
+                };
 
-        let values_bind_group = if let Some(ref gpu_line) = gpu_line {
-            gpu_line.values_bind_group.clone()
-        } else {
-            let size = Some(VALUE_BUFFER_SIZE);
-            render_device.create_bind_group(
-                "line values",
-                &values_layout.layout,
-                &[
-                    BindGroupEntry {
-                        binding: 0,
-                        resource: BindingResource::Buffer(BufferBinding {
-                            buffer: line.x_buffer_shard_alloc().expect("no x buf").buffer(),
-                            offset: 0,
-                            size,
-                        }),
-                    },
-                    BindGroupEntry {
-                        binding: 1,
-                        resource: BindingResource::Buffer(BufferBinding {
-                            buffer: line.y_buffer_shard_alloc().expect("no y buf").buffer(),
-                            offset: 0,
-                            size,
-                        }),
-                    },
-                    BindGroupEntry {
-                        binding: 2,
-                        resource: BindingResource::Buffer(BufferBinding {
-                            buffer: &index_buffer,
-                            offset: 0,
-                            size: Some(INDEX_BUFFER_SIZE),
-                        }),
-                    },
-                ],
-            )
-        };
-        let range_key = (
-            selected_span_micros,
-            clip_range.start.0,
-            clip_range.end.0,
-            width.0 as i64,
-        );
-        let prev_key = gpu_line.as_ref().and_then(|g| {
-            let (sa, sb) = g.last_index_range?;
-            let (ca, cb) = g.last_clip_range?;
-            Some((sa, sb, ca, cb))
-        });
-        let count = if prev_key == Some(range_key) {
-            gpu_line.as_ref().map(|g| g.count).unwrap_or(0)
-        } else {
-            line.write_to_index_buffer_sampled(
-                &index_buffer,
-                &render_queue,
-                clip_range.clone(),
-                selected_span_micros,
-                width.0,
-            )
-        };
-        let gpu_line = GpuLine {
-            values_bind_group,
-            index_buffer,
-            count,
-            last_index_range: Some((range_key.0, range_key.1)),
-            last_clip_range: Some((range_key.2, range_key.3)),
-        };
+                // Persist for the next frame's extract.
+                if let Some(ref mut cache) = cache {
+                    cache.0 = Some(gpu_line.clone());
+                } else {
+                    main_commands
+                        .entity(entity)
+                        .insert(GpuLineCache(Some(gpu_line.clone())));
+                }
 
-        commands.spawn((
-            MainEntity::from(entity),
-            LineBundle {
-                line: line_handle.clone(),
-                config: config.clone(),
-                uniform: *uniform,
-                line_visible_range: line_visible_range.clone(),
-                graph_type: *graph_type,
-            },
-            gpu_line,
-            TemporaryRenderEntity,
-        ));
-    }
+                commands.spawn((
+                    MainEntity::from(entity),
+                    LineBundle {
+                        line: line_handle.clone(),
+                        config: config.clone(),
+                        uniform: *uniform,
+                        line_visible_range: line_visible_range.clone(),
+                        graph_type: *graph_type,
+                    },
+                    gpu_line,
+                    TemporaryRenderEntity,
+                ));
+            }
+            cached_state.state.apply(world);
+        },
+    );
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/libs/elodin-editor/src/ui/plot/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot/gpu.rs
@@ -227,6 +227,16 @@ impl LineMut<'_> {
             LineMut::XY(xy_line) => xy_line.y_shard_alloc.as_ref(),
         }
     }
+
+    /// Content generation for index-cache invalidation: bumps whenever the
+    /// tree is cleared/rebuilt (shard offsets move within the same buffers).
+    /// XY lines are append-only, so the point count serves as their gen.
+    pub fn content_gen(&self) -> u64 {
+        match self {
+            LineMut::Timeseries(line) => line.data.content_gen(),
+            LineMut::XY(xy_line) => xy_line.point_count() as u64,
+        }
+    }
 }
 
 impl LineHandle {
@@ -464,6 +474,10 @@ pub struct GpuLine {
     last_index_range: Option<(i64, i64)>,
     /// Cache key part B: `(clip_end, pixel_width)`.
     last_clip_range: Option<(i64, i64)>,
+    /// Cache key part C: LineTree `content_gen` — a clear/rebuild moves shard
+    /// offsets inside the same buffers, so the index strip must be rewritten
+    /// even when the visible range is unchanged (same as `plot_3d`).
+    content_gen: u64,
     /// Identity of the x/y value buffers the bind group references; the bind
     /// group must be rebuilt if the underlying `BufferShardAlloc` changes.
     value_buffer_ids: (BufferId, BufferId),
@@ -675,6 +689,7 @@ fn extract_lines(
                     );
                     (index_buffer, values_bind_group)
                 };
+                let content_gen = line.content_gen();
                 let range_key = (
                     selected_span_micros,
                     clip_range.start.0,
@@ -684,9 +699,16 @@ fn extract_lines(
                 let prev_key = cached.and_then(|g| {
                     let (sa, sb) = g.last_index_range?;
                     let (ca, cb) = g.last_clip_range?;
-                    Some((sa, sb, ca, cb))
+                    Some((sa, sb, ca, cb, g.content_gen))
                 });
-                let count = if prev_key == Some(range_key) {
+                let count = if prev_key
+                    == Some((
+                        range_key.0,
+                        range_key.1,
+                        range_key.2,
+                        range_key.3,
+                        content_gen,
+                    )) {
                     cached.map(|g| g.count).unwrap_or(0)
                 } else {
                     line.write_to_index_buffer_sampled(
@@ -703,6 +725,7 @@ fn extract_lines(
                     count,
                     last_index_range: Some((range_key.0, range_key.1)),
                     last_clip_range: Some((range_key.2, range_key.3)),
+                    content_gen,
                     value_buffer_ids,
                 };
 

--- a/libs/elodin-editor/src/ui/plot/state.rs
+++ b/libs/elodin-editor/src/ui/plot/state.rs
@@ -47,6 +47,7 @@ pub struct GraphState {
     pub y_range: Range<f64>,
     /// `(range_start, range_end, content_sig)` of the last auto-Y pass.
     /// Unchanged FULL RANGE views skip the percentile walk after the first hit.
+    /// Cleared whenever auto-Y is off so re-enabling Auto Bounds recomputes.
     pub(crate) auto_y_cache: Option<(i64, i64, u64)>,
     pub auto_x_range: bool,
     pub x_range: Range<f64>,

--- a/libs/elodin-editor/src/ui/plot/state.rs
+++ b/libs/elodin-editor/src/ui/plot/state.rs
@@ -45,6 +45,9 @@ pub struct GraphState {
     pub label: String,
     pub auto_y_range: bool,
     pub y_range: Range<f64>,
+    /// `(range_start, range_end, content_sig)` of the last auto-Y pass.
+    /// Unchanged FULL RANGE views skip the percentile walk after the first hit.
+    pub(crate) auto_y_cache: Option<(i64, i64, u64)>,
     pub auto_x_range: bool,
     pub x_range: Range<f64>,
     pub widget_width: f64,
@@ -74,6 +77,7 @@ impl GraphBundle {
             graph_type: GraphType::Line,
             label,
             y_range: 0.0..1.0,
+            auto_y_cache: None,
             x_range: 0.0..1.0,
             auto_y_range: true,
             auto_x_range: true,

--- a/libs/elodin-editor/src/ui/plot/widget.rs
+++ b/libs/elodin-editor/src/ui/plot/widget.rs
@@ -1396,6 +1396,15 @@ pub fn auto_y_bounds(
     let due = last_run
         .map(|t| t.elapsed() >= std::time::Duration::from_millis(50))
         .unwrap_or(true);
+
+    // Drop the cache while auto-Y is off, even between 50ms ticks, so turning
+    // Auto Bounds back on after a manual min/max does not reuse the old pass.
+    for mut graph_state in graph_states.iter_mut() {
+        if !graph_state.auto_y_range {
+            graph_state.auto_y_cache = None;
+        }
+    }
+
     if short {
         if !due {
             return;

--- a/libs/elodin-editor/src/ui/plot/widget.rs
+++ b/libs/elodin-editor/src/ui/plot/widget.rs
@@ -1406,63 +1406,72 @@ pub fn auto_y_bounds(
     *last_run = Some(std::time::Instant::now());
 
     for mut graph_state in graph_states.iter_mut() {
-        if graph_state.auto_y_range {
-            let mut y_min: Option<f32> = None;
-            let mut y_max: Option<f32> = None;
+        if !graph_state.auto_y_range {
+            continue;
+        }
 
-            for (entity, _) in graph_state.enabled_lines.values() {
-                let Ok(handle) = line_handles.get(*entity) else {
-                    continue;
-                };
-                let Some(line) = handle.get(&mut lines, &mut xy_lines) else {
-                    continue;
-                };
-                if let gpu::LineMut::Timeseries(line) = line {
-                    // For small datasets (live streaming), use fast range_summary
-                    // For large datasets (historical/overview), use percentile_bounds to filter outliers
-                    let summary = line.data.range_summary(selected_range.0.clone());
+        let mut content_sig = graph_state.enabled_lines.len() as u64;
+        for (entity, _) in graph_state.enabled_lines.values() {
+            let Ok(handle) = line_handles.get(*entity) else {
+                continue;
+            };
+            let Some(line) = handle.get(&mut lines, &mut xy_lines) else {
+                continue;
+            };
+            content_sig = content_sig
+                .rotate_left(7)
+                .wrapping_add(line.content_gen())
+                .wrapping_add(entity.to_bits());
+        }
+        let cache_key = (
+            selected_range.0.start.0,
+            selected_range.0.end.0,
+            content_sig,
+        );
+        if graph_state.auto_y_cache == Some(cache_key) {
+            continue;
+        }
 
-                    let (line_min, line_max) = if summary.len > OVERVIEW_MAX_POINTS {
-                        // Large dataset - use percentile bounds to filter outliers
-                        // This is expensive but necessary for historical data with corrupt values
-                        line.data
-                            .percentile_bounds(selected_range.0.clone(), 1.0, 99.0)
-                            .unwrap_or((summary.min.unwrap_or(0.0), summary.max.unwrap_or(1.0)))
-                    } else {
-                        // Small dataset (live streaming) - use fast summary
-                        // Fresh data from sensors doesn't have the outlier problem
-                        (summary.min.unwrap_or(0.0), summary.max.unwrap_or(1.0))
-                    };
+        let mut y_min: Option<f32> = None;
+        let mut y_max: Option<f32> = None;
+        for (entity, _) in graph_state.enabled_lines.values() {
+            let Ok(handle) = line_handles.get(*entity) else {
+                continue;
+            };
+            let Some(line) = handle.get(&mut lines, &mut xy_lines) else {
+                continue;
+            };
+            let gpu::LineMut::Timeseries(line) = line else {
+                continue;
+            };
+            let summary = line.data.range_summary(selected_range.0.clone());
+            let (line_min, line_max) = if summary.len > OVERVIEW_MAX_POINTS {
+                line.data
+                    .percentile_bounds(selected_range.0.clone(), 1.0, 99.0)
+                    .unwrap_or((summary.min.unwrap_or(0.0), summary.max.unwrap_or(1.0)))
+            } else {
+                (summary.min.unwrap_or(0.0), summary.max.unwrap_or(1.0))
+            };
 
-                    if line_min.is_finite() {
-                        if let Some(v) = &mut y_min {
-                            *v = v.min(line_min);
-                        } else {
-                            y_min = Some(line_min)
-                        }
-                    }
-                    if line_max.is_finite() {
-                        if let Some(v) = &mut y_max {
-                            *v = v.max(line_max);
-                        } else {
-                            y_max = Some(line_max)
-                        }
-                    }
-                }
+            if line_min.is_finite() {
+                y_min = Some(y_min.map_or(line_min, |v| v.min(line_min)));
             }
-
-            // Only update y_range if we found valid data from enabled_lines
-            // Skip if no lines found - this prevents overwriting y_range set by other systems
-            // (e.g., query_plot's auto_bounds which uses line_entity, not enabled_lines)
-            if let (Some(min), Some(max)) = (y_min, y_max) {
-                let (padded_min, padded_max) = calculate_padded_y_bounds(min as f64, max as f64);
-                if short
-                    && !should_update_short_window_y(&graph_state.y_range, padded_min, padded_max)
-                {
-                    continue;
-                }
-                graph_state.y_range = padded_min..padded_max;
+            if line_max.is_finite() {
+                y_max = Some(y_max.map_or(line_max, |v| v.max(line_max)));
             }
+        }
+
+        // Skip if no lines found — do not overwrite y_range set by other systems
+        // (e.g., query_plot's auto_bounds which uses line_entity, not enabled_lines).
+        if let (Some(min), Some(max)) = (y_min, y_max) {
+            let (padded_min, padded_max) = calculate_padded_y_bounds(min as f64, max as f64);
+            if short && !should_update_short_window_y(&graph_state.y_range, padded_min, padded_max)
+            {
+                graph_state.auto_y_cache = Some(cache_key);
+                continue;
+            }
+            graph_state.y_range = padded_min..padded_max;
+            graph_state.auto_y_cache = Some(cache_key);
         }
     }
 }

--- a/libs/elodin-editor/src/ui/window/default.rs
+++ b/libs/elodin-editor/src/ui/window/default.rs
@@ -22,9 +22,20 @@ pub fn default_composite_alpha_mode() -> CompositeAlphaMode {
     }
 }
 
+/// `ELODIN_PRESENT_MODE=novsync|vsync|fifo` overrides the compiled-in default;
+/// used to diagnose presentation-pacing FPS caps (e.g. ProMotion settling low).
+pub fn present_mode_from_env() -> PresentMode {
+    match std::env::var("ELODIN_PRESENT_MODE").as_deref() {
+        Ok("novsync") => PresentMode::AutoNoVsync,
+        Ok("vsync") => PresentMode::AutoVsync,
+        Ok("fifo") => PresentMode::Fifo,
+        _ => default_present_mode(),
+    }
+}
+
 pub fn base_window() -> Window {
     Window {
-        present_mode: default_present_mode(),
+        present_mode: present_mode_from_env(),
         window_theme: default_window_theme(),
         composite_alpha_mode: default_composite_alpha_mode(),
         ..Default::default()

--- a/libs/elodin-editor/src/ui/window/mod.rs
+++ b/libs/elodin-editor/src/ui/window/mod.rs
@@ -6,7 +6,7 @@ pub mod spawn;
 pub use context::window_entity_from_target;
 pub use default::{
     base_window, default_composite_alpha_mode, default_present_mode, default_window_theme,
-    window_theme_for_mode,
+    present_mode_from_env, window_theme_for_mode,
 };
 pub use placement::{
     collect_sorted_screens, detect_window_screen, handle_window_close, handle_window_destroyed,

--- a/libs/impeller2/bevy/src/lib.rs
+++ b/libs/impeller2/bevy/src/lib.rs
@@ -250,6 +250,18 @@ impl TelemetryCache {
             .unwrap_or(0)
     }
 
+    /// True if at least one sample exists in `[range.start, range.end)`.
+    /// O(log n), unlike `sample_count_in_range` which walks the whole range.
+    pub fn has_samples_in_range(
+        &self,
+        component_id: &ComponentId,
+        range: &std::ops::Range<Timestamp>,
+    ) -> bool {
+        self.components
+            .get(component_id)
+            .is_some_and(|s| s.range(range.start..range.end).next().is_some())
+    }
+
     /// First/last sample timestamps in range, if any.
     pub fn sample_span_in_range(
         &self,

--- a/nix/pkgs/common.nix
+++ b/nix/pkgs/common.nix
@@ -114,6 +114,33 @@
     # defaults when the host driver libraries are not present.
     [ "$have_glx" = 1 ] || exit 0
 
+    # The driver links against the host libX11/libxcb, and having two Xlib
+    # copies in one process (Nix's and the host's) crashes inside the driver, so
+    # route the whole process at the host X libraries. glibc is deliberately
+    # left alone: the host libc is older than Nix's and loading it breaks
+    # symbol resolution for everything else.
+    for lib_dir in \
+      /run/opengl-driver/lib \
+      /usr/lib/x86_64-linux-gnu \
+      /usr/lib/aarch64-linux-gnu \
+      /usr/lib64; do
+      for lib in \
+        "$lib_dir"/libX11.so.6 \
+        "$lib_dir"/libXext.so.6 \
+        "$lib_dir"/libXau.so.6 \
+        "$lib_dir"/libXdmcp.so.6 \
+        "$lib_dir"/libbsd.so.0 \
+        "$lib_dir"/libmd.so.0 \
+        "$lib_dir"/libxcb.so.1 \
+        "$lib_dir"/libxcb-*.so.*; do
+        [ -e "$lib" ] || continue
+        lib_name="$(basename "$lib")"
+        [ -z "''${linked_libs[$lib_name]+x}" ] || continue
+        ln -sf "$lib" "$nvidia_lib_dir/$lib_name"
+        linked_libs["$lib_name"]=1
+      done
+    done
+
     printf 'export VK_ICD_FILENAMES=%s\n' "$nvidia_icd"
     printf 'export VK_DRIVER_FILES=%s\n' "$nvidia_icd"
     printf 'export __GLX_VENDOR_LIBRARY_NAME=nvidia\n'

--- a/nix/pkgs/common.nix
+++ b/nix/pkgs/common.nix
@@ -49,32 +49,14 @@
       [ -e /proc/driver/nvidia/version ] && [ -n "$nvidia_icd" ]
     }
 
-    # A Mesa-capable GPU (Intel 0x8086 / AMD 0x1002) means the editor has a
-    # working non-NVIDIA path, so do not force the host NVIDIA driver. Match
-    # those vendors explicitly: BMC/IPMI framebuffers (e.g. ASPEED 0x1a03,
-    # Matrox 0x102b) also expose render nodes but are not performance GPUs, so a
-    # "not 0x10de" test would wrongly skip the hook on a Quadro-only server.
-    has_mesa_gpu() {
-      for vendor in /sys/class/drm/renderD*/device/vendor; do
-        case "$(cat "$vendor" 2>/dev/null)" in
-          0x8086 | 0x1002) return 0 ;;
-        esac
-      done
-      return 1
-    }
-
+    # Prefer the discrete NVIDIA GPU whenever its driver is usable, including on
+    # hybrid hosts where an Intel or AMD GPU drives the display. Every other
+    # mode stays on Mesa: `mesa` opts out, and `nvk` reaches the same NVIDIA GPU
+    # through Mesa's own driver, so engaging the proprietary one would break it.
     use_nvidia=0
     case "$mode" in
-      nvidia)
+      nvidia | auto)
         if nvidia_present; then
-          use_nvidia=1
-        fi
-        ;;
-      mesa)
-        use_nvidia=0
-        ;;
-      *)
-        if nvidia_present && ! has_mesa_gpu; then
           use_nvidia=1
         fi
         ;;

--- a/nix/pkgs/common.nix
+++ b/nix/pkgs/common.nix
@@ -292,6 +292,16 @@ in {
     ALSA_CONFIG_PATH = "${asoundConf}";
   };
 
+  # Tools required to launch Gamescope and run scripts/elodin_capture.sh.
+  linuxCaptureTools = with pkgs; [
+    gamescope
+    xwayland
+    util-linux # setsid for capture process-group cleanup
+    procps # pkill / pgrep
+    jq
+    libva-utils
+  ];
+
   # Common wrapper arguments for executables
   makeWrapperArgs = {
     pkgs,

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -191,8 +191,8 @@ with pkgs; let
         mesa
         libGL
       ])}:''${LD_LIBRARY_PATH}"
-          # Mesa by default; route to the host NVIDIA driver only when it is the
-          # sole GPU (or ELODIN_GPU=nvidia). No-op on hybrid/Mesa hosts.
+          # Route to the host NVIDIA driver when one is usable, including on
+          # hybrid hosts. Set ELODIN_GPU=mesa to stay on Mesa.
           . ${common.nvidiaHookScript}
         ;;
       esac


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches hot-path plot GPU extraction and auto-Y bounds logic on large telemetry windows; Nix NVIDIA hook changes can affect hybrid Linux graphics setups.
> 
> **Overview**
> **Improves editor FPS on DB-heavy, graph-heavy sessions** by cutting per-frame GPU plot work and cheaper telemetry/plot bookkeeping, plus small presentation and Nix GPU fixes.
> 
> **Plot GPU path:** `extract_lines` now keeps a main-world **`GpuLineCache`** so index buffers, bind groups, and index rewrites are reused unless the visible range, pixel width, value buffers, or **`LineTree` `content_gen`** change. **`content_gen`** bumps on inserts/clears so the live tip still advances.
> 
> **Plot data / auto-Y:** **`percentile_bounds`** uses uniform stride sampling (cap 8192) and **`select_nth_unstable`** instead of collecting and sorting the full window. Auto-Y gets an **`auto_y_cache`** keyed by time range and line content signatures. Prefetch/projection use **`has_samples_in_range`** (O(log n)) instead of counting every sample in range.
> 
> **Editor pacing / diagnostics:** macOS focused mode is **Continuous** (fixes ~50 FPS cap from reactive wait + vsync). **`ELODIN_WINIT_MODE=continuous`**, **`ELODIN_PRESENT_MODE`**, and optional **`ELODIN_FPS_LOG`** CSV logging support benchmarking.
> 
> **GPU / Nix:** New **`gpu_info`** plugin logs the adapter and augments the “no GPU” panic with **`ELODIN_GPU=… nix develop`** hints (**`ELODIN_GPU_PANIC=true`** for testing). Nix **`auto`/`nvidia`** prefers discrete NVIDIA on hybrid laptops and symlinks host X11 libs for the proprietary driver hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d8852123097afef8da76535165c978e8840149a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->