### PR TITLE
fix(examples): use ASCII LL^T in covariance ellipsoid viewport title.

### DIFF
--- a/examples/covariance-ellipsoids/main.py
+++ b/examples/covariance-ellipsoids/main.py
@@ -95,7 +95,7 @@ def world() -> el.World:
         """
         coordinate frame=ENU
         hsplit {
-            viewport name="Cholesky: P = LLᵀ" pos="(0,0,0,1, 0,-6,4)" look_at="cholesky.world_pos" far=30.0 show_grid=#true active=#true
+            viewport name="Cholesky: P = LL^T" pos="(0,0,0,1, 0,-6,4)" look_at="cholesky.world_pos" far=30.0 show_grid=#true active=#true
             viewport frame=ENU name="Direct covariance: P" pos="(0,0,0,1, 8,-6,4)" look_at="covariance.world_pos" far=30.0 show_grid=#true active=#true
         }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Cosmetic string change in an example viewport name only; no runtime or API impact.
> 
> **Overview**
> Updates the left viewport label in the **covariance-ellipsoids** example schematic from `P = LLᵀ` (Unicode superscript **T**) to **`P = LL^T`** so the Cholesky decomposition caption renders reliably across fonts and environments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33dcc8da6eb98cb0f123987be4cad4cf487e6504. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->