### PR TITLE
Fix issue where scrubbing with particles causes Editor crash

### DIFF
--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -49,7 +49,9 @@ use ui::{
     UI_ORDER_BASE,
     colors::{ColorExt, get_scheme},
     create_egui_context, default_present_mode,
-    inspector::viewport::{set_viewport_pos, sync_viewport_focus_pick_targets},
+    inspector::viewport::{
+        retry_viewport_eql_compile, set_viewport_pos, sync_viewport_focus_pick_targets,
+    },
     plot::{CollectedGraphData, gpu::LineHandle},
     tiles,
     utils::FriendlyEpoch,
@@ -363,7 +365,8 @@ impl Plugin for EditorPlugin {
             )
             .add_systems(
                 Update,
-                ui::gauges::compile_gauge_exprs.after(update_eql_context),
+                (ui::gauges::compile_gauge_exprs, retry_viewport_eql_compile)
+                    .after(update_eql_context),
             )
             .add_systems(Startup, spawn_ui_cam)
             .add_systems(Update, ui::video_stream::connect_streams)

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -90,7 +90,7 @@ pub fn resolve_db_asset_url_prefer_local(
     {
         let key = key.trim_start_matches('/');
         if root.join(key).is_file() {
-            bevy::log::info!(
+            bevy::log::info_once!(
                 key = %key,
                 root = %root.display(),
                 "db asset shadowed by local file (--kdl session)"
@@ -154,6 +154,17 @@ impl EditableEQL {
         Self {
             eql,
             compiled_expr: Some(compiled_expr),
+        }
+    }
+
+    /// Retry a spawn-time compile that failed because the component set was
+    /// still empty or partial. No-op when the text is empty or already compiled.
+    pub fn retry_compile(&mut self, ctx: &eql::Context) {
+        if self.eql.trim().is_empty() || self.compiled_expr.is_some() {
+            return;
+        }
+        if let Ok(expr) = ctx.parse_str(&self.eql) {
+            self.compiled_expr = compile_eql_expr(expr).ok();
         }
     }
 }

--- a/libs/elodin-editor/src/plugins/kdl_document/mod.rs
+++ b/libs/elodin-editor/src/plugins/kdl_document/mod.rs
@@ -485,7 +485,7 @@ mod tests {
     }
 
     #[test]
-    fn config_sync_opens_given_path_when_not_loaded() {
+    fn config_sync_defers_given_path_to_sticky_open() {
         let temp = TempTestDir::new("config-sync-open");
         let path = temp.path().join("drone.kdl");
         fs::write(&path, "timeline\n").expect("write kdl");
@@ -511,9 +511,12 @@ mod tests {
             );
         app.update();
 
-        assert_eq!(
-            app.world().resource::<SeenOpenDocumentRequests>().0,
-            vec![path]
+        assert!(
+            app.world()
+                .resource::<SeenOpenDocumentRequests>()
+                .0
+                .is_empty(),
+            "sync must not open --kdl before EQL settles; sticky open owns that"
         );
     }
 
@@ -1189,27 +1192,28 @@ mod tests {
         );
     }
 
-    /// When EQL metadata settles, sticky `--kdl` must re-open so panels that
-    /// failed `ComponentNotFound` on the empty/partial first open can recompile.
-    #[test]
-    fn reload_sticky_kdl_when_eql_ready_reopens_once() {
-        use std::sync::Arc;
-
-        use bevy::time::TimeUpdateStrategy;
+    fn eql_component(name: &str) -> std::sync::Arc<eql::Component> {
         use impeller2::schema::Schema;
-        use impeller2::types::{ComponentId, PrimType, Timestamp};
+        use impeller2::types::{ComponentId, PrimType};
 
-        let temp = TempTestDir::new("sticky-kdl-eql-ready");
-        let path = temp.path().join("local.kdl");
-        fs::write(&path, "timeline\n").expect("write kdl");
+        std::sync::Arc::new(eql::Component::new(
+            name.to_string(),
+            ComponentId::new(name),
+            Schema::new(PrimType::F64, [7usize]).unwrap(),
+        ))
+    }
+
+    fn sticky_kdl_test_app(path: PathBuf) -> App {
+        use bevy::time::TimeUpdateStrategy;
 
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
-            .insert_resource(super::InitialKdlPath(Some(path.clone())))
+            .insert_resource(super::InitialKdlPath(Some(path)))
             .insert_resource(TimeUpdateStrategy::ManualDuration(Duration::from_millis(
                 100,
             )))
             .init_resource::<crate::EqlContext>()
+            .init_resource::<CurrentDocument>()
             .init_resource::<SeenOpenDocumentRequests>()
             .add_message::<OpenDocumentRequest>()
             .add_systems(
@@ -1220,49 +1224,117 @@ mod tests {
                 )
                     .chain(),
             );
+        app
+    }
 
-        app.update();
-        assert!(
-            app.world()
-                .resource::<SeenOpenDocumentRequests>()
-                .0
-                .is_empty(),
-            "must not reload while EQL context is empty"
-        );
-
-        let component = Arc::new(eql::Component::new(
-            "body.WORLD_POS".to_string(),
-            ComponentId::new("body.WORLD_POS"),
-            Schema::new(PrimType::F64, [7usize]).unwrap(),
-        ));
-        app.world_mut().resource_mut::<crate::EqlContext>().0 =
-            eql::Context::from_leaves([component], Timestamp(0), Timestamp(1000));
-
-        // Fingerprint change arms the settle timer; must not reopen immediately.
-        app.update();
-        assert!(
-            app.world()
-                .resource::<SeenOpenDocumentRequests>()
-                .0
-                .is_empty(),
-            "must wait for EQL metadata settle before reopening"
-        );
-
-        // 0.35s settle; ManualDuration advances 100ms per update.
-        for _ in 0..4 {
+    fn advance_until(app: &mut App, secs: f64) {
+        let steps = (secs / 0.1).ceil() as u32 + 1;
+        for _ in 0..steps {
             app.update();
         }
+    }
+
+    /// Sticky `--kdl` opens once after EQL settles, then ignores later
+    /// fingerprint changes so large FSW dumps cannot respawn the 3D scene.
+    #[test]
+    fn reload_sticky_kdl_when_eql_ready_opens_once() {
+        use impeller2::types::Timestamp;
+
+        let temp = TempTestDir::new("sticky-kdl-eql-ready");
+        let path = temp.path().join("local.kdl");
+        fs::write(&path, "timeline\n").expect("write kdl");
+
+        let mut app = sticky_kdl_test_app(path.clone());
+
+        app.update();
+        assert!(
+            app.world()
+                .resource::<SeenOpenDocumentRequests>()
+                .0
+                .is_empty(),
+            "must not open while EQL context is empty"
+        );
+
+        app.world_mut().resource_mut::<crate::EqlContext>().0 = eql::Context::from_leaves(
+            [eql_component("body.WORLD_POS")],
+            Timestamp(0),
+            Timestamp(1000),
+        );
+
+        app.update();
+        assert!(
+            app.world()
+                .resource::<SeenOpenDocumentRequests>()
+                .0
+                .is_empty(),
+            "must wait for EQL metadata settle before opening"
+        );
+
+        advance_until(&mut app, super::operations::STICKY_KDL_EQL_SETTLE_SECS);
         assert_eq!(
             app.world().resource::<SeenOpenDocumentRequests>().0,
             vec![path.clone()],
-            "must reopen sticky --kdl once after metadata settles"
+            "must open sticky --kdl once after metadata settles"
         );
 
-        app.update();
+        app.world_mut().resource_mut::<crate::EqlContext>().0 = eql::Context::from_leaves(
+            [eql_component("body.WORLD_POS"), eql_component("body.VEL")],
+            Timestamp(0),
+            Timestamp(1000),
+        );
+        advance_until(&mut app, super::operations::STICKY_KDL_EQL_SETTLE_SECS);
         assert_eq!(
             app.world().resource::<SeenOpenDocumentRequests>().0.len(),
             1,
-            "must not reopen every frame after EQL is ready"
+            "later EQL fingerprint changes must not reopen the schematic"
+        );
+    }
+
+    #[test]
+    fn reload_sticky_kdl_opens_after_empty_eql_fallback() {
+        let temp = TempTestDir::new("sticky-kdl-empty-fallback");
+        let path = temp.path().join("local.kdl");
+        fs::write(&path, "timeline\n").expect("write kdl");
+
+        let mut app = sticky_kdl_test_app(path.clone());
+        advance_until(
+            &mut app,
+            super::operations::STICKY_KDL_EMPTY_EQL_FALLBACK_SECS,
+        );
+        assert_eq!(
+            app.world().resource::<SeenOpenDocumentRequests>().0,
+            vec![path],
+            "offline --kdl must open after the empty-EQL fallback"
+        );
+    }
+
+    #[test]
+    fn reload_sticky_kdl_skips_when_document_already_loaded() {
+        use impeller2::types::Timestamp;
+
+        let temp = TempTestDir::new("sticky-kdl-already-loaded");
+        let path = temp.path().join("local.kdl");
+        fs::write(&path, "timeline\n").expect("write kdl");
+        let resolved_path = impeller2_kdl::env::schematic_file(&path);
+
+        let mut app = sticky_kdl_test_app(path);
+        {
+            let mut current_document = app.world_mut().resource_mut::<CurrentDocument>();
+            current_document.handle = Some(Handle::<SchematicDocumentAsset>::default());
+            current_document.save_path = Some(resolved_path);
+        }
+        app.world_mut().resource_mut::<crate::EqlContext>().0 = eql::Context::from_leaves(
+            [eql_component("body.WORLD_POS")],
+            Timestamp(0),
+            Timestamp(1000),
+        );
+        advance_until(&mut app, super::operations::STICKY_KDL_EQL_SETTLE_SECS);
+        assert!(
+            app.world()
+                .resource::<SeenOpenDocumentRequests>()
+                .0
+                .is_empty(),
+            "already-loaded --kdl document must not reopen on EQL settle"
         );
     }
 

--- a/libs/elodin-editor/src/plugins/kdl_document/operations.rs
+++ b/libs/elodin-editor/src/plugins/kdl_document/operations.rs
@@ -434,16 +434,20 @@ fn put_db_asset(
 /// Feeds `InitialKdlPath` into `sync_document_from_config` as an explicit path
 /// override. Sticky for the session: every sync receives the CLI path while it
 /// remains set, so later `DbConfig` / `schematic.active` updates cannot fall
-/// through and replace the local file. `current_document_matches_path` in
-/// `sync_document_from_config` prevents re-open spam once loaded.
+/// through and replace the local file. The actual open is done once by
+/// `reload_sticky_kdl_when_eql_ready` after metadata settles.
 pub fn apply_initial_kdl_path(initial: Res<InitialKdlPath>) -> Option<PathBuf> {
     initial.0.clone()
 }
 
-/// Settle time after the EQL component fingerprint last changes before a sticky
-/// `--kdl` reopen. Metadata dumps often arrive in several packets; reloading on
-/// the first non-empty context still leaves graphs with `ComponentNotFound`.
-const STICKY_KDL_EQL_SETTLE_SECS: f64 = 0.35;
+/// Quiet time after the EQL component set last changes before the first `--kdl`
+/// open. FSW dumps arrive as several packets (metadata, then schema); opening
+/// on the first non-empty context still leaves `ComponentNotFound`.
+pub(crate) const STICKY_KDL_EQL_SETTLE_SECS: f64 = 1.0;
+
+/// If no EQL components ever appear (offline `--kdl`, no DB), open anyway so
+/// the local file is not stuck behind an empty context forever.
+pub(crate) const STICKY_KDL_EMPTY_EQL_FALLBACK_SECS: f64 = 2.5;
 
 /// Topology fingerprint of leaf components in an EQL context. Ignores
 /// timestamp-range updates so sticky-KDL reloads only run when the component
@@ -467,29 +471,54 @@ fn eql_component_fingerprint(ctx: &eql::Context) -> u64 {
     hash
 }
 
-/// When CLI `--kdl` is sticky and the EQL component set changes (then settles),
-/// reopen the local schematic so panels that hit `ComponentNotFound` on an
-/// empty/partial first open can compile against the real component set.
+/// Opens the CLI `--kdl` file once, after EQL metadata settles (or after the
+/// empty-context fallback). Later fingerprint changes must not tear down the
+/// scene: a full reopen respawns every viewport camera and GLB, which DeviceLost
+/// on large FSW schematics (earth + ~24 cameras). Late components compile in
+/// place (`retry_viewport_eql_compile`, pending `object_3d` spawns).
 pub fn reload_sticky_kdl_when_eql_ready(
     eql: Res<crate::EqlContext>,
     initial: Res<InitialKdlPath>,
+    current_document: Res<CurrentDocument>,
     time: Res<Time>,
     mut open: MessageWriter<OpenDocumentRequest>,
     mut last_fingerprint: Local<u64>,
     mut pending_since: Local<Option<f64>>,
-    mut last_reloaded_fp: Local<u64>,
+    mut empty_since: Local<Option<f64>>,
+    mut opened: Local<bool>,
 ) {
     let Some(path) = initial.0.clone() else {
         *last_fingerprint = 0;
         *pending_since = None;
-        *last_reloaded_fp = 0;
+        *empty_since = None;
+        *opened = false;
         return;
     };
-    if eql.0.component_parts.is_empty() {
+    if current_document_matches_path(&current_document, &schematic_file(&path)) {
+        *opened = true;
         return;
     }
-    let fingerprint = eql_component_fingerprint(&eql.0);
+    if *opened {
+        return;
+    }
+
     let now = time.elapsed_secs_f64();
+    if eql.0.component_parts.is_empty() {
+        let since = *empty_since.get_or_insert(now);
+        if now - since < STICKY_KDL_EMPTY_EQL_FALLBACK_SECS {
+            return;
+        }
+        *opened = true;
+        info!(
+            path = %path.display(),
+            "Opening --kdl schematic after empty-EQL fallback"
+        );
+        open.write(OpenDocumentRequest(path));
+        return;
+    }
+    *empty_since = None;
+
+    let fingerprint = eql_component_fingerprint(&eql.0);
     if fingerprint != *last_fingerprint {
         *last_fingerprint = fingerprint;
         *pending_since = Some(now);
@@ -500,15 +529,12 @@ pub fn reload_sticky_kdl_when_eql_ready(
     if now - since < STICKY_KDL_EQL_SETTLE_SECS {
         return;
     }
+    *opened = true;
     *pending_since = None;
-    if fingerprint == *last_reloaded_fp {
-        return;
-    }
-    *last_reloaded_fp = fingerprint;
     info!(
         path = %path.display(),
         fingerprint,
-        "Reloading --kdl schematic after EQL metadata settled"
+        "Opening --kdl schematic after EQL metadata settled"
     );
     open.write(OpenDocumentRequest(path));
 }
@@ -537,7 +563,6 @@ pub fn sync_document_from_config(
     mut pending_active: ResMut<PendingActiveSchematic>,
     save_in_flight: Option<Res<crate::ui::command_palette::palette_items::SchematicSaveInFlight>>,
     mut current_document: ResMut<CurrentDocument>,
-    mut open_document: MessageWriter<OpenDocumentRequest>,
     mut open_document_from_active: MessageWriter<OpenDocumentFromActiveRequest>,
     mut cleared: MessageWriter<DocumentCleared>,
 ) {
@@ -545,14 +570,13 @@ pub fn sync_document_from_config(
         return;
     }
 
-    // An explicit path override (user opened a specific file) wins outright.
+    // CLI `--kdl` pin: keep the local file in front of `schematic.active`, but
+    // do not open it here. `reload_sticky_kdl_when_eql_ready` opens once after
+    // metadata settles. Opening (and re-opening) from sync spawned the scene
+    // before EQL existed, then tore it down on every dump packet.
     if let Some(path) = given_path {
         let resolved_path = schematic_file(&path);
         if resolved_path.try_exists().unwrap_or(false) {
-            if current_document_matches_path(&current_document, &resolved_path) {
-                return;
-            }
-            open_document.write(OpenDocumentRequest(path));
             return;
         }
         // Overridden path is missing: fall through to the DB-backed sources.

--- a/libs/elodin-editor/src/plugins/kdl_document/operations.rs
+++ b/libs/elodin-editor/src/plugins/kdl_document/operations.rs
@@ -476,6 +476,7 @@ fn eql_component_fingerprint(ctx: &eql::Context) -> u64 {
 /// scene: a full reopen respawns every viewport camera and GLB, which DeviceLost
 /// on large FSW schematics (earth + ~24 cameras). Late components compile in
 /// place (`retry_viewport_eql_compile`, pending `object_3d` spawns).
+#[allow(clippy::too_many_arguments)]
 pub fn reload_sticky_kdl_when_eql_ready(
     eql: Res<crate::EqlContext>,
     initial: Res<InitialKdlPath>,

--- a/libs/elodin-editor/src/plugins/thruster_particles/mod.rs
+++ b/libs/elodin-editor/src/plugins/thruster_particles/mod.rs
@@ -1692,8 +1692,14 @@ mod tests {
         assert!(is_playhead_seek(5.1, false), "forward jump over 5s");
         assert!(is_playhead_seek(-5.1, false), "backward jump over 5s");
         assert!(!is_playhead_seek(5.0, false), "exactly 5s is not a seek");
-        assert!(!is_playhead_seek(1.0, false), "playback-sized step is not a seek");
-        assert!(!is_playhead_seek(0.0, false), "still playhead is not a seek");
+        assert!(
+            !is_playhead_seek(1.0, false),
+            "playback-sized step is not a seek"
+        );
+        assert!(
+            !is_playhead_seek(0.0, false),
+            "still playhead is not a seek"
+        );
         assert!(
             !is_playhead_seek(6.0, true),
             "follow-latest catch-up is not a scrub"

--- a/libs/elodin-editor/src/plugins/thruster_particles/mod.rs
+++ b/libs/elodin-editor/src/plugins/thruster_particles/mod.rs
@@ -7,9 +7,10 @@
 //!
 //! Particle integration uses hanabi `Time<EffectSimulation>`, synced each
 //! frame to the Impeller playhead (`CurrentTimestamp` / `Paused`): pause freezes
-//! trails, playback speed scales spawn/integration, and backward seeks rebuild
-//! thruster rigs so particles do not integrate in reverse. Live 1x viewing does
-//! not require paced sim ticks for trail correctness under timeline replay.
+//! trails, playback speed scales spawn/integration, and playhead seeks despawn
+//! jet entities so Hanabi frees the GPU particle slab (there is no clear API).
+//! `ensure_kdl_thrusters` rebuilds from cached effect/image handles. Live 1x
+//! viewing does not require paced sim ticks for trail correctness.
 //!
 //! Effects come from two sources:
 //! - built-in Rust presets (`plume`, `cold_gas`), or
@@ -61,6 +62,7 @@ use crate::object_3d::{
 use crate::plugins::kdl_document::InitialKdlPath;
 use crate::plugins::render_layer_alloc::THRUSTER_PARTICLES_RENDER_LAYER;
 use crate::ui::Paused;
+use crate::ui::timeline::LatestFollow;
 use crate::vector_arrow::component_value_tail_to_vec3;
 
 /// Reference exhaust axis used to build each emitter's local orientation (Bevy Y-up).
@@ -101,12 +103,8 @@ impl ThrusterEffectAssets {
     }
 }
 
-/// Retained strong handles for hanabi `.effect` files loaded from the DB /
-/// asset root. Seek rebuilds and schematic refresh despawn jet entities (and
-/// their `pending_effect` / `ParticleEffect` handles); without this map Bevy
-/// unloads the asset and the next `ensure_kdl_thrusters` re-enters
-/// `AssetReader::read` (another HTTP GET). Presets already live forever in
-/// [`ThrusterEffectAssets`]; file effects need the same residency.
+/// Retained strong handles for hanabi `.effect` files. Schematic refresh still
+/// despawns jets; this map keeps the asset resident across that rebuild.
 #[derive(Resource, Default)]
 struct FileEffectAssets {
     /// Keyed by the resolved load path (`db:…` → `http://…` URL, or bare path).
@@ -123,6 +121,36 @@ impl FileEffectAssets {
         handle
     }
 }
+
+/// Retained sprite handles (`smoke` / fallback). Seek despawns jets; this map
+/// keeps textures resident so `slot_image` does not call `AssetServer::load`.
+#[derive(Resource, Default)]
+struct FileImageAssets {
+    /// Keyed by the logical `db:` path so resolve + load run only on first miss.
+    handles: HashMap<String, Handle<Image>>,
+}
+
+impl FileImageAssets {
+    fn get_or_load(
+        &mut self,
+        db_path: &str,
+        asset_server: &AssetServer,
+        connection_addr: Option<std::net::SocketAddr>,
+        local_root: Option<&std::path::Path>,
+    ) -> Handle<Image> {
+        if let Some(handle) = self.handles.get(db_path) {
+            return handle.clone();
+        }
+        let resolved = resolve_db_asset_url_prefer_local(db_path, connection_addr, local_root);
+        let handle = asset_server.load::<Image>(resolved);
+        self.handles.insert(db_path.to_string(), handle.clone());
+        handle
+    }
+}
+
+/// One-shot flag: a playhead seek should despawn jets so Hanabi drops GPU particles.
+#[derive(Resource, Default)]
+struct SeekParticleReset(bool);
 
 #[derive(Component)]
 struct KdlThrusterRig {
@@ -199,12 +227,19 @@ impl Plugin for ThrusterParticlesPlugin {
         app.add_plugins(HanabiPlugin)
             .init_resource::<EffectPlayheadClock>()
             .init_resource::<FileEffectAssets>()
+            .init_resource::<FileImageAssets>()
+            .init_resource::<SeekParticleReset>()
             .add_systems(Startup, setup_thruster_effects)
             // Drive hanabi's EffectSimulation clock from the Impeller playhead
             // before TimeSystems advances it from Virtual.
             .add_systems(
                 First,
-                sync_effect_simulation_clock.before(bevy::time::TimeSystems),
+                (
+                    sync_effect_simulation_clock,
+                    reset_thruster_particles_on_seek,
+                )
+                    .chain()
+                    .before(bevy::time::TimeSystems),
             )
             .add_systems(
                 PostUpdate,
@@ -223,28 +258,40 @@ impl Plugin for ThrusterParticlesPlugin {
 }
 
 /// Tracks the last Impeller playhead sample so we can derive sim-time Δt and
-/// detect backward seeks (which reset thruster instances).
+/// detect playhead seeks (which reset thruster GPU instances).
 #[derive(Resource, Default)]
 struct EffectPlayheadClock {
     last_playhead_us: Option<i64>,
     last_wall: Option<std::time::Instant>,
+    last_seek_wall: Option<std::time::Instant>,
 }
 
 /// Max sim-time advance applied to particles in one render frame (avoids
 /// spawn bursts / capacity clamps at high playback speeds).
 const MAX_EFFECT_DT_S: f64 = 0.25;
 
+/// Playhead jump (seconds) that counts as a timeline scrub in either direction.
+const SEEK_SIM_DT_S: f64 = 5.0;
+/// Wall-time gap between jet despawns so a dragged slider cannot rebuild every frame.
+const SEEK_DEBOUNCE_S: f64 = 0.5;
+
+/// True when the playhead jumped by more than [`SEEK_SIM_DT_S`] and the user
+/// is not in follow-latest (live-tail snaps are not scrubs).
+fn is_playhead_seek(sim_dt: f64, following_latest: bool) -> bool {
+    !following_latest && sim_dt.abs() > SEEK_SIM_DT_S
+}
+
 /// Sync `Time<EffectSimulation>` to the editor playhead: pause when the
 /// timeline is paused or the playhead stalls; set `relative_speed` so particle
-/// integration tracks sim time; on backward seek, tear down thruster rigs so
-/// they rebuild empty (no reverse integration).
+/// integration tracks sim time; on a seek, despawn jets so Hanabi frees the
+/// GPU slab (no reverse integration; caches keep assets resident).
 fn sync_effect_simulation_clock(
     mut effect_time: ResMut<Time<EffectSimulation>>,
     current: Res<CurrentTimestamp>,
     paused: Res<Paused>,
+    latest_follow: Res<LatestFollow>,
     mut clock: ResMut<EffectPlayheadClock>,
-    mut commands: Commands,
-    rigs: Query<(Entity, &KdlThrusterRig)>,
+    mut seek_reset: ResMut<SeekParticleReset>,
 ) {
     let now = std::time::Instant::now();
     let playhead = current.0.0;
@@ -261,12 +308,13 @@ fn sync_effect_simulation_clock(
         .max(1e-6);
     let sim_dt = (playhead - last_ph) as f64 * 1e-6;
 
-    if sim_dt < -0.05 {
-        for (object, rig) in &rigs {
-            for &jet in &rig.jets {
-                commands.entity(jet).despawn();
-            }
-            commands.entity(object).remove::<KdlThrusterRig>();
+    if is_playhead_seek(sim_dt, latest_follow.0) {
+        let cooled_down = clock
+            .last_seek_wall
+            .is_none_or(|t| now.saturating_duration_since(t).as_secs_f64() >= SEEK_DEBOUNCE_S);
+        if cooled_down {
+            seek_reset.0 = true;
+            clock.last_seek_wall = Some(now);
         }
         effect_time.pause();
         clock.last_playhead_us = Some(playhead);
@@ -285,6 +333,25 @@ fn sync_effect_simulation_clock(
 
     clock.last_playhead_us = Some(playhead);
     clock.last_wall = Some(now);
+}
+
+/// Despawn jet entities so Hanabi drops the GPU particle slab (no public
+/// clear API; the cache is keyed by entity). `ensure_kdl_thrusters` rebuilds
+/// from `FileEffectAssets` / `FileImageAssets`.
+fn reset_thruster_particles_on_seek(
+    mut pending: ResMut<SeekParticleReset>,
+    mut commands: Commands,
+    rigs: Query<(Entity, &KdlThrusterRig)>,
+) {
+    if !std::mem::take(&mut pending.0) {
+        return;
+    }
+    for (object, rig) in &rigs {
+        for &jet in &rig.jets {
+            commands.entity(jet).despawn();
+        }
+        commands.entity(object).remove::<KdlThrusterRig>();
+    }
 }
 
 fn setup_thruster_effects(
@@ -665,22 +732,25 @@ fn spawn_thruster_light(
 fn slot_image(
     slot: &str,
     assets: &ThrusterEffectAssets,
+    file_images: &mut FileImageAssets,
     asset_server: &AssetServer,
     connection_addr: Option<std::net::SocketAddr>,
     local_root: Option<&std::path::Path>,
 ) -> Handle<Image> {
     match slot {
         "mask" => assets.mask.clone(),
-        "smoke" => asset_server.load(resolve_db_asset_url_prefer_local(
+        "smoke" => file_images.get_or_load(
             "db:textures/smoke_puff.png",
+            asset_server,
             connection_addr,
             local_root,
-        )),
-        _ => asset_server.load(resolve_db_asset_url_prefer_local(
+        ),
+        _ => file_images.get_or_load(
             "db:textures/soft_circle.png",
+            asset_server,
             connection_addr,
             local_root,
-        )),
+        ),
     }
 }
 
@@ -710,16 +780,24 @@ fn frame_up(frame: GeoFrame, position_in_frame: DVec3) -> DVec3 {
 /// Caller must pass a pose that has already been set from telemetry
 /// (`WorldPosReceived`); default/missing `(0,0,0)` would pin ECEF trails at
 /// Earth's center for the whole flight.
+fn trail_anchor_pose(frame: Option<GeoFrame>, world_pos: &WorldPos) -> (GeoPosition, GeoRotation) {
+    let frame = frame.unwrap_or_default();
+    let position = world_pos.pos();
+    let up = frame_up(frame, position);
+    let rotation = DQuat::from_rotation_arc(DVec3::Y, up);
+    (
+        GeoPosition(frame, position),
+        GeoRotation::absolute(frame, rotation),
+    )
+}
+
 fn spawn_trail_anchor(
     commands: &mut Commands,
     jet_entity: Entity,
     frame: Option<GeoFrame>,
     world_pos: &WorldPos,
 ) -> Entity {
-    let frame = frame.unwrap_or_default();
-    let position = world_pos.pos();
-    let up = frame_up(frame, position);
-    let rotation = DQuat::from_rotation_arc(DVec3::Y, up);
+    let (geo_pos, geo_rot) = trail_anchor_pose(frame, world_pos);
     commands
         .spawn((
             KdlTrailAnchorOf(jet_entity),
@@ -730,8 +808,8 @@ fn spawn_trail_anchor(
             // The `GridCell` add hook parents this under the big_space root.
             #[cfg(feature = "big_space")]
             crate::spatial::GridCell::default(),
-            GeoPosition(frame, position),
-            GeoRotation::absolute(frame, rotation),
+            geo_pos,
+            geo_rot,
         ))
         .id()
 }
@@ -751,6 +829,7 @@ fn bind_file_effect_assets(
     objects: Query<&WorldPos, (With<Object3DState>, With<WorldPosReceived>)>,
     effects: Res<Assets<EffectAsset>>,
     assets: Res<ThrusterEffectAssets>,
+    mut file_images: ResMut<FileImageAssets>,
     asset_server: Res<AssetServer>,
     connection_addr: Option<Res<ConnectionAddr>>,
     initial_kdl: Option<Res<InitialKdlPath>>,
@@ -785,6 +864,7 @@ fn bind_file_effect_assets(
                 slot_image(
                     &slot.name,
                     &assets,
+                    &mut file_images,
                     &asset_server,
                     connection_addr,
                     local_root.as_deref(),
@@ -1484,9 +1564,23 @@ mod tests {
         );
     }
 
-    /// Seek rebuilds despawn jets (and their EffectAsset handles). The file
-    /// cache must keep a strong handle so Bevy does not unload the asset and
-    /// the next ensure reuses the same handle id.
+    fn test_jet(frame: Option<GeoFrame>) -> KdlThrusterJet {
+        KdlThrusterJet {
+            body_offset: Vec3::ZERO,
+            fixed_exhaust: DPS_EXHAUST_BODY,
+            vector_intensity: false,
+            body_frame: true,
+            frame,
+            intensity: None,
+            scale: 1.0,
+            base_rate: Some(100.0),
+            pending_effect: None,
+            authored_settings: None,
+            has_intensity_property: false,
+            cutoff: 0.0,
+        }
+    }
+
     #[test]
     fn trail_anchor_freezes_telemetry_pose_not_default_origin() {
         let mut world = World::new();
@@ -1554,5 +1648,153 @@ mod tests {
             "rebuild must clone the retained handle, not allocate a new asset"
         );
         assert_eq!(cache.handles.len(), 1);
+    }
+
+    #[test]
+    fn file_image_cache_survives_material_drop() {
+        let mut images = Assets::<Image>::default();
+        let mut cache = FileImageAssets::default();
+        let path = "db:textures/smoke_puff.png".to_string();
+
+        let loaded = images.add(build_soft_particle_image());
+        cache.handles.insert(path.clone(), loaded.clone());
+
+        let jet_handle = cache
+            .handles
+            .get(&path)
+            .cloned()
+            .expect("cache populated on first load");
+        assert_eq!(jet_handle.id(), loaded.id());
+
+        drop(jet_handle);
+        drop(loaded);
+
+        let retained = cache
+            .handles
+            .get(&path)
+            .expect("FileImageAssets must retain across seek recycle");
+        assert!(
+            images.get(retained).is_some(),
+            "Image must stay resident while the cache holds a strong handle"
+        );
+
+        let again = cache.handles.get(&path).cloned().unwrap();
+        assert_eq!(
+            retained.id(),
+            again.id(),
+            "rebind must clone the retained handle, not allocate a new asset"
+        );
+        assert_eq!(cache.handles.len(), 1);
+    }
+
+    #[test]
+    fn playhead_seek_is_five_second_jump() {
+        assert!(is_playhead_seek(5.1, false), "forward jump over 5s");
+        assert!(is_playhead_seek(-5.1, false), "backward jump over 5s");
+        assert!(!is_playhead_seek(5.0, false), "exactly 5s is not a seek");
+        assert!(!is_playhead_seek(1.0, false), "playback-sized step is not a seek");
+        assert!(!is_playhead_seek(0.0, false), "still playhead is not a seek");
+        assert!(
+            !is_playhead_seek(6.0, true),
+            "follow-latest catch-up is not a scrub"
+        );
+    }
+
+    #[test]
+    fn seek_despawns_jets_and_removes_rig() {
+        let mut app = App::new();
+        app.init_resource::<SeekParticleReset>()
+            .add_systems(Update, reset_thruster_particles_on_seek);
+
+        let configs = vec![test_thruster((0.0, -1.9, 0.0))];
+        let object = app
+            .world_mut()
+            .spawn(test_object_state(configs.clone()))
+            .id();
+        let jet = app
+            .world_mut()
+            .spawn((test_jet(None), KdlThrusterJetOf(object)))
+            .id();
+        app.world_mut().entity_mut(object).insert(KdlThrusterRig {
+            jets: vec![jet],
+            configs,
+        });
+
+        app.world_mut().resource_mut::<SeekParticleReset>().0 = true;
+        app.update();
+
+        assert!(
+            app.world().get::<KdlThrusterRig>(object).is_none(),
+            "seek must remove the rig so ensure rebuilds new jet entities"
+        );
+        assert!(
+            app.world().get_entity(jet).is_err(),
+            "seek must despawn jets so Hanabi frees the GPU slab"
+        );
+    }
+
+    #[test]
+    fn backward_seek_clock_flags_reset() {
+        let mut app = App::new();
+        app.init_resource::<Time<EffectSimulation>>()
+            .init_resource::<EffectPlayheadClock>()
+            .init_resource::<SeekParticleReset>()
+            .insert_resource(Paused(false))
+            .insert_resource(LatestFollow(false))
+            .insert_resource(CurrentTimestamp(impeller2::types::Timestamp(6_000_000)))
+            .add_systems(Update, sync_effect_simulation_clock);
+
+        app.update();
+        app.world_mut().resource_mut::<CurrentTimestamp>().0 = impeller2::types::Timestamp(0);
+        app.update();
+
+        assert!(
+            app.world().resource::<SeekParticleReset>().0,
+            "backward jump over 5s must flag a particle reset"
+        );
+    }
+
+    #[test]
+    fn forward_seek_clock_flags_reset() {
+        let mut app = App::new();
+        app.init_resource::<Time<EffectSimulation>>()
+            .init_resource::<EffectPlayheadClock>()
+            .init_resource::<SeekParticleReset>()
+            .insert_resource(Paused(false))
+            .insert_resource(LatestFollow(false))
+            .insert_resource(CurrentTimestamp(impeller2::types::Timestamp(0)))
+            .add_systems(Update, sync_effect_simulation_clock);
+
+        app.update();
+        app.world_mut().resource_mut::<CurrentTimestamp>().0 =
+            impeller2::types::Timestamp(6_000_000);
+        app.update();
+
+        assert!(
+            app.world().resource::<SeekParticleReset>().0,
+            "forward jump over 5s must flag a particle reset"
+        );
+    }
+
+    #[test]
+    fn follow_latest_jump_does_not_flag_reset() {
+        let mut app = App::new();
+        app.init_resource::<Time<EffectSimulation>>()
+            .init_resource::<EffectPlayheadClock>()
+            .init_resource::<SeekParticleReset>()
+            .insert_resource(Paused(false))
+            .insert_resource(LatestFollow(true))
+            .insert_resource(CurrentTimestamp(impeller2::types::Timestamp(0)))
+            .add_systems(Update, sync_effect_simulation_clock);
+
+        app.update();
+        app.world_mut().resource_mut::<CurrentTimestamp>().0 =
+            impeller2::types::Timestamp(6_000_000);
+        app.update();
+
+        assert!(
+            !app.world().resource::<SeekParticleReset>().0,
+            "follow-latest must not despawn jets on a live-tail jump"
+        );
     }
 }

--- a/libs/elodin-editor/src/ui/inspector/viewport.rs
+++ b/libs/elodin-editor/src/ui/inspector/viewport.rs
@@ -789,6 +789,19 @@ impl WidgetSystem for InspectorViewport<'_, '_> {
     }
 }
 
+/// Compile viewport pos/look_at/up that failed at spawn because EQL metadata
+/// had not landed yet. `--kdl` no longer full-reloads the schematic for that.
+pub fn retry_viewport_eql_compile(
+    mut viewports: Query<&mut Viewport>,
+    eql_context: Res<EqlContext>,
+) {
+    for mut viewport in &mut viewports {
+        viewport.pos.retry_compile(&eql_context.0);
+        viewport.look_at.retry_compile(&eql_context.0);
+        viewport.up.retry_compile(&eql_context.0);
+    }
+}
+
 fn eql_input(ui: &mut egui::Ui, editable_expr: &mut EditableEQL, ctx: &eql::Context) {
     ui.scope(|ui| {
         ui.spacing_mut().item_spacing.y = 0.0;

--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -244,10 +244,18 @@ pub struct PendingWindowSchematics {
 #[derive(Component)]
 pub struct MonitorsRoot;
 
+/// `object_3d` nodes that failed to parse at load because EQL metadata was
+/// still incomplete. Retried in place so `--kdl` does not need a full reopen.
+#[derive(Resource, Default)]
+pub struct PendingObject3dSpawns {
+    objects: Vec<impeller2_wkt::Object3D>,
+}
+
 pub(crate) fn plugin(app: &mut App) {
-    app.add_systems(Startup, |mut commands: Commands| {
-        commands.spawn((MonitorsRoot, Name::new("monitors")));
-    });
+    app.init_resource::<PendingObject3dSpawns>()
+        .add_systems(Startup, |mut commands: Commands| {
+            commands.spawn((MonitorsRoot, Name::new("monitors")));
+        });
 }
 
 #[derive(SystemParam)]
@@ -284,6 +292,7 @@ pub struct LoadSchematicParams<'w, 's> {
     pub schematic_bindings: ResMut<'w, super::SchematicBindings>,
     pub current_schematic: ResMut<'w, CurrentSchematic>,
     pending_windows: ResMut<'w, PendingWindowSchematics>,
+    pending_object_3d: Option<ResMut<'w, PendingObject3dSpawns>>,
     /// Records each spawned `db:` window's stored KDL so a revision-gated
     /// refetch can tell a window-only remote save apart from an unrelated
     /// asset write (RFD #724, Bug 2). Optional: absent in minimal test apps.
@@ -454,6 +463,9 @@ impl LoadSchematicParams<'_, '_> {
         // Drop any remote window fetches still in flight from a prior load so
         // their windows can't spawn into this freshly-cleared document.
         self.pending_windows.loads.clear();
+        if let Some(pending) = self.pending_object_3d.as_mut() {
+            pending.objects.clear();
+        }
         for (id, window_id, mut window_state) in &mut self.window_states {
             if window_id.is_primary() {
                 continue;
@@ -950,6 +962,9 @@ impl LoadSchematicParams<'_, '_> {
 
     pub fn spawn_object_3d(&mut self, object_3d: Object3D) {
         let Ok(expr) = self.eql.0.parse_str(&object_3d.eql) else {
+            if let Some(pending) = self.pending_object_3d.as_mut() {
+                pending.objects.push(object_3d);
+            }
             return;
         };
         let icon = object_3d.icon.clone();
@@ -1705,6 +1720,26 @@ pub fn apply_document_cleared(
     }
 }
 
+/// Spawn `object_3d` nodes that failed EQL parse on the first load, now that
+/// more components are registered. Failures are re-queued.
+pub fn retry_pending_object_3d_spawns(mut params: LoadSchematicParams) {
+    if params.eql.0.component_parts.is_empty() {
+        return;
+    }
+    let objects = {
+        let Some(pending) = params.pending_object_3d.as_mut() else {
+            return;
+        };
+        if pending.objects.is_empty() {
+            return;
+        }
+        std::mem::take(&mut pending.objects)
+    };
+    for object_3d in objects {
+        params.spawn_object_3d(object_3d);
+    }
+}
+
 /// Finish a pending Data Overview once component metadata is available.
 pub fn retry_pending_data_overview(
     mut pending: ResMut<PendingDataOverview>,
@@ -1803,6 +1838,7 @@ mod tests {
             .init_resource::<Coordinate>()
             .init_resource::<SchematicBindings>()
             .init_resource::<super::PendingWindowSchematics>()
+            .init_resource::<super::PendingObject3dSpawns>()
             .insert_resource(CurrentSchematic(Default::default()));
 
         app.world_mut().spawn((Window::default(), PrimaryWindow));

--- a/libs/elodin-editor/src/ui/schematic/mod.rs
+++ b/libs/elodin-editor/src/ui/schematic/mod.rs
@@ -655,6 +655,7 @@ impl Plugin for SchematicPlugin {
                 (
                     load::apply_document_cleared,
                     load::retry_pending_data_overview,
+                    load::retry_pending_object_3d_spawns,
                     load::apply_document_loaded.before(crate::ui::sync_windows),
                     load::apply_document_reloaded.before(crate::ui::sync_windows),
                     load::apply_pending_window_schematics.before(crate::ui::sync_windows),


### PR DESCRIPTION
Specific bug to using the editor with --kdl, and scrubbing, when there are particles

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sticky schematic open timing, 3D scene lifecycle, and GPU particle teardown on timeline seeks—areas tied to the reported scrub crash, with broad test coverage but non-trivial rendering behavior.
> 
> **Overview**
> Fixes editor crashes when using **`--kdl`** with particle-heavy schematics and **scrubbing** the timeline.
> 
> **Sticky `--kdl` open (no more full schematic reloads)**  
> Config sync no longer opens the CLI file immediately; **`reload_sticky_kdl_when_eql_ready`** opens it **once** after EQL metadata settles (1s quiet) or after an **empty-EQL fallback** (2.5s offline). Later FSW dump packets must **not** reopen the schematic—that was respawning viewports/GLBs and contributing to **DeviceLost** on large scenes. Late EQL is handled in place via **`retry_viewport_eql_compile`**, **`EditableEQL::retry_compile`**, and **`PendingObject3dSpawns`** / **`retry_pending_object_3d_spawns`**.
> 
> **Thruster particles on scrub**  
> Playhead jumps **>5s** (forward or back), debounced and skipped during **follow-latest**, trigger jet despawn so Hanabi can drop GPU particle state (no clear API). **`FileImageAssets`** caches smoke/soft-circle textures across rebuilds; **`info_once`** reduces log spam for local `db:` shadowing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd8e1ca7fe0836ee78beef0c539fae5195d34ffb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->