### PR TITLE
feat(voyager): add heliocentric relative dynamics chapter

### DIFF
--- a/examples/voyager/README.md
+++ b/examples/voyager/README.md
@@ -1,122 +1,130 @@
 # Voyager
 
-This example simulates Voyager 1 and Voyager 2 under gravity from
-the Sun and major planets, while also drawing SPICE-driven "truth"
-trajectories for comparison. The planets and truth probes are updated
-directly from NASA SPICE kernels each tick, and the simulated probes
-are integrated by Elodin.
+This example simulates Voyager 1 and Voyager 2 under gravity from the Sun and
+major planets, while drawing NASA SPICE trajectories for comparison.
 
-SPICE is NASA's toolkit and data format for spacecraft geometry,
-time systems, and ephemerides (time-indexed descriptions of where
-celestial bodies and spacecraft are, and how fast they are moving).
-In this example it provides reference
-positions and velocities for the planets and the Voyager spacecraft
-from published files (aka SPICE kernels).
+The example is an educational journey. `main.py` is the intentionally simple
+Chapter 1 model; later chapters add one astrodynamics idea at a time.
 
-This example is a work in progress. It is organized as an educational
-progression rather than a high-fidelity reconstruction of the Voyager
-missions. Chapter 1 intentionally keeps the dynamics simple; Chapter 2
-adds one subtle correction to the same model.
+## What you will see
 
-The editor exposes that divergence numerically as two telemetry signals
-for each simulated probe:
+The editor shows:
 
-- `position_error_km`: Euclidean distance from the matching SPICE truth
-  position, in kilometers.
-- `velocity_error_mps`: Euclidean difference from the matching SPICE truth
-  velocity, in meters per second.
+- red propagated Voyager trajectories;
+- green SPICE reference trajectories;
+- `position_error_km` for Voyager 1 and Voyager 2;
+- `velocity_error_mps` for Voyager 1 and Voyager 2.
 
-The default schematic graphs both signals for Voyager 1 and Voyager 2.
-These diagnostics make it possible to see when the trajectory starts
-diverging instead of relying only on the red simulated and green truth
-paths in the 3D viewport.
+The error telemetry makes the difference between the simulated and reference
+trajectories visible without relying only on the 3D paths.
 
+## Prerequisites
 
-## Setup
+Run these commands from the repository root unless noted otherwise.
 
-Create the repo-local Python venv if needed:
+Create the repo-local Python environment if needed:
 
 ```bash
-cd elodin
 uv venv --python=3.13 python-env
 ```
 
-Install `spiceypy` into that venv:
+Activate it:
 
 ```bash
 source python-env/bin/activate
+```
+
+Install `spiceypy`:
+
+```bash
 uv pip install spiceypy
 ```
 
-Download the required SPICE kernels:
+## Download the SPICE data
+
+From the Voyager example directory:
+
+```bash
+cd examples/voyager
+./download_spice_data.sh
+cd ../..
+```
+
+The script writes the required kernels to:
+
+```text
+examples/voyager/nasa_spice_data/
+```
+
+The example loads:
+
+- the NAIF leap-seconds kernel;
+- DE440 planetary ephemerides;
+- Voyager 1 trajectory data;
+- Voyager 2 trajectory data.
+
+## Run Chapter 1
+
+From the repository root:
+
+```bash
+python examples/voyager/main.py run
+```
+
+Chapter 1 is the original gravity "hello world": the Sun is placed at the
+origin and the probes receive direct gravitational attraction from the Sun and
+major planets.
+
+Read the Chapter 1 notes after you have the example running:
+
+[Chapter 1 — Simple interplanetary gravity](docs/chapter_1.md)
+
+## Run Chapter 2
+
+From the repository root:
+
+```bash
+python examples/voyager/chapter_2.py run
+```
+
+Chapter 2 keeps the same kernels, constants, timestep, integrator, telemetry,
+and visualization, but adds the heliocentric indirect acceleration required
+when the coordinate origin follows the accelerating Sun.
+
+Read the derivation, experiment, and measured results here:
+
+[Chapter 2 — Heliocentric relative dynamics](docs/chapter_2.md)
+
+## Educational journey
+
+| Chapter | Topic | Run |
+| --- | --- | --- |
+| [1](docs/chapter_1.md) | Simple interplanetary gravity | `python examples/voyager/main.py run` |
+| [2](docs/chapter_2.md) | Heliocentric relative dynamics | `python examples/voyager/chapter_2.py run` |
+
+The chapters intentionally build on one another rather than turning the first
+example into a single high-fidelity mission reconstruction.
+
+## Troubleshooting
+
+If SPICE reports a missing kernel, rerun:
 
 ```bash
 cd examples/voyager
 ./download_spice_data.sh
 ```
 
