### PR TITLE
fix(editor): generate schematic planes in Z-up so identity pose is ground.

### DIFF
--- a/docs/public/content/reference/python-api.md
+++ b/docs/public/content/reference/python-api.md
@@ -1198,6 +1198,8 @@ object_3d cylinder.world_pos {
 }
 ```
 
+A `plane` is a horizontal ground rectangle in the object's frame (XY, normal +Z / up). Identity attitude `(0,0,0,1, …)` therefore stays a floor after the frame→Bevy basis change.
+
 ### Ellipsoids with Dynamic Scaling
 
 Create ellipsoids that can dynamically change size based on component values:

--- a/docs/public/content/reference/schematic.md
+++ b/docs/public/content/reference/schematic.md
@@ -134,7 +134,7 @@ viewport hdr=#true {
 - Positional `eql`: required. Evaluated to a `world_pos`-like value to place the mesh.
 - `frame`: optional; `ENU`, `NED`, or `ECEF`. Specifies the coordinate frame for interpreting position. Inherits from global `coordinate` if omitted.
 - `frame_orientation`: optional; `ENU`, `NED`, or `ECEF`. Coordinate frame used for orientation (`GeoRotation`). Falls back to `frame`, then the global default, when omitted.
-- `orientation`: optional; `relative` (default) or `absolute`. With `relative`, an identity rotation in any frame maps to identity in the editor's Bevy view (legacy ENU-compatible behavior). With `absolute`, mesh geometry is oriented to the declared orientation frame's axes — use this for frame-aligned visuals such as compasses in multi-frame scenes.
+- `orientation`: optional; `relative` (default) or `absolute`. Both compose the object's attitude with the frame→Bevy basis (`bevy_R * att`). An identity attitude therefore aligns mesh local axes with the schematic frame (ENU: +X east, +Y north, +Z up) — not with the editor's Bevy Y-up axes. Use `absolute` when you want to be explicit about frame-aligned geometry (compasses, multi-frame scenes).
 - Mesh child (required, exactly one):
   - `glb`: `path` (required), `scale` (default 1.0), `translate` `(x,y,z)` (default 0s), `rotate` `(deg_x,deg_y,deg_z)` in degrees (default 0s). On DB record, local paths are stored as `db:…` and served over HTTP on replay; see [DB Asset Server](/reference/db-asset-server). Material overrides (both open-ended strengths, default 0.0 = use the GLB's own materials):
     - `emissivity`: brightens the surface — boosts the model's emissive by `4 × emissivity`, modulated by its base-color texture so the pattern still shows.
@@ -148,7 +148,7 @@ viewport hdr=#true {
   - `sphere`: `radius` (required); `color` (default white).
   - `box`: `x`, `y`, `z` (all required); `color` (default white).
   - `cylinder`: `radius`, `height` (both required); `color` (default white).
-  - `plane`: `width`/`depth` (default `size` if set, else 10.0); optional `size` shorthand; `color` (default white).
+  - `plane`: `width`/`depth` (default `size` if set, else 10.0); optional `size` shorthand; `color` (default white). Horizontal ground rectangle in the object frame (XY, normal +Z / up).
   - `ellipsoid`: `color` (default white), `show_grid` (default `#false`).
     - Physical measure
       - `scale`: runtime EQL string that must evaluate to at least 3 values in meters. It can be a literal tuple, a vector component, indexed component values, scalar-vector math, or values from multiple components.

--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -1187,10 +1187,13 @@ impl BevyExt for impeller2_wkt::Mesh {
                 bevy::math::primitives::Cylinder::new(radius, height).into()
             }
             impeller2_wkt::Mesh::Plane { width, depth } => {
-                bevy::math::primitives::Plane3d::default()
-                    .mesh()
-                    .size(width, depth)
-                    .into()
+                // Schematic-frame Z-up (not Bevy Y-up): identity att is ground.
+                bevy::math::primitives::Plane3d {
+                    normal: Dir3::Z,
+                    half_size: Vec2::new(width * 0.5, depth * 0.5),
+                }
+                .mesh()
+                .into()
             }
         }
     }
@@ -2471,6 +2474,7 @@ mod tests {
     use super::*;
     use bevy::app::App;
     use bevy::math::{DQuat, EulerRot};
+    use bevy::mesh::VertexAttributeValues;
     use impeller2::types::{ComponentId, Timestamp};
     use impeller2_wkt::ComponentValue;
 
@@ -2510,6 +2514,33 @@ mod tests {
             q.dot(expected).abs() > 1.0 - 1e-9,
             "got {q:?}, expected {expected:?}"
         );
+    }
+
+    #[test]
+    fn plane_mesh_is_horizontal_in_schematic_frame() {
+        let mesh = impeller2_wkt::Mesh::plane(10.0, 20.0).into_bevy();
+        let Some(VertexAttributeValues::Float32x3(normals)) = mesh.attribute(Mesh::ATTRIBUTE_NORMAL)
+        else {
+            panic!("plane mesh missing normals");
+        };
+        assert!(!normals.is_empty());
+        for n in normals {
+            assert!(
+                n[2].abs() > 0.99 && n[0].abs() < 1e-5 && n[1].abs() < 1e-5,
+                "plane normal should be ±Z, got {n:?}"
+            );
+        }
+        let Some(VertexAttributeValues::Float32x3(positions)) =
+            mesh.attribute(Mesh::ATTRIBUTE_POSITION)
+        else {
+            panic!("plane mesh missing positions");
+        };
+        for p in positions {
+            assert!(
+                p[2].abs() < 1e-5,
+                "plane vertices should lie in XY, got {p:?}"
+            );
+        }
     }
 
     fn sample_addr(port: u16) -> std::net::SocketAddr {

--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -2519,7 +2519,8 @@ mod tests {
     #[test]
     fn plane_mesh_is_horizontal_in_schematic_frame() {
         let mesh = impeller2_wkt::Mesh::plane(10.0, 20.0).into_bevy();
-        let Some(VertexAttributeValues::Float32x3(normals)) = mesh.attribute(Mesh::ATTRIBUTE_NORMAL)
+        let Some(VertexAttributeValues::Float32x3(normals)) =
+            mesh.attribute(Mesh::ATTRIBUTE_NORMAL)
         else {
             panic!("plane mesh missing normals");
         };


### PR DESCRIPTION
> This bug was identified during testing on main, before the release: in ball and other examples, the green plane was vertical.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized mesh conversion and documentation; behavior change only affects schematic plane visuals, with a regression test on generated geometry.
> 
> **Overview**
> **Schematic `plane` meshes now render as horizontal ground** when an object has identity attitude, instead of aligning to Bevy’s default Y-up plane.
> 
> The editor builds `Mesh::Plane` with **normal +Z** and extent in **XY** (schematic frame), so after the usual frame→Bevy composition, a floor at zero rotation reads as a floor. A unit test checks plane normals and vertex positions in mesh space.
> 
> **Docs** (`schematic.md`, `python-api.md`) describe `plane` as an XY rectangle with normal +Z/up, and clarify that default `object_3d` **orientation** composes attitude with the frame→Bevy basis so identity aligns with schematic axes (e.g. ENU), not raw Bevy Y-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5da4b0e8a46ac2722139c8a61df1e597a9a411d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->