### PR TITLE
feat(voyager): add reconstructed trajectory validation

### DIFF
--- a/examples/voyager/README.md
+++ b/examples/voyager/README.md
@@ -1,122 +1,130 @@
 # Voyager
 
-This example simulates Voyager 1 and Voyager 2 under gravity from
-the Sun and major planets, while also drawing SPICE-driven "truth"
-trajectories for comparison. The planets and truth probes are updated
-directly from NASA SPICE kernels each tick, and the simulated probes
-are integrated by Elodin.
+This example simulates Voyager 1 and Voyager 2 under gravity from the Sun and
+major planets, while drawing NASA SPICE trajectories for comparison.
 
-SPICE is NASA's toolkit and data format for spacecraft geometry,
-time systems, and ephemerides (time-indexed descriptions of where
-celestial bodies and spacecraft are, and how fast they are moving).
-In this example it provides reference
-positions and velocities for the planets and the Voyager spacecraft
-from published files (aka SPICE kernels).
+The example is an educational journey. `main.py` is the intentionally simple
+Chapter 1 model; later chapters add one astrodynamics idea at a time.
 
-This example is a work in progress. It is organized as an educational
-progression rather than a high-fidelity reconstruction of the Voyager
-missions. Chapter 1 intentionally keeps the dynamics simple; Chapter 2
-adds one subtle correction to the same model.
+## What you will see
 
-The editor exposes that divergence numerically as two telemetry signals
-for each simulated probe:
+The editor shows:
 
-- `position_error_km`: Euclidean distance from the matching SPICE truth
-  position, in kilometers.
-- `velocity_error_mps`: Euclidean difference from the matching SPICE truth
-  velocity, in meters per second.
+- red propagated Voyager trajectories;
+- green SPICE reference trajectories;
+- `position_error_km` for Voyager 1 and Voyager 2;
+- `velocity_error_mps` for Voyager 1 and Voyager 2.
 
-The default schematic graphs both signals for Voyager 1 and Voyager 2.
-These diagnostics make it possible to see when the trajectory starts
-diverging instead of relying only on the red simulated and green truth
-paths in the 3D viewport.
+The error telemetry makes the difference between the simulated and reference
+trajectories visible without relying only on the 3D paths.
 
+## Prerequisites
 
-## Setup
+Run these commands from the repository root unless noted otherwise.
 
-Create the repo-local Python venv if needed:
+Create the repo-local Python environment if needed:
 
 ```bash
-cd elodin
 uv venv --python=3.13 python-env
 ```
 
-Install `spiceypy` into that venv:
+Activate it:
 
 ```bash
 source python-env/bin/activate
+```
+
+Install `spiceypy`:
+
+```bash
 uv pip install spiceypy
 ```
 
-Download the required SPICE kernels:
+## Download the SPICE data
+
+From the Voyager example directory:
+
+```bash
+cd examples/voyager
+./download_spice_data.sh
+cd ../..
+```
+
+The script writes the required kernels to:
+
+```text
+examples/voyager/nasa_spice_data/
+```
+
+The example loads:
+
+- the NAIF leap-seconds kernel;
+- DE440 planetary ephemerides;
+- Voyager 1 trajectory data;
+- Voyager 2 trajectory data.
+
+## Run Chapter 1
+
+From the repository root:
+
+```bash
+python examples/voyager/main.py run
+```
+
+Chapter 1 is the original gravity "hello world": the Sun is placed at the
+origin and the probes receive direct gravitational attraction from the Sun and
+major planets.
+
+Read the Chapter 1 notes after you have the example running:
+
+[Chapter 1 — Simple interplanetary gravity](docs/chapter_1.md)
+
+## Run Chapter 2
+
+From the repository root:
+
+```bash
+python examples/voyager/chapter_2.py run
+```
+
+Chapter 2 keeps the same kernels, constants, timestep, integrator, telemetry,
+and visualization, but adds the heliocentric indirect acceleration required
+when the coordinate origin follows the accelerating Sun.
+
+Read the derivation, experiment, and measured results here:
+
+[Chapter 2 — Heliocentric relative dynamics](docs/chapter_2.md)
+
+## Educational journey
+
+| Chapter | Topic | Run |
+| --- | --- | --- |
+| [1](docs/chapter_1.md) | Simple interplanetary gravity | `python examples/voyager/main.py run` |
+| [2](docs/chapter_2.md) | Heliocentric relative dynamics | `python examples/voyager/chapter_2.py run` |
+
+The chapters intentionally build on one another rather than turning the first
+example into a single high-fidelity mission reconstruction.
+
+## Troubleshooting
+
+If SPICE reports a missing kernel, rerun:
 
 ```bash
 cd examples/voyager
 ./download_spice_data.sh
 ```
 
-This writes the kernels into `examples/voyager/nasa_spice_data/`,
-which `main.py` loads at startup.
-
-
-## Run
-
-Run Chapter 1, the original Newtonian-gravity "hello world":
+If Python cannot import `spiceypy`, activate `python-env` and install it with:
 
 ```bash
-python examples/voyager/main.py run
+uv pip install spiceypy
 ```
 
-Run Chapter 2, which corrects the dynamics for the accelerating
-Sun-centered origin:
+If you want a fresh persistent simulation database, set `DB_PATH` to a new
+location before running the example.
 
-```bash
-python examples/voyager/chapter_2.py run
-```
+## Next step
 
-## Chapter 2: the Sun-centered origin accelerates
-
-Chapter 1 looks reasonable: put the Sun at the origin, then add the Sun's and
-planets' direct gravity. But what happens to the Sun?
-
-SPICE supplies the Voyager and planetary states relative to the Sun in
-`ECLIPJ2000`. Its axes are nonrotating, but its origin is attached to the Sun,
-and the planets accelerate that origin.
-
-Let the heliocentric probe position be
-
-```text
-r = R_probe - R_sun
-```
-
-Differentiating twice gives
-
-```text
-r'' = R_probe'' - R_sun''
-```
-
-For a planet at heliocentric position `r_i`, Chapter 2 therefore uses
-
-```text
-mu_i * ((r_i - r) / |r_i - r|^3 - r_i / |r_i|^3)
-```
-
-The first term is the planet's direct acceleration of Voyager. The second is
-the same planet's acceleration of the Sun, which must be subtracted to obtain
-relative acceleration in a Sun-centered frame.
-
-The experiment changes only this equation. It uses the same kernels, constants,
-RK4 integrator, and 3600-second timestep for a 400-day native Elodin run:
-
-| Probe | Chapter 1 position / velocity error | Chapter 2 position / velocity error |
-| --- | ---: | ---: |
-| Voyager 1 | 122,783.010 km / 9.08717 m/s | 32,101.379 km / 1.94987 m/s |
-| Voyager 2 | 121,720.889 km / 8.05398 m/s | 34,124.210 km / 1.75436 m/s |
-
-That is about 72--74% less position disagreement and 78% less velocity
-disagreement. Tens of thousands of kilometers still remain. Later chapters can
-address gravitational parameters, encounter-specific force models, maneuvers,
-and other fidelity limits without obscuring the lesson in Chapters 1 and 2.
-
-Run either command above and compare the existing position- and velocity-error
-graphs for the two probes to reproduce the experiment interactively.
+Start with Chapter 1, watch the position and velocity error graphs, and then
+continue to Chapter 2 to see how one coordinate-system correction changes the
+long-horizon trajectory.

--- a/examples/voyager/README.md
+++ b/examples/voyager/README.md
@@ -105,6 +105,15 @@ Read the derivation, experiment, and measured results here:
 The chapters intentionally build on one another rather than turning the first
 example into a single high-fidelity mission reconstruction.
 
+## Truth reference and reproducible validation
+
+The interactive journey uses long-span merged Voyager SPKs for mission-scale
+visualization. A separate headless benchmark uses NAIF's current-best
+reconstructed Jupiter and Saturn encounter SPKs, initializing and scoring from
+the same solution.
+
+[Read the truth-reference contract and Chapter 1–2 revalidation](docs/truth_reference.md)
+
 ## Troubleshooting
 
 If SPICE reports a missing kernel, rerun:

--- a/examples/voyager/README.md
+++ b/examples/voyager/README.md
@@ -13,9 +13,10 @@ In this example it provides reference
 positions and velocities for the planets and the Voyager spacecraft
 from published files (aka SPICE kernels).
 
-This example is a work in progress. Right now the simulated probes do
-not make it to Saturn. Future work is needed to isolate the error
-sources and improve the simulation.
+This example is a work in progress. It is organized as an educational
+progression rather than a high-fidelity reconstruction of the Voyager
+missions. Chapter 1 intentionally keeps the dynamics simple; Chapter 2
+adds one subtle correction to the same model.
 
 The editor exposes that divergence numerically as two telemetry signals
 for each simulated probe:
@@ -60,6 +61,62 @@ which `main.py` loads at startup.
 
 ## Run
 
+Run Chapter 1, the original Newtonian-gravity "hello world":
+
 ```bash
 python examples/voyager/main.py run
 ```
+
+Run Chapter 2, which corrects the dynamics for the accelerating
+Sun-centered origin:
+
+```bash
+python examples/voyager/chapter_2.py run
+```
+
+## Chapter 2: the Sun-centered origin accelerates
+
+Chapter 1 looks reasonable: put the Sun at the origin, then add the Sun's and
+planets' direct gravity. But what happens to the Sun?
+
+SPICE supplies the Voyager and planetary states relative to the Sun in
+`ECLIPJ2000`. Its axes are nonrotating, but its origin is attached to the Sun,
+and the planets accelerate that origin.
+
+Let the heliocentric probe position be
+
+```text
+r = R_probe - R_sun
+```
+
+Differentiating twice gives
+
+```text
+r'' = R_probe'' - R_sun''
+```
+
+For a planet at heliocentric position `r_i`, Chapter 2 therefore uses
+
+```text
+mu_i * ((r_i - r) / |r_i - r|^3 - r_i / |r_i|^3)
+```
+
+The first term is the planet's direct acceleration of Voyager. The second is
+the same planet's acceleration of the Sun, which must be subtracted to obtain
+relative acceleration in a Sun-centered frame.
+
+The experiment changes only this equation. It uses the same kernels, constants,
+RK4 integrator, and 3600-second timestep for a 400-day native Elodin run:
+
+| Probe | Chapter 1 position / velocity error | Chapter 2 position / velocity error |
+| --- | ---: | ---: |
+| Voyager 1 | 122,783.010 km / 9.08717 m/s | 32,101.379 km / 1.94987 m/s |
+| Voyager 2 | 121,720.889 km / 8.05398 m/s | 34,124.210 km / 1.75436 m/s |
+
+That is about 72--74% less position disagreement and 78% less velocity
+disagreement. Tens of thousands of kilometers still remain. Later chapters can
+address gravitational parameters, encounter-specific force models, maneuvers,
+and other fidelity limits without obscuring the lesson in Chapters 1 and 2.
+
+Run either command above and compare the existing position- and velocity-error
+graphs for the two probes to reproduce the experiment interactively.

--- a/examples/voyager/chapter_2.py
+++ b/examples/voyager/chapter_2.py
@@ -1,0 +1,9 @@
+"""Run Voyager Chapter 2: heliocentric relative dynamics."""
+
+import os
+from pathlib import Path
+import runpy
+
+
+os.environ["VOYAGER_DYNAMICS_CHAPTER"] = "2"
+runpy.run_path(Path(__file__).with_name("main.py"), run_name="__main__")

--- a/examples/voyager/docs/chapter_1.md
+++ b/examples/voyager/docs/chapter_1.md
@@ -1,0 +1,69 @@
+# Chapter 1 — Simple interplanetary gravity
+
+Chapter 1 is the Voyager example's intentionally simple starting point.
+
+It answers the first question in the educational journey:
+
+> What happens if we initialize Voyager from SPICE and propagate it using
+> Newtonian gravity from the Sun and major planets?
+
+## Run it
+
+From the repository root:
+
+```bash
+python examples/voyager/main.py run
+```
+
+The simulation begins at the same SPICE state as the reference trajectory.
+Elodin then propagates the red Voyager bodies while SPICE updates the green
+reference bodies.
+
+## Model
+
+For one gravity source, Chapter 1 uses the direct Newtonian attraction
+
+```text
+r = r_probe - r_source
+F = -G M m r / |r|^3
+```
+
+where:
+
+- `M` is the source mass;
+- `m` is the Voyager mass;
+- `r` points from the source to the probe;
+- the minus sign points the force back toward the source.
+
+The model includes the Sun and the eight major-planet entries already defined
+by the example.
+
+## What stays intentionally simple
+
+Chapter 1 is a useful first interplanetary model, not a high-fidelity
+reconstruction of the Voyager missions.
+
+It deliberately keeps the original assumptions so each later chapter can add
+one concept and measure what that concept changes.
+
+The existing telemetry records:
+
+- `position_error_km`;
+- `velocity_error_mps`.
+
+Those signals turn the difference from SPICE into something we can investigate
+rather than hiding it behind two visually similar trajectories.
+
+## Question for Chapter 2
+
+The state vectors are expressed relative to the Sun.
+
+The Chapter 1 model gives the planets' direct gravitational acceleration to
+Voyager, while the Sun remains at the coordinate origin.
+
+That raises the next question:
+
+> If the planets pull on Voyager, what happens when those same planets also
+> accelerate the Sun that defines our origin?
+
+[Continue to Chapter 2 — Heliocentric relative dynamics](chapter_2.md)

--- a/examples/voyager/docs/chapter_1.md
+++ b/examples/voyager/docs/chapter_1.md
@@ -19,6 +19,11 @@ The simulation begins at the same SPICE state as the reference trajectory.
 Elodin then propagates the red Voyager bodies while SPICE updates the green
 reference bodies.
 
+The interactive run uses the long-span merged Voyager SPKs. Reconstructed
+encounter arcs are kept separate for scientific validation so disagreement
+between two trajectory solutions is not counted as force-model error. See the
+[truth-reference contract](truth_reference.md) for that distinction.
+
 ## Model
 
 For one gravity source, Chapter 1 uses the direct Newtonian attraction

--- a/examples/voyager/docs/chapter_2.md
+++ b/examples/voyager/docs/chapter_2.md
@@ -60,7 +60,7 @@ because the propagated coordinate is `R_probe - R_sun`.
 For the Sun's own gravity edge, the source position is the origin, so the
 indirect contribution is zero and the usual central attraction remains.
 
-## Controlled experiment
+## Original long-span controlled experiment
 
 Chapter 2 changes only this force formulation.
 
@@ -75,7 +75,8 @@ The comparison keeps the same:
 - 3,600-second timestep;
 - telemetry and visualization.
 
-The canonical 400-day runs used native Elodin/Cranelift.
+The original 400-day runs used native Elodin/Cranelift and the long-span merged
+Voyager SPKs.
 
 | Probe | Chapter 1 position error | Chapter 2 position error | Chapter 1 velocity error | Chapter 2 velocity error |
 | --- | ---: | ---: | ---: | ---: |
@@ -88,6 +89,11 @@ That is:
 - 72.0% lower Voyager 2 position disagreement;
 - 78.5% lower Voyager 1 velocity disagreement;
 - 78.2% lower Voyager 2 velocity disagreement.
+
+These numbers measure agreement with the published merged supertrajectory.
+They should not be read as absolute navigation accuracy: the separate
+current-best encounter solutions differ materially over overlapping early
+mission coverage.
 
 The improvement grows smoothly over the trajectory rather than appearing only
 at the final endpoint.
@@ -121,6 +127,16 @@ The focused Chapter 2 tests cover:
 The native Chapter 1 runs reproduce the original reference checkpoints, while
 Chapter 2 improves both position and velocity disagreement for both probes at
 4, 100, and 400 days.
+
+The later truth-reference audit re-ran both chapters against four independent
+NAIF reconstructed encounter solutions. Each case initializes from the same
+SPK segment that it scores, with explicit kernel hashes and runtime segment
+audits. At eight selected pre-encounter checkpoints, Chapter 2 reduced
+position disagreement by 8.97% to 97.49%. At the cleaner early checkpoints it
+reduced both position and velocity disagreement; near Jupiter encounter, the
+simple model no longer improves every velocity metric.
+
+[Read the complete truth contract, results, and limitations](truth_reference.md).
 
 Equivalent alternating native runs measured roughly 3% runtime overhead for
 Chapter 2. Treat that as an indicative microbenchmark rather than a universal

--- a/examples/voyager/docs/chapter_2.md
+++ b/examples/voyager/docs/chapter_2.md
@@ -1,0 +1,155 @@
+# Chapter 2 — Heliocentric relative dynamics
+
+Chapter 2 keeps the Chapter 1 simulation intact and adds one astrodynamics
+concept: the acceleration of the Sun-centered origin.
+
+The goal is not to make Voyager "fully accurate." It is to isolate one modeling
+assumption, derive the correction, and measure its effect.
+
+## Run it
+
+From the repository root:
+
+```bash
+python examples/voyager/chapter_2.py run
+```
+
+For comparison, Chapter 1 remains:
+
+```bash
+python examples/voyager/main.py run
+```
+
+## The subtlety
+
+SPICE supplies the Voyager and planetary states relative to the Sun in
+`ECLIPJ2000`.
+
+`ECLIPJ2000` provides nonrotating axes, but that does not make the Sun-centered
+origin inertial. The planets gravitationally accelerate the Sun.
+
+Define the probe's heliocentric position as
+
+```text
+r = R_probe - R_sun
+```
+
+Differentiate twice:
+
+```text
+r'' = R_probe'' - R_sun''
+```
+
+The acceleration of the probe relative to the Sun therefore needs both the
+probe's planetary acceleration and the corresponding acceleration of the Sun.
+
+For a planet at heliocentric position `r_i`, the Chapter 2 contribution is
+
+```text
+mu_i * (
+    (r_i - r) / |r_i - r|^3
+    - r_i / |r_i|^3
+)
+```
+
+The first term is the planet's direct acceleration of Voyager.
+
+The second term is that planet's acceleration of the Sun. It is subtracted
+because the propagated coordinate is `R_probe - R_sun`.
+
+For the Sun's own gravity edge, the source position is the origin, so the
+indirect contribution is zero and the usual central attraction remains.
+
+## Controlled experiment
+
+Chapter 2 changes only this force formulation.
+
+The comparison keeps the same:
+
+- SPICE kernels;
+- gravitational constants;
+- initial states;
+- `ECLIPJ2000` frame;
+- `SUN` observer;
+- classical RK4 integrator;
+- 3,600-second timestep;
+- telemetry and visualization.
+
+The canonical 400-day runs used native Elodin/Cranelift.
+
+| Probe | Chapter 1 position error | Chapter 2 position error | Chapter 1 velocity error | Chapter 2 velocity error |
+| --- | ---: | ---: | ---: | ---: |
+| Voyager 1 | 122,783.010 km | 32,101.379 km | 9.08717 m/s | 1.94987 m/s |
+| Voyager 2 | 121,720.889 km | 34,124.210 km | 8.05398 m/s | 1.75436 m/s |
+
+That is:
+
+- 73.9% lower Voyager 1 position disagreement;
+- 72.0% lower Voyager 2 position disagreement;
+- 78.5% lower Voyager 1 velocity disagreement;
+- 78.2% lower Voyager 2 velocity disagreement.
+
+The improvement grows smoothly over the trajectory rather than appearing only
+at the final endpoint.
+
+## Why this is not just a timestep effect
+
+The Chapter 2 400-day endpoint was also run at 3,600, 1,800, and 900 seconds.
+
+Across that eightfold increase in step count, the position spread was only
+about:
+
+- 5.65 km for Voyager 1;
+- 6.33 km for Voyager 2.
+
+That is tiny compared with the roughly 88,000–91,000 km of disagreement removed
+by the heliocentric correction.
+
+The result therefore points to a model-form limitation during cruise rather
+than ordinary RK4 timestep error being the dominant cause.
+
+## Validation
+
+The focused Chapter 2 tests cover:
+
+- direct-force direction and magnitude;
+- the sign of the indirect acceleration;
+- accumulation across multiple gravity sources;
+- the Sun-at-origin case without division by zero;
+- isolation of the propagated dynamics from post-initialization Voyager truth.
+
+The native Chapter 1 runs reproduce the original reference checkpoints, while
+Chapter 2 improves both position and velocity disagreement for both probes at
+4, 100, and 400 days.
+
+Equivalent alternating native runs measured roughly 3% runtime overhead for
+Chapter 2. Treat that as an indicative microbenchmark rather than a universal
+performance guarantee.
+
+## What Chapter 2 does not claim
+
+Tens of thousands of kilometers of disagreement still remain after 400 days.
+
+Chapter 2 does not add:
+
+- DE440-consistent gravitational parameters;
+- new SPICE kernels;
+- moons;
+- maneuvers;
+- solar-radiation pressure;
+- thermal recoil;
+- alternate or adaptive integration;
+- encounter-specific modeling.
+
+Those are separate questions for later chapters so this chapter keeps one
+lesson and one controlled change.
+
+## Takeaway
+
+A coordinate system can have nonrotating axes while its origin still
+accelerates.
+
+When the state is measured relative to that accelerating origin, the origin's
+acceleration must appear in the relative-motion equation.
+
+[Back to Chapter 1](chapter_1.md) · [Back to Voyager setup](../README.md)

