### PR TITLE
Bump Bevy Hanabi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2054,8 +2054,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_hanabi"
-version = "0.19.1-dev"
-source = "git+https://github.com/elodin-sys/bevy_hanabi?rev=e721a3c5f8c730baa6bb9885f08d55237404640b#e721a3c5f8c730baa6bb9885f08d55237404640b"
+version = "0.20.0-dev"
+source = "git+https://github.com/elodin-sys/bevy_hanabi?rev=91176ce93c2b6226f320c3f2ae11b10170dd6317#91176ce93c2b6226f320c3f2ae11b10170dd6317"
 dependencies = [
  "anyhow",
  "bevy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,7 +187,7 @@ version = "0.2.5"
 map_3d = { git = "https://github.com/shanecelis/map_3d.git", branch = "feat/sphere" }
 # Local-space FaceCamera/AlongVelocity: full inverse affine for camera
 # position in effect space (elodin-sys fork; upstream candidate).
-bevy_hanabi = { git = "https://github.com/elodin-sys/bevy_hanabi", rev = "e721a3c5f8c730baa6bb9885f08d55237404640b" }
+bevy_hanabi = { git = "https://github.com/elodin-sys/bevy_hanabi", rev = "91176ce93c2b6226f320c3f2ae11b10170dd6317" }
 
 # bevy_editor_cam's bevy-0.19 branch depends on bevy_framepace from this
 # personal git branch; redirect it to the official v0.22.0 tag so the whole

--- a/libs/elodin-editor/Cargo.toml
+++ b/libs/elodin-editor/Cargo.toml
@@ -135,7 +135,7 @@ impeller2-bevy.path = "../../libs/impeller2/bevy"
 impeller2-bevy.default-features = false
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-bevy_hanabi = { version = "0.19.1-dev", default-features = false, features = ["3d"] }
+bevy_hanabi = { version = "0.20.0-dev", default-features = false, features = ["3d"] }
 tokio = { version = "1.34", features = ["rt-multi-thread", "net"] }
 # os
 directories = "5.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency-only pin bump with no app code changes. Residual risk is limited to possible runtime/visual regressions in thruster particle rendering from the new fork revision.
> 
> **Overview**
> Bumps the elodin-sys `bevy_hanabi` fork from **0.19.1-dev** to **0.20.0-dev** (new git rev), updating the workspace patch, `elodin-editor` dependency, and lockfile.
> 
> No application code changes; thruster particle effects continue to use the same API surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d75e82c6d54d4f5189e55fe968c231a932296a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->