-This writes the kernels into `examples/voyager/nasa_spice_data/`,
-which `main.py` loads at startup.
-
-
-## Run
-
-Run Chapter 1, the original Newtonian-gravity "hello world":
+If Python cannot import `spiceypy`, activate `python-env` and install it with:
 
 ```bash
-python examples/voyager/main.py run
+uv pip install spiceypy
 ```
 
-Run Chapter 2, which corrects the dynamics for the accelerating
-Sun-centered origin:
+If you want a fresh persistent simulation database, set `DB_PATH` to a new
+location before running the example.
 
-```bash
-python examples/voyager/chapter_2.py run
-```
+## Next step
 
-## Chapter 2: the Sun-centered origin accelerates
-
-Chapter 1 looks reasonable: put the Sun at the origin, then add the Sun's and
-planets' direct gravity. But what happens to the Sun?
-
-SPICE supplies the Voyager and planetary states relative to the Sun in
-`ECLIPJ2000`. Its axes are nonrotating, but its origin is attached to the Sun,
-and the planets accelerate that origin.
-
-Let the heliocentric probe position be
-
-```text
-r = R_probe - R_sun
-```
-
-Differentiating twice gives
-
-```text
-r'' = R_probe'' - R_sun''
-```
-
-For a planet at heliocentric position `r_i`, Chapter 2 therefore uses
-
-```text
-mu_i * ((r_i - r) / |r_i - r|^3 - r_i / |r_i|^3)
-```
-
-The first term is the planet's direct acceleration of Voyager. The second is
-the same planet's acceleration of the Sun, which must be subtracted to obtain
-relative acceleration in a Sun-centered frame.
-
-The experiment changes only this equation. It uses the same kernels, constants,
-RK4 integrator, and 3600-second timestep for a 400-day native Elodin run:
-
-| Probe | Chapter 1 position / velocity error | Chapter 2 position / velocity error |
-| --- | ---: | ---: |
-| Voyager 1 | 122,783.010 km / 9.08717 m/s | 32,101.379 km / 1.94987 m/s |
-| Voyager 2 | 121,720.889 km / 8.05398 m/s | 34,124.210 km / 1.75436 m/s |
-
-That is about 72--74% less position disagreement and 78% less velocity
-disagreement. Tens of thousands of kilometers still remain. Later chapters can
-address gravitational parameters, encounter-specific force models, maneuvers,
-and other fidelity limits without obscuring the lesson in Chapters 1 and 2.
-
-Run either command above and compare the existing position- and velocity-error
-graphs for the two probes to reproduce the experiment interactively.
+Start with Chapter 1, watch the position and velocity error graphs, and then
+continue to Chapter 2 to see how one coordinate-system correction changes the
+long-horizon trajectory.

--- a/examples/voyager/README.md
+++ b/examples/voyager/README.md
@@ -13,9 +13,10 @@ In this example it provides reference
 positions and velocities for the planets and the Voyager spacecraft
 from published files (aka SPICE kernels).
 
-This example is a work in progress. Right now the simulated probes do
-not make it to Saturn. Future work is needed to isolate the error
-sources and improve the simulation.
+This example is a work in progress. It is organized as an educational
+progression rather than a high-fidelity reconstruction of the Voyager
+missions. Chapter 1 intentionally keeps the dynamics simple; Chapter 2
+adds one subtle correction to the same model.
 
 The editor exposes that divergence numerically as two telemetry signals
 for each simulated probe:
@@ -60,6 +61,62 @@ which `main.py` loads at startup.
 
 ## Run
 
+Run Chapter 1, the original Newtonian-gravity "hello world":
+
 ```bash
 python examples/voyager/main.py run
 ```