--- a/examples/voyager/docs/truth_reference.md
+++ b/examples/voyager/docs/truth_reference.md
@@ -1,0 +1,218 @@
+# Voyager truth-reference contract
+
+This document defines which Voyager trajectory data this example uses, what
+each data set can support, and how Chapters 1 and 2 are validated without
+mixing disagreement between trajectory solutions into force-model error.
+
+The machine-readable contract is
+[`truth_reference.json`](../truth_reference.json). The checked-in output from
+the reference run is
+[`truth_validation_results.json`](../truth_validation_results.json).
+
+## Why there are two kinds of reference
+
+The long-span merged Voyager SPKs are useful for the tutorial's mission-scale
+visualization. They provide continuous spacecraft coverage from launch through
+the outer mission and let a learner see model divergence develop over hundreds
+of days.
+
+They are not the best available solution for every early encounter interval.
+NAIF identifies separate Jupiter and Saturn SPKs as the current-best encounter
+solutions. Those solutions differ materially from the overlapping trajectory
+in the merged kernels.
+
+The example therefore keeps the two uses separate:
+
+- **Long-span educational reference:** the merged SPKs remain the default for
+  the interactive Chapters 1 and 2 journey.
+- **Reconstructed-arc validation:** four short encounter SPKs initialize and
+  score the headless validation cases.
+
+This distinction prevents a benchmark from initializing on one trajectory
+solution and later measuring the difference to another as if it were entirely
+simulation error.
+
+NAIF also cautions that the primary Voyager mission predates SPICE and that the
+restored ancillary data should be used carefully. “Current-best” here means the
+best solution identified by the official Voyager kernel archive; it does not
+remove that archive-level caveat.
+
+Authoritative archive descriptions:
+
+- [NAIF Voyager kernel status and solution notes](https://naif.jpl.nasa.gov/pub/naif/VOYAGER/kernels/aareadme.txt)
+- [NAIF Voyager SPK coverage summaries](https://naif.jpl.nasa.gov/pub/naif/VOYAGER/kernels/spk/aa_summaries.txt)
+
+## Reconstructed validation cases
+
+Every case uses geometric states (`NONE`) expressed relative to the Sun in
+`ECLIPJ2000`. The spacecraft is initialized from the same reconstructed SPK
+segment used at every scoring checkpoint. DE440 supplies the planetary states
+used to translate the segment's native center and update the model's gravity
+sources.
+
+| Case | Encounter kernel and segment | Native center | Initialization | Closest approach | Scoring end |
+| --- | --- | ---: | --- | --- | --- |
+| Voyager 1 Jupiter | `vgr1_jup230.bsp` / `vgr1.jup230.nio` | 5, Jupiter barycenter | 1979-02-01 | 1979-03-05 12:04:46.794 | 1979-03-18 |
+| Voyager 2 Jupiter | `vgr2_jup230.bsp` / `vgr2.jup230.nio` | 5, Jupiter barycenter | 1979-06-05 | 1979-07-09 22:28:52.806 | 1979-07-20 |
+| Voyager 1 Saturn | `vgr1_sat337.bsp` / `vgr1.sat337.nio` | 6, Saturn barycenter | 1980-10-07 | 1980-11-12 23:45:27.463 | 1980-11-18 |
+| Voyager 2 Saturn | `vgr2_sat337.bsp` / `vgr2.sat337.nio` | 6, Saturn barycenter | 1981-07-15 | 1981-08-26 03:23:50.181 | 1981-08-29 |
+
+Voyager 1 Saturn intentionally begins after the reconstructed SPK changes from
+a Sun-centered segment to a Saturn-barycenter segment. The complete coverage,
+URLs, SHA-256 values, target IDs, native frames, segment types, and declared
+checkpoints are recorded in the manifest. The closest-approach epochs were
+derived by minimizing the spacecraft-to-native-center distance within each
+selected reconstructed segment.
+
+## Kernel precedence
+
+SPICE gives a competing segment from the file loaded later higher priority.
+The validation load order is therefore part of the contract:
+
+1. `naif0012.tls`
+2. `Voyager_1.a54206u_V0.2_merged.bsp`
+3. `Voyager_2.m05016u.merged.bsp`
+4. the selected reconstructed encounter SPK
+5. `de440.bsp`
+
+The encounter file wins for the selected spacecraft target. DE440 wins for the
+planetary targets that are also embedded in the merged kernels. The harness
+uses SPICE's segment-selection API to verify the winning spacecraft file,
+segment, target, center, native frame, and type at both initialization and the
+end of the scoring interval. A run fails instead of producing metrics if that
+selection differs from the manifest.
+
+See [NAIF's SPK data-precedence documentation](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/spk.html#Data%20Precedence).
+
+## Revalidated Chapters 1 and 2
+
+The baseline uses native Elodin `six_dof` RK4 at a 100-second timestep. The
+chapters keep their existing force models and rounded body masses. The truth
+source, initialization epoch, output frame, observer, integrator, timestep, and
+planet states are identical within every Chapter 1/Chapter 2 pair. Every run
+records position and velocity residuals both as `ECLIPJ2000` Cartesian vectors
+and in the truth trajectory's radial-transverse-normal basis.
+
+| Case | Day | Chapter 1 position | Chapter 2 position | Reduction | Chapter 1 velocity | Chapter 2 velocity |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| V1 Jupiter | 20 | 338.580 km | 33.699 km | **90.05%** | 0.3619 m/s | 0.0746 m/s |
+| V1 Jupiter | 30 | 675.890 km | 555.321 km | **17.84%** | 0.4139 m/s | 1.0137 m/s |
+| V2 Jupiter | 20 | 227.324 km | 99.366 km | **56.29%** | 0.2524 m/s | 0.1422 m/s |
+| V2 Jupiter | 30 | 632.275 km | 575.536 km | **8.97%** | 0.7133 m/s | 0.9028 m/s |
+| V1 Saturn | 1 | 0.729 km | 0.018 km | **97.49%** | 0.0170 m/s | 0.0004 m/s |
+| V1 Saturn | 3 | 6.509 km | 0.179 km | **97.26%** | 0.0498 m/s | 0.0016 m/s |
+| V2 Saturn | 1 | 0.850 km | 0.266 km | **68.71%** | 0.0197 m/s | 0.0062 m/s |
+| V2 Saturn | 4 | 13.550 km | 4.257 km | **68.59%** | 0.0782 m/s | 0.0246 m/s |
+
+Chapter 2 reduces position disagreement at all eight selected maneuver-free
+approach checkpoints. At the earlier checkpoints it also reduces velocity
+disagreement. The two
+Jupiter day-30 velocity values are not improvements, even though their
+position values remain smaller. They are reported rather than hidden: the
+simple point-mass model is approaching a close-encounter regime where omitted
+physics and trajectory events become more important.
+
+The defensible Chapter 2 conclusion is consequently narrow and strong:
+
+> The heliocentric indirect-acceleration correction materially improves all
+> four reconstructed, pre-encounter position comparisons. It is not a claim
+> that the educational gravity model reconstructs each flyby or every velocity
+> component throughout an encounter arc.
+
+The labeled mid-arc, closest-approach, and end checkpoints deliberately remain
+in the result artifact even when Chapter 2 is worse. They expose where omitted
+maneuvers and close-encounter physics dominate instead of allowing a favorable
+approach-only score to stand in for flyby reconstruction:
+
+| Case | Closest-approach change | End-of-arc change |
+| --- | ---: | ---: |
+| V1 Jupiter | 88.85% worse | 21.19% worse |
+| V2 Jupiter | 74.08% worse | 4.02% worse |
+| V1 Saturn | 5.20% worse | 4.36% better |
+| V2 Saturn | 48.31% better | 0.16% worse |
+
+## Timestep control and the remaining floor
+
+The investigation also ran the Jupiter cases at 3,600, 900, 300, and 100
+seconds and the Saturn cases at 3,600, 300, and 100 seconds. At clean Chapter 2
+checkpoints, the full position-error spread was:
+
+| Case | Checkpoint | Position-error spread |
+| --- | ---: | ---: |
+| V1 Jupiter | day 20 | 0.0126 km |
+| V2 Jupiter | day 20 | 0.0254 km |
+| V1 Saturn | day 3 | <0.000002 km |
+| V2 Saturn | day 4 | <0.000002 km |
+
+Those spreads are far smaller than the Chapter 1-to-Chapter 2 changes, so the
+clean-approach improvement is a force-model effect rather than ordinary RK4
+truncation error.
+
+One-hour integration is inadequate through the close flybys. Smaller steps
+reduce that numerical error, but a substantial residual remains because the
+current chapters deliberately omit:
+
+- documented trajectory-correction maneuvers represented by the reconstructed
+  trajectory;
+- major satellite gravity, including Titan and the Galilean moons;
+- planet-center motion versus a single planet-system barycenter point mass;
+- giant-planet gravity harmonics;
+- planetary ephemeris evaluation at the RK intermediate stages.
+
+These effects belong to later controlled experiments. They are not reasons to
+alter Chapter 2's reference-frame correction.
+
+## Cruise-reference limitation
+
+The January 1978 to February 1979 investigation found useful navigation
+reports, maneuver histories, and the merged spacecraft trajectory, but no
+separate public tracking-fit state-vector SPK covering that complete cruise
+interval in the NAIF Voyager archive or NASA technical material surveyed.
+
+The merged SPKs can therefore support a claim of **agreement with the published
+mission-design/supertrajectory reference** during that interval. This work does
+not label the same comparison **absolute navigation accuracy**.
+
+That is a data limitation, not a force-model diagnosis. If a navigation-grade
+cruise reconstruction becomes available, it can be added as another manifest
+case without changing the chapter dynamics.
+
+Relevant NASA material includes the
+[Voyager navigation strategy record](https://ntrs.nasa.gov/citations/19780047969)
+and the
+[1978–1979 cruise-phase maneuver summary](https://ntrs.nasa.gov/api/citations/19790009610/downloads/19790009610.pdf).
+
+## Reproduce the baseline
+
+Download and verify all declared kernels:
+
+```bash
+cd examples/voyager
+./download_spice_data.sh
+cd ../..
+```
+
+From the repository's Nix development shell, run:
+
+```bash
+uv run python examples/voyager/validate_truth.py --include-convergence
+```
+
+The command verifies every required SHA-256 before propagation, runs both
+chapters across all four cases, adds the declared Chapter 2 timestep-control
+matrix, audits active segment precedence, and writes
+`examples/voyager/truth_validation_results.json`. The checked-in artifact
+contains 18 runs: eight 100-second Chapter 1/2 baselines and ten additional
+Chapter 2 convergence runs.
+
+For a focused reproduction:
+
+```bash
+uv run python examples/voyager/validate_truth.py \
+    --case v1_jupiter \
+    --chapter 1 \
+    --chapter 2
+```
+
+No editor, GUI, or Elodin DB query tooling is required to obtain the numerical
+measurements.

--- a/examples/voyager/download_spice_data.sh
+++ b/examples/voyager/download_spice_data.sh
@@ -4,11 +4,53 @@ set -euo pipefail
 
 mkdir -p ./nasa_spice_data
 
-curl -fL https://naif.jpl.nasa.gov/pub/naif/generic_kernels/lsk/naif0012.tls \
-    -o ./nasa_spice_data/naif0012.tls
-curl -fL https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de440.bsp \
-    -o ./nasa_spice_data/de440.bsp
-curl -fL https://naif.jpl.nasa.gov/pub/naif/VOYAGER/kernels/spk/Voyager_1.a54206u_V0.2_merged.bsp \
-    -o ./nasa_spice_data/Voyager_1.a54206u_V0.2_merged.bsp
-curl -fL https://naif.jpl.nasa.gov/pub/naif/VOYAGER/kernels/spk/Voyager_2.m05016u.merged.bsp \
-    -o ./nasa_spice_data/Voyager_2.m05016u.merged.bsp
+download() {
+    local name="$1"
+    local url="$2"
+    local expected_sha256="$3"
+    local output="./nasa_spice_data/${name}"
+    local temporary="${output}.download"
+
+    if [[ -f "${output}" ]] && echo "${expected_sha256}  ${output}" | sha256sum --check --status; then
+        echo "verified ${name}"
+        return
+    fi
+
+    curl -fL "${url}" -o "${temporary}"
+    echo "${expected_sha256}  ${temporary}" | sha256sum --check --status
+    mv "${temporary}" "${output}"
+    echo "downloaded and verified ${name}"
+}
+
+download \
+    naif0012.tls \
+    https://naif.jpl.nasa.gov/pub/naif/generic_kernels/lsk/naif0012.tls \
+    678e32bdb5a744117a467cd9601cd6b373f0e9bc9bbde1371d5eee39600a039b
+download \
+    de440.bsp \
+    https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de440.bsp \
+    a4ce9bf9b3282becc9f4b2ac3cebe03a2ae7599981aabd7265fd8482fff7c4b5
+download \
+    Voyager_1.a54206u_V0.2_merged.bsp \
+    https://naif.jpl.nasa.gov/pub/naif/VOYAGER/kernels/spk/Voyager_1.a54206u_V0.2_merged.bsp \
+    47c6f2be03668b50a1efb5f96978a2b68b2b501dae6f585841b1569baa3f4311
+download \
+    Voyager_2.m05016u.merged.bsp \
+    https://naif.jpl.nasa.gov/pub/naif/VOYAGER/kernels/spk/Voyager_2.m05016u.merged.bsp \
+    ce66cba12cf77bf3a1097f44142ef978f46656788ed08f9052238a102ed2e706
+download \
+    vgr1_jup230.bsp \
+    https://naif.jpl.nasa.gov/pub/naif/VOYAGER/kernels/spk/vgr1_jup230.bsp \
+    e1ea3f72f19b15508bc45979771a36a97d02f33056b76867d444304cb82205c9
+download \
+    vgr2_jup230.bsp \
+    https://naif.jpl.nasa.gov/pub/naif/VOYAGER/kernels/spk/vgr2_jup230.bsp \
+    9c00be3c83915f6c1fd8448d9266420e3c462e9d78e4c32b17145dac81529d5a
+download \
+    vgr1_sat337.bsp \
+    https://naif.jpl.nasa.gov/pub/naif/VOYAGER/kernels/spk/vgr1_sat337.bsp \
+    f451f9f095bc4ad175cde701367cbf1ccc061dd706ad0008cda75fd939d94efa
+download \
+    vgr2_sat337.bsp \
+    https://naif.jpl.nasa.gov/pub/naif/VOYAGER/kernels/spk/vgr2_sat337.bsp \
+    1d15debf7bdc6c6ba4c0462b5f4f6af85ddf9948735f434792a1c41418bb39a8

--- a/examples/voyager/dynamics.py
+++ b/examples/voyager/dynamics.py
@@ -1,0 +1,41 @@
+"""Small, testable pieces of the Voyager gravity models."""
+
+from collections.abc import Iterable, Mapping
+
+import jax.numpy as jnp
+
+
+def direct_planetary_acceleration(
+    probe_position,
+    source_position,
+    gravitational_parameter,
+):
+    """Acceleration of a probe toward one gravity source, in m/s^2."""
+    source_to_probe = source_position - probe_position
+    distance = jnp.linalg.norm(source_to_probe)
+    return gravitational_parameter * source_to_probe / distance**3
+
+
+def planetary_acceleration_of_sun(source_position, gravitational_parameter):
+    """Acceleration of the heliocentric origin toward one planet, in m/s^2."""
+    source_distance = jnp.linalg.norm(source_position)
+    safe_distance = jnp.where(source_distance > 0.0, source_distance, 1.0)
+    return gravitational_parameter * source_position / safe_distance**3
+
+
+def heliocentric_relative_acceleration(
+    probe_position,
+    source_position,
+    gravitational_parameter,
+):
+    """Probe acceleration relative to the accelerating Sun, in m/s^2."""
+    direct_acceleration = direct_planetary_acceleration(
+        probe_position, source_position, gravitational_parameter
+    )
+    sun_acceleration = planetary_acceleration_of_sun(source_position, gravitational_parameter)
+    return direct_acceleration - sun_acceleration
+
+
+def gravity_source_entity_names(planets: Iterable[Mapping[str, object]]) -> tuple[str, ...]:
+    """Return the Sun and planet entities that may source probe gravity."""
+    return ("Sun", *(str(planet["entity_name"]) for planet in planets))

--- a/examples/voyager/main.py
+++ b/examples/voyager/main.py
@@ -9,6 +9,11 @@ import spiceypy as spice
 import numpy as np
 from pathlib import Path
 
+from dynamics import (
+    gravity_source_entity_names,
+    heliocentric_relative_acceleration,
+)
+
 # SIM_TIME_STEP = 1.0 / 120.0
 SIM_TIME_STEP = 3600.0
 # SIM_TIME_STEP = 86400.0
@@ -18,6 +23,7 @@ G = 6.6743e-11
 DEFAULT_DB_PATH = "dbs/voyager"
 DB_PATH_ENV = "DB_PATH"
 MAX_TICKS_ENV = "MAX_TICKS"
+DYNAMICS_CHAPTER_ENV = "VOYAGER_DYNAMICS_CHAPTER"
 
 SPICE_DIR = Path(__file__).resolve().parent / "nasa_spice_data"
 SPICE_KERNELS = [
@@ -288,9 +294,35 @@ def gravity(
     )
 
 
+@el.system
+def heliocentric_gravity(
+    graph: el.GraphQuery[GravityEdge],
+    query: el.Query[el.WorldPos, el.Inertia],
+) -> el.Query[el.Force]:
+    """Chapter 2 gravity in a nonrotating frame with a Sun-centered origin."""
+
+    def gravity_fn(force, probe_pos, probe_inertia, source_pos, source_inertia):
+        probe_mass = probe_inertia.mass()
+        gravitational_parameter = G * source_inertia.mass()
+
+        relative_acceleration = heliocentric_relative_acceleration(
+            probe_pos.linear(), source_pos.linear(), gravitational_parameter
+        )
+
+        return el.Force(linear=force.force() + probe_mass * relative_acceleration)
+
+    return graph.edge_fold(
+        left_query=query,
+        right_query=query,
+        return_type=el.Force,
+        init_value=el.Force(),
+        fold_fn=gravity_fn,
+    )
+
+
 for probe in PROBES:
     probe_id = body_entity_ids[probe["entity_name"]]
-    for source_name in ["Sun", *[planet["entity_name"] for planet in PLANETS]]:
+    for source_name in gravity_source_entity_names(PLANETS):
         w.spawn(
             GravityConstraint(probe_id, body_entity_ids[source_name]),
             name=f"{probe['entity_name']} -> {source_name}",
@@ -336,7 +368,12 @@ w.schematic(
 """.format(body_objects=body_objects)
 )
 
-sys = el.six_dof(sys=gravity)
+dynamics_chapter = os.environ.get(DYNAMICS_CHAPTER_ENV, "1")
+if dynamics_chapter not in ("1", "2"):
+    raise ValueError(f"{DYNAMICS_CHAPTER_ENV} must be '1' or '2'")
+
+gravity_system = gravity if dynamics_chapter == "1" else heliocentric_gravity
+sys = el.six_dof(sys=gravity_system)
 db_path = Path(os.environ.get(DB_PATH_ENV, DEFAULT_DB_PATH))
 max_ticks_env = os.environ.get(MAX_TICKS_ENV)
 max_ticks = int(max_ticks_env) if max_ticks_env is not None else None

--- a/examples/voyager/main.py
+++ b/examples/voyager/main.py
@@ -14,6 +14,7 @@ from dynamics import (
     gravity_source_entity_names,
     heliocentric_relative_acceleration,
 )
+from time_utils import utc_epoch_microseconds
 
 DEFAULT_SIM_TIME_STEP = 3600.0
 SIM_TIME_STEP = float(os.environ.get("VOYAGER_TIME_STEP", DEFAULT_SIM_TIME_STEP))
@@ -74,7 +75,7 @@ for kernel in SPICE_KERNELS:
 
 START_UTC = os.environ.get(START_UTC_ENV, "1978-01-01T00:00:00")
 start_time_et = spice.utc2et(START_UTC)
-start_time_epoch_us = 252_452_400_000_000
+start_time_epoch_us = utc_epoch_microseconds(START_UTC)
 
 PLANETS = [
     {

--- a/examples/voyager/main.py
+++ b/examples/voyager/main.py
@@ -1,3 +1,4 @@
+import json
 import os
 import typing as ty
 
@@ -14,9 +15,8 @@ from dynamics import (
     heliocentric_relative_acceleration,
 )
 
-# SIM_TIME_STEP = 1.0 / 120.0
-SIM_TIME_STEP = 3600.0
-# SIM_TIME_STEP = 86400.0
+DEFAULT_SIM_TIME_STEP = 3600.0
+SIM_TIME_STEP = float(os.environ.get("VOYAGER_TIME_STEP", DEFAULT_SIM_TIME_STEP))
 # Set the gravitational constant for Newton's law of universal gravitation
 SIMULATION_RATE_HZ = 1 / SIM_TIME_STEP
 G = 6.6743e-11
@@ -24,19 +24,56 @@ DEFAULT_DB_PATH = "dbs/voyager"
 DB_PATH_ENV = "DB_PATH"
 MAX_TICKS_ENV = "MAX_TICKS"
 DYNAMICS_CHAPTER_ENV = "VOYAGER_DYNAMICS_CHAPTER"
+START_UTC_ENV = "VOYAGER_START_UTC"
+SPICE_DIR_ENV = "VOYAGER_SPICE_DIR"
+TRUTH_KERNEL_ENV = "VOYAGER_TRUTH_KERNEL"
+SCORED_PROBE_ENV = "VOYAGER_SCORED_PROBE"
+CHECKPOINTS_ENV = "VOYAGER_CHECKPOINTS_JSON"
+METRIC_PREFIX = "VOYAGER_VALIDATION_METRIC"
+SEGMENT_PREFIX = "VOYAGER_ACTIVE_SEGMENT"
+INITIAL_STATE_PREFIX = "VOYAGER_INITIAL_STATE"
 
-SPICE_DIR = Path(__file__).resolve().parent / "nasa_spice_data"
-SPICE_KERNELS = [
-    SPICE_DIR / "naif0012.tls",
-    SPICE_DIR / "de440.bsp",
+SPICE_DIR = Path(
+    os.environ.get(
+        SPICE_DIR_ENV,
+        Path(__file__).resolve().parent / "nasa_spice_data",
+    )
+)
+LEAP_SECONDS_KERNEL = SPICE_DIR / "naif0012.tls"
+PLANET_KERNEL = SPICE_DIR / "de440.bsp"
+MERGED_VOYAGER_KERNELS = [
     SPICE_DIR / "Voyager_1.a54206u_V0.2_merged.bsp",
     SPICE_DIR / "Voyager_2.m05016u.merged.bsp",
 ]
+truth_kernel_name = os.environ.get(TRUTH_KERNEL_ENV)
+if truth_kernel_name:
+    truth_kernel = Path(truth_kernel_name)
+    if not truth_kernel.is_absolute():
+        truth_kernel = SPICE_DIR / truth_kernel
+
+    # SPICE searches segments in reverse load order. Load DE440 last during a
+    # validation run so its planetary states win over the planetary segments
+    # bundled in the long-span Voyager kernels. The encounter kernel remains
+    # the highest-precedence file containing the selected spacecraft target.
+    SPICE_KERNELS = [
+        LEAP_SECONDS_KERNEL,
+        *MERGED_VOYAGER_KERNELS,
+        truth_kernel,
+        PLANET_KERNEL,
+    ]
+else:
+    # Preserve the tutorial's historical kernel order and numerical behavior.
+    SPICE_KERNELS = [
+        LEAP_SECONDS_KERNEL,
+        PLANET_KERNEL,
+        *MERGED_VOYAGER_KERNELS,
+    ]
 
 for kernel in SPICE_KERNELS:
     spice.furnsh(str(kernel))
 
-start_time_et = spice.utc2et("1978-01-01T00:00:00")
+START_UTC = os.environ.get(START_UTC_ENV, "1978-01-01T00:00:00")
+start_time_et = spice.utc2et(START_UTC)
 start_time_epoch_us = 252_452_400_000_000
 
 PLANETS = [
@@ -124,6 +161,17 @@ PROBES = [
         "mass": 825.0,
     },
 ]
+scored_probe_name = os.environ.get(SCORED_PROBE_ENV)
+SCORED_PROBES = (
+    {scored_probe_name} if scored_probe_name else {probe["entity_name"] for probe in PROBES}
+)
+unknown_scored_probes = SCORED_PROBES - {probe["entity_name"] for probe in PROBES}
+if unknown_scored_probes:
+    raise ValueError(
+        f"{SCORED_PROBE_ENV} contains an unknown probe: {sorted(unknown_scored_probes)}"
+    )
+
+CHECKPOINTS = tuple(json.loads(os.environ.get(CHECKPOINTS_ENV, "[]")))
 TRUTH_PROBES = [
     {
         "spice_name": "VOYAGER 1",
@@ -185,6 +233,23 @@ for body in EPHEMERIS_BODIES + PROBES + TRUTH_PROBES:
     init_pos = jnp.array(init_state[:3]) * 1000.0
     init_vel = jnp.array(init_state[3:]) * 1000.0
 
+    if truth_kernel_name and body in PROBES and body["entity_name"] in SCORED_PROBES:
+        print(
+            INITIAL_STATE_PREFIX,
+            json.dumps(
+                {
+                    "epoch_utc": START_UTC,
+                    "frame": "ECLIPJ2000",
+                    "observer": "SUN",
+                    "position_m": np.asarray(init_pos, dtype=np.float64).tolist(),
+                    "probe": body["entity_name"],
+                    "velocity_mps": np.asarray(init_vel, dtype=np.float64).tolist(),
+                },
+                sort_keys=True,
+            ),
+            flush=True,
+        )
+
     print(body["spice_name"])
     print(init_pos)
     print(init_vel)
@@ -233,6 +298,8 @@ def post_step(tick: int, ctx: el.StepContext) -> None:
     current_time_et = start_time_et + (tick + 1) * SIM_TIME_STEP
 
     for probe in PROBES:
+        if probe["entity_name"] not in SCORED_PROBES:
+            continue
         simulated_pos = np.asarray(
             ctx.read_component(f"{probe['entity_name']}.world_pos"),
             dtype=np.float64,
@@ -250,6 +317,44 @@ def post_step(tick: int, ctx: el.StepContext) -> None:
 
         position_error_km = np.linalg.norm(simulated_pos - truth_pos) / 1000.0
         velocity_error_mps = np.linalg.norm(simulated_vel - truth_vel)
+
+        completed_seconds = (tick + 1) * SIM_TIME_STEP
+        checkpoint = next(
+            (
+                candidate
+                for candidate in CHECKPOINTS
+                if abs(completed_seconds - candidate["elapsed_seconds"]) <= SIM_TIME_STEP / 2.0
+            ),
+            None,
+        )
+        if checkpoint is not None:
+            position_residual_km = (simulated_pos - truth_pos) / 1000.0
+            velocity_residual_mps = simulated_vel - truth_vel
+            radial = truth_pos / np.linalg.norm(truth_pos)
+            normal = np.cross(truth_pos, truth_vel)
+            normal /= np.linalg.norm(normal)
+            transverse = np.cross(normal, radial)
+            rtn_basis = np.stack((radial, transverse, normal))
+            print(
+                METRIC_PREFIX,
+                json.dumps(
+                    {
+                        "actual_elapsed_seconds": completed_seconds,
+                        "actual_epoch_utc": spice.et2utc(current_time_et, "ISOC", 3),
+                        "checkpoint": checkpoint["name"],
+                        "position_error_km": position_error_km,
+                        "position_residual_km": position_residual_km.tolist(),
+                        "position_rtn_km": (rtn_basis @ position_residual_km).tolist(),
+                        "probe": probe["entity_name"],
+                        "requested_elapsed_seconds": checkpoint["elapsed_seconds"],
+                        "velocity_error_mps": velocity_error_mps,
+                        "velocity_residual_mps": velocity_residual_mps.tolist(),
+                        "velocity_rtn_mps": (rtn_basis @ velocity_residual_mps).tolist(),
+                    },
+                    sort_keys=True,
+                ),
+                flush=True,
+            )
 
         ctx.write_component(
             f"{probe['entity_name']}.position_error_km",
@@ -377,6 +482,41 @@ sys = el.six_dof(sys=gravity_system)
 db_path = Path(os.environ.get(DB_PATH_ENV, DEFAULT_DB_PATH))
 max_ticks_env = os.environ.get(MAX_TICKS_ENV)
 max_ticks = int(max_ticks_env) if max_ticks_env is not None else None
+
+if truth_kernel_name:
+    loaded_spk_files = {
+        handle: filename
+        for index in range(spice.ktotal("SPK"))
+        for filename, _, _, handle in (spice.kdata(index, "SPK"),)
+    }
+    validation_epochs = {"initialization": start_time_et}
+    if max_ticks is not None:
+        validation_epochs["scoring_end"] = start_time_et + max_ticks * SIM_TIME_STEP
+
+    for probe in PROBES:
+        if probe["entity_name"] not in SCORED_PROBES:
+            continue
+        target_code = spice.bodn2c(probe["spice_name"])
+        for epoch_name, epoch_et in validation_epochs.items():
+            handle, descriptor, identifier = spice.spksfs(target_code, epoch_et, 256)
+            target, center, frame, segment_type, *_ = spice.spkuds(descriptor)
+            print(
+                SEGMENT_PREFIX,
+                json.dumps(
+                    {
+                        "center": center,
+                        "epoch": epoch_name,
+                        "file": Path(loaded_spk_files[handle]).name,
+                        "native_frame": spice.frmnam(frame),
+                        "probe": probe["entity_name"],
+                        "segment_id": identifier.strip(),
+                        "segment_type": segment_type,
+                        "target": target,
+                    },
+                    sort_keys=True,
+                ),
+                flush=True,
+            )
 
 # sim = w.run(sys, SIM_TIME_STEP, run_time_step=1 / 120.0, pre_step=pre_step)
 sim = w.run(

--- a/examples/voyager/test_dynamics.py
+++ b/examples/voyager/test_dynamics.py
@@ -1,0 +1,110 @@
+"""Focused checks for the Voyager Chapter 2 force equation."""
+
+import ast
+from pathlib import Path
+
+import jax.numpy as jnp
+import numpy as np
+
+from dynamics import (
+    direct_planetary_acceleration,
+    gravity_source_entity_names,
+    heliocentric_relative_acceleration,
+    planetary_acceleration_of_sun,
+)
+
+
+def test_direct_planetary_acceleration_points_toward_source():
+    probe_position = jnp.array([2.0, 0.0, 0.0])
+    source_position = jnp.array([5.0, 0.0, 0.0])
+
+    acceleration = direct_planetary_acceleration(
+        probe_position,
+        source_position,
+        gravitational_parameter=18.0,
+    )
+
+    np.testing.assert_allclose(acceleration, [2.0, 0.0, 0.0])
+
+
+def test_sun_acceleration_is_subtracted_from_direct_acceleration():
+    probe_position = jnp.array([5.0, 0.0, 0.0])
+    source_position = jnp.array([3.0, 0.0, 0.0])
+    gravitational_parameter = 9.0
+
+    direct_acceleration = direct_planetary_acceleration(
+        probe_position, source_position, gravitational_parameter
+    )
+    sun_acceleration = planetary_acceleration_of_sun(source_position, gravitational_parameter)
+    relative_acceleration = heliocentric_relative_acceleration(
+        probe_position, source_position, gravitational_parameter
+    )
+
+    np.testing.assert_allclose(direct_acceleration, [-2.25, 0.0, 0.0])
+    np.testing.assert_allclose(sun_acceleration, [1.0, 0.0, 0.0])
+    np.testing.assert_allclose(relative_acceleration, [-3.25, 0.0, 0.0])
+
+
+def test_relative_acceleration_accumulates_over_multiple_sources():
+    probe_position = jnp.array([4.0, 0.0, 0.0])
+    sources = (
+        (jnp.array([2.0, 0.0, 0.0]), 8.0),
+        (jnp.array([-2.0, 0.0, 0.0]), 18.0),
+    )
+
+    relative_acceleration = sum(
+        (
+            heliocentric_relative_acceleration(probe_position, source_position, mu)
+            for source_position, mu in sources
+        ),
+        start=jnp.zeros(3),
+    )
+
+    # The two independently hand-computed contributions are -4 and +4 m/s^2.
+    np.testing.assert_allclose(relative_acceleration, [0.0, 0.0, 0.0])
+
+
+def test_source_at_origin_has_no_indirect_acceleration():
+    probe_position = jnp.array([2.0, 0.0, 0.0])
+    source_position = jnp.zeros(3)
+
+    direct_acceleration = direct_planetary_acceleration(
+        probe_position, source_position, gravitational_parameter=16.0
+    )
+    sun_acceleration = planetary_acceleration_of_sun(source_position, gravitational_parameter=16.0)
+
+    relative_acceleration = heliocentric_relative_acceleration(
+        probe_position, source_position, gravitational_parameter=16.0
+    )
+
+    np.testing.assert_allclose(sun_acceleration, jnp.zeros(3))
+    np.testing.assert_allclose(relative_acceleration, direct_acceleration)
+    np.testing.assert_allclose(relative_acceleration, [-4.0, 0.0, 0.0])
+
+
+def test_truth_probes_are_not_wired_into_chapter_2_gravity():
+    planets = (
+        {"entity_name": "earth"},
+        {"entity_name": "jupiter"},
+    )
+    assert gravity_source_entity_names(planets) == ("Sun", "earth", "jupiter")
+
+    main_tree = ast.parse(Path(__file__).with_name("main.py").read_text())
+    gravity_source_calls = [
+        node
+        for node in ast.walk(main_tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "gravity_source_entity_names"
+    ]
+    assert len(gravity_source_calls) == 1
+    assert ast.unparse(gravity_source_calls[0].args[0]) == "PLANETS"
+
+    relative_acceleration_calls = [
+        node
+        for node in ast.walk(main_tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "heliocentric_relative_acceleration"
+    ]
+    assert len(relative_acceleration_calls) == 1

--- a/examples/voyager/test_truth_reference.py
+++ b/examples/voyager/test_truth_reference.py
@@ -1,0 +1,106 @@
+"""Contract tests for the Voyager reconstructed-arc validation harness."""
+
+from datetime import datetime
+import json
+from pathlib import Path
+
+from validate_truth import (
+    MANIFEST_PATH,
+    load_manifest,
+    required_kernel_names,
+    selected_cases,
+    sha256,
+    validate_run_record,
+)
+
+
+EXAMPLE_DIR = Path(__file__).resolve().parent
+
+
+def parse_utc(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+def test_truth_cases_initialize_and_score_inside_one_segment():
+    manifest = load_manifest()
+
+    for case in manifest["cases"]:
+        coverage_start, coverage_end = map(parse_utc, case["coverage_utc"])
+        initialization = parse_utc(case["initialization_utc"])
+        scoring_end = parse_utc(case["scoring_end_utc"])
+
+        assert coverage_start <= initialization < scoring_end <= coverage_end
+        assert (scoring_end - initialization).total_seconds() == (case["duration_days"] * 86400)
+        checkpoints = case["checkpoints"]
+        checkpoint_names = [checkpoint["name"] for checkpoint in checkpoints]
+        elapsed_seconds = [checkpoint["elapsed_seconds"] for checkpoint in checkpoints]
+
+        assert checkpoint_names[0] == "start"
+        assert checkpoint_names[-2:] == ["closest_approach", "end"]
+        assert elapsed_seconds == sorted(elapsed_seconds)
+        assert elapsed_seconds[0] == 0
+        assert elapsed_seconds[-1] == case["duration_days"] * 86400
+
+
+def test_every_referenced_kernel_has_provenance_and_checksum():
+    manifest = load_manifest()
+    cases = selected_cases(manifest, set())
+
+    for name in required_kernel_names(manifest, cases):
+        kernel = manifest["kernels"][name]
+        assert kernel["url"].startswith("https://naif.jpl.nasa.gov/")
+        assert len(kernel["sha256"]) == 64
+        int(kernel["sha256"], 16)
+
+
+def test_reconstructed_cases_do_not_claim_cruise_navigation_truth():
+    manifest = load_manifest()
+
+    assert "absolute navigation accuracy" in manifest["cruise_reference"]["unsupported_claim"]
+    assert {case["solution_status"] for case in manifest["cases"]} != {
+        manifest["cruise_reference"]["status"]
+    }
+
+
+def test_kernel_precedence_is_unambiguous():
+    manifest = load_manifest()
+    load_order = manifest["kernel_load_order"]
+
+    assert load_order[-2:] == ["<case encounter kernel>", "de440.bsp"]
+
+
+def test_checked_in_baseline_matches_the_contract():
+    manifest = load_manifest()
+    results = json.loads(
+        (EXAMPLE_DIR / "truth_validation_results.json").read_text(encoding="utf-8")
+    )
+    cases = {case["id"]: case for case in manifest["cases"]}
+
+    assert results["manifest_sha256"] == sha256(MANIFEST_PATH)
+    assert results["kernel_load_order"] == manifest["kernel_load_order"]
+    baseline_timestep = manifest["validation_protocol"]["baseline_timestep_s"]
+    baseline_records = [
+        record for record in results["records"] if record["timestep_s"] == baseline_timestep
+    ]
+    assert len(baseline_records) == len(cases) * 2
+    expected_record_count = sum(
+        2 + len(case["convergence_timesteps_s"]) - 1 for case in manifest["cases"]
+    )
+    assert len(results["records"]) == expected_record_count
+
+    for record in results["records"]:
+        case = cases[record["case"]]
+        assert record["chapter"] in (1, 2)
+        assert record["truth_kernel"] == case["kernel"]
+        assert record["truth_kernel_sha256"] == manifest["kernels"][case["kernel"]]["sha256"]
+        validate_run_record(case, record)
+
+    clean_rows = [row for row in results["summary"] if row["checkpoint"] == "clean_approach"]
+    assert len(clean_rows) == len(cases)
+    assert all(row["position_error_reduction_percent"] > 0 for row in clean_rows)
+    assert len(results["timestep_controls"]) == len(cases) * 2
+    for control in results["timestep_controls"]:
+        case = cases[control["case"]]
+        assert {float(timestep) for timestep in control["position_error_km_by_timestep_s"]} == set(
+            case["convergence_timesteps_s"]
+        )

--- a/examples/voyager/test_truth_reference.py
+++ b/examples/voyager/test_truth_reference.py
@@ -9,9 +9,11 @@ from validate_truth import (
     load_manifest,
     required_kernel_names,
     selected_cases,
+    selected_convergence_timesteps,
     sha256,
     validate_run_record,
 )
+from time_utils import utc_epoch_microseconds
 
 
 EXAMPLE_DIR = Path(__file__).resolve().parent
@@ -67,6 +69,37 @@ def test_kernel_precedence_is_unambiguous():
     load_order = manifest["kernel_load_order"]
 
     assert load_order[-2:] == ["<case encounter kernel>", "de440.bsp"]
+
+
+def test_validation_start_utc_controls_database_epoch():
+    assert utc_epoch_microseconds("1978-01-01T00:00:00") == 252_460_800_000_000
+    assert utc_epoch_microseconds("1979-02-01T00:00:00Z") == 286_675_200_000_000
+    assert utc_epoch_microseconds("1979-01-31T16:00:00-08:00") == 286_675_200_000_000
+
+
+def test_explicit_chapter_two_still_runs_convergence_matrix():
+    manifest = load_manifest()
+    case = manifest["cases"][0]
+    baseline = manifest["validation_protocol"]["baseline_timestep_s"]
+
+    selected = selected_convergence_timesteps(manifest, case, [2], True, None)
+
+    assert selected == [
+        timestep for timestep in case["convergence_timesteps_s"] if timestep != baseline
+    ]
+
+
+def test_incompatible_convergence_selections_are_rejected():
+    manifest = load_manifest()
+    case = manifest["cases"][0]
+
+    for chapters, timestep in (([1], None), ([2], 300.0)):
+        try:
+            selected_convergence_timesteps(manifest, case, chapters, True, timestep)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("incompatible convergence selection was silently ignored")
 
 
 def test_checked_in_baseline_matches_the_contract():

--- a/examples/voyager/time_utils.py
+++ b/examples/voyager/time_utils.py
@@ -1,0 +1,15 @@
+"""Time conversion helpers for the Voyager example."""
+
+from datetime import datetime, timedelta, timezone
+
+
+UNIX_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+def utc_epoch_microseconds(value: str) -> int:
+    """Convert an ISO-8601 UTC timestamp to Unix epoch microseconds."""
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    elapsed = parsed.astimezone(timezone.utc) - UNIX_EPOCH
+    return elapsed // timedelta(microseconds=1)

--- a/examples/voyager/truth_reference.json
+++ b/examples/voyager/truth_reference.json
@@ -1,0 +1,182 @@
+{
+  "schema_version": 1,
+  "reference_state": {
+    "observer": "SUN",
+    "output_frame": "ECLIPJ2000",
+    "aberration_correction": "NONE",
+    "units": {
+      "position": "km",
+      "velocity": "km/s"
+    }
+  },
+  "validation_protocol": {
+    "baseline_timestep_s": 100,
+    "chapters": [1, 2],
+    "convergence_chapter": 2,
+    "initialization": "query the selected reconstructed segment at initialization_utc",
+    "scoring": "query that same selected segment at each predeclared checkpoint",
+    "planet_state_source": "de440.bsp",
+    "model_parameters": "preserve each chapter's existing G multiplied by rounded body masses",
+    "integrator": "Elodin six_dof classical RK4"
+  },
+  "kernel_load_order": [
+    "naif0012.tls",
+    "Voyager_1.a54206u_V0.2_merged.bsp",
+    "Voyager_2.m05016u.merged.bsp",
+    "<case encounter kernel>",
+    "de440.bsp"
+  ],
+  "kernel_precedence": "SPICE gives the last-loaded competing SPK segment the highest priority. The encounter kernel therefore wins for the selected spacecraft, and DE440 wins for planetary states.",
+  "kernels": {
+    "naif0012.tls": {
+      "role": "leap-seconds",
+      "url": "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/lsk/naif0012.tls",
+      "sha256": "678e32bdb5a744117a467cd9601cd6b373f0e9bc9bbde1371d5eee39600a039b"
+    },
+    "de440.bsp": {
+      "role": "planetary ephemeris for translation and model source states",
+      "url": "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de440.bsp",
+      "sha256": "a4ce9bf9b3282becc9f4b2ac3cebe03a2ae7599981aabd7265fd8482fff7c4b5"
+    },
+    "Voyager_1.a54206u_V0.2_merged.bsp": {
+      "role": "long-span educational/mission-design reference and fallback spacecraft coverage",
+      "url": "https://naif.jpl.nasa.gov/pub/naif/VOYAGER/kernels/spk/Voyager_1.a54206u_V0.2_merged.bsp",
+      "sha256": "47c6f2be03668b50a1efb5f96978a2b68b2b501dae6f585841b1569baa3f4311"
+    },
+    "Voyager_2.m05016u.merged.bsp": {
+      "role": "long-span educational/mission-design reference and fallback spacecraft coverage",
+      "url": "https://naif.jpl.nasa.gov/pub/naif/VOYAGER/kernels/spk/Voyager_2.m05016u.merged.bsp",
+      "sha256": "ce66cba12cf77bf3a1097f44142ef978f46656788ed08f9052238a102ed2e706"
+    },
+    "vgr1_jup230.bsp": {
+      "role": "NAIF current-best Voyager 1 Jupiter encounter reconstruction",
+      "url": "https://naif.jpl.nasa.gov/pub/naif/VOYAGER/kernels/spk/vgr1_jup230.bsp",
+      "sha256": "e1ea3f72f19b15508bc45979771a36a97d02f33056b76867d444304cb82205c9"
+    },
+    "vgr2_jup230.bsp": {
+      "role": "NAIF current-best Voyager 2 Jupiter encounter reconstruction",
+      "url": "https://naif.jpl.nasa.gov/pub/naif/VOYAGER/kernels/spk/vgr2_jup230.bsp",
+      "sha256": "9c00be3c83915f6c1fd8448d9266420e3c462e9d78e4c32b17145dac81529d5a"
+    },
+    "vgr1_sat337.bsp": {
+      "role": "NAIF current-best Voyager 1 Saturn encounter reconstruction",
+      "url": "https://naif.jpl.nasa.gov/pub/naif/VOYAGER/kernels/spk/vgr1_sat337.bsp",
+      "sha256": "f451f9f095bc4ad175cde701367cbf1ccc061dd706ad0008cda75fd939d94efa"
+    },
+    "vgr2_sat337.bsp": {
+      "role": "NAIF current-best Voyager 2 Saturn encounter reconstruction",
+      "url": "https://naif.jpl.nasa.gov/pub/naif/VOYAGER/kernels/spk/vgr2_sat337.bsp",
+      "sha256": "1d15debf7bdc6c6ba4c0462b5f4f6af85ddf9948735f434792a1c41418bb39a8"
+    }
+  },
+  "cases": [
+    {
+      "id": "v1_jupiter",
+      "probe": "voyager1",
+      "spice_target": -31,
+      "kernel": "vgr1_jup230.bsp",
+      "segment_id": "vgr1.jup230.nio",
+      "native_center": 5,
+      "native_frame": "J2000",
+      "segment_type": 1,
+      "coverage_utc": ["1979-02-01T00:00:00", "1979-03-19T00:00:00"],
+      "initialization_utc": "1979-02-01T00:00:00",
+      "scoring_end_utc": "1979-03-18T00:00:00",
+      "duration_days": 45,
+      "checkpoints": [
+        {"name": "start", "elapsed_seconds": 0, "phase": "initialization"},
+        {"name": "clean_approach", "elapsed_seconds": 1728000, "phase": "maneuver-free approach"},
+        {"name": "mid_arc", "elapsed_seconds": 1944000, "phase": "approach"},
+        {"name": "late_approach", "elapsed_seconds": 2592000, "phase": "approach"},
+        {"name": "closest_approach", "elapsed_seconds": 2808286.794, "epoch_utc": "1979-03-05T12:04:46.794", "phase": "close encounter"},
+        {"name": "end", "elapsed_seconds": 3888000, "phase": "post-encounter"}
+      ],
+      "convergence_timesteps_s": [3600, 900, 300, 100],
+      "convergence_checkpoint": "clean_approach",
+      "solution_status": "current-best encounter solution identified by the NAIF Voyager kernel archive"
+    },
+    {
+      "id": "v2_jupiter",
+      "probe": "voyager2",
+      "spice_target": -32,
+      "kernel": "vgr2_jup230.bsp",
+      "segment_id": "vgr2.jup230.nio",
+      "native_center": 5,
+      "native_frame": "J2000",
+      "segment_type": 1,
+      "coverage_utc": ["1979-06-04T17:00:00", "1979-07-21T00:00:00"],
+      "initialization_utc": "1979-06-05T00:00:00",
+      "scoring_end_utc": "1979-07-20T00:00:00",
+      "duration_days": 45,
+      "checkpoints": [
+        {"name": "start", "elapsed_seconds": 0, "phase": "initialization"},
+        {"name": "clean_approach", "elapsed_seconds": 1728000, "phase": "maneuver-free approach"},
+        {"name": "mid_arc", "elapsed_seconds": 1944000, "phase": "approach"},
+        {"name": "late_approach", "elapsed_seconds": 2592000, "phase": "approach"},
+        {"name": "closest_approach", "elapsed_seconds": 3018532.806, "epoch_utc": "1979-07-09T22:28:52.806", "phase": "close encounter"},
+        {"name": "end", "elapsed_seconds": 3888000, "phase": "post-encounter"}
+      ],
+      "convergence_timesteps_s": [3600, 900, 300, 100],
+      "convergence_checkpoint": "clean_approach",
+      "solution_status": "current-best encounter solution identified by the NAIF Voyager kernel archive"
+    },
+    {
+      "id": "v1_saturn",
+      "probe": "voyager1",
+      "spice_target": -31,
+      "kernel": "vgr1_sat337.bsp",
+      "segment_id": "vgr1.sat337.nio",
+      "native_center": 6,
+      "native_frame": "J2000",
+      "segment_type": 1,
+      "coverage_utc": ["1980-10-06T10:10:09.657", "1980-11-20T00:00:00"],
+      "initialization_utc": "1980-10-07T00:00:00",
+      "scoring_end_utc": "1980-11-18T00:00:00",
+      "duration_days": 42,
+      "checkpoints": [
+        {"name": "start", "elapsed_seconds": 0, "phase": "initialization"},
+        {"name": "early_approach", "elapsed_seconds": 86400, "phase": "maneuver-free approach"},
+        {"name": "clean_approach", "elapsed_seconds": 259200, "phase": "maneuver-free approach"},
+        {"name": "mid_arc", "elapsed_seconds": 1814400, "phase": "post-maneuver approach"},
+        {"name": "closest_approach", "elapsed_seconds": 3195927.463, "epoch_utc": "1980-11-12T23:45:27.463", "phase": "close encounter"},
+        {"name": "end", "elapsed_seconds": 3628800, "phase": "post-encounter"}
+      ],
+      "convergence_timesteps_s": [3600, 300, 100],
+      "convergence_checkpoint": "clean_approach",
+      "solution_status": "current-best encounter solution identified by the NAIF Voyager kernel archive; case begins after its center transition"
+    },
+    {
+      "id": "v2_saturn",
+      "probe": "voyager2",
+      "spice_target": -32,
+      "kernel": "vgr2_sat337.bsp",
+      "segment_id": "vgr2.sat337.nio",
+      "native_center": 6,
+      "native_frame": "J2000",
+      "segment_type": 1,
+      "coverage_utc": ["1981-07-04T11:59:58.942", "1981-09-22T00:00:00"],
+      "initialization_utc": "1981-07-15T00:00:00",
+      "scoring_end_utc": "1981-08-29T00:00:00",
+      "duration_days": 45,
+      "checkpoints": [
+        {"name": "start", "elapsed_seconds": 0, "phase": "initialization"},
+        {"name": "early_approach", "elapsed_seconds": 86400, "phase": "maneuver-free approach"},
+        {"name": "clean_approach", "elapsed_seconds": 345600, "phase": "maneuver-free approach"},
+        {"name": "mid_arc", "elapsed_seconds": 1944000, "phase": "post-maneuver approach"},
+        {"name": "closest_approach", "elapsed_seconds": 3641030.181, "epoch_utc": "1981-08-26T03:23:50.181", "phase": "close encounter"},
+        {"name": "end", "elapsed_seconds": 3888000, "phase": "post-encounter"}
+      ],
+      "convergence_timesteps_s": [3600, 300, 100],
+      "convergence_checkpoint": "clean_approach",
+      "solution_status": "current-best encounter solution identified by the NAIF Voyager kernel archive"
+    }
+  ],
+  "cruise_reference": {
+    "interval_investigated": ["1978-01-01T00:00:00", "1979-02-01T00:00:00"],
+    "available_reference": "the spacecraft segments in the merged Voyager supertrajectory kernels",
+    "status": "educational/mission-design reference; not established here as a navigation-grade reconstructed orbit",
+    "supported_claim": "agreement with the published merged supertrajectory",
+    "unsupported_claim": "absolute navigation accuracy over the cruise interval",
+    "research_result": "No separate public tracking-fit state-vector SPK for this complete interval was identified in the NAIF Voyager archive or the NASA technical material surveyed. Navigation reports describe orbit determination and maneuvers but do not publish a machine-readable reconstructed trajectory covering the interval."
+  }
+}

--- a/examples/voyager/truth_validation_results.json
+++ b/examples/voyager/truth_validation_results.json
@@ -1,0 +1,4287 @@
+{
+  "schema_version": 1,
+  "manifest_sha256": "cbacff8bff559172c15c287dba8fcc83adc90e2bdcc39d0c803e56a6020fe06e",
+  "kernel_load_order": [
+    "naif0012.tls",
+    "Voyager_1.a54206u_V0.2_merged.bsp",
+    "Voyager_2.m05016u.merged.bsp",
+    "<case encounter kernel>",
+    "de440.bsp"
+  ],
+  "records": [
+    {
+      "case": "v1_jupiter",
+      "chapter": 1,
+      "timestep_s": 100,
+      "truth_kernel": "vgr1_jup230.bsp",
+      "truth_kernel_sha256": "e1ea3f72f19b15508bc45979771a36a97d02f33056b76867d444304cb82205c9",
+      "initial_state": {
+        "epoch_utc": "1979-02-01T00:00:00",
+        "frame": "ECLIPJ2000",
+        "observer": "SUN",
+        "position_m": [
+          -446090844730.51874,
+          614640633481.2283,
+          8246684978.669226
+        ],
+        "probe": "voyager1",
+        "velocity_mps": [
+          -12598.454536619882,
+          4108.594839233414,
+          -6.8990140887426055
+        ]
+      },
+      "active_segments": [
+        {
+          "center": 5,
+          "epoch": "initialization",
+          "file": "vgr1_jup230.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager1",
+          "segment_id": "vgr1.jup230.nio",
+          "segment_type": 1,
+          "target": -31
+        },
+        {
+          "center": 5,
+          "epoch": "scoring_end",
+          "file": "vgr1_jup230.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager1",
+          "segment_id": "vgr1.jup230.nio",
+          "segment_type": 1,
+          "target": -31
+        }
+      ],
+      "metrics": [
+        {
+          "actual_elapsed_seconds": 0.0,
+          "actual_epoch_utc": "1979-02-01T00:00:00",
+          "checkpoint": "start",
+          "position_error_km": 0.0,
+          "position_residual_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "position_rtn_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 0.0,
+          "velocity_error_mps": 0.0,
+          "velocity_residual_mps": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "velocity_rtn_mps": [
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 1728000.0,
+          "actual_epoch_utc": "1979-02-21T00:00:00.000",
+          "checkpoint": "clean_approach",
+          "position_error_km": 338.58032096679256,
+          "position_residual_km": [
+            -251.91846368408204,
+            226.10813903808594,
+            6.987908253669739
+          ],
+          "position_rtn_km": [
+            332.18751931142504,
+            65.31582471619187,
+            4.682819806655692
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 1728000,
+          "velocity_error_mps": 0.3618808901609073,
+          "velocity_residual_mps": [
+            -0.28102151221537497,
+            0.22784440915802406,
+            0.008462479025997283
+          ],
+          "velocity_rtn_mps": [
+            0.35108494149886266,
+            0.08750199308983375,
+            0.00636739520506737
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 1944000.0,
+          "actual_epoch_utc": "1979-02-23T12:00:00.000",
+          "checkpoint": "mid_arc",
+          "position_error_km": 400.7162454020164,
+          "position_residual_km": [
+            -294.3550803222656,
+            249.34159020996094,
+            108.43139494228363
+          ],
+          "position_rtn_km": [
+            377.5040629077151,
+            82.52406209609056,
+            106.08473496416667
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 1944000,
+          "velocity_error_mps": 0.548893318134779,
+          "velocity_residual_mps": [
+            -0.20254292349272873,
+            0.10187088393649901,
+            0.49988254804706145
+          ],
+          "velocity_rtn_mps": [
+            0.20862584015458804,
+            0.09051589031545806,
+            0.49956581859971155
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 2592000.0,
+          "actual_epoch_utc": "1979-03-02T23:59:59.999",
+          "checkpoint": "late_approach",
+          "position_error_km": 675.8895280859023,
+          "position_residual_km": [
+            -432.31597131347655,
+            309.50934301757815,
+            417.29308849811554
+          ],
+          "position_rtn_km": [
+            512.7775706779006,
+            143.41337063568835,
+            416.3152919468187
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 2592000,
+          "velocity_error_mps": 0.41394713401977357,
+          "velocity_residual_mps": [
+            -0.15828815703753207,
+            0.10457301633232419,
+            0.3679151714186375
+          ],
+          "velocity_rtn_mps": [
+            0.18303481078037812,
+            0.05158318336168897,
+            0.36768146948146563
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 2808300.0,
+          "actual_epoch_utc": "1979-03-05T12:04:59.999",
+          "checkpoint": "closest_approach",
+          "position_error_km": 904.8377346391785,
+          "position_residual_km": [
+            -799.2641919555664,
+            384.02143029785157,
+            180.09891325759887
+          ],
+          "position_rtn_km": [
+            793.16316966268,
+            406.6814872680337,
+            155.67170658495039
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 2808286.794,
+          "velocity_error_mps": 25.652704365639664,
+          "velocity_residual_mps": [
+            -10.915855069004465,
+            -17.857165582609923,
+            -14.833306669069088
+          ],
+          "velocity_rtn_mps": [
+            -7.669597178205545,
+            18.924229763868585,
+            -15.527783107684115
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3888000.0,
+          "actual_epoch_utc": "1979-03-17T23:59:59.999",
+          "checkpoint": "end",
+          "position_error_km": 29289.431253903942,
+          "position_residual_km": [
+            4026.2208516845703,
+            15674.073658203126,
+            -24412.778288999558
+          ],
+          "position_rtn_km": [
+            9255.911710532499,
+            -14094.11452837522,
+            -23949.0045146982
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 3888000,
+          "velocity_error_mps": 24.343060016045325,
+          "velocity_residual_mps": [
+            5.152294935614918,
+            14.190161012946191,
+            -19.096537860771605
+          ],
+          "velocity_rtn_mps": [
+            7.457616359474294,
+            -13.794997266840715,
+            -18.618984386575523
+          ]
+        }
+      ]
+    },
+    {
+      "case": "v1_jupiter",
+      "chapter": 2,
+      "timestep_s": 100,
+      "truth_kernel": "vgr1_jup230.bsp",
+      "truth_kernel_sha256": "e1ea3f72f19b15508bc45979771a36a97d02f33056b76867d444304cb82205c9",
+      "initial_state": {
+        "epoch_utc": "1979-02-01T00:00:00",
+        "frame": "ECLIPJ2000",
+        "observer": "SUN",
+        "position_m": [
+          -446090844730.51874,
+          614640633481.2283,
+          8246684978.669226
+        ],
+        "probe": "voyager1",
+        "velocity_mps": [
+          -12598.454536619882,
+          4108.594839233414,
+          -6.8990140887426055
+        ]
+      },
+      "active_segments": [
+        {
+          "center": 5,
+          "epoch": "initialization",
+          "file": "vgr1_jup230.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager1",
+          "segment_id": "vgr1.jup230.nio",
+          "segment_type": 1,
+          "target": -31
+        },
+        {
+          "center": 5,
+          "epoch": "scoring_end",
+          "file": "vgr1_jup230.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager1",
+          "segment_id": "vgr1.jup230.nio",
+          "segment_type": 1,
+          "target": -31
+        }
+      ],
+      "metrics": [
+        {
+          "actual_elapsed_seconds": 0.0,
+          "actual_epoch_utc": "1979-02-01T00:00:00",
+          "checkpoint": "start",
+          "position_error_km": 0.0,
+          "position_residual_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "position_rtn_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 0.0,
+          "velocity_error_mps": 0.0,
+          "velocity_residual_mps": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "velocity_rtn_mps": [
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 1728000.0,
+          "actual_epoch_utc": "1979-02-21T00:00:00.000",
+          "checkpoint": "clean_approach",
+          "position_error_km": 33.69857169438939,
+          "position_residual_km": [
+            5.314855773925781,
+            -33.21084143066406,
+            2.094290765762329
+          ],
+          "position_rtn_km": [
+            -29.711158653287175,
+            15.670386195282733,
+            2.6981071535046555
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 1728000,
+          "velocity_error_mps": 0.07460407916015303,
+          "velocity_residual_mps": [
+            0.015034639760415303,
+            -0.07300427824520739,
+            0.0031786148721195673
+          ],
+          "velocity_rtn_mps": [
+            -0.06734096260718887,
+            0.031794807996183644,
+            0.004478120918129403
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 1944000.0,
+          "actual_epoch_utc": "1979-02-23T12:00:00.000",
+          "checkpoint": "mid_arc",
+          "position_error_km": 133.29835883164282,
+          "position_residual_km": [
+            30.70006951904297,
+            -79.6781220703125,
+            102.3589520368576
+          ],
+          "position_rtn_km": [
+            -80.99855395340347,
+            21.522873716796976,
+            103.65545152879226
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 1944000,
+          "velocity_error_mps": 0.5662238567665515,
+          "velocity_residual_mps": [
+            0.1293019081786042,
+            -0.2440494788088472,
+            0.49429780942877954
+          ],
+          "velocity_rtn_mps": [
+            -0.2674484988042744,
+            0.034270587654516245,
+            0.49790188117815176
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 2592000.0,
+          "actual_epoch_utc": "1979-03-02T23:59:59.999",
+          "checkpoint": "late_approach",
+          "position_error_km": 555.3206400177319,
+          "position_residual_km": [
+            146.4005718383789,
+            -345.99720434570315,
+            408.9423191356659
+          ],
+          "position_rtn_km": [
+            -359.50764708373885,
+            81.86034963490073,
+            415.25190917763297
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 2592000,
+          "velocity_error_mps": 1.0137429256544963,
+          "velocity_residual_mps": [
+            0.34713714988356514,
+            -0.8761280106855338,
+            0.3735909894222047
+          ],
+          "velocity_rtn_mps": [
+            -0.9029039555826905,
+            0.24520118940284114,
+            0.3902762393780848
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 2808300.0,
+          "actual_epoch_utc": "1979-03-05T12:04:59.999",
+          "checkpoint": "closest_approach",
+          "position_error_km": 1708.8183782827505,
+          "position_residual_km": [
+            1586.024984436035,
+            -631.6574089355469,
+            74.79248918437958
+          ],
+          "position_rtn_km": [
+            -1466.033492907786,
+            -869.0096548898348,
+            125.01306866778229
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 2808286.794,
+          "velocity_error_mps": 80.50152438376857,
+          "velocity_residual_mps": [
+            52.78178890098934,
+            56.92126419073065,
+            -21.320128316943283
+          ],
+          "velocity_rtn_mps": [
+            12.783798528806116,
+            -77.33020594673395,
+            -18.36053298575755
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3888000.0,
+          "actual_epoch_utc": "1979-03-17T23:59:59.999",
+          "checkpoint": "end",
+          "position_error_km": 35494.56382865734,
+          "position_residual_km": [
+            3637.0100919799806,
+            25143.156569702147,
+            -24788.261267965318
+          ],
+          "position_rtn_km": [
+            16810.370657064246,
+            -19824.437050247892,
+            -24171.61962714749
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 3888000,
+          "velocity_error_mps": 28.815520594232446,
+          "velocity_residual_mps": [
+            3.650987563196395,
+            21.080179834920273,
+            -19.30364046125601
+          ],
+          "velocity_rtn_mps": [
+            13.729160162067126,
+            -17.022367193905183,
+            -18.763885617771273
+          ]
+        }
+      ]
+    },
+    {
+      "case": "v1_jupiter",
+      "chapter": 2,
+      "timestep_s": 3600,
+      "truth_kernel": "vgr1_jup230.bsp",
+      "truth_kernel_sha256": "e1ea3f72f19b15508bc45979771a36a97d02f33056b76867d444304cb82205c9",
+      "initial_state": {
+        "epoch_utc": "1979-02-01T00:00:00",
+        "frame": "ECLIPJ2000",
+        "observer": "SUN",
+        "position_m": [
+          -446090844730.51874,
+          614640633481.2283,
+          8246684978.669226
+        ],
+        "probe": "voyager1",
+        "velocity_mps": [
+          -12598.454536619882,
+          4108.594839233414,
+          -6.8990140887426055
+        ]
+      },
+      "active_segments": [
+        {
+          "center": 5,
+          "epoch": "initialization",
+          "file": "vgr1_jup230.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager1",
+          "segment_id": "vgr1.jup230.nio",
+          "segment_type": 1,
+          "target": -31
+        },
+        {
+          "center": 5,
+          "epoch": "scoring_end",
+          "file": "vgr1_jup230.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager1",
+          "segment_id": "vgr1.jup230.nio",
+          "segment_type": 1,
+          "target": -31
+        }
+      ],
+      "metrics": [
+        {
+          "actual_elapsed_seconds": 0.0,
+          "actual_epoch_utc": "1979-02-01T00:00:00",
+          "checkpoint": "start",
+          "position_error_km": 0.0,
+          "position_residual_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "position_rtn_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 0.0,
+          "velocity_error_mps": 0.0,
+          "velocity_residual_mps": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "velocity_rtn_mps": [
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 1728000.0,
+          "actual_epoch_utc": "1979-02-21T00:00:00.000",
+          "checkpoint": "clean_approach",
+          "position_error_km": 33.711215867221874,
+          "position_residual_km": [
+            5.317563354492187,
+            -33.223221313476564,
+            2.0945550298690794
+          ],
+          "position_rtn_km": [
+            -29.722676072761026,
+            15.675656653681965,
+            2.69859052025814
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 1728000,
+          "velocity_error_mps": 0.07464267412685885,
+          "velocity_residual_mps": [
+            0.015043016646814067,
+            -0.07304195882898057,
+            0.003179418405562018
+          ],
+          "velocity_rtn_mps": [
+            -0.06737609977906513,
+            0.03181074112733966,
+            0.004479590193230339
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 1944000.0,
+          "actual_epoch_utc": "1979-02-23T12:00:00.000",
+          "checkpoint": "mid_arc",
+          "position_error_km": 133.3148196901619,
+          "position_residual_km": [
+            30.70556903076172,
+            -79.70286364746094,
+            102.359477850914
+          ],
+          "position_rtn_km": [
+            -81.02160360837101,
+            21.533382451386167,
+            103.6564244895159
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 1944000,
+          "velocity_error_mps": 0.5662664775586554,
+          "velocity_residual_mps": [
+            0.12932138645737723,
+            -0.244134422659954,
+            0.49429959162831594
+          ],
+          "velocity_rtn_mps": [
+            -0.26752799402900423,
+            0.0343061907157752,
+            0.4979051930800453
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 2592000.0,
+          "actual_epoch_utc": "1979-03-02T23:59:59.999",
+          "checkpoint": "late_approach",
+          "position_error_km": 555.924839292993,
+          "position_residual_km": [
+            146.66387573242187,
+            -346.8389234619141,
+            408.95586029529574
+          ],
+          "position_rtn_km": [
+            -360.33604455965417,
+            82.16168940245463,
+            415.28281776227834
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 2592000,
+          "velocity_error_mps": 1.0227901630819503,
+          "velocity_residual_mps": [
+            0.3504647826812288,
+            -0.885220867926364,
+            0.3737086683301527
+          ],
+          "velocity_rtn_mps": [
+            -0.9121467086055909,
+            0.2480735077092285,
+            0.3905734686970285
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 2808000.0,
+          "actual_epoch_utc": "1979-03-05T11:59:59.999",
+          "checkpoint": "closest_approach",
+          "position_error_km": 2743.919711676148,
+          "position_residual_km": [
+            2700.8166131591797,
+            -484.3725711669922,
+            8.259449701309205
+          ],
+          "position_rtn_km": [
+            -2028.7471312965906,
+            -1844.6442100211177,
+            102.80175006455842
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 2808286.794,
+          "velocity_error_mps": 234.78055261150865,
+          "velocity_residual_mps": [
+            179.45196514621784,
+            148.01227731310792,
+            -31.80040651176705
+          ],
+          "velocity_rtn_mps": [
+            7.7885562423079895,
+            -233.5602821543755,
+            -22.601789225508494
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3888000.0,
+          "actual_epoch_utc": "1979-03-17T23:59:59.999",
+          "checkpoint": "end",
+          "position_error_km": 245827.21119258954,
+          "position_residual_km": [
+            -93723.65202667237,
+            225771.67863024902,
+            -25962.356248785018
+          ],
+          "position_rtn_km": [
+            233568.6165666003,
+            -72225.020088417,
+            -25695.63369754184
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 3888000,
+          "velocity_error_mps": 210.31625296289806,
+          "velocity_residual_mps": [
+            -97.93718869938675,
+            185.15350425637916,
+            -18.95819589511143
+          ],
+          "velocity_rtn_mps": [
+            204.96482077173113,
+            -42.87916738442343,
+            -19.588912955661055
+          ]
+        }
+      ]
+    },
+    {
+      "case": "v1_jupiter",
+      "chapter": 2,
+      "timestep_s": 900,
+      "truth_kernel": "vgr1_jup230.bsp",
+      "truth_kernel_sha256": "e1ea3f72f19b15508bc45979771a36a97d02f33056b76867d444304cb82205c9",
+      "initial_state": {
+        "epoch_utc": "1979-02-01T00:00:00",
+        "frame": "ECLIPJ2000",
+        "observer": "SUN",
+        "position_m": [
+          -446090844730.51874,
+          614640633481.2283,
+          8246684978.669226
+        ],
+        "probe": "voyager1",
+        "velocity_mps": [
+          -12598.454536619882,
+          4108.594839233414,
+          -6.8990140887426055
+        ]
+      },
+      "active_segments": [
+        {
+          "center": 5,
+          "epoch": "initialization",
+          "file": "vgr1_jup230.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager1",
+          "segment_id": "vgr1.jup230.nio",
+          "segment_type": 1,
+          "target": -31
+        },
+        {
+          "center": 5,
+          "epoch": "scoring_end",
+          "file": "vgr1_jup230.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager1",
+          "segment_id": "vgr1.jup230.nio",
+          "segment_type": 1,
+          "target": -31
+        }
+      ],
+      "metrics": [
+        {
+          "actual_elapsed_seconds": 0.0,
+          "actual_epoch_utc": "1979-02-01T00:00:00",
+          "checkpoint": "start",
+          "position_error_km": 0.0,
+          "position_residual_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "position_rtn_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 0.0,
+          "velocity_error_mps": 0.0,
+          "velocity_residual_mps": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "velocity_rtn_mps": [
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 1728000.0,
+          "actual_epoch_utc": "1979-02-21T00:00:00.000",
+          "checkpoint": "clean_approach",
+          "position_error_km": 33.699353725251854,
+          "position_residual_km": [
+            5.315021301269531,
+            -33.211607421875,
+            2.0943071699142455
+          ],
+          "position_rtn_km": [
+            -29.7118700770759,
+            15.670713897076302,
+            2.6981371311679405
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 1728000,
+          "velocity_error_mps": 0.07460646246485154,
+          "velocity_residual_mps": [
+            0.015035156984595233,
+            -0.0730066050982714,
+            0.0031786644983284873
+          ],
+          "velocity_rtn_mps": [
+            -0.0673431323598227,
+            0.03179579195196426,
+            0.004478211655796241
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 1944000.0,
+          "actual_epoch_utc": "1979-02-23T12:00:00.000",
+          "checkpoint": "mid_arc",
+          "position_error_km": 133.29937720163997,
+          "position_residual_km": [
+            30.700408386230468,
+            -79.6796533203125,
+            102.3589846277237
+          ],
+          "position_rtn_km": [
+            -80.9999795884166,
+            21.523525292600766,
+            103.65551180713915
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 1944000,
+          "velocity_error_mps": 0.5662264880958792,
+          "velocity_residual_mps": [
+            0.1293031105724367,
+            -0.2440547237838473,
+            0.4942979194943824
+          ],
+          "velocity_rtn_mps": [
+            -0.2674534071536589,
+            0.034272786268886274,
+            0.49790208570025
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 2592000.0,
+          "actual_epoch_utc": "1979-03-02T23:59:59.999",
+          "checkpoint": "late_approach",
+          "position_error_km": 555.3581508754613,
+          "position_residual_km": [
+            146.4169186401367,
+            -346.04949462890625,
+            408.9431610221863
+          ],
+          "position_rtn_km": [
+            -359.5591034128633,
+            81.87907812767888,
+            415.25383015898956
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 2592000,
+          "velocity_error_mps": 1.0143005635266513,
+          "velocity_residual_mps": [
+            0.34734198545265826,
+            -0.8766889453709155,
+            0.3735982753931282
+          ],
+          "velocity_rtn_mps": [
+            -0.9034738668685719,
+            0.2453787340287608,
+            0.3902946091639941
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 2808000.0,
+          "actual_epoch_utc": "1979-03-05T11:59:59.999",
+          "checkpoint": "closest_approach",
+          "position_error_km": 1767.2972593377656,
+          "position_residual_km": [
+            1646.1197094726563,
+            -638.5991424560547,
+            76.29312028503418
+          ],
+          "position_rtn_km": [
+            -1508.110739394018,
+            -912.3968971381823,
+            128.34914366610738
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 2808286.794,
+          "velocity_error_mps": 89.61205928949792,
+          "velocity_residual_mps": [
+            62.08224045683164,
+            60.83469885668819,
+            -21.800367083622405
+          ],
+          "velocity_rtn_mps": [
+            10.219917676505585,
+            -87.09365851509932,
+            -18.454514332412252
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3888000.0,
+          "actual_epoch_utc": "1979-03-17T23:59:59.999",
+          "checkpoint": "end",
+          "position_error_km": 44693.12160954444,
+          "position_residual_km": [
+            -143.78928302001952,
+            37062.11722705078,
+            -24977.06769210434
+          ],
+          "position_rtn_km": [
+            28413.47689142069,
+            -24487.37731535466,
+            -24300.572058321675
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 3888000,
+          "velocity_error_mps": 36.44010474478164,
+          "velocity_residual_mps": [
+            -0.24184764009987703,
+            30.838968692047274,
+            -19.41084113428792
+          ],
+          "velocity_rtn_mps": [
+            23.736416546046758,
+            -20.22334913121225,
+            -18.854174956234818
+          ]
+        }
+      ]
+    },
+    {
+      "case": "v1_jupiter",
+      "chapter": 2,
+      "timestep_s": 300,
+      "truth_kernel": "vgr1_jup230.bsp",
+      "truth_kernel_sha256": "e1ea3f72f19b15508bc45979771a36a97d02f33056b76867d444304cb82205c9",
+      "initial_state": {
+        "epoch_utc": "1979-02-01T00:00:00",
+        "frame": "ECLIPJ2000",
+        "observer": "SUN",
+        "position_m": [
+          -446090844730.51874,
+          614640633481.2283,
+          8246684978.669226
+        ],
+        "probe": "voyager1",
+        "velocity_mps": [
+          -12598.454536619882,
+          4108.594839233414,
+          -6.8990140887426055
+        ]
+      },
+      "active_segments": [
+        {
+          "center": 5,
+          "epoch": "initialization",
+          "file": "vgr1_jup230.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager1",
+          "segment_id": "vgr1.jup230.nio",
+          "segment_type": 1,
+          "target": -31
+        },
+        {
+          "center": 5,
+          "epoch": "scoring_end",
+          "file": "vgr1_jup230.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager1",
+          "segment_id": "vgr1.jup230.nio",
+          "segment_type": 1,
+          "target": -31
+        }
+      ],
+      "metrics": [
+        {
+          "actual_elapsed_seconds": 0.0,
+          "actual_epoch_utc": "1979-02-01T00:00:00",
+          "checkpoint": "start",
+          "position_error_km": 0.0,
+          "position_residual_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "position_rtn_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 0.0,
+          "velocity_error_mps": 0.0,
+          "velocity_residual_mps": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "velocity_rtn_mps": [
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 1728000.0,
+          "actual_epoch_utc": "1979-02-21T00:00:00.000",
+          "checkpoint": "clean_approach",
+          "position_error_km": 33.69865145317726,
+          "position_residual_km": [
+            5.314865783691406,
+            -33.21092065429688,
+            2.0942924242019654
+          ],
+          "position_rtn_km": [
+            -29.71122795959136,
+            15.670425770770828,
+            2.6981102754862727
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 1728000,
+          "velocity_error_mps": 0.0746043174651988,
+          "velocity_residual_mps": [
+            0.015034691596156335,
+            -0.07300451088121918,
+            0.0031786198342338423
+          ],
+          "velocity_rtn_mps": [
+            -0.06734117961118745,
+            0.03179490627159201,
+            0.004478129989475307
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 1944000.0,
+          "actual_epoch_utc": "1979-02-23T12:00:00.000",
+          "checkpoint": "mid_arc",
+          "position_error_km": 133.29845960695147,
+          "position_residual_km": [
+            30.7000966796875,
+            -79.67827600097657,
+            102.35895530414581
+          ],
+          "position_rtn_km": [
+            -80.99869310550297,
+            21.52294472623017,
+            103.65545764260685
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 1944000,
+          "velocity_error_mps": 0.5662241198813305,
+          "velocity_residual_mps": [
+            0.12930202858660778,
+            -0.24405000318165548,
+            0.4942978204340065
+          ],
+          "velocity_rtn_mps": [
+            -0.26744898964137553,
+            0.034270807306313204,
+            0.497901901624977
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 2592000.0,
+          "actual_epoch_utc": "1979-03-02T23:59:59.999",
+          "checkpoint": "late_approach",
+          "position_error_km": 555.324392928873,
+          "position_residual_km": [
+            146.4022026977539,
+            -346.00243798828126,
+            408.94240344238284
+          ],
+          "position_rtn_km": [
+            -359.5127940600273,
+            81.86222831585216,
+            415.25210157702617
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 2592000,
+          "velocity_error_mps": 1.0137986640456105,
+          "velocity_residual_mps": [
+            0.3471576180163538,
+            -0.8761840830929941,
+            0.3735917183348221
+          ],
+          "velocity_rtn_mps": [
+            -0.9029609206099696,
+            0.24521894332422134,
+            0.39027807638504747
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 2808300.0,
+          "actual_epoch_utc": "1979-03-05T12:04:59.999",
+          "checkpoint": "closest_approach",
+          "position_error_km": 1715.7951833151974,
+          "position_residual_km": [
+            1594.010477722168,
+            -630.5286495361328,
+            74.27873258018494
+          ],
+          "position_rtn_km": [
+            -1470.0063568580767,
+            -876.0443106838172,
+            124.8230251315526
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 2808286.794,
+          "velocity_error_mps": 81.4804875393181,
+          "velocity_residual_mps": [
+            53.63830952493299,
+            57.48430430533335,
+            -21.390567067852317
+          ],
+          "velocity_rtn_mps": [
+            12.708054810496831,
+            -78.35443889510714,
+            -18.38904831717236
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3888000.0,
+          "actual_epoch_utc": "1979-03-17T23:59:59.999",
+          "checkpoint": "end",
+          "position_error_km": 36318.38622615711,
+          "position_residual_km": [
+            3315.9782567138673,
+            26315.409251220703,
+            -24809.85091075897
+          ],
+          "position_rtn_km": [
+            17919.237610608205,
+            -20322.36421564903,
+            -24185.27680663157
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 3888000,
+          "velocity_error_mps": 29.495496278972535,
+          "velocity_residual_mps": [
+            3.32205650031392,
+            22.040552026715886,
+            -19.317409446124884
+          ],
+          "velocity_rtn_mps": [
+            14.679532963320957,
+            -17.379288789444356,
+            -18.773809786368613
+          ]
+        }
+      ]
+    },
+    {
+      "case": "v2_jupiter",
+      "chapter": 1,
+      "timestep_s": 100,
+      "truth_kernel": "vgr2_jup230.bsp",
+      "truth_kernel_sha256": "9c00be3c83915f6c1fd8448d9266420e3c462e9d78e4c32b17145dac81529d5a",
+      "initial_state": {
+        "epoch_utc": "1979-06-05T00:00:00",
+        "frame": "ECLIPJ2000",
+        "observer": "SUN",
+        "position_m": [
+          -557519270752.5472,
+          536977111308.3644,
+          12844713490.611553
+        ],
+        "probe": "voyager2",
+        "velocity_mps": [
+          -9991.286216251581,
+          -448.5100717712319,
+          -564.4276098688595
+        ]
+      },
+      "active_segments": [
+        {
+          "center": 5,
+          "epoch": "initialization",
+          "file": "vgr2_jup230.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager2",
+          "segment_id": "vgr2.jup230.nio",
+          "segment_type": 1,
+          "target": -32
+        },
+        {
+          "center": 5,
+          "epoch": "scoring_end",
+          "file": "vgr2_jup230.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager2",
+          "segment_id": "vgr2.jup230.nio",
+          "segment_type": 1,
+          "target": -32
+        }
+      ],
+      "metrics": [
+        {
+          "actual_elapsed_seconds": 0.0,
+          "actual_epoch_utc": "1979-06-05T00:00:00",
+          "checkpoint": "start",
+          "position_error_km": 0.0,
+          "position_residual_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "position_rtn_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 0.0,
+          "velocity_error_mps": 0.0,
+          "velocity_residual_mps": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "velocity_rtn_mps": [
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 1728000.0,
+          "actual_epoch_utc": "1979-06-25T00:00:00.001",
+          "checkpoint": "clean_approach",
+          "position_error_km": 227.3244984958045,
+          "position_residual_km": [
+            -187.3810606689453,
+            128.35812335205077,
+            9.431748962402343
+          ],
+          "position_rtn_km": [
+            224.6814693336056,
+            33.18408822839637,
+            9.668569848280205
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 1728000,
+          "velocity_error_mps": 0.25236194333514805,
+          "velocity_residual_mps": [
+            -0.21854895406977448,
+            0.12548247424201975,
+            0.013306155605619097
+          ],
+          "velocity_rtn_mps": [
+            0.24555936268601686,
+            0.05603699926423374,
+            0.015716378545644945
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 1944000.0,
+          "actual_epoch_utc": "1979-06-27T12:00:00.001",
+          "checkpoint": "mid_arc",
+          "position_error_km": 283.60912246192146,
+          "position_residual_km": [
+            -236.8951572265625,
+            155.42126123046876,
+            12.61151790046692
+          ],
+          "position_rtn_km": [
+            279.4719987563666,
+            46.273127924083234,
+            13.723479400793536
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 1944000,
+          "velocity_error_mps": 0.26952228811048573,
+          "velocity_residual_mps": [
+            -0.23902871876271092,
+            0.12346505033588784,
+            0.016245514474007905
+          ],
+          "velocity_rtn_mps": [
+            0.25932799117920324,
+            0.07053126757025102,
+            0.02041070979178338
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 2592000.0,
+          "actual_epoch_utc": "1979-07-05T00:00:00.001",
+          "checkpoint": "late_approach",
+          "position_error_km": 632.2747774479303,
+          "position_residual_km": [
+            -427.2254505615234,
+            178.74604919433594,
+            -430.46446832084655
+          ],
+          "position_rtn_km": [
+            429.25214673618825,
+            219.9254630248888,
+            -408.8358832496138
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 2592000,
+          "velocity_error_mps": 0.7133210654419028,
+          "velocity_residual_mps": [
+            -0.2684617647992127,
+            0.004058948304646037,
+            -0.6608621249419002
+          ],
+          "velocity_rtn_mps": [
+            0.19089113654268464,
+            0.2739237102792942,
+            -0.6303596729958529
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3018500.0,
+          "actual_epoch_utc": "1979-07-09T22:28:20.001",
+          "checkpoint": "closest_approach",
+          "position_error_km": 1239.1710824141016,
+          "position_residual_km": [
+            -273.69750427246095,
+            602.7068139648437,
+            -1047.5586590003968
+          ],
+          "position_rtn_km": [
+            594.3334237935826,
+            -238.98642177960508,
+            -1060.7536203370291
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 3018532.806,
+          "velocity_error_mps": 16.36105207448002,
+          "velocity_residual_mps": [
+            4.781956405175151,
+            14.006212689365384,
+            -6.9744479367984
+          ],
+          "velocity_rtn_mps": [
+            5.826853558288307,
+            -13.419926021188424,
+            -7.323755060072648
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3888000.0,
+          "actual_epoch_utc": "1979-07-20T00:00:00.001",
+          "checkpoint": "end",
+          "position_error_km": 60199.09698760914,
+          "position_residual_km": [
+            -35440.72720397949,
+            48554.36851629639,
+            3218.6070528049468
+          ],
+          "position_rtn_km": [
+            58678.932629845796,
+            -13115.930263322427,
+            2947.2897504745024
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 3888000,
+          "velocity_error_mps": 75.94274665925636,
+          "velocity_residual_mps": [
+            -55.33663772982254,
+            51.659854786139476,
+            6.034624958135737
+          ],
+          "velocity_rtn_mps": [
+            75.74226235568652,
+            -2.256848971290483,
+            5.031609694236065
+          ]
+        }
+      ]
+    },
+    {
+      "case": "v2_jupiter",
+      "chapter": 2,
+      "timestep_s": 100,
+      "truth_kernel": "vgr2_jup230.bsp",
+      "truth_kernel_sha256": "9c00be3c83915f6c1fd8448d9266420e3c462e9d78e4c32b17145dac81529d5a",
+      "initial_state": {
+        "epoch_utc": "1979-06-05T00:00:00",
+        "frame": "ECLIPJ2000",
+        "observer": "SUN",
+        "position_m": [
+          -557519270752.5472,
+          536977111308.3644,
+          12844713490.611553
+        ],
+        "probe": "voyager2",
+        "velocity_mps": [
+          -9991.286216251581,
+          -448.5100717712319,
+          -564.4276098688595
+        ]
+      },
+      "active_segments": [
+        {
+          "center": 5,
+          "epoch": "initialization",
+          "file": "vgr2_jup230.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager2",
+          "segment_id": "vgr2.jup230.nio",
+          "segment_type": 1,
+          "target": -32
+        },
+        {
+          "center": 5,
+          "epoch": "scoring_end",
+          "file": "vgr2_jup230.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager2",
+          "segment_id": "vgr2.jup230.nio",
+          "segment_type": 1,
+          "target": -32
+        }
+      ],
+      "metrics": [
+        {
+          "actual_elapsed_seconds": 0.0,
+          "actual_epoch_utc": "1979-06-05T00:00:00",
+          "checkpoint": "start",
+          "position_error_km": 0.0,
+          "position_residual_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "position_rtn_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 0.0,
+          "velocity_error_mps": 0.0,
+          "velocity_residual_mps": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "velocity_rtn_mps": [
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 1728000.0,
+          "actual_epoch_utc": "1979-06-25T00:00:00.001",
+          "checkpoint": "clean_approach",
+          "position_error_km": 99.3662586000908,
+          "position_residual_km": [
+            29.851629028320314,
+            -94.62938165283204,
+            5.273871494293213
+          ],
+          "position_rtn_km": [
+            -86.30431479162101,
+            47.81875866009735,
+            11.772209509530043
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 1728000,
+          "velocity_error_mps": 0.1421673163113676,
+          "velocity_residual_mps": [
+            0.03448856917566445,
+            -0.13760143607285613,
+            0.009377057858387161
+          ],
+          "velocity_rtn_mps": [
+            -0.11895103078323246,
+            0.07541174361730137,
+            0.019371810121445596
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 1944000.0,
+          "actual_epoch_utc": "1979-06-27T12:00:00.001",
+          "checkpoint": "mid_arc",
+          "position_error_km": 134.5345322017574,
+          "position_residual_km": [
+            38.419160888671875,
+            -128.70447155761718,
+            7.6594668502807615
+          ],
+          "position_rtn_km": [
+            -115.65601238225621,
+            66.60793857772053,
+            16.929550289588228
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 1944000,
+          "velocity_error_mps": 0.1868577990297835,
+          "velocity_residual_mps": [
+            0.045703056439379,
+            -0.1807174079151821,
+            0.012972515822752939
+          ],
+          "velocity_rtn_mps": [
+            -0.15632783280424842,
+            0.09886604226639018,
+            0.026513231330078484
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 2592000.0,
+          "actual_epoch_utc": "1979-07-05T00:00:00.001",
+          "checkpoint": "late_approach",
+          "position_error_km": 575.5358026213137,
+          "position_residual_km": [
+            65.78968310546875,
+            -373.1789448242188,
+            -433.1866258735657
+          ],
+          "position_rtn_km": [
+            -307.2337553246341,
+            290.2775006573081,
+            -390.62495094429033
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 2592000,
+          "velocity_error_mps": 0.9028379473543827,
+          "velocity_residual_mps": [
+            0.13766589051738265,
+            -0.6228570668763496,
+            -0.6389159068401113
+          ],
+          "velocity_rtn_mps": [
+            -0.5320947642521381,
+            0.4534891148186649,
+            -0.571261011954711
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3018500.0,
+          "actual_epoch_utc": "1979-07-09T22:28:20.001",
+          "checkpoint": "closest_approach",
+          "position_error_km": 2157.119245599024,
+          "position_residual_km": [
+            1811.9482944335937,
+            -425.69033502197266,
+            -1090.3185574417114
+          ],
+          "position_rtn_km": [
+            -1639.1939254508773,
+            -887.1140574362803,
+            -1085.9260396535237
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 3018532.806,
+          "velocity_error_mps": 44.596499015695564,
+          "velocity_residual_mps": [
+            27.514301883376902,
+            33.602549454131804,
+            -10.133093629783748
+          ],
+          "velocity_rtn_mps": [
+            2.2320140304864196,
+            -43.153993406503176,
+            -11.02717964377686
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3888000.0,
+          "actual_epoch_utc": "1979-07-20T00:00:00.001",
+          "checkpoint": "end",
+          "position_error_km": 62618.40250361525,
+          "position_residual_km": [
+            -33782.6372557373,
+            52642.67045892334,
+            2923.525116231918
+          ],
+          "position_rtn_km": [
+            60116.55794192744,
+            -17295.271548010718,
+            2817.3348044241598
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 3888000,
+          "velocity_error_mps": 78.18461705275998,
+          "velocity_residual_mps": [
+            -55.476660277152405,
+            54.76943101102188,
+            5.9568393388659615
+          ],
+          "velocity_rtn_mps": [
+            77.89274061243007,
+            -4.508622781501466,
+            5.022710840326879
+          ]
+        }
+      ]
+    },
+    {
+      "case": "v2_jupiter",
+      "chapter": 2,
+      "timestep_s": 3600,
+      "truth_kernel": "vgr2_jup230.bsp",
+      "truth_kernel_sha256": "9c00be3c83915f6c1fd8448d9266420e3c462e9d78e4c32b17145dac81529d5a",
+      "initial_state": {
+        "epoch_utc": "1979-06-05T00:00:00",
+        "frame": "ECLIPJ2000",
+        "observer": "SUN",
+        "position_m": [
+          -557519270752.5472,
+          536977111308.3644,
+          12844713490.611553
+        ],
+        "probe": "voyager2",
+        "velocity_mps": [
+          -9991.286216251581,
+          -448.5100717712319,
+          -564.4276098688595
+        ]
+      },
+      "active_segments": [
+        {
+          "center": 5,
+          "epoch": "initialization",
+          "file": "vgr2_jup230.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager2",
+          "segment_id": "vgr2.jup230.nio",
+          "segment_type": 1,
+          "target": -32
+        },
+        {
+          "center": 5,
+          "epoch": "scoring_end",
+          "file": "vgr2_jup230.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager2",
+          "segment_id": "vgr2.jup230.nio",
+          "segment_type": 1,
+          "target": -32
+        }
+      ],
+      "metrics": [
+        {
+          "actual_elapsed_seconds": 0.0,
+          "actual_epoch_utc": "1979-06-05T00:00:00",
+          "checkpoint": "start",
+          "position_error_km": 0.0,
+          "position_residual_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "position_rtn_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 0.0,
+          "velocity_error_mps": 0.0,
+          "velocity_residual_mps": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "velocity_rtn_mps": [
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 1728000.0,
+          "actual_epoch_utc": "1979-06-25T00:00:00.001",
+          "checkpoint": "clean_approach",
+          "position_error_km": 99.39163294651752,
+          "position_residual_km": [
+            29.85614221191406,
+            -94.65447454833985,
+            5.276165271759033
+          ],
+          "position_rtn_km": [
+            -86.3246996022045,
+            47.833655113546094,
+            11.776433112056873
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 1728000,
+          "velocity_error_mps": 0.1422332482873323,
+          "velocity_residual_mps": [
+            0.034500950225265115,
+            -0.13766605271544563,
+            0.009382925005979814
+          ],
+          "velocity_rtn_mps": [
+            -0.11900407914202224,
+            0.07544959174591233,
+            0.019382599704383986
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 1944000.0,
+          "actual_epoch_utc": "1979-06-27T12:00:00.001",
+          "checkpoint": "mid_arc",
+          "position_error_km": 134.57973533752568,
+          "position_residual_km": [
+            38.427537231445314,
+            -128.74898083496095,
+            7.663516151428222
+          ],
+          "position_rtn_km": [
+            -115.6923933328019,
+            66.63414550454223,
+            16.93711726729794
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 1944000,
+          "velocity_error_mps": 0.18698404859349194,
+          "velocity_residual_mps": [
+            0.04572843247660785,
+            -0.18084073237469056,
+            0.012983620674958729
+          ],
+          "velocity_rtn_mps": [
+            -0.1564302241553129,
+            0.09893719888532891,
+            0.026533941958494824
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 2592000.0,
+          "actual_epoch_utc": "1979-07-05T00:00:00.001",
+          "checkpoint": "late_approach",
+          "position_error_km": 575.8283974447955,
+          "position_residual_km": [
+            65.92144860839844,
+            -373.6539967041016,
+            -433.1459299869537
+          ],
+          "position_rtn_km": [
+            -307.65178579664655,
+            290.5282083375903,
+            -390.5407560807521
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 2592000,
+          "velocity_error_mps": 0.9046191310625077,
+          "velocity_residual_mps": [
+            0.13855581663119665,
+            -0.6254561837035908,
+            -0.6387038595694321
+          ],
+          "velocity_rtn_mps": [
+            -0.5345064007809808,
+            0.4547488688982729,
+            -0.5708258456343664
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3016800.0,
+          "actual_epoch_utc": "1979-07-09T22:00:00.001",
+          "checkpoint": "closest_approach",
+          "position_error_km": 2362.775769978434,
+          "position_residual_km": [
+            2040.6054243164062,
+            -477.6758278808594,
+            -1091.0841603221893
+          ],
+          "position_rtn_km": [
+            -1842.9806563822629,
+            -998.6217952173819,
+            -1090.3605594090413
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 3018532.806,
+          "velocity_error_mps": 55.08141228136623,
+          "velocity_residual_mps": [
+            38.525699435507704,
+            37.561989940594685,
+            -11.782587730096779
+          ],
+          "velocity_rtn_mps": [
+            -3.242685873402071,
+            -53.41989086620051,
+            -13.02928344459155
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3888000.0,
+          "actual_epoch_utc": "1979-07-20T00:00:00.001",
+          "checkpoint": "end",
+          "position_error_km": 76072.82415395082,
+          "position_residual_km": [
+            -34996.96985424805,
+            67529.01696899414,
+            1455.521549161911
+          ],
+          "position_rtn_km": [
+            70804.96502921345,
+            -27766.55068689475,
+            1658.3621202510026
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 3888000,
+          "velocity_error_mps": 91.43025330366157,
+          "velocity_residual_mps": [
+            -59.188810661922616,
+            69.52999180925508,
+            4.664348893866531
+          ],
+          "velocity_rtn_mps": [
+            90.38142208948969,
+            -13.23645128099215,
+            3.9352404931773357
+          ]
+        }
+      ]
+    },
+    {
+      "case": "v2_jupiter",
+      "chapter": 2,
+      "timestep_s": 900,
+      "truth_kernel": "vgr2_jup230.bsp",
+      "truth_kernel_sha256": "9c00be3c83915f6c1fd8448d9266420e3c462e9d78e4c32b17145dac81529d5a",
+      "initial_state": {
+        "epoch_utc": "1979-06-05T00:00:00",
+        "frame": "ECLIPJ2000",
+        "observer": "SUN",
+        "position_m": [
+          -557519270752.5472,
+          536977111308.3644,
+          12844713490.611553
+        ],
+        "probe": "voyager2",
+        "velocity_mps": [
+          -9991.286216251581,
+          -448.5100717712319,
+          -564.4276098688595
+        ]
+      },
+      "active_segments": [
+        {
+          "center": 5,
+          "epoch": "initialization",
+          "file": "vgr2_jup230.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager2",
+          "segment_id": "vgr2.jup230.nio",
+          "segment_type": 1,
+          "target": -32
+        },
+        {
+          "center": 5,
+          "epoch": "scoring_end",
+          "file": "vgr2_jup230.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager2",
+          "segment_id": "vgr2.jup230.nio",
+          "segment_type": 1,
+          "target": -32
+        }
+      ],
+      "metrics": [
+        {
+          "actual_elapsed_seconds": 0.0,
+          "actual_epoch_utc": "1979-06-05T00:00:00",
+          "checkpoint": "start",
+          "position_error_km": 0.0,
+          "position_residual_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "position_rtn_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 0.0,
+          "velocity_error_mps": 0.0,
+          "velocity_residual_mps": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "velocity_rtn_mps": [
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 1728000.0,
+          "actual_epoch_utc": "1979-06-25T00:00:00.001",
+          "checkpoint": "clean_approach",
+          "position_error_km": 99.3678297243014,
+          "position_residual_km": [
+            29.851908081054688,
+            -94.63093548583984,
+            5.2740133781433105
+          ],
+          "position_rtn_km": [
+            -86.30557678151128,
+            47.81968139725543,
+            11.772470921323295
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 1728000,
+          "velocity_error_mps": 0.14217138806434707,
+          "velocity_residual_mps": [
+            0.03448933342224336,
+            -0.1376054266881397,
+            0.009377420231999167
+          ],
+          "velocity_rtn_mps": [
+            -0.11895430667799932,
+            0.0754140813135763,
+            0.019372476520284062
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 1944000.0,
+          "actual_epoch_utc": "1979-06-27T12:00:00.001",
+          "checkpoint": "mid_arc",
+          "position_error_km": 134.53733113176108,
+          "position_residual_km": [
+            38.41968017578125,
+            -128.70722735595703,
+            7.659717330932617
+          ],
+          "position_rtn_km": [
+            -115.65826540415874,
+            66.60956075876754,
+            16.930018525753272
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 1944000,
+          "velocity_error_mps": 0.18686559534145783,
+          "velocity_residual_mps": [
+            0.04570462262927322,
+            -0.180725023809984,
+            0.012973201667819012
+          ],
+          "velocity_rtn_mps": [
+            -0.15633415531196304,
+            0.09887043714600846,
+            0.026514510438053748
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 2592000.0,
+          "actual_epoch_utc": "1979-07-05T00:00:00.001",
+          "checkpoint": "late_approach",
+          "position_error_km": 575.5539248882453,
+          "position_residual_km": [
+            65.79784399414062,
+            -373.2083815307617,
+            -433.18410420417786
+          ],
+          "position_rtn_km": [
+            -307.25965574856866,
+            290.2930385103944,
+            -390.6197334952979
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 2592000,
+          "velocity_error_mps": 0.9029477483747107,
+          "velocity_residual_mps": [
+            0.1377207449040725,
+            -0.6230175207231241,
+            -0.63890281075453
+          ],
+          "velocity_rtn_mps": [
+            -0.5322435820892287,
+            0.45356694025064503,
+            -0.5712341344242778
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3018600.0,
+          "actual_epoch_utc": "1979-07-09T22:30:00.001",
+          "checkpoint": "closest_approach",
+          "position_error_km": 2175.524870619698,
+          "position_residual_km": [
+            1833.3960369873048,
+            -421.5987777099609,
+            -1092.6215744152069
+          ],
+          "position_rtn_km": [
+            -1652.2927640495554,
+            -904.8164228126087,
+            -1088.1839575930753
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 3018532.806,
+          "velocity_error_mps": 45.38609724662366,
+          "velocity_residual_mps": [
+            28.21677687067131,
+            34.055493821843356,
+            -10.194835303285563
+          ],
+          "velocity_rtn_mps": [
+            2.018354195673336,
+            -43.963606629004545,
+            -11.091679845313562
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3888000.0,
+          "actual_epoch_utc": "1979-07-20T00:00:00.001",
+          "checkpoint": "end",
+          "position_error_km": 63386.847725970096,
+          "position_residual_km": [
+            -33817.84715979004,
+            53537.09494329834,
+            2832.8683599243163
+          ],
+          "position_rtn_km": [
+            60730.298289134305,
+            -17949.333637664655,
+            2746.77198032367
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 3888000,
+          "velocity_error_mps": 78.9193997541381,
+          "velocity_residual_mps": [
+            -55.64767913380638,
+            55.65138302468222,
+            5.87631108898222
+          ],
+          "velocity_rtn_mps": [
+            78.60066538831443,
+            -5.063625810020475,
+            4.956485824026875
+          ]
+        }
+      ]
+    },
+    {
+      "case": "v2_jupiter",
+      "chapter": 2,
+      "timestep_s": 300,
+      "truth_kernel": "vgr2_jup230.bsp",
+      "truth_kernel_sha256": "9c00be3c83915f6c1fd8448d9266420e3c462e9d78e4c32b17145dac81529d5a",
+      "initial_state": {
+        "epoch_utc": "1979-06-05T00:00:00",
+        "frame": "ECLIPJ2000",
+        "observer": "SUN",
+        "position_m": [
+          -557519270752.5472,
+          536977111308.3644,
+          12844713490.611553
+        ],
+        "probe": "voyager2",
+        "velocity_mps": [
+          -9991.286216251581,
+          -448.5100717712319,
+          -564.4276098688595
+        ]
+      },
+      "active_segments": [
+        {
+          "center": 5,
+          "epoch": "initialization",
+          "file": "vgr2_jup230.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager2",
+          "segment_id": "vgr2.jup230.nio",
+          "segment_type": 1,
+          "target": -32
+        },
+        {
+          "center": 5,
+          "epoch": "scoring_end",
+          "file": "vgr2_jup230.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager2",
+          "segment_id": "vgr2.jup230.nio",
+          "segment_type": 1,
+          "target": -32
+        }
+      ],
+      "metrics": [
+        {
+          "actual_elapsed_seconds": 0.0,
+          "actual_epoch_utc": "1979-06-05T00:00:00",
+          "checkpoint": "start",
+          "position_error_km": 0.0,
+          "position_residual_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "position_rtn_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 0.0,
+          "velocity_error_mps": 0.0,
+          "velocity_residual_mps": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "velocity_rtn_mps": [
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 1728000.0,
+          "actual_epoch_utc": "1979-06-25T00:00:00.001",
+          "checkpoint": "clean_approach",
+          "position_error_km": 99.36641875212455,
+          "position_residual_km": [
+            29.85165869140625,
+            -94.62953967285156,
+            5.273885692596435
+          ],
+          "position_rtn_km": [
+            -86.30444407429437,
+            47.818851651582925,
+            11.772235784823394
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 1728000,
+          "velocity_error_mps": 0.14216772354626353,
+          "velocity_residual_mps": [
+            0.03448864544589014,
+            -0.13760183523385194,
+            0.009377094108003803
+          ],
+          "velocity_rtn_mps": [
+            -0.11895135832751041,
+            0.07541197756274917,
+            0.019371876791949103
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 1944000.0,
+          "actual_epoch_utc": "1979-06-27T12:00:00.001",
+          "checkpoint": "mid_arc",
+          "position_error_km": 134.53481631864844,
+          "position_residual_km": [
+            38.419216796875,
+            -128.70475036621093,
+            7.659491874694824
+          ],
+          "position_rtn_km": [
+            -115.65624279713077,
+            66.60810044641117,
+            16.929597126464596
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 1944000,
+          "velocity_error_mps": 0.18685857877724654,
+          "velocity_residual_mps": [
+            0.04570321284882084,
+            -0.18071816967619014,
+            0.012972584431622636
+          ],
+          "velocity_rtn_mps": [
+            -0.15632846501802844,
+            0.09886648201831699,
+            0.02651335929453858
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 2592000.0,
+          "actual_epoch_utc": "1979-07-05T00:00:00.001",
+          "checkpoint": "late_approach",
+          "position_error_km": 575.5376189669606,
+          "position_residual_km": [
+            65.79050415039063,
+            -373.1818943481445,
+            -433.1863734474182
+          ],
+          "position_rtn_km": [
+            -307.2363529730498,
+            290.2790553295366,
+            -390.6244286971434
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 2592000,
+          "velocity_error_mps": 0.9028489256317659,
+          "velocity_residual_mps": [
+            0.1376713729769108,
+            -0.6228731116166273,
+            -0.6389145971114658
+          ],
+          "velocity_rtn_mps": [
+            -0.5321096434059239,
+            0.4534968988764172,
+            -0.5712583238941266
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3018600.0,
+          "actual_epoch_utc": "1979-07-09T22:30:00.001",
+          "checkpoint": "closest_approach",
+          "position_error_km": 2160.912530916535,
+          "position_residual_km": [
+            1816.5784645996093,
+            -422.2564765625,
+            -1091.4600845775603
+          ],
+          "position_rtn_km": [
+            -1640.3107689285407,
+            -893.0041746507089,
+            -1086.9531230304146
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 3018532.806,
+          "velocity_error_mps": 44.72416994065243,
+          "velocity_residual_mps": [
+            27.577601630480785,
+            33.72440466937769,
+            -10.118883084951534
+          ],
+          "velocity_rtn_mps": [
+            2.2676431863796216,
+            -43.289500991712245,
+            -11.005829144056758
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3888000.0,
+          "actual_epoch_utc": "1979-07-20T00:00:00.001",
+          "checkpoint": "end",
+          "position_error_km": 62694.080883898976,
+          "position_residual_km": [
+            -33785.270388427736,
+            52731.48170581055,
+            2914.467321392059
+          ],
+          "position_rtn_km": [
+            60176.84831977882,
+            -17360.785641932067,
+            2810.3071131254974
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 3888000,
+          "velocity_error_mps": 78.2564994960942,
+          "velocity_residual_mps": [
+            -55.49245751166018,
+            54.85689488647222,
+            5.948777699100674
+          ],
+          "velocity_rtn_mps": [
+            77.96206952179199,
+            -4.564430174444976,
+            5.016114676128935
+          ]
+        }
+      ]
+    },
+    {
+      "case": "v1_saturn",
+      "chapter": 1,
+      "timestep_s": 100,
+      "truth_kernel": "vgr1_sat337.bsp",
+      "truth_kernel_sha256": "f451f9f095bc4ad175cde701367cbf1ccc061dd706ad0008cda75fd939d94efa",
+      "initial_state": {
+        "epoch_utc": "1980-10-07T00:00:00",
+        "frame": "ECLIPJ2000",
+        "observer": "SUN",
+        "position_m": [
+          -1372875711496.1628,
+          -11404332522.42913,
+          54486999660.03995
+        ],
+        "probe": "voyager1",
+        "velocity_mps": [
+          -15102.091676444903,
+          -13431.496491436345,
+          826.9305078636578
+        ]
+      },
+      "active_segments": [
+        {
+          "center": 6,
+          "epoch": "initialization",
+          "file": "vgr1_sat337.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager1",
+          "segment_id": "vgr1.sat337.nio",
+          "segment_type": 1,
+          "target": -31
+        },
+        {
+          "center": 6,
+          "epoch": "scoring_end",
+          "file": "vgr1_sat337.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager1",
+          "segment_id": "vgr1.sat337.nio",
+          "segment_type": 1,
+          "target": -31
+        }
+      ],
+      "metrics": [
+        {
+          "actual_elapsed_seconds": 0.0,
+          "actual_epoch_utc": "1980-10-07T00:00:00",
+          "checkpoint": "start",
+          "position_error_km": 0.0,
+          "position_residual_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "position_rtn_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 0.0,
+          "velocity_error_mps": 0.0,
+          "velocity_residual_mps": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "velocity_rtn_mps": [
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 86400.0,
+          "actual_epoch_utc": "1980-10-08T00:00:00.000",
+          "checkpoint": "early_approach",
+          "position_error_km": 0.7285002867284305,
+          "position_residual_km": [
+            -0.704886474609375,
+            0.1839754695892334,
+            -0.0008673324584960938
+          ],
+          "position_rtn_km": [
+            0.7025869900138991,
+            -0.19086702870640143,
+            -0.025572770272395278
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 86400,
+          "velocity_error_mps": 0.01701144422259732,
+          "velocity_residual_mps": [
+            -0.01647045951904147,
+            0.004255935353285167,
+            -1.4561552575287351e-05
+          ],
+          "velocity_rtn_mps": [
+            0.01641734733245632,
+            -0.004416877040378543,
+            -0.0005925692484477209
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 259200.0,
+          "actual_epoch_utc": "1980-10-10T00:00:00.000",
+          "checkpoint": "clean_approach",
+          "position_error_km": 6.509332089644968,
+          "position_residual_km": [
+            -6.293765869140625,
+            1.6612715034484864,
+            -0.009614028930664063
+          ],
+          "position_rtn_km": [
+            6.270109055213419,
+            -1.7332891447524712,
+            -0.22988133829356744
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 259200,
+          "velocity_error_mps": 0.04981617219810787,
+          "velocity_residual_mps": [
+            -0.04812910779401136,
+            0.012854257684011827,
+            -8.974863226285379e-05
+          ],
+          "velocity_rtn_mps": [
+            0.04794593327553093,
+            -0.013405223802936725,
+            -0.0017715726355556846
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 1814400.0,
+          "actual_epoch_utc": "1980-10-28T00:00:00.000",
+          "checkpoint": "mid_arc",
+          "position_error_km": 2333.1664701548398,
+          "position_residual_km": [
+            1701.2428273925782,
+            -1289.8308847198487,
+            941.1561552276611
+          ],
+          "position_rtn_km": [
+            -1628.818579863089,
+            1348.876641509134,
+            985.4682223890446
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 1814400,
+          "velocity_error_mps": 1.4522160795429924,
+          "velocity_residual_mps": [
+            1.0112053320990526,
+            -0.8287589645606204,
+            0.6321027580054306
+          ],
+          "velocity_rtn_mps": [
+            -0.9636689602310631,
+            0.8649927994846826,
+            0.6573135732738619
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3195900.0,
+          "actual_epoch_utc": "1980-11-12T23:45:00.000",
+          "checkpoint": "closest_approach",
+          "position_error_km": 6174.863920547962,
+          "position_residual_km": [
+            -1217.73195703125,
+            5399.212198028565,
+            -2737.623231704712
+          ],
+          "position_rtn_km": [
+            898.7961030388119,
+            -6098.474990339629,
+            360.1566251636686
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 3195927.463,
+          "velocity_error_mps": 388.24584032757184,
+          "velocity_residual_mps": [
+            -67.5332876452776,
+            44.80424108456282,
+            -379.692859522429
+          ],
+          "velocity_rtn_mps": [
+            50.43548569812194,
+            -234.2064997597563,
+            -305.5133545106339
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3628800.0,
+          "actual_epoch_utc": "1980-11-18T00:00:00.000",
+          "checkpoint": "end",
+          "position_error_km": 190861.73744516686,
+          "position_residual_km": [
+            -133493.05208081054,
+            -85647.72196896363,
+            -106170.97337909699
+          ],
+          "position_rtn_km": [
+            132282.65777442537,
+            -1431.3427387335723,
+            -137577.07850760003
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 3628800,
+          "velocity_error_mps": 423.11028140945564,
+          "velocity_residual_mps": [
+            -296.4169742552667,
+            -210.88612122124323,
+            -216.07020036090216
+          ],
+          "velocity_rtn_mps": [
+            295.49571624966893,
+            25.093387656087092,
+            -301.78620546410866
+          ]
+        }
+      ]
+    },
+    {
+      "case": "v1_saturn",
+      "chapter": 2,
+      "timestep_s": 100,
+      "truth_kernel": "vgr1_sat337.bsp",
+      "truth_kernel_sha256": "f451f9f095bc4ad175cde701367cbf1ccc061dd706ad0008cda75fd939d94efa",
+      "initial_state": {
+        "epoch_utc": "1980-10-07T00:00:00",
+        "frame": "ECLIPJ2000",
+        "observer": "SUN",
+        "position_m": [
+          -1372875711496.1628,
+          -11404332522.42913,
+          54486999660.03995
+        ],
+        "probe": "voyager1",
+        "velocity_mps": [
+          -15102.091676444903,
+          -13431.496491436345,
+          826.9305078636578
+        ]
+      },
+      "active_segments": [
+        {
+          "center": 6,
+          "epoch": "initialization",
+          "file": "vgr1_sat337.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager1",
+          "segment_id": "vgr1.sat337.nio",
+          "segment_type": 1,
+          "target": -31
+        },
+        {
+          "center": 6,
+          "epoch": "scoring_end",
+          "file": "vgr1_sat337.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager1",
+          "segment_id": "vgr1.sat337.nio",
+          "segment_type": 1,
+          "target": -31
+        }
+      ],
+      "metrics": [
+        {
+          "actual_elapsed_seconds": 0.0,
+          "actual_epoch_utc": "1980-10-07T00:00:00",
+          "checkpoint": "start",
+          "position_error_km": 0.0,
+          "position_residual_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "position_rtn_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 0.0,
+          "velocity_error_mps": 0.0,
+          "velocity_residual_mps": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "velocity_rtn_mps": [
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 86400.0,
+          "actual_epoch_utc": "1980-10-08T00:00:00.000",
+          "checkpoint": "early_approach",
+          "position_error_km": 0.01829887537942534,
+          "position_residual_km": [
+            -6.8603515625e-05,
+            -0.0008376617431640625,
+            -0.018279563903808593
+          ],
+          "position_rtn_km": [
+            -0.0006489439301598693,
+            0.0005313575027805106,
+            -0.01827964362703733
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 86400,
+          "velocity_error_mps": 0.00044353865510765844,
+          "velocity_residual_mps": [
+            -0.00014645003830082715,
+            -2.3732798581477255e-05,
+            -0.00041799004668519046
+          ],
+          "velocity_rtn_mps": [
+            0.00012996395741950506,
+            1.5307226326234468e-05,
+            -0.00042379428638051383
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 259200.0,
+          "actual_epoch_utc": "1980-10-10T00:00:00.000",
+          "checkpoint": "clean_approach",
+          "position_error_km": 0.17851994787141812,
+          "position_residual_km": [
+            0.0632158203125,
+            -0.004358131408691407,
+            -0.16689559173583984
+          ],
+          "position_rtn_km": [
+            -0.06974054424837334,
+            0.00230419501692363,
+            -0.1643177378169457
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 259200,
+          "velocity_error_mps": 0.0016456318657696808,
+          "velocity_residual_mps": [
+            0.0010003367660829099,
+            -1.0318954082322307e-05,
+            -0.001306646130842637
+          ],
+          "velocity_rtn_mps": [
+            -0.0010512488480081703,
+            4.098842550662187e-08,
+            -0.0012660885022454174
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 1814400.0,
+          "actual_epoch_utc": "1980-10-28T00:00:00.000",
+          "checkpoint": "mid_arc",
+          "position_error_km": 2613.1227980419103,
+          "position_residual_km": [
+            2018.68059375,
+            -1372.0532083282471,
+            933.1716945877075
+          ],
+          "position_rtn_km": [
+            -1944.1196244483556,
+            1439.2440113019575,
+            988.6285042484959
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 1814400,
+          "velocity_error_mps": 1.760014959745756,
+          "velocity_residual_mps": [
+            1.365113413079598,
+            -0.9197331907889748,
+            0.623064110441419
+          ],
+          "velocity_rtn_mps": [
+            -1.3152180281819301,
+            0.965045984264592,
+            0.6607120743023206
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3195900.0,
+          "actual_epoch_utc": "1980-11-12T23:45:00.000",
+          "checkpoint": "closest_approach",
+          "position_error_km": 6496.068696052292,
+          "position_residual_km": [
+            -76.16209741210938,
+            5629.194355949402,
+            -3241.184774383545
+          ],
+          "position_rtn_km": [
+            -270.08378500648746,
+            -6490.172000478943,
+            60.25493428979943
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 3195927.463,
+          "velocity_error_mps": 423.6026512927911,
+          "velocity_residual_mps": [
+            -104.27027906073636,
+            67.45125576237479,
+            -404.990423569443
+          ],
+          "velocity_rtn_mps": [
+            85.23002345172108,
+            -268.46280578405316,
+            -316.39021981606015
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3628800.0,
+          "actual_epoch_utc": "1980-11-18T00:00:00.000",
+          "checkpoint": "end",
+          "position_error_km": 182531.9607643122,
+          "position_residual_km": [
+            -130443.44122607422,
+            -78254.4068899765,
+            -100889.4104644394
+          ],
+          "position_rtn_km": [
+            129150.273872503,
+            -4106.980920132947,
+            -128923.45080257334
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 3628800,
+          "velocity_error_mps": 404.6505182557545,
+          "velocity_residual_mps": [
+            -290.6281339069046,
+            -194.5253907346123,
+            -203.56129805537057
+          ],
+          "velocity_rtn_mps": [
+            289.5580384898991,
+            19.596444408720938,
+            -281.9825591008577
+          ]
+        }
+      ]
+    },
+    {
+      "case": "v1_saturn",
+      "chapter": 2,
+      "timestep_s": 3600,
+      "truth_kernel": "vgr1_sat337.bsp",
+      "truth_kernel_sha256": "f451f9f095bc4ad175cde701367cbf1ccc061dd706ad0008cda75fd939d94efa",
+      "initial_state": {
+        "epoch_utc": "1980-10-07T00:00:00",
+        "frame": "ECLIPJ2000",
+        "observer": "SUN",
+        "position_m": [
+          -1372875711496.1628,
+          -11404332522.42913,
+          54486999660.03995
+        ],
+        "probe": "voyager1",
+        "velocity_mps": [
+          -15102.091676444903,
+          -13431.496491436345,
+          826.9305078636578
+        ]
+      },
+      "active_segments": [
+        {
+          "center": 6,
+          "epoch": "initialization",
+          "file": "vgr1_sat337.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager1",
+          "segment_id": "vgr1.sat337.nio",
+          "segment_type": 1,
+          "target": -31
+        },
+        {
+          "center": 6,
+          "epoch": "scoring_end",
+          "file": "vgr1_sat337.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager1",
+          "segment_id": "vgr1.sat337.nio",
+          "segment_type": 1,
+          "target": -31
+        }
+      ],
+      "metrics": [
+        {
+          "actual_elapsed_seconds": 0.0,
+          "actual_epoch_utc": "1980-10-07T00:00:00",
+          "checkpoint": "start",
+          "position_error_km": 0.0,
+          "position_residual_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "position_rtn_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 0.0,
+          "velocity_error_mps": 0.0,
+          "velocity_residual_mps": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "velocity_rtn_mps": [
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 86400.0,
+          "actual_epoch_utc": "1980-10-08T00:00:00.000",
+          "checkpoint": "early_approach",
+          "position_error_km": 0.01829886075149874,
+          "position_residual_km": [
+            -6.9091796875e-05,
+            -0.0008376350402832031,
+            -0.01827954864501953
+          ],
+          "position_rtn_km": [
+            -0.0006484556922989837,
+            0.0005313262721769889,
+            -0.018279647217885817
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 86400,
+          "velocity_error_mps": 0.00044353839994015217,
+          "velocity_residual_mps": [
+            -0.00014644907787442207,
+            -2.3732158297207206e-05,
+            -0.00041799014877597074
+          ],
+          "velocity_rtn_mps": [
+            0.0001299629878897194,
+            1.5306593873334497e-05,
+            -0.0004237943394905646
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 259200.0,
+          "actual_epoch_utc": "1980-10-10T00:00:00.000",
+          "checkpoint": "clean_approach",
+          "position_error_km": 0.17851896850641916,
+          "position_residual_km": [
+            0.063212890625,
+            -0.004357879638671875,
+            -0.16689566040039064
+          ],
+          "position_rtn_km": [
+            -0.0697376224869502,
+            0.002303908548280386,
+            -0.16431791786614344
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 259200,
+          "velocity_error_mps": 0.001645634451312649,
+          "velocity_residual_mps": [
+            0.0010003405786846997,
+            -1.0316887710359879e-05,
+            -0.001306646484636076
+          ],
+          "velocity_rtn_mps": [
+            -0.0010512526937494844,
+            3.896032161623739e-08,
+            -0.0012660886697674965
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 1814400.0,
+          "actual_epoch_utc": "1980-10-28T00:00:00.000",
+          "checkpoint": "mid_arc",
+          "position_error_km": 2613.1228804177044,
+          "position_residual_km": [
+            2018.6807336425782,
+            -1372.053165397644,
+            933.171685760498
+          ],
+          "position_rtn_km": [
+            -1944.1197656320971,
+            1439.2439719129525,
+            988.6285016897654
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 1814400,
+          "velocity_error_mps": 1.7600152224727807,
+          "velocity_residual_mps": [
+            1.3651138390414417,
+            -0.9197330780134507,
+            0.6230640857900198
+          ],
+          "velocity_rtn_mps": [
+            -1.315218457528271,
+            0.9650458823002325,
+            0.6607120684293829
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3196800.0,
+          "actual_epoch_utc": "1980-11-13T00:00:00.000",
+          "checkpoint": "closest_approach",
+          "position_error_km": 7389.58612988897,
+          "position_residual_km": [
+            -137.59293481445312,
+            6015.959237937927,
+            -4288.972581260681
+          ],
+          "position_rtn_km": [
+            -265.83082269631,
+            -7370.10808215668,
+            -465.6436428008532
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 3195927.463,
+          "velocity_error_mps": 636.393098282673,
+          "velocity_residual_mps": [
+            -212.07841657811514,
+            107.33900956993966,
+            -590.3365631468914
+          ],
+          "velocity_rtn_mps": [
+            183.88004214656843,
+            -413.47966650123374,
+            -447.4582338409079
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3628800.0,
+          "actual_epoch_utc": "1980-11-18T00:00:00.000",
+          "checkpoint": "end",
+          "position_error_km": 288914.9685943234,
+          "position_residual_km": [
+            -238420.59457055663,
+            -84828.04740411376,
+            -139397.5664640045
+          ],
+          "position_rtn_km": [
+            235510.28440037332,
+            -28022.48211872709,
+            -164989.41031296452
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 3628800,
+          "velocity_error_mps": 642.6628605535477,
+          "velocity_residual_mps": [
+            -537.4082403989514,
+            -215.78005873915026,
+            -278.6519365385793
+          ],
+          "velocity_rtn_mps": [
+            533.4818641843714,
+            -22.443548117629323,
+            -357.64359363635793
+          ]
+        }
+      ]
+    },
+    {
+      "case": "v1_saturn",
+      "chapter": 2,
+      "timestep_s": 300,
+      "truth_kernel": "vgr1_sat337.bsp",
+      "truth_kernel_sha256": "f451f9f095bc4ad175cde701367cbf1ccc061dd706ad0008cda75fd939d94efa",
+      "initial_state": {
+        "epoch_utc": "1980-10-07T00:00:00",
+        "frame": "ECLIPJ2000",
+        "observer": "SUN",
+        "position_m": [
+          -1372875711496.1628,
+          -11404332522.42913,
+          54486999660.03995
+        ],
+        "probe": "voyager1",
+        "velocity_mps": [
+          -15102.091676444903,
+          -13431.496491436345,
+          826.9305078636578
+        ]
+      },
+      "active_segments": [
+        {
+          "center": 6,
+          "epoch": "initialization",
+          "file": "vgr1_sat337.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager1",
+          "segment_id": "vgr1.sat337.nio",
+          "segment_type": 1,
+          "target": -31
+        },
+        {
+          "center": 6,
+          "epoch": "scoring_end",
+          "file": "vgr1_sat337.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager1",
+          "segment_id": "vgr1.sat337.nio",
+          "segment_type": 1,
+          "target": -31
+        }
+      ],
+      "metrics": [
+        {
+          "actual_elapsed_seconds": 0.0,
+          "actual_epoch_utc": "1980-10-07T00:00:00",
+          "checkpoint": "start",
+          "position_error_km": 0.0,
+          "position_residual_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "position_rtn_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 0.0,
+          "velocity_error_mps": 0.0,
+          "velocity_residual_mps": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "velocity_rtn_mps": [
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 86400.0,
+          "actual_epoch_utc": "1980-10-08T00:00:00.000",
+          "checkpoint": "early_approach",
+          "position_error_km": 0.018298839024334226,
+          "position_residual_km": [
+            -6.7138671875e-05,
+            -0.0008376522064208984,
+            -0.01827953338623047
+          ],
+          "position_rtn_km": [
+            -0.0006504064361842282,
+            0.0005313628410007626,
+            -0.018279555099549635
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 86400,
+          "velocity_error_mps": 0.00044353865490303555,
+          "velocity_residual_mps": [
+            -0.00014645002738689072,
+            -2.3732804038445465e-05,
+            -0.00041799004998210876
+          ],
+          "velocity_rtn_mps": [
+            0.00012996394643368232,
+            1.5307231834096745e-05,
+            -0.0004237942893364118
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 259200.0,
+          "actual_epoch_utc": "1980-10-10T00:00:00.000",
+          "checkpoint": "clean_approach",
+          "position_error_km": 0.17851996840789613,
+          "position_residual_km": [
+            0.063215576171875,
+            -0.004358131408691407,
+            -0.1668957061767578
+          ],
+          "position_rtn_km": [
+            -0.06974030485746104,
+            0.00230419031130806,
+            -0.16431786179765698
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 259200,
+          "velocity_error_mps": 0.0016456318851244256,
+          "velocity_residual_mps": [
+            0.001000336793367751,
+            -1.0319021384930238e-05,
+            -0.0013066461337984947
+          ],
+          "velocity_rtn_mps": [
+            -0.0010512488746601879,
+            4.105597814598114e-08,
+            -0.0012660885052705698
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 1814400.0,
+          "actual_epoch_utc": "1980-10-28T00:00:00.000",
+          "checkpoint": "mid_arc",
+          "position_error_km": 2613.1227965996104,
+          "position_residual_km": [
+            2018.680591796875,
+            -1372.0532082214356,
+            933.1716949310303
+          ],
+          "position_rtn_km": [
+            -1944.1196224864407,
+            1439.2440111495657,
+            988.6285045161585
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 1814400,
+          "velocity_error_mps": 1.7600149613997988,
+          "velocity_residual_mps": [
+            1.365113415689848,
+            -0.9197331901868893,
+            0.6230641102835079
+          ],
+          "velocity_rtn_mps": [
+            -1.3152180308109218,
+            0.9650459837286042,
+            0.6607120742579684
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3195900.0,
+          "actual_epoch_utc": "1980-11-12T23:45:00.000",
+          "checkpoint": "closest_approach",
+          "position_error_km": 6499.928597414571,
+          "position_residual_km": [
+            -75.40981518554688,
+            5631.32449684906,
+            -3245.237979324341
+          ],
+          "position_rtn_km": [
+            -271.07961246435553,
+            -6494.015750053023,
+            57.85372293325308
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 3195927.463,
+          "velocity_error_mps": 424.62903631197776,
+          "velocity_residual_mps": [
+            -104.48263505697105,
+            67.86032783251358,
+            -405.94109592064524
+          ],
+          "velocity_rtn_mps": [
+            85.38812571075931,
+            -269.30715707701904,
+            -317.00527064062567
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3628800.0,
+          "actual_epoch_utc": "1980-11-18T00:00:00.000",
+          "checkpoint": "end",
+          "position_error_km": 183134.0610779046,
+          "position_residual_km": [
+            -131042.0982084961,
+            -78234.58230886841,
+            -101219.57792323304
+          ],
+          "position_rtn_km": [
+            129732.38205471364,
+            -4353.530744137646,
+            -129184.51975122775
+          ],
+          "probe": "voyager1",
+          "requested_elapsed_seconds": 3628800,
+          "velocity_error_mps": 405.9580848522018,
+          "velocity_residual_mps": [
+            -291.9769934515907,
+            -194.50684847053344,
+            -204.25104124556674
+          ],
+          "velocity_rtn_mps": [
+            290.8731320303113,
+            19.093842576162857,
+            -282.5424090210553
+          ]
+        }
+      ]
+    },
+    {
+      "case": "v2_saturn",
+      "chapter": 1,
+      "timestep_s": 100,
+      "truth_kernel": "vgr2_sat337.bsp",
+      "truth_kernel_sha256": "1d15debf7bdc6c6ba4c0462b5f4f6af85ddf9948735f434792a1c41418bb39a8",
+      "initial_state": {
+        "epoch_utc": "1981-07-15T00:00:00",
+        "frame": "ECLIPJ2000",
+        "observer": "SUN",
+        "position_m": [
+          -1371584144326.5857,
+          -245500545297.09964,
+          58626214247.67185
+        ],
+        "probe": "voyager2",
+        "velocity_mps": [
+          -9069.786878762035,
+          -12657.497845940761,
+          628.4029205927233
+        ]
+      },
+      "active_segments": [
+        {
+          "center": 6,
+          "epoch": "initialization",
+          "file": "vgr2_sat337.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager2",
+          "segment_id": "vgr2.sat337.nio",
+          "segment_type": 1,
+          "target": -32
+        },
+        {
+          "center": 6,
+          "epoch": "scoring_end",
+          "file": "vgr2_sat337.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager2",
+          "segment_id": "vgr2.sat337.nio",
+          "segment_type": 1,
+          "target": -32
+        }
+      ],
+      "metrics": [
+        {
+          "actual_elapsed_seconds": 0.0,
+          "actual_epoch_utc": "1981-07-15T00:00:00",
+          "checkpoint": "start",
+          "position_error_km": 0.0,
+          "position_residual_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "position_rtn_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 0.0,
+          "velocity_error_mps": 0.0,
+          "velocity_residual_mps": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "velocity_rtn_mps": [
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 86400.0,
+          "actual_epoch_utc": "1981-07-16T00:00:00.000",
+          "checkpoint": "early_approach",
+          "position_error_km": 0.8498583769305214,
+          "position_residual_km": [
+            -0.805720458984375,
+            -0.149439453125,
+            -0.22525907897949218
+          ],
+          "position_rtn_km": [
+            0.8092526653120679,
+            0.0008028556728660306,
+            -0.25955488812014926
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 86400,
+          "velocity_error_mps": 0.019662319376536688,
+          "velocity_residual_mps": [
+            -0.018639114385223365,
+            -0.003464139223069651,
+            -0.005214399068222519
+          ],
+          "velocity_rtn_mps": [
+            0.018721936687725184,
+            2.5495781407449436e-05,
+            -0.006007931415293479
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 345600.0,
+          "actual_epoch_utc": "1981-07-19T00:00:00.000",
+          "checkpoint": "clean_approach",
+          "position_error_km": 13.549833828544603,
+          "position_residual_km": [
+            -12.837763427734375,
+            -2.4080949096679687,
+            -3.604289924621582
+          ],
+          "position_rtn_km": [
+            12.898234695844158,
+            0.013207862867882184,
+            -4.151308717073695
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 345600,
+          "velocity_error_mps": 0.07820223821375363,
+          "velocity_residual_mps": [
+            -0.07405977022426669,
+            -0.013987969776280806,
+            -0.020858504201100914
+          ],
+          "velocity_rtn_mps": [
+            0.07442299487234219,
+            0.00016958722216501524,
+            -0.024016226515547214
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 1944000.0,
+          "actual_epoch_utc": "1981-08-06T12:00:00.001",
+          "checkpoint": "mid_arc",
+          "position_error_km": 1672.4098133060538,
+          "position_residual_km": [
+            327.68175561523435,
+            -917.1623834533691,
+            1359.5559617233275
+          ],
+          "position_rtn_km": [
+            -89.03367090095075,
+            981.7710038134713,
+            1350.9823408021953
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 1944000,
+          "velocity_error_mps": 1.0136725963884698,
+          "velocity_residual_mps": [
+            0.05190671488890075,
+            -0.588859504152424,
+            0.8234575338095738
+          ],
+          "velocity_rtn_mps": [
+            0.0961750298218018,
+            0.5993160685508214,
+            0.8118514311649049
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3641000.0,
+          "actual_epoch_utc": "1981-08-26T03:23:20.001",
+          "checkpoint": "closest_approach",
+          "position_error_km": 4870.770147467719,
+          "position_residual_km": [
+            -559.3464580078125,
+            -4691.251609313965,
+            1184.7749606933594
+          ],
+          "position_rtn_km": [
+            1551.2098543747752,
+            4454.619662695086,
+            1214.295465644015
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 3641030.181,
+          "velocity_error_mps": 353.98357196189517,
+          "velocity_residual_mps": [
+            212.14003346658683,
+            -227.02402821144642,
+            -169.59087839369784
+          ],
+          "velocity_rtn_mps": [
+            -168.55025584412778,
+            268.8170487590966,
+            -156.94768163381949
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3888000.0,
+          "actual_epoch_utc": "1981-08-29T00:00:00.001",
+          "checkpoint": "end",
+          "position_error_km": 37015.73143689103,
+          "position_residual_km": [
+            13774.208829345704,
+            -9.858678466796874,
+            -34357.465676910404
+          ],
+          "position_rtn_km": [
+            -14915.084055052379,
+            3553.6729174446646,
+            -33690.889721623345
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 3888000,
+          "velocity_error_mps": 133.82731452326195,
+          "velocity_residual_mps": [
+            38.08904222141018,
+            15.657882719777263,
+            -127.33344291228997
+          ],
+          "velocity_rtn_mps": [
+            -45.8620036301228,
+            -4.858513031106723,
+            -125.62970025700628
+          ]
+        }
+      ]
+    },
+    {
+      "case": "v2_saturn",
+      "chapter": 2,
+      "timestep_s": 100,
+      "truth_kernel": "vgr2_sat337.bsp",
+      "truth_kernel_sha256": "1d15debf7bdc6c6ba4c0462b5f4f6af85ddf9948735f434792a1c41418bb39a8",
+      "initial_state": {
+        "epoch_utc": "1981-07-15T00:00:00",
+        "frame": "ECLIPJ2000",
+        "observer": "SUN",
+        "position_m": [
+          -1371584144326.5857,
+          -245500545297.09964,
+          58626214247.67185
+        ],
+        "probe": "voyager2",
+        "velocity_mps": [
+          -9069.786878762035,
+          -12657.497845940761,
+          628.4029205927233
+        ]
+      },
+      "active_segments": [
+        {
+          "center": 6,
+          "epoch": "initialization",
+          "file": "vgr2_sat337.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager2",
+          "segment_id": "vgr2.sat337.nio",
+          "segment_type": 1,
+          "target": -32
+        },
+        {
+          "center": 6,
+          "epoch": "scoring_end",
+          "file": "vgr2_sat337.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager2",
+          "segment_id": "vgr2.sat337.nio",
+          "segment_type": 1,
+          "target": -32
+        }
+      ],
+      "metrics": [
+        {
+          "actual_elapsed_seconds": 0.0,
+          "actual_epoch_utc": "1981-07-15T00:00:00",
+          "checkpoint": "start",
+          "position_error_km": 0.0,
+          "position_residual_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "position_rtn_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 0.0,
+          "velocity_error_mps": 0.0,
+          "velocity_residual_mps": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "velocity_rtn_mps": [
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 86400.0,
+          "actual_epoch_utc": "1981-07-16T00:00:00.000",
+          "checkpoint": "early_approach",
+          "position_error_km": 0.26587948235613607,
+          "position_residual_km": [
+            0.0037373046875,
+            0.09672579956054687,
+            -0.24763289642333985
+          ],
+          "position_rtn_km": [
+            -0.031178562288245806,
+            -0.098127363858648,
+            -0.24513428330969403
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 86400,
+          "velocity_error_mps": 0.006155135407546993,
+          "velocity_residual_mps": [
+            8.93645265023224e-05,
+            0.002240031588371494,
+            -0.005732361149625831
+          ],
+          "velocity_rtn_mps": [
+            -0.0007247145297030331,
+            -0.0022719546156125224,
+            -0.005674390095884574
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 345600.0,
+          "actual_epoch_utc": "1981-07-19T00:00:00.000",
+          "checkpoint": "clean_approach",
+          "position_error_km": 4.256615375311923,
+          "position_residual_km": [
+            0.07701025390625,
+            1.5521854553222656,
+            -3.962772285461426
+          ],
+          "position_rtn_km": [
+            -0.5197801019351599,
+            -1.5704636170525017,
+            -3.9220207962845524
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 345600,
+          "velocity_error_mps": 0.024645701420217634,
+          "velocity_residual_mps": [
+            0.0005408881334005855,
+            0.009002578231957159,
+            -0.02293625130005239
+          ],
+          "velocity_rtn_mps": [
+            -0.003105322260852518,
+            -0.009090993652718949,
+            -0.022696286184241576
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 1944000.0,
+          "actual_epoch_utc": "1981-08-06T12:00:00.001",
+          "checkpoint": "mid_arc",
+          "position_error_km": 1725.5515847062604,
+          "position_residual_km": [
+            733.2966762695313,
+            -789.8711395263672,
+            1347.556247062683
+          ],
+          "position_rtn_km": [
+            -511.6169921028267,
+            934.3228984827202,
+            1357.5039765115944
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 1944000,
+          "velocity_error_mps": 1.0420769940205834,
+          "velocity_residual_mps": [
+            0.4705692636234744,
+            -0.4556099587935023,
+            0.8104989790542731
+          ],
+          "velocity_rtn_mps": [
+            -0.3403813385631607,
+            0.5485046875838394,
+            0.8180511069141588
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3641000.0,
+          "actual_epoch_utc": "1981-08-26T03:23:20.001",
+          "checkpoint": "closest_approach",
+          "position_error_km": 2517.6072171372825,
+          "position_residual_km": [
+            1034.1550112304687,
+            -1949.5218659057616,
+            1211.7070631484985
+          ],
+          "position_rtn_km": [
+            -563.8378473899952,
+            2092.5969314118965,
+            1281.1990728524056
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 3641030.181,
+          "velocity_error_mps": 207.0754151304551,
+          "velocity_residual_mps": [
+            44.974663464412515,
+            -128.50197417174422,
+            -156.02804181196893
+          ],
+          "velocity_rtn_mps": [
+            -24.48586467701827,
+            138.21021655675656,
+            -152.24521674523479
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3888000.0,
+          "actual_epoch_utc": "1981-08-29T00:00:00.001",
+          "checkpoint": "end",
+          "position_error_km": 37073.26376183482,
+          "position_residual_km": [
+            13481.020553710938,
+            1675.5730323486328,
+            -34494.65793131256
+          ],
+          "position_rtn_km": [
+            -14983.528801506078,
+            1847.1757061078433,
+            -33860.134266121546
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 3888000,
+          "velocity_error_mps": 134.73364872111125,
+          "velocity_residual_mps": [
+            38.3098352460097,
+            16.026037623149023,
+            -128.17440750488691
+          ],
+          "velocity_rtn_mps": [
+            -46.18967904575655,
+            -5.155935059440659,
+            -126.4637733938721
+          ]
+        }
+      ]
+    },
+    {
+      "case": "v2_saturn",
+      "chapter": 2,
+      "timestep_s": 3600,
+      "truth_kernel": "vgr2_sat337.bsp",
+      "truth_kernel_sha256": "1d15debf7bdc6c6ba4c0462b5f4f6af85ddf9948735f434792a1c41418bb39a8",
+      "initial_state": {
+        "epoch_utc": "1981-07-15T00:00:00",
+        "frame": "ECLIPJ2000",
+        "observer": "SUN",
+        "position_m": [
+          -1371584144326.5857,
+          -245500545297.09964,
+          58626214247.67185
+        ],
+        "probe": "voyager2",
+        "velocity_mps": [
+          -9069.786878762035,
+          -12657.497845940761,
+          628.4029205927233
+        ]
+      },
+      "active_segments": [
+        {
+          "center": 6,
+          "epoch": "initialization",
+          "file": "vgr2_sat337.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager2",
+          "segment_id": "vgr2.sat337.nio",
+          "segment_type": 1,
+          "target": -32
+        },
+        {
+          "center": 6,
+          "epoch": "scoring_end",
+          "file": "vgr2_sat337.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager2",
+          "segment_id": "vgr2.sat337.nio",
+          "segment_type": 1,
+          "target": -32
+        }
+      ],
+      "metrics": [
+        {
+          "actual_elapsed_seconds": 0.0,
+          "actual_epoch_utc": "1981-07-15T00:00:00",
+          "checkpoint": "start",
+          "position_error_km": 0.0,
+          "position_residual_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "position_rtn_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 0.0,
+          "velocity_error_mps": 0.0,
+          "velocity_residual_mps": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "velocity_rtn_mps": [
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 86400.0,
+          "actual_epoch_utc": "1981-07-16T00:00:00.000",
+          "checkpoint": "early_approach",
+          "position_error_km": 0.26587939035054853,
+          "position_residual_km": [
+            0.003736572265625,
+            0.09672555541992188,
+            -0.2476329040527344
+          ],
+          "position_rtn_km": [
+            -0.031177799230859015,
+            -0.09812725368901291,
+            -0.24513432467068277
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 86400,
+          "velocity_error_mps": 0.006155136005179769,
+          "velocity_residual_mps": [
+            8.936924677982461e-05,
+            0.002240032174086082,
+            -0.005732361488867355
+          ],
+          "velocity_rtn_mps": [
+            -0.0007247192892254039,
+            -0.002271954359359184,
+            -0.005674390238877988
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 345600.0,
+          "actual_epoch_utc": "1981-07-19T00:00:00.000",
+          "checkpoint": "clean_approach",
+          "position_error_km": 4.256615712513273,
+          "position_residual_km": [
+            0.077013671875,
+            1.55218603515625,
+            -3.9627723541259767
+          ],
+          "position_rtn_km": [
+            -0.5197835683168806,
+            -1.5704635751720173,
+            -3.922020719626629
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 345600,
+          "velocity_error_mps": 0.024645705080688658,
+          "velocity_residual_mps": [
+            0.0005409125042206142,
+            0.009002582733955933,
+            -0.02293625289155443
+          ],
+          "velocity_rtn_mps": [
+            -0.0031053470889242313,
+            -0.009090993731734701,
+            -0.022696286730457756
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 1944000.0,
+          "actual_epoch_utc": "1981-08-06T12:00:00.001",
+          "checkpoint": "mid_arc",
+          "position_error_km": 1725.5516779455847,
+          "position_residual_km": [
+            733.2970954589844,
+            -789.8709870605469,
+            1347.5562277145386
+          ],
+          "position_rtn_km": [
+            -511.6174331103086,
+            934.322828824191,
+            1357.503976766331
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 1944000,
+          "velocity_error_mps": 1.0420772307743307,
+          "velocity_residual_mps": [
+            0.4705701874681836,
+            -0.4556096194919519,
+            0.8104989378098253
+          ],
+          "velocity_rtn_mps": [
+            -0.3403823110596139,
+            0.5485045308604247,
+            0.8180511089422221
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3639600.0,
+          "actual_epoch_utc": "1981-08-26T03:00:00.001",
+          "checkpoint": "closest_approach",
+          "position_error_km": 1913.8564326178644,
+          "position_residual_km": [
+            931.1979936523437,
+            -809.2147887573242,
+            1463.1774215545654
+          ],
+          "position_rtn_km": [
+            -684.3260371720676,
+            952.9042684971197,
+            1512.1235976602975
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 3641030.181,
+          "velocity_error_mps": 215.04756944415433,
+          "velocity_residual_mps": [
+            -142.25880586218955,
+            109.69351306541648,
+            -118.21684511891505
+          ],
+          "velocity_rtn_mps": [
+            111.84326491321616,
+            -133.95662668683883,
+            -125.66687464910328
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3888000.0,
+          "actual_epoch_utc": "1981-08-29T00:00:00.001",
+          "checkpoint": "end",
+          "position_error_km": 125846.633010589,
+          "position_residual_km": [
+            -113935.58321484375,
+            -45191.83999121094,
+            -28526.400330291748
+          ],
+          "position_rtn_km": [
+            119514.4709235739,
+            21263.74752212675,
+            -33189.14463006427
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 3888000,
+          "velocity_error_mps": 497.4101884153723,
+          "velocity_residual_mps": [
+            -426.86679089086965,
+            -230.60606587537768,
+            -109.64707362911116
+          ],
+          "velocity_rtn_mps": [
+            460.3498840915603,
+            139.6805928816127,
+            -126.42868238079681
+          ]
+        }
+      ]
+    },
+    {
+      "case": "v2_saturn",
+      "chapter": 2,
+      "timestep_s": 300,
+      "truth_kernel": "vgr2_sat337.bsp",
+      "truth_kernel_sha256": "1d15debf7bdc6c6ba4c0462b5f4f6af85ddf9948735f434792a1c41418bb39a8",
+      "initial_state": {
+        "epoch_utc": "1981-07-15T00:00:00",
+        "frame": "ECLIPJ2000",
+        "observer": "SUN",
+        "position_m": [
+          -1371584144326.5857,
+          -245500545297.09964,
+          58626214247.67185
+        ],
+        "probe": "voyager2",
+        "velocity_mps": [
+          -9069.786878762035,
+          -12657.497845940761,
+          628.4029205927233
+        ]
+      },
+      "active_segments": [
+        {
+          "center": 6,
+          "epoch": "initialization",
+          "file": "vgr2_sat337.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager2",
+          "segment_id": "vgr2.sat337.nio",
+          "segment_type": 1,
+          "target": -32
+        },
+        {
+          "center": 6,
+          "epoch": "scoring_end",
+          "file": "vgr2_sat337.bsp",
+          "native_frame": "J2000",
+          "probe": "voyager2",
+          "segment_id": "vgr2.sat337.nio",
+          "segment_type": 1,
+          "target": -32
+        }
+      ],
+      "metrics": [
+        {
+          "actual_elapsed_seconds": 0.0,
+          "actual_epoch_utc": "1981-07-15T00:00:00",
+          "checkpoint": "start",
+          "position_error_km": 0.0,
+          "position_residual_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "position_rtn_km": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 0.0,
+          "velocity_error_mps": 0.0,
+          "velocity_residual_mps": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "velocity_rtn_mps": [
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 86400.0,
+          "actual_epoch_utc": "1981-07-16T00:00:00.000",
+          "checkpoint": "early_approach",
+          "position_error_km": 0.26587940520578196,
+          "position_residual_km": [
+            0.003737060546875,
+            0.09672561645507813,
+            -0.24763288879394532
+          ],
+          "position_rtn_km": [
+            -0.03117828953356196,
+            -0.09812722688704104,
+            -0.24513428915147903
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 86400,
+          "velocity_error_mps": 0.006155135414403831,
+          "velocity_residual_mps": [
+            8.936454105423763e-05,
+            0.0022400316011044197,
+            -0.005732361151785881
+          ],
+          "velocity_rtn_mps": [
+            -0.0007247145463535916,
+            -0.002271954625591456,
+            -0.005674390097200342
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 345600.0,
+          "actual_epoch_utc": "1981-07-19T00:00:00.000",
+          "checkpoint": "clean_approach",
+          "position_error_km": 4.256615178185528,
+          "position_residual_km": [
+            0.077008544921875,
+            1.5521852722167968,
+            -3.962772178649902
+          ],
+          "position_rtn_km": [
+            -0.5197783847792748,
+            -1.570463742008932,
+            -3.922020759877612
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 345600,
+          "velocity_error_mps": 0.024645701436911218,
+          "velocity_residual_mps": [
+            0.0005408882407209603,
+            0.009002578248328064,
+            -0.02293625130903365
+          ],
+          "velocity_rtn_mps": [
+            -0.003105322369652278,
+            -0.00909099364969764,
+            -0.02269628618869312
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 1944000.0,
+          "actual_epoch_utc": "1981-08-06T12:00:00.001",
+          "checkpoint": "mid_arc",
+          "position_error_km": 1725.5515789198896,
+          "position_residual_km": [
+            733.2966643066407,
+            -789.8711379394531,
+            1347.5562470932007
+          ],
+          "position_rtn_km": [
+            -511.61698067166196,
+            934.3228946357684,
+            1357.5039761123262
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 1944000,
+          "velocity_error_mps": 1.0420769954058262,
+          "velocity_residual_mps": [
+            0.47056926922959974,
+            -0.45560995660525805,
+            0.8104989788105286
+          ],
+          "velocity_rtn_mps": [
+            -0.340381344488893,
+            0.5485046865060202,
+            0.8180511069358077
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3641100.0,
+          "actual_epoch_utc": "1981-08-26T03:25:00.001",
+          "checkpoint": "closest_approach",
+          "position_error_km": 2513.6369781567314,
+          "position_residual_km": [
+            1036.7801049804686,
+            -1952.333054626465,
+            1196.6008171844483
+          ],
+          "position_rtn_km": [
+            -566.4709123682,
+            2096.0460806914075,
+            1266.5197949561762
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 3641030.181,
+          "velocity_error_mps": 207.0082867350125,
+          "velocity_residual_mps": [
+            46.33423937763109,
+            -126.56898552184794,
+            -157.11734768074393
+          ],
+          "velocity_rtn_mps": [
+            -26.25474567496936,
+            136.63490169838772,
+            -153.2776002695102
+          ]
+        },
+        {
+          "actual_elapsed_seconds": 3888000.0,
+          "actual_epoch_utc": "1981-08-29T00:00:00.001",
+          "checkpoint": "end",
+          "position_error_km": 36753.721018261305,
+          "position_residual_km": [
+            12708.886370361328,
+            1562.0639469604491,
+            -34451.12729852295
+          ],
+          "position_rtn_km": [
+            -14203.495915053954,
+            1797.8954160955732,
+            -33850.61719602777
+          ],
+          "probe": "voyager2",
+          "requested_elapsed_seconds": 3888000,
+          "velocity_error_mps": 133.7524826005209,
+          "velocity_residual_mps": [
+            35.534042584030885,
+            15.344178905248555,
+            -128.02974104934623
+          ],
+          "velocity_rtn_mps": [
+            -43.3292647433879,
+            -5.065015354235416,
+            -126.43831317310986
+          ]
+        }
+      ]
+    }
+  ],
+  "summary": [
+    {
+      "case": "v1_jupiter",
+      "checkpoint": "clean_approach",
+      "elapsed_days": 20.0,
+      "chapter1_position_error_km": 338.58032096679256,
+      "chapter1_velocity_error_mps": 0.3618808901609073,
+      "chapter2_position_error_km": 33.69857169438939,
+      "chapter2_velocity_error_mps": 0.07460407916015303,
+      "position_error_reduction_percent": 90.04709677214392
+    },
+    {
+      "case": "v1_jupiter",
+      "checkpoint": "mid_arc",
+      "elapsed_days": 22.5,
+      "chapter1_position_error_km": 400.7162454020164,
+      "chapter1_velocity_error_mps": 0.548893318134779,
+      "chapter2_position_error_km": 133.29835883164282,
+      "chapter2_velocity_error_mps": 0.5662238567665515,
+      "position_error_reduction_percent": 66.73497509492984
+    },
+    {
+      "case": "v1_jupiter",
+      "checkpoint": "late_approach",
+      "elapsed_days": 30.0,
+      "chapter1_position_error_km": 675.8895280859023,
+      "chapter1_velocity_error_mps": 0.41394713401977357,
+      "chapter2_position_error_km": 555.3206400177319,
+      "chapter2_velocity_error_mps": 1.0137429256544963,
+      "position_error_reduction_percent": 17.838549505215397
+    },
+    {
+      "case": "v1_jupiter",
+      "checkpoint": "closest_approach",
+      "elapsed_days": 32.503319375000004,
+      "chapter1_position_error_km": 904.8377346391785,
+      "chapter1_velocity_error_mps": 25.652704365639664,
+      "chapter2_position_error_km": 1708.8183782827505,
+      "chapter2_velocity_error_mps": 80.50152438376857,
+      "position_error_reduction_percent": -88.85357151513743
+    },
+    {
+      "case": "v1_jupiter",
+      "checkpoint": "end",
+      "elapsed_days": 45.0,
+      "chapter1_position_error_km": 29289.431253903942,
+      "chapter1_velocity_error_mps": 24.343060016045325,
+      "chapter2_position_error_km": 35494.56382865734,
+      "chapter2_velocity_error_mps": 28.815520594232446,
+      "position_error_reduction_percent": -21.18556868162581
+    },
+    {
+      "case": "v2_jupiter",
+      "checkpoint": "clean_approach",
+      "elapsed_days": 20.0,
+      "chapter1_position_error_km": 227.3244984958045,
+      "chapter1_velocity_error_mps": 0.25236194333514805,
+      "chapter2_position_error_km": 99.3662586000908,
+      "chapter2_velocity_error_mps": 0.1421673163113676,
+      "position_error_reduction_percent": 56.288803337259004
+    },
+    {
+      "case": "v2_jupiter",
+      "checkpoint": "mid_arc",
+      "elapsed_days": 22.5,
+      "chapter1_position_error_km": 283.60912246192146,
+      "chapter1_velocity_error_mps": 0.26952228811048573,
+      "chapter2_position_error_km": 134.5345322017574,
+      "chapter2_velocity_error_mps": 0.1868577990297835,
+      "position_error_reduction_percent": 52.56339745565816
+    },
+    {
+      "case": "v2_jupiter",
+      "checkpoint": "late_approach",
+      "elapsed_days": 30.0,
+      "chapter1_position_error_km": 632.2747774479303,
+      "chapter1_velocity_error_mps": 0.7133210654419028,
+      "chapter2_position_error_km": 575.5358026213137,
+      "chapter2_velocity_error_mps": 0.9028379473543827,
+      "position_error_reduction_percent": 8.97378431820954
+    },
+    {
+      "case": "v2_jupiter",
+      "checkpoint": "closest_approach",
+      "elapsed_days": 34.93672229166666,
+      "chapter1_position_error_km": 1239.1710824141016,
+      "chapter1_velocity_error_mps": 16.36105207448002,
+      "chapter2_position_error_km": 2157.119245599024,
+      "chapter2_velocity_error_mps": 44.596499015695564,
+      "position_error_reduction_percent": -74.07759721092053
+    },
+    {
+      "case": "v2_jupiter",
+      "checkpoint": "end",
+      "elapsed_days": 45.0,
+      "chapter1_position_error_km": 60199.09698760914,
+      "chapter1_velocity_error_mps": 75.94274665925636,
+      "chapter2_position_error_km": 62618.40250361525,
+      "chapter2_velocity_error_mps": 78.18461705275998,
+      "position_error_reduction_percent": -4.018840210350798
+    },
+    {
+      "case": "v1_saturn",
+      "checkpoint": "early_approach",
+      "elapsed_days": 1.0,
+      "chapter1_position_error_km": 0.7285002867284305,
+      "chapter1_velocity_error_mps": 0.01701144422259732,
+      "chapter2_position_error_km": 0.01829887537942534,
+      "chapter2_velocity_error_mps": 0.00044353865510765844,
+      "position_error_reduction_percent": 97.48814438198748
+    },
+    {
+      "case": "v1_saturn",
+      "checkpoint": "clean_approach",
+      "elapsed_days": 3.0,
+      "chapter1_position_error_km": 6.509332089644968,
+      "chapter1_velocity_error_mps": 0.04981617219810787,
+      "chapter2_position_error_km": 0.17851994787141812,
+      "chapter2_velocity_error_mps": 0.0016456318657696808,
+      "position_error_reduction_percent": 97.25747672091569
+    },
+    {
+      "case": "v1_saturn",
+      "checkpoint": "mid_arc",
+      "elapsed_days": 21.0,
+      "chapter1_position_error_km": 2333.1664701548398,
+      "chapter1_velocity_error_mps": 1.4522160795429924,
+      "chapter2_position_error_km": 2613.1227980419103,
+      "chapter2_velocity_error_mps": 1.760014959745756,
+      "position_error_reduction_percent": -11.9989864190227
+    },
+    {
+      "case": "v1_saturn",
+      "checkpoint": "closest_approach",
+      "elapsed_days": 36.98990119212963,
+      "chapter1_position_error_km": 6174.863920547962,
+      "chapter1_velocity_error_mps": 388.24584032757184,
+      "chapter2_position_error_km": 6496.068696052292,
+      "chapter2_velocity_error_mps": 423.6026512927911,
+      "position_error_reduction_percent": -5.201811402441813
+    },
+    {
+      "case": "v1_saturn",
+      "checkpoint": "end",
+      "elapsed_days": 42.0,
+      "chapter1_position_error_km": 190861.73744516686,
+      "chapter1_velocity_error_mps": 423.11028140945564,
+      "chapter2_position_error_km": 182531.9607643122,
+      "chapter2_velocity_error_mps": 404.6505182557545,
+      "position_error_reduction_percent": 4.364298885861147
+    },
+    {
+      "case": "v2_saturn",
+      "checkpoint": "early_approach",
+      "elapsed_days": 1.0,
+      "chapter1_position_error_km": 0.8498583769305214,
+      "chapter1_velocity_error_mps": 0.019662319376536688,
+      "chapter2_position_error_km": 0.26587948235613607,
+      "chapter2_velocity_error_mps": 0.006155135407546993,
+      "position_error_reduction_percent": 68.71484831197087
+    },
+    {
+      "case": "v2_saturn",
+      "checkpoint": "clean_approach",
+      "elapsed_days": 4.0,
+      "chapter1_position_error_km": 13.549833828544603,
+      "chapter1_velocity_error_mps": 0.07820223821375363,
+      "chapter2_position_error_km": 4.256615375311923,
+      "chapter2_velocity_error_mps": 0.024645701420217634,
+      "position_error_reduction_percent": 68.58547913447637
+    },
+    {
+      "case": "v2_saturn",
+      "checkpoint": "mid_arc",
+      "elapsed_days": 22.5,
+      "chapter1_position_error_km": 1672.4098133060538,
+      "chapter1_velocity_error_mps": 1.0136725963884698,
+      "chapter2_position_error_km": 1725.5515847062604,
+      "chapter2_velocity_error_mps": 1.0420769940205834,
+      "position_error_reduction_percent": -3.177556779289334
+    },
+    {
+      "case": "v2_saturn",
+      "checkpoint": "closest_approach",
+      "elapsed_days": 42.141553020833335,
+      "chapter1_position_error_km": 4870.770147467719,
+      "chapter1_velocity_error_mps": 353.98357196189517,
+      "chapter2_position_error_km": 2517.6072171372825,
+      "chapter2_velocity_error_mps": 207.0754151304551,
+      "position_error_reduction_percent": 48.31192725351308
+    },
+    {
+      "case": "v2_saturn",
+      "checkpoint": "end",
+      "elapsed_days": 45.0,
+      "chapter1_position_error_km": 37015.73143689103,
+      "chapter1_velocity_error_mps": 133.82731452326195,
+      "chapter2_position_error_km": 37073.26376183482,
+      "chapter2_velocity_error_mps": 134.73364872111125,
+      "position_error_reduction_percent": -0.1554266867369122
+    }
+  ],
+  "timestep_controls": [
+    {
+      "case": "v1_jupiter",
+      "checkpoint": "clean_approach",
+      "chapter": 2,
+      "position_error_km_by_timestep_s": {
+        "3600": 33.711215867221874,
+        "900": 33.699353725251854,
+        "300": 33.69865145317726,
+        "100": 33.69857169438939
+      },
+      "spread_km": 0.012644172832480649
+    },
+    {
+      "case": "v1_jupiter",
+      "checkpoint": "end",
+      "chapter": 2,
+      "position_error_km_by_timestep_s": {
+        "3600": 245827.21119258954,
+        "900": 44693.12160954444,
+        "300": 36318.38622615711,
+        "100": 35494.56382865734
+      },
+      "spread_km": 210332.64736393222
+    },
+    {
+      "case": "v2_jupiter",
+      "checkpoint": "clean_approach",
+      "chapter": 2,
+      "position_error_km_by_timestep_s": {
+        "3600": 99.39163294651752,
+        "900": 99.3678297243014,
+        "300": 99.36641875212455,
+        "100": 99.3662586000908
+      },
+      "spread_km": 0.025374346426715988
+    },
+    {
+      "case": "v2_jupiter",
+      "checkpoint": "end",
+      "chapter": 2,
+      "position_error_km_by_timestep_s": {
+        "3600": 76072.82415395082,
+        "900": 63386.847725970096,
+        "300": 62694.080883898976,
+        "100": 62618.40250361525
+      },
+      "spread_km": 13454.421650335564
+    },
+    {
+      "case": "v1_saturn",
+      "checkpoint": "clean_approach",
+      "chapter": 2,
+      "position_error_km_by_timestep_s": {
+        "3600": 0.17851896850641916,
+        "300": 0.17851996840789613,
+        "100": 0.17851994787141812
+      },
+      "spread_km": 9.999014769779269e-07
+    },
+    {
+      "case": "v1_saturn",
+      "checkpoint": "end",
+      "chapter": 2,
+      "position_error_km_by_timestep_s": {
+        "3600": 288914.9685943234,
+        "300": 183134.0610779046,
+        "100": 182531.9607643122
+      },
+      "spread_km": 106383.00783001116
+    },
+    {
+      "case": "v2_saturn",
+      "checkpoint": "clean_approach",
+      "chapter": 2,
+      "position_error_km_by_timestep_s": {
+        "3600": 4.256615712513273,
+        "300": 4.256615178185528,
+        "100": 4.256615375311923
+      },
+      "spread_km": 5.343277456049123e-07
+    },
+    {
+      "case": "v2_saturn",
+      "checkpoint": "end",
+      "chapter": 2,
+      "position_error_km_by_timestep_s": {
+        "3600": 125846.633010589,
+        "300": 36753.721018261305,
+        "100": 37073.26376183482
+      },
+      "spread_km": 89092.91199232769
+    }
+  ]
+}

--- a/examples/voyager/validate_truth.py
+++ b/examples/voyager/validate_truth.py
@@ -1,0 +1,406 @@
+"""Run reproducible Voyager Chapter 1/2 reconstructed-arc validations."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Any
+
+
+EXAMPLE_DIR = Path(__file__).resolve().parent
+REPO_ROOT = EXAMPLE_DIR.parents[1]
+MANIFEST_PATH = EXAMPLE_DIR / "truth_reference.json"
+DEFAULT_SPICE_DIR = EXAMPLE_DIR / "nasa_spice_data"
+DEFAULT_OUTPUT = EXAMPLE_DIR / "truth_validation_results.json"
+
+METRIC_PREFIX = "VOYAGER_VALIDATION_METRIC "
+SEGMENT_PREFIX = "VOYAGER_ACTIVE_SEGMENT "
+INITIAL_STATE_PREFIX = "VOYAGER_INITIAL_STATE "
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def load_manifest(path: Path = MANIFEST_PATH) -> dict[str, Any]:
+    manifest = json.loads(path.read_text(encoding="utf-8"))
+    if manifest.get("schema_version") != 1:
+        raise ValueError("Unsupported Voyager truth-reference schema")
+    return manifest
+
+
+def selected_cases(manifest: dict[str, Any], requested: set[str]) -> list[dict[str, Any]]:
+    cases = manifest["cases"]
+    known = {case["id"] for case in cases}
+    unknown = requested - known
+    if unknown:
+        raise ValueError(f"Unknown validation case(s): {sorted(unknown)}")
+    return [case for case in cases if not requested or case["id"] in requested]
+
+
+def required_kernel_names(manifest: dict[str, Any], cases: list[dict[str, Any]]) -> set[str]:
+    load_order = manifest["kernel_load_order"]
+    names = {name for name in load_order if not name.startswith("<")}
+    names.update(case["kernel"] for case in cases)
+    return names
+
+
+def verify_kernels(manifest: dict[str, Any], cases: list[dict[str, Any]], spice_dir: Path) -> None:
+    failures = []
+    for name in sorted(required_kernel_names(manifest, cases)):
+        path = spice_dir / name
+        if not path.is_file():
+            failures.append(f"missing {path}")
+            continue
+        actual = sha256(path)
+        expected = manifest["kernels"][name]["sha256"]
+        if actual != expected:
+            failures.append(f"SHA-256 mismatch for {path}: expected {expected}, got {actual}")
+    if failures:
+        raise RuntimeError("Kernel verification failed:\n- " + "\n- ".join(failures))
+
+
+def parse_prefixed_json(output: str, prefix: str) -> list[dict[str, Any]]:
+    return [
+        json.loads(line.removeprefix(prefix))
+        for line in output.splitlines()
+        if line.startswith(prefix)
+    ]
+
+
+def validate_run_record(case: dict[str, Any], record: dict[str, Any]) -> None:
+    segments = record["active_segments"]
+    if {segment["epoch"] for segment in segments} != {
+        "initialization",
+        "scoring_end",
+    }:
+        raise AssertionError(f"{case['id']}: missing endpoint segment audit")
+
+    for segment in segments:
+        expected = {
+            "file": case["kernel"],
+            "target": case["spice_target"],
+            "center": case["native_center"],
+            "native_frame": case["native_frame"],
+            "segment_type": case["segment_type"],
+            "segment_id": case["segment_id"],
+            "probe": case["probe"],
+        }
+        for key, value in expected.items():
+            if segment[key] != value:
+                raise AssertionError(
+                    f"{case['id']} {segment['epoch']}: expected {key}={value!r}, "
+                    f"got {segment[key]!r}"
+                )
+
+    expected_checkpoints = [checkpoint["name"] for checkpoint in case["checkpoints"]]
+    actual_checkpoints = [metric["checkpoint"] for metric in record["metrics"]]
+    if actual_checkpoints != expected_checkpoints:
+        raise AssertionError(
+            f"{case['id']}: expected checkpoints {expected_checkpoints}, got {actual_checkpoints}"
+        )
+
+    for metric in record["metrics"]:
+        if (
+            abs(metric["actual_elapsed_seconds"] - metric["requested_elapsed_seconds"])
+            > record["timestep_s"] / 2.0
+        ):
+            raise AssertionError(
+                f"{case['id']} {metric['checkpoint']}: checkpoint epoch "
+                "is farther than half a timestep from the contract"
+            )
+        for key in (
+            "position_residual_km",
+            "position_rtn_km",
+            "velocity_residual_mps",
+            "velocity_rtn_mps",
+        ):
+            if len(metric[key]) != 3 or not all(math.isfinite(value) for value in metric[key]):
+                raise AssertionError(f"{case['id']} {metric['checkpoint']}: invalid {key}")
+        for vector_key, norm_key in (
+            ("position_residual_km", "position_error_km"),
+            ("position_rtn_km", "position_error_km"),
+            ("velocity_residual_mps", "velocity_error_mps"),
+            ("velocity_rtn_mps", "velocity_error_mps"),
+        ):
+            vector_norm = math.sqrt(sum(value * value for value in metric[vector_key]))
+            if not math.isclose(
+                vector_norm,
+                metric[norm_key],
+                rel_tol=1.0e-10,
+                abs_tol=1.0e-10,
+            ):
+                raise AssertionError(
+                    f"{case['id']} {metric['checkpoint']}: {vector_key} does not match {norm_key}"
+                )
+
+    initial_state = record["initial_state"]
+    if initial_state["epoch_utc"] != case["initialization_utc"]:
+        raise AssertionError(f"{case['id']}: initialization epoch changed")
+
+
+def run_case(
+    manifest: dict[str, Any],
+    case: dict[str, Any],
+    chapter: int,
+    timestep_s: float,
+    spice_dir: Path,
+) -> dict[str, Any]:
+    ticks = case["duration_days"] * 86400.0 / timestep_s
+    if not ticks.is_integer():
+        raise ValueError(f"{case['id']}: timestep {timestep_s:g}s does not divide the arc")
+
+    with tempfile.TemporaryDirectory(prefix="voyager-truth-") as temporary_root:
+        database = Path(temporary_root) / "db"
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "DB_PATH": str(database),
+                "JAX_ENABLE_X64": "True",
+                "MAX_TICKS": str(int(ticks)),
+                "VOYAGER_CHECKPOINTS_JSON": json.dumps(
+                    [
+                        checkpoint
+                        for checkpoint in case["checkpoints"]
+                        if checkpoint["elapsed_seconds"] > 0
+                    ],
+                    separators=(",", ":"),
+                ),
+                "VOYAGER_DYNAMICS_CHAPTER": str(chapter),
+                "VOYAGER_SCORED_PROBE": case["probe"],
+                "VOYAGER_SPICE_DIR": str(spice_dir),
+                "VOYAGER_START_UTC": case["initialization_utc"],
+                "VOYAGER_TIME_STEP": str(timestep_s),
+                "VOYAGER_TRUTH_KERNEL": case["kernel"],
+            }
+        )
+
+        started = time.perf_counter()
+        process = subprocess.run(
+            [sys.executable, str(EXAMPLE_DIR / "main.py"), "run"],
+            cwd=REPO_ROOT,
+            env=environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            check=False,
+        )
+        elapsed_s = time.perf_counter() - started
+
+    if process.returncode:
+        tail = "\n".join(process.stdout.splitlines()[-100:])
+        raise RuntimeError(
+            f"{case['id']} Chapter {chapter} failed with exit code {process.returncode}:\n{tail}"
+        )
+
+    initial_states = parse_prefixed_json(process.stdout, INITIAL_STATE_PREFIX)
+    if len(initial_states) != 1:
+        raise AssertionError(f"{case['id']}: expected one initial state, got {len(initial_states)}")
+
+    zero_vector = [0.0, 0.0, 0.0]
+    initial_metric = {
+        "actual_elapsed_seconds": 0.0,
+        "actual_epoch_utc": case["initialization_utc"],
+        "checkpoint": "start",
+        "position_error_km": 0.0,
+        "position_residual_km": zero_vector,
+        "position_rtn_km": zero_vector,
+        "probe": case["probe"],
+        "requested_elapsed_seconds": 0.0,
+        "velocity_error_mps": 0.0,
+        "velocity_residual_mps": zero_vector,
+        "velocity_rtn_mps": zero_vector,
+    }
+    record = {
+        "case": case["id"],
+        "chapter": chapter,
+        "timestep_s": timestep_s,
+        "truth_kernel": case["kernel"],
+        "truth_kernel_sha256": manifest["kernels"][case["kernel"]]["sha256"],
+        "initial_state": initial_states[0],
+        "active_segments": parse_prefixed_json(process.stdout, SEGMENT_PREFIX),
+        "metrics": [
+            initial_metric,
+            *parse_prefixed_json(process.stdout, METRIC_PREFIX),
+        ],
+    }
+    validate_run_record(case, record)
+    print(
+        f"finished {case['id']} Chapter {chapter} in {elapsed_s:.1f}s",
+        flush=True,
+    )
+    return record
+
+
+def summarize(manifest: dict[str, Any], records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    baseline_timestep = manifest["validation_protocol"]["baseline_timestep_s"]
+    by_key = {
+        (record["case"], record["chapter"], record["timestep_s"]): record for record in records
+    }
+    rows = []
+    for case in manifest["cases"]:
+        chapter1_key = (case["id"], 1, baseline_timestep)
+        chapter2_key = (case["id"], 2, baseline_timestep)
+        if chapter1_key not in by_key or chapter2_key not in by_key:
+            continue
+        chapter1 = by_key[chapter1_key]
+        chapter2 = by_key[chapter2_key]
+        for metric1, metric2 in zip(chapter1["metrics"], chapter2["metrics"], strict=True):
+            if metric1["checkpoint"] == "start":
+                continue
+            reduction = (
+                100.0
+                * (metric1["position_error_km"] - metric2["position_error_km"])
+                / metric1["position_error_km"]
+            )
+            rows.append(
+                {
+                    "case": case["id"],
+                    "checkpoint": metric1["checkpoint"],
+                    "elapsed_days": metric1["requested_elapsed_seconds"] / 86400.0,
+                    "chapter1_position_error_km": metric1["position_error_km"],
+                    "chapter1_velocity_error_mps": metric1["velocity_error_mps"],
+                    "chapter2_position_error_km": metric2["position_error_km"],
+                    "chapter2_velocity_error_mps": metric2["velocity_error_mps"],
+                    "position_error_reduction_percent": reduction,
+                }
+            )
+    return rows
+
+
+def summarize_timestep_controls(
+    manifest: dict[str, Any], records: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    chapter = manifest["validation_protocol"]["convergence_chapter"]
+    by_key = {
+        (record["case"], record["chapter"], record["timestep_s"]): record for record in records
+    }
+    rows = []
+    for case in manifest["cases"]:
+        timesteps = case["convergence_timesteps_s"]
+        case_records = [by_key.get((case["id"], chapter, timestep)) for timestep in timesteps]
+        if any(record is None for record in case_records):
+            continue
+        for checkpoint_name in (case["convergence_checkpoint"], "end"):
+            errors = {
+                str(timestep): next(
+                    metric["position_error_km"]
+                    for metric in record["metrics"]
+                    if metric["checkpoint"] == checkpoint_name
+                )
+                for timestep, record in zip(timesteps, case_records, strict=True)
+            }
+            rows.append(
+                {
+                    "case": case["id"],
+                    "checkpoint": checkpoint_name,
+                    "chapter": chapter,
+                    "position_error_km_by_timestep_s": errors,
+                    "spread_km": max(errors.values()) - min(errors.values()),
+                }
+            )
+    return rows
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--case",
+        action="append",
+        default=[],
+        help="case ID to run; repeat for multiple cases (default: all)",
+    )
+    parser.add_argument(
+        "--chapter",
+        action="append",
+        type=int,
+        choices=(1, 2),
+        default=[],
+        help="chapter to run; repeat for both (default: both)",
+    )
+    parser.add_argument(
+        "--timestep",
+        type=float,
+        help="override the manifest baseline timestep for focused runs",
+    )
+    parser.add_argument(
+        "--include-convergence",
+        action="store_true",
+        help="also run the declared Chapter 2 timestep-control matrix",
+    )
+    parser.add_argument("--spice-dir", type=Path, default=DEFAULT_SPICE_DIR)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    manifest = load_manifest()
+    cases = selected_cases(manifest, set(args.case))
+    chapters = args.chapter or manifest["validation_protocol"]["chapters"]
+    baseline_timestep = manifest["validation_protocol"]["baseline_timestep_s"]
+    selected_timestep = args.timestep or baseline_timestep
+    verify_kernels(manifest, cases, args.spice_dir)
+
+    records = []
+    for case in cases:
+        for chapter in chapters:
+            print(
+                f"running {case['id']} Chapter {chapter} at dt={selected_timestep:g}s",
+                flush=True,
+            )
+            records.append(
+                run_case(
+                    manifest,
+                    case,
+                    chapter,
+                    selected_timestep,
+                    args.spice_dir,
+                )
+            )
+        if args.include_convergence and args.timestep is None and not args.chapter:
+            for timestep in case["convergence_timesteps_s"]:
+                if timestep == baseline_timestep:
+                    continue
+                chapter = manifest["validation_protocol"]["convergence_chapter"]
+                print(
+                    f"running {case['id']} Chapter {chapter} timestep control at dt={timestep:g}s",
+                    flush=True,
+                )
+                records.append(
+                    run_case(
+                        manifest,
+                        case,
+                        chapter,
+                        timestep,
+                        args.spice_dir,
+                    )
+                )
+
+    output = {
+        "schema_version": 1,
+        "manifest_sha256": sha256(MANIFEST_PATH),
+        "kernel_load_order": manifest["kernel_load_order"],
+        "records": records,
+        "summary": summarize(manifest, records),
+        "timestep_controls": summarize_timestep_controls(manifest, records),
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(output, indent=2) + "\n", encoding="utf-8")
+    print(f"wrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/voyager/validate_truth.py
+++ b/examples/voyager/validate_truth.py
@@ -50,6 +50,33 @@ def selected_cases(manifest: dict[str, Any], requested: set[str]) -> list[dict[s
     return [case for case in cases if not requested or case["id"] in requested]
 
 
+def selected_convergence_timesteps(
+    manifest: dict[str, Any],
+    case: dict[str, Any],
+    chapters: list[int],
+    include_convergence: bool,
+    timestep_override: float | None,
+) -> list[float]:
+    """Return non-baseline convergence steps or reject incompatible selections."""
+    if not include_convergence:
+        return []
+    if timestep_override is not None:
+        raise ValueError("--include-convergence cannot be combined with --timestep")
+
+    protocol = manifest["validation_protocol"]
+    convergence_chapter = protocol["convergence_chapter"]
+    if convergence_chapter not in chapters:
+        raise ValueError(
+            f"--include-convergence requires Chapter {convergence_chapter}; "
+            f"selected chapters: {chapters}"
+        )
+
+    baseline_timestep = protocol["baseline_timestep_s"]
+    return [
+        timestep for timestep in case["convergence_timesteps_s"] if timestep != baseline_timestep
+    ]
+
+
 def required_kernel_names(manifest: dict[str, Any], cases: list[dict[str, Any]]) -> set[str]:
     load_order = manifest["kernel_load_order"]
     names = {name for name in load_order if not name.startswith("<")}
@@ -352,6 +379,16 @@ def main() -> None:
     chapters = args.chapter or manifest["validation_protocol"]["chapters"]
     baseline_timestep = manifest["validation_protocol"]["baseline_timestep_s"]
     selected_timestep = args.timestep or baseline_timestep
+    convergence_timesteps = {
+        case["id"]: selected_convergence_timesteps(
+            manifest,
+            case,
+            chapters,
+            args.include_convergence,
+            args.timestep,
+        )
+        for case in cases
+    }
     verify_kernels(manifest, cases, args.spice_dir)
 
     records = []
@@ -370,24 +407,21 @@ def main() -> None:
                     args.spice_dir,
                 )
             )
-        if args.include_convergence and args.timestep is None and not args.chapter:
-            for timestep in case["convergence_timesteps_s"]:
-                if timestep == baseline_timestep:
-                    continue
-                chapter = manifest["validation_protocol"]["convergence_chapter"]
-                print(
-                    f"running {case['id']} Chapter {chapter} timestep control at dt={timestep:g}s",
-                    flush=True,
+        for timestep in convergence_timesteps[case["id"]]:
+            chapter = manifest["validation_protocol"]["convergence_chapter"]
+            print(
+                f"running {case['id']} Chapter {chapter} timestep control at dt={timestep:g}s",
+                flush=True,
+            )
+            records.append(
+                run_case(
+                    manifest,
+                    case,
+                    chapter,
+                    timestep,
+                    args.spice_dir,
                 )
-                records.append(
-                    run_case(
-                        manifest,
-                        case,
-                        chapter,
-                        timestep,
-                        args.spice_dir,
-                    )
-                )
+            )
 
     output = {
         "schema_version": 1,


### PR DESCRIPTION
## What

Adds a reproducible reconstructed-trajectory truth reference and headless validation workflow for the Voyager learning journey.

- keeps the official SPK files in their existing format
- records kernel URLs, SHA-256 hashes, load order, frames, observers, and selected reconstructed arcs in a machine-readable manifest
- verifies kernel provenance before propagation
- validates the active SPICE segment at initialization and scoring time
- scores Chapters 1 and 2 at labeled checkpoints using Cartesian and RTN position/velocity residuals
- checks in the complete Chapter 1/2 baseline and timestep-control results
- documents how the truth reference was selected, what it supports, and where its limits remain

## Why

The earlier long-span Voyager supertrajectory is useful as an educational and mission-design reference, but it differs materially from JPL's reconstructed encounter solutions. Before choosing a Chapter 3 fidelity change, Chapters 1 and 2 need to be re-evaluated against a traceable reconstructed reference.

This preserves the existing educational trajectory while adding a separate, provenance-backed validation reference and the process used to curate it.

## Truth contract

The validation manifest pins:

- official NAIF/JPL kernel sources and SHA-256 hashes
- deterministic kernel precedence
- selected Voyager 1 and Voyager 2 Jupiter and Saturn reconstructed arcs
- `ECLIPJ2000`, Sun-relative output, and no aberration correction
- exact reconstructed closest-approach epochs
- labeled start, approach, mid-arc, closest-approach, and end checkpoints
- convergence timesteps for each encounter

The harness verifies that the expected spacecraft segment, target, center, frame, type, and kernel are active at both initialization and scoring time.

## Revalidated Chapter 1 → Chapter 2 result

At clean pre-encounter checkpoints, the heliocentric indirect-acceleration correction continues to materially reduce position error:

| Arc | Checkpoint | Chapter 1 | Chapter 2 | Reduction |
| --- | ---: | ---: | ---: | ---: |
| Voyager 1 / Jupiter | day 20 | 338.580 km | 33.699 km | 90.05% |
| Voyager 2 / Jupiter | day 20 | 227.324 km | 99.366 km | 56.29% |
| Voyager 1 / Saturn | day 3 | 6.509 km | 0.179 km | 97.26% |
| Voyager 2 / Saturn | day 4 | 13.550 km | 4.257 km | 68.59% |

Closest-approach and post-encounter results are intentionally retained even where Chapter 2 does not improve them. Those mixed results establish the boundary of the current lesson: Chapter 2 fixes the Sun-relative formulation, but does not claim to reconstruct the complete flyby.

## Timestep controls

The Chapter 2 clean-approach position result is effectively insensitive to the tested timestep range:

- Voyager 1 / Jupiter spread: ~0.01264 km
- Voyager 2 / Jupiter spread: ~0.02537 km
- Voyager 1 / Saturn spread: ~0.000001 km
- Voyager 2 / Saturn spread: ~0.0000005 km

The much larger timestep spread after close approach shows that a one-hour step is not suitable through the flyby and that residual encounter-model effects still need to be separated from numerical integration behavior.

## Cruise limitation

No separate public tracking-fit state-vector SPK was found that covers the complete January 1978–February 1979 cruise interval. Long-span comparisons against the merged trajectory are therefore documented as agreement with that educational supertrajectory, not absolute navigation-truth accuracy.

## Validation

- downloaded and SHA-256 verified all eight required kernels
- completed the full 18-run native validation campaign
- passed focused truth-reference tests: 10 passed
- passed Ruff formatting and lint checks
- passed default Chapter 1 and Chapter 2 smoke runs
- passed `git diff --check`

Reproduce the complete campaign with:

```bash
nix develop
uv run python examples/voyager/validate_truth.py --include-convergence
```

## Scope

This PR adds the reconstructed truth data, provenance/selection process, validation harness, documentation, and revalidated Chapter 1/2 results. It does not introduce a Chapter 3 force-model or integrator change.

> [!IMPORTANT]
> This is stacked on #776. Until #776 merges, GitHub will also show that PR's Chapter 2 commit in this comparison. Once #776 lands on `main`, this PR will contain only the reconstructed truth-reference work.

Depends on #776.

Refs #779, #780, and #781.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the Voyager example (docs, tests, validation harness, and optional env flags on the sim); no core auth, security, or production runtime paths are modified.
> 
> **Overview**
> Adds a **reproducible truth-reference workflow** for the Voyager example: a machine-readable manifest (`truth_reference.json`), SHA-256–verified kernel downloads (including four encounter SPKs), and a headless `validate_truth.py` harness that re-scores Chapters 1 and 2 against NAIF reconstructed Jupiter/Saturn arcs—not the long-span merged supertrajectory used in the interactive tutorial.
> 
> **`main.py`** gains environment-driven validation mode: configurable start epoch, truth kernel, scored probe, checkpoints, and kernel load order (encounter SPK + DE440 last); it emits JSON metrics (Cartesian and RTN residuals), initial-state records, and active SPK segment audits at init and scoring end.
> 
> **Chapter 2** dynamics are factored into `dynamics.py` with unit tests; `chapter_2.py` selects Chapter 2 via env. Docs expand into a chapter journey plus `truth_reference.md` with contract, results, and cruise limitations. Checked-in `truth_validation_results.json` captures the full 18-run campaign and timestep controls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 384ae4e25dc712da52fb8c30c82e1efcc768d784. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->