### PR TITLE
Fix reconnect replay time travel

### DIFF
--- a/libs/db/src/grpc/ingest.rs
+++ b/libs/db/src/grpc/ingest.rs
@@ -2402,6 +2402,70 @@ mod tests {
         });
     }
 
+    #[test]
+    fn replay_repairs_partial_occurrence_after_complete_match() {
+        let (_dir, db) = test_db();
+        let service = IngestServiceImpl::new(db.clone());
+        let (_, _) = accepted(&service, "client", b"instance", packed_schema());
+        let vector = [1.0f32, 2.0]
+            .into_iter()
+            .flat_map(f32::to_le_bytes)
+            .collect::<Vec<_>>();
+        db.with_state(|state| {
+            let time = state
+                .get_component(ComponentId::new("PACKED.TIME"))
+                .unwrap();
+            let values = state.get_component(ComponentId::new("PACKED.VEC")).unwrap();
+            time.time_series
+                .push_buf(Timestamp(1000), &1_000_000u64.to_le_bytes())
+                .unwrap();
+            values
+                .time_series
+                .push_buf(Timestamp(1000), &vector)
+                .unwrap();
+            time.time_series
+                .push_buf(Timestamp(1000), &1_000_000u64.to_le_bytes())
+                .unwrap();
+            time.time_series
+                .push_buf(Timestamp(2000), &2_000_000u64.to_le_bytes())
+                .unwrap();
+        });
+
+        let (accept, mut session) = accepted(&service, "client", b"reconnect", packed_schema());
+        let responses = service
+            .process_batch(
+                &mut session,
+                TelemetryBatch {
+                    first_seq: 1,
+                    rows: vec![packed_row(
+                        accept.message_handles["PackedMessage"],
+                        1_000_000,
+                        [1.0, 2.0],
+                    )],
+                },
+            )
+            .unwrap();
+        assert!(!responses.iter().any(is_row_error));
+        db.with_state(|state| {
+            assert_eq!(
+                state
+                    .get_component(ComponentId::new("PACKED.TIME"))
+                    .unwrap()
+                    .time_series
+                    .sample_count(),
+                3
+            );
+            assert_eq!(
+                state
+                    .get_component(ComponentId::new("PACKED.VEC"))
+                    .unwrap()
+                    .time_series
+                    .sample_count(),
+                2
+            );
+        });
+    }
+
     fn read_append_log_committed(path: &Path) -> Vec<u8> {
         let data = fs::read(path).unwrap();
         let committed_len = u64::from_ne_bytes(data[0..8].try_into().unwrap()) as usize;

--- a/libs/db/src/grpc/ingest.rs
+++ b/libs/db/src/grpc/ingest.rs
@@ -2310,6 +2310,55 @@ mod tests {
     }
 
     #[test]
+    fn db_restart_replay_accepts_complete_rows_behind_the_tail() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_path_buf();
+        let schema = packed_schema();
+        let rows = |handle| {
+            vec![
+                packed_row(handle, 1_000_000, [1.0, 2.0]),
+                packed_row(handle, 2_000_000, [3.0, 4.0]),
+            ]
+        };
+        {
+            let db = Arc::new(DB::create(path.clone()).unwrap());
+            let service = IngestServiceImpl::new(db);
+            let (accept, mut session) = accepted(&service, "client", b"instance", schema.clone());
+            service
+                .process_batch(
+                    &mut session,
+                    TelemetryBatch {
+                        first_seq: 1,
+                        rows: rows(accept.message_handles["PackedMessage"]),
+                    },
+                )
+                .unwrap();
+        }
+
+        let db = Arc::new(DB::open(path).unwrap());
+        let service = IngestServiceImpl::new(db.clone());
+        let (accept, mut session) = accepted(&service, "client", b"instance", schema);
+        let responses = service
+            .process_batch(
+                &mut session,
+                TelemetryBatch {
+                    first_seq: 1,
+                    rows: rows(accept.message_handles["PackedMessage"]),
+                },
+            )
+            .unwrap();
+        assert!(!responses.iter().any(is_row_error));
+        assert_eq!(
+            db.with_state(|state| state
+                .get_component(ComponentId::new("PACKED.VEC"))
+                .unwrap()
+                .time_series
+                .sample_count()),
+            3
+        );
+    }
+
+    #[test]
     fn replay_fills_components_missing_from_a_partial_row() {
         let (_dir, db) = test_db();
         let service = IngestServiceImpl::new(db.clone());

--- a/libs/db/src/lib.rs
+++ b/libs/db/src/lib.rs
@@ -1007,6 +1007,7 @@ impl DB {
             let mut seen = HashSet::with_capacity(values.len());
             let mut occurrences = Vec::with_capacity(values.len());
             let mut max_occurrences = 0;
+            let mut would_time_travel = false;
             for (component_id, value) in values {
                 if !seen.insert(*component_id) {
                     return Err(ComponentRowApplyError::Internal(Error::BadMessage));
@@ -1025,6 +1026,10 @@ impl DB {
                     .time_series
                     .get_all(timestamp)
                     .map_or(0, |data| data.len() / value.len());
+                would_time_travel |= component
+                    .time_series
+                    .latest()
+                    .is_some_and(|(latest, _)| *latest > timestamp);
                 max_occurrences = max_occurrences.max(count);
                 occurrences.push(count);
             }
@@ -1053,9 +1058,14 @@ impl DB {
                             break;
                         }
                     }
-                    if valid && matched && candidate.iter().any(|write| *write) {
-                        pending = candidate;
-                        break;
+                    if valid && matched {
+                        if candidate.iter().all(|write| !write) && would_time_travel {
+                            return Ok(());
+                        }
+                        if candidate.iter().any(|write| *write) {
+                            pending = candidate;
+                            break;
+                        }
                     }
                 }
             }

--- a/libs/db/src/lib.rs
+++ b/libs/db/src/lib.rs
@@ -1036,6 +1036,7 @@ impl DB {
 
             let mut pending = vec![true; values.len()];
             if repair_partial {
+                let mut complete_historical_match = false;
                 for occurrence in 0..max_occurrences {
                     let mut candidate = Vec::with_capacity(values.len());
                     let mut matched = false;
@@ -1059,14 +1060,15 @@ impl DB {
                         }
                     }
                     if valid && matched {
-                        if candidate.iter().all(|write| !write) && would_time_travel {
-                            return Ok(());
-                        }
                         if candidate.iter().any(|write| *write) {
                             pending = candidate;
                             break;
                         }
+                        complete_historical_match |= would_time_travel;
                     }
+                }
+                if complete_historical_match && pending.iter().all(|write| *write) {
+                    return Ok(());
                 }
             }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core ingest row-apply and idempotency behavior on reconnect; mistakes could drop legitimate replays or allow bad writes, but scope is limited to repair-partial paths and is covered by new tests.
> 
> **Overview**
> Fixes gRPC **reconnect replay** so rows at timestamps already behind the series tail are handled correctly in `apply_component_row` when `repair_partial` is on.
> 
> **`apply_component_row`** now tracks whether the row would be **time travel** (any component’s latest timestamp is newer than the row). In repair mode, a **fully matching historical occurrence** with nothing left to patch sets `complete_historical_match` when that time-travel condition applies. If the row would otherwise be written in full and only that idempotent historical match applies, the apply **returns success without appending**, avoiding bogus duplicates or time-travel errors on replay.
> 
> Repair iteration is tightened so a **partial** match (some components still need writes) still wins and breaks early; **complete** matches no longer force the wrong pending state.
> 
> Adds ingest tests for **DB restart replay** of complete rows behind the tail and for **repairing a partial occurrence** after an earlier complete match at the same timestamp.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71247f66be4a11b7a7e18572998b90ea9ae9e3a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->