+
+Run Chapter 2, which corrects the dynamics for the accelerating
+Sun-centered origin:
+
+```bash
+python examples/voyager/chapter_2.py run
+```
+
+## Chapter 2: the Sun-centered origin accelerates
+
+Chapter 1 looks reasonable: put the Sun at the origin, then add the Sun's and
+planets' direct gravity. But what happens to the Sun?
+
+SPICE supplies the Voyager and planetary states relative to the Sun in
+`ECLIPJ2000`. Its axes are nonrotating, but its origin is attached to the Sun,
+and the planets accelerate that origin.
+
+Let the heliocentric probe position be
+
+```text
+r = R_probe - R_sun
+```
+
+Differentiating twice gives
+
+```text
+r'' = R_probe'' - R_sun''
+```
+
+For a planet at heliocentric position `r_i`, Chapter 2 therefore uses
+
+```text
+mu_i * ((r_i - r) / |r_i - r|^3 - r_i / |r_i|^3)
+```
+
+The first term is the planet's direct acceleration of Voyager. The second is
+the same planet's acceleration of the Sun, which must be subtracted to obtain
+relative acceleration in a Sun-centered frame.
+
+The experiment changes only this equation. It uses the same kernels, constants,
+RK4 integrator, and 3600-second timestep for a 400-day native Elodin run:
+
+| Probe | Chapter 1 position / velocity error | Chapter 2 position / velocity error |
+| --- | ---: | ---: |
+| Voyager 1 | 122,783.010 km / 9.08717 m/s | 32,101.379 km / 1.94987 m/s |
+| Voyager 2 | 121,720.889 km / 8.05398 m/s | 34,124.210 km / 1.75436 m/s |
+
+That is about 72--74% less position disagreement and 78% less velocity
+disagreement. Tens of thousands of kilometers still remain. Later chapters can
+address gravitational parameters, encounter-specific force models, maneuvers,
+and other fidelity limits without obscuring the lesson in Chapters 1 and 2.
+
+Run either command above and compare the existing position- and velocity-error
+graphs for the two probes to reproduce the experiment interactively.

--- a/examples/voyager/chapter_2.py
+++ b/examples/voyager/chapter_2.py
@@ -1,0 +1,9 @@
+"""Run Voyager Chapter 2: heliocentric relative dynamics."""
+
+import os
+from pathlib import Path
+import runpy
+
+
+os.environ["VOYAGER_DYNAMICS_CHAPTER"] = "2"
+runpy.run_path(Path(__file__).with_name("main.py"), run_name="__main__")

--- a/examples/voyager/docs/chapter_1.md
+++ b/examples/voyager/docs/chapter_1.md
@@ -1,0 +1,69 @@
+# Chapter 1 — Simple interplanetary gravity
+
+Chapter 1 is the Voyager example's intentionally simple starting point.
+
+It answers the first question in the educational journey:
+
+> What happens if we initialize Voyager from SPICE and propagate it using
+> Newtonian gravity from the Sun and major planets?
+
+## Run it
+
+From the repository root:
+
+```bash
+python examples/voyager/main.py run
+```
+
+The simulation begins at the same SPICE state as the reference trajectory.
+Elodin then propagates the red Voyager bodies while SPICE updates the green
+reference bodies.
+
+## Model
+
+For one gravity source, Chapter 1 uses the direct Newtonian attraction
+
+```text
+r = r_probe - r_source
+F = -G M m r / |r|^3
+```
+
+where:
+
+- `M` is the source mass;
+- `m` is the Voyager mass;
+- `r` points from the source to the probe;
+- the minus sign points the force back toward the source.
+
+The model includes the Sun and the eight major-planet entries already defined
+by the example.
+
+## What stays intentionally simple
+
+Chapter 1 is a useful first interplanetary model, not a high-fidelity
+reconstruction of the Voyager missions.
+
+It deliberately keeps the original assumptions so each later chapter can add
+one concept and measure what that concept changes.
+
+The existing telemetry records:
+
+- `position_error_km`;
+- `velocity_error_mps`.
+
+Those signals turn the difference from SPICE into something we can investigate
+rather than hiding it behind two visually similar trajectories.
+
+## Question for Chapter 2
+
+The state vectors are expressed relative to the Sun.
+
+The Chapter 1 model gives the planets' direct gravitational acceleration to
+Voyager, while the Sun remains at the coordinate origin.
+
+That raises the next question:
+
+> If the planets pull on Voyager, what happens when those same planets also
+> accelerate the Sun that defines our origin?
+
+[Continue to Chapter 2 — Heliocentric relative dynamics](chapter_2.md)

--- a/examples/voyager/docs/chapter_2.md
+++ b/examples/voyager/docs/chapter_2.md
@@ -1,0 +1,155 @@
+# Chapter 2 — Heliocentric relative dynamics
+
+Chapter 2 keeps the Chapter 1 simulation intact and adds one astrodynamics
+concept: the acceleration of the Sun-centered origin.
+
+The goal is not to make Voyager "fully accurate." It is to isolate one modeling
+assumption, derive the correction, and measure its effect.
+
+## Run it
+
+From the repository root:
+
+```bash
+python examples/voyager/chapter_2.py run
+```
+
+For comparison, Chapter 1 remains:
+
+```bash
+python examples/voyager/main.py run
+```
+
+## The subtlety
+
+SPICE supplies the Voyager and planetary states relative to the Sun in
+`ECLIPJ2000`.
+
+`ECLIPJ2000` provides nonrotating axes, but that does not make the Sun-centered
+origin inertial. The planets gravitationally accelerate the Sun.
+
+Define the probe's heliocentric position as
+
+```text
+r = R_probe - R_sun
+```
+
+Differentiate twice:
+
+```text
+r'' = R_probe'' - R_sun''
+```
+
+The acceleration of the probe relative to the Sun therefore needs both the
+probe's planetary acceleration and the corresponding acceleration of the Sun.
+
+For a planet at heliocentric position `r_i`, the Chapter 2 contribution is
+
+```text
+mu_i * (
+    (r_i - r) / |r_i - r|^3
+    - r_i / |r_i|^3
+)
+```
+
+The first term is the planet's direct acceleration of Voyager.
+
+The second term is that planet's acceleration of the Sun. It is subtracted
+because the propagated coordinate is `R_probe - R_sun`.
+
+For the Sun's own gravity edge, the source position is the origin, so the
+indirect contribution is zero and the usual central attraction remains.
+
+## Controlled experiment
+
+Chapter 2 changes only this force formulation.
+
+The comparison keeps the same:
+
+- SPICE kernels;
+- gravitational constants;
+- initial states;
+- `ECLIPJ2000` frame;
+- `SUN` observer;
+- classical RK4 integrator;
+- 3,600-second timestep;
+- telemetry and visualization.
+
+The canonical 400-day runs used native Elodin/Cranelift.
+
+| Probe | Chapter 1 position error | Chapter 2 position error | Chapter 1 velocity error | Chapter 2 velocity error |
+| --- | ---: | ---: | ---: | ---: |
+| Voyager 1 | 122,783.010 km | 32,101.379 km | 9.08717 m/s | 1.94987 m/s |
+| Voyager 2 | 121,720.889 km | 34,124.210 km | 8.05398 m/s | 1.75436 m/s |
+
+That is:
+
+- 73.9% lower Voyager 1 position disagreement;
+- 72.0% lower Voyager 2 position disagreement;
+- 78.5% lower Voyager 1 velocity disagreement;
+- 78.2% lower Voyager 2 velocity disagreement.
+
+The improvement grows smoothly over the trajectory rather than appearing only
+at the final endpoint.
+
+## Why this is not just a timestep effect
+
+The Chapter 2 400-day endpoint was also run at 3,600, 1,800, and 900 seconds.
+
+Across that eightfold increase in step count, the position spread was only
+about:
+
+- 5.65 km for Voyager 1;
+- 6.33 km for Voyager 2.
+
+That is tiny compared with the roughly 88,000–91,000 km of disagreement removed
+by the heliocentric correction.
+
+The result therefore points to a model-form limitation during cruise rather
+than ordinary RK4 timestep error being the dominant cause.
+
+## Validation
+
+The focused Chapter 2 tests cover:
+
+- direct-force direction and magnitude;
+- the sign of the indirect acceleration;
+- accumulation across multiple gravity sources;
+- the Sun-at-origin case without division by zero;
+- isolation of the propagated dynamics from post-initialization Voyager truth.
+
+The native Chapter 1 runs reproduce the original reference checkpoints, while
+Chapter 2 improves both position and velocity disagreement for both probes at
+4, 100, and 400 days.
+
+Equivalent alternating native runs measured roughly 3% runtime overhead for
+Chapter 2. Treat that as an indicative microbenchmark rather than a universal
+performance guarantee.
+
+## What Chapter 2 does not claim
+
+Tens of thousands of kilometers of disagreement still remain after 400 days.
+
+Chapter 2 does not add:
+
+- DE440-consistent gravitational parameters;
+- new SPICE kernels;
+- moons;
+- maneuvers;
+- solar-radiation pressure;
+- thermal recoil;
+- alternate or adaptive integration;
+- encounter-specific modeling.
+
+Those are separate questions for later chapters so this chapter keeps one
+lesson and one controlled change.
+
+## Takeaway
+
+A coordinate system can have nonrotating axes while its origin still
+accelerates.
+
+When the state is measured relative to that accelerating origin, the origin's
+acceleration must appear in the relative-motion equation.
+
+[Back to Chapter 1](chapter_1.md) · [Back to Voyager setup](../README.md)

--- a/examples/voyager/dynamics.py
+++ b/examples/voyager/dynamics.py
@@ -1,0 +1,41 @@
+"""Small, testable pieces of the Voyager gravity models."""
+
+from collections.abc import Iterable, Mapping
+
+import jax.numpy as jnp
+
+
+def direct_planetary_acceleration(
+    probe_position,
+    source_position,
+    gravitational_parameter,
+):
+    """Acceleration of a probe toward one gravity source, in m/s^2."""
+    source_to_probe = source_position - probe_position
+    distance = jnp.linalg.norm(source_to_probe)
+    return gravitational_parameter * source_to_probe / distance**3
+
+
+def planetary_acceleration_of_sun(source_position, gravitational_parameter):
+    """Acceleration of the heliocentric origin toward one planet, in m/s^2."""
+    source_distance = jnp.linalg.norm(source_position)
+    safe_distance = jnp.where(source_distance > 0.0, source_distance, 1.0)
+    return gravitational_parameter * source_position / safe_distance**3
+
+
+def heliocentric_relative_acceleration(
+    probe_position,
+    source_position,
+    gravitational_parameter,
+):
+    """Probe acceleration relative to the accelerating Sun, in m/s^2."""
+    direct_acceleration = direct_planetary_acceleration(
+        probe_position, source_position, gravitational_parameter
+    )
+    sun_acceleration = planetary_acceleration_of_sun(source_position, gravitational_parameter)
+    return direct_acceleration - sun_acceleration
+
+
+def gravity_source_entity_names(planets: Iterable[Mapping[str, object]]) -> tuple[str, ...]:
+    """Return the Sun and planet entities that may source probe gravity."""
+    return ("Sun", *(str(planet["entity_name"]) for planet in planets))

--- a/examples/voyager/main.py
+++ b/examples/voyager/main.py
@@ -9,6 +9,11 @@ import spiceypy as spice
 import numpy as np
 from pathlib import Path
 
+from dynamics import (
+    gravity_source_entity_names,
+    heliocentric_relative_acceleration,
+)
+
 # SIM_TIME_STEP = 1.0 / 120.0
 SIM_TIME_STEP = 3600.0
 # SIM_TIME_STEP = 86400.0
@@ -18,6 +23,7 @@ G = 6.6743e-11
 DEFAULT_DB_PATH = "dbs/voyager"
 DB_PATH_ENV = "DB_PATH"
 MAX_TICKS_ENV = "MAX_TICKS"
+DYNAMICS_CHAPTER_ENV = "VOYAGER_DYNAMICS_CHAPTER"
 
 SPICE_DIR = Path(__file__).resolve().parent / "nasa_spice_data"
 SPICE_KERNELS = [
@@ -288,9 +294,35 @@ def gravity(
     )
 
 
+@el.system
+def heliocentric_gravity(
+    graph: el.GraphQuery[GravityEdge],
+    query: el.Query[el.WorldPos, el.Inertia],
+) -> el.Query[el.Force]:
+    """Chapter 2 gravity in a nonrotating frame with a Sun-centered origin."""
+
+    def gravity_fn(force, probe_pos, probe_inertia, source_pos, source_inertia):
+        probe_mass = probe_inertia.mass()
+        gravitational_parameter = G * source_inertia.mass()
+
+        relative_acceleration = heliocentric_relative_acceleration(
+            probe_pos.linear(), source_pos.linear(), gravitational_parameter
+        )
+
+        return el.Force(linear=force.force() + probe_mass * relative_acceleration)
+
+    return graph.edge_fold(
+        left_query=query,
+        right_query=query,
+        return_type=el.Force,
+        init_value=el.Force(),
+        fold_fn=gravity_fn,
+    )
+
+
 for probe in PROBES:
     probe_id = body_entity_ids[probe["entity_name"]]
-    for source_name in ["Sun", *[planet["entity_name"] for planet in PLANETS]]:
+    for source_name in gravity_source_entity_names(PLANETS):
         w.spawn(
             GravityConstraint(probe_id, body_entity_ids[source_name]),
             name=f"{probe['entity_name']} -> {source_name}",
@@ -336,7 +368,12 @@ w.schematic(
 """.format(body_objects=body_objects)
 )
 
-sys = el.six_dof(sys=gravity)
+dynamics_chapter = os.environ.get(DYNAMICS_CHAPTER_ENV, "1")
+if dynamics_chapter not in ("1", "2"):
+    raise ValueError(f"{DYNAMICS_CHAPTER_ENV} must be '1' or '2'")
+
+gravity_system = gravity if dynamics_chapter == "1" else heliocentric_gravity
+sys = el.six_dof(sys=gravity_system)
 db_path = Path(os.environ.get(DB_PATH_ENV, DEFAULT_DB_PATH))
 max_ticks_env = os.environ.get(MAX_TICKS_ENV)
 max_ticks = int(max_ticks_env) if max_ticks_env is not None else None

--- a/examples/voyager/test_dynamics.py
+++ b/examples/voyager/test_dynamics.py
@@ -1,0 +1,110 @@
+"""Focused checks for the Voyager Chapter 2 force equation."""
+
+import ast
+from pathlib import Path
+
+import jax.numpy as jnp
+import numpy as np
+
+from dynamics import (
+    direct_planetary_acceleration,
+    gravity_source_entity_names,
+    heliocentric_relative_acceleration,
+    planetary_acceleration_of_sun,
+)
+
+
+def test_direct_planetary_acceleration_points_toward_source():
+    probe_position = jnp.array([2.0, 0.0, 0.0])
+    source_position = jnp.array([5.0, 0.0, 0.0])
+
+    acceleration = direct_planetary_acceleration(
+        probe_position,
+        source_position,
+        gravitational_parameter=18.0,
+    )
+
+    np.testing.assert_allclose(acceleration, [2.0, 0.0, 0.0])
+
+
+def test_sun_acceleration_is_subtracted_from_direct_acceleration():
+    probe_position = jnp.array([5.0, 0.0, 0.0])
+    source_position = jnp.array([3.0, 0.0, 0.0])
+    gravitational_parameter = 9.0
+
+    direct_acceleration = direct_planetary_acceleration(
+        probe_position, source_position, gravitational_parameter
+    )
+    sun_acceleration = planetary_acceleration_of_sun(source_position, gravitational_parameter)
+    relative_acceleration = heliocentric_relative_acceleration(
+        probe_position, source_position, gravitational_parameter
+    )
+
+    np.testing.assert_allclose(direct_acceleration, [-2.25, 0.0, 0.0])
+    np.testing.assert_allclose(sun_acceleration, [1.0, 0.0, 0.0])
+    np.testing.assert_allclose(relative_acceleration, [-3.25, 0.0, 0.0])
+
+
+def test_relative_acceleration_accumulates_over_multiple_sources():
+    probe_position = jnp.array([4.0, 0.0, 0.0])
+    sources = (
+        (jnp.array([2.0, 0.0, 0.0]), 8.0),
+        (jnp.array([-2.0, 0.0, 0.0]), 18.0),
+    )
+
+    relative_acceleration = sum(
+        (
+            heliocentric_relative_acceleration(probe_position, source_position, mu)
+            for source_position, mu in sources
+        ),
+        start=jnp.zeros(3),
+    )
+
+    # The two independently hand-computed contributions are -4 and +4 m/s^2.
+    np.testing.assert_allclose(relative_acceleration, [0.0, 0.0, 0.0])
+
+
+def test_source_at_origin_has_no_indirect_acceleration():
+    probe_position = jnp.array([2.0, 0.0, 0.0])
+    source_position = jnp.zeros(3)
+
+    direct_acceleration = direct_planetary_acceleration(
+        probe_position, source_position, gravitational_parameter=16.0
+    )
+    sun_acceleration = planetary_acceleration_of_sun(source_position, gravitational_parameter=16.0)
+
+    relative_acceleration = heliocentric_relative_acceleration(
+        probe_position, source_position, gravitational_parameter=16.0
+    )
+
+    np.testing.assert_allclose(sun_acceleration, jnp.zeros(3))
+    np.testing.assert_allclose(relative_acceleration, direct_acceleration)
+    np.testing.assert_allclose(relative_acceleration, [-4.0, 0.0, 0.0])
+
+
+def test_truth_probes_are_not_wired_into_chapter_2_gravity():
+    planets = (
+        {"entity_name": "earth"},
+        {"entity_name": "jupiter"},
+    )
+    assert gravity_source_entity_names(planets) == ("Sun", "earth", "jupiter")
+
+    main_tree = ast.parse(Path(__file__).with_name("main.py").read_text())
+    gravity_source_calls = [
+        node
+        for node in ast.walk(main_tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "gravity_source_entity_names"
+    ]
+    assert len(gravity_source_calls) == 1
+    assert ast.unparse(gravity_source_calls[0].args[0]) == "PLANETS"
+
+    relative_acceleration_calls = [
+        node
+        for node in ast.walk(main_tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "heliocentric_relative_acceleration"
+    ]
+    assert len(relative_acceleration_calls) == 1


### PR DESCRIPTION
## What

Adds a second educational Voyager dynamics chapter that accounts for the acceleration of the Sun in heliocentric coordinates. Chapter 1 remains unchanged and is still the default.

## Why

The current example propagates Sun-relative states but applies only direct planetary acceleration. For

```text
r = R_probe - R_sun
r'' = R_probe'' - R_sun''
```

each planet must contribute its direct acceleration of the spacecraft minus its acceleration of the Sun:

```text
mu_i * ((r_i - r) / |r_i - r|^3 - r_i / |r_i|^3)
```

## Results

With the same SPICE kernels, gravitational constants, RK4 integrator, and 1-hour timestep, a 400-day native Elodin run gives:

| Probe | Chapter 1 | Chapter 2 |
| --- | ---: | ---: |
| V1 position | 122,783.010 km | 32,101.379 km |
| V1 velocity | 9.087 m/s | 1.950 m/s |
| V2 position | 121,720.889 km | 34,124.210 km |
| V2 velocity | 8.054 m/s | 1.754 m/s |

That is a 72--74% reduction in position disagreement and about a 78% reduction in velocity disagreement.

## Educational structure

- `python examples/voyager/main.py run` runs Chapter 1.
- `python examples/voyager/chapter_2.py run` runs Chapter 2.
- The root `README.md` stays focused on setup and running the example.
- `docs/chapter_1.md` explains the simple starting model and motivates the next step.
- `docs/chapter_2.md` contains the derivation, controlled experiment, validation, and measured results.

This keeps the chapter code at the Voyager top level while moving the tutorial/math material into chapter documents so the root README can remain concise as the journey expands.

## Validation

- Five focused equation/wiring tests exercise the sign, direct-force direction, source accumulation, the Sun-at-origin case, and isolation from SPICE truth entities.
- Native Chapter 1 and Chapter 2 runs reproduced both probes at 4, 100, and 400 days.
- Chapter 2 at 400 days changed by only 5.65 km (V1) and 6.33 km (V2) across 3600, 1800, and 900 second timesteps.
- Alternating equivalent native runs measured approximately 3% runtime overhead; treat this as an indicative microbenchmark.
- `pytest`, `ruff check`, `ruff format --check`, and `git diff --check` pass.

## Not included

This intentionally does not add DE440 gravitational parameters, alternate or adaptive integration, encounter kernels, moons, maneuvers, solar-radiation pressure, or other high-fidelity effects. Those belong in later educational chapters.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the Voyager educational example; default behavior is unchanged and the new physics is additive behind an environment flag.
> 
> **Overview**
> Adds **Chapter 2** to the Voyager example: probe gravity in a Sun-centered frame now uses **heliocentric relative acceleration** (each planet’s direct pull on the probe minus that planet’s acceleration of the Sun). Chapter 1’s direct Newtonian model stays the default.
> 
> `main.py` picks the integrator system via `VOYAGER_DYNAMICS_CHAPTER` (`1` or `2`); `chapter_2.py` sets chapter `2` and reuses `main.py`. Force math lives in new `dynamics.py`, wired through a new `heliocentric_gravity` Elodin system.
> 
> The README is reframed as a multi-chapter tutorial with setup, run commands, and links to **`docs/chapter_1.md`** and **`docs/chapter_2.md`** (derivation, controlled comparison, and reported ~72–78% lower SPICE error at 400 days). **`test_dynamics.py`** covers the acceleration formulas and that SPICE truth bodies are not gravity sources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef2298621362010228673762eb75cd2e439e6ae9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->