### PR TITLE
Fix: GPU OOM error and fins animation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3944,15 +3944,6 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "convert_case"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
@@ -5563,7 +5554,6 @@ dependencies = [
  "axum-streams",
  "base64 0.22.1",
  "clap 4.6.1",
- "convert_case 0.8.0",
  "datafusion",
  "directories",
  "eql",
@@ -5695,7 +5685,6 @@ dependencies = [
  "big_space",
  "bitvec",
  "const-fnv1a-hash",
- "convert_case 0.7.1",
  "crossbeam-channel",
  "crossbeam-queue",
  "directories",
@@ -5982,6 +5971,7 @@ version = "0.18.1-alpha.0"
 dependencies = [
  "bevy_geo_frames",
  "bevy_math",
+ "convert_case 0.8.0",
  "hifitime",
  "impeller2",
  "impeller2-wkt",

--- a/libs/db/Cargo.toml
+++ b/libs/db/Cargo.toml
@@ -112,7 +112,6 @@ arrow.features = ["canonical_extension_types", "csv"]
 arrow-schema.version = "55"
 arrow-schema.features = ["canonical_extension_types"]
 datafusion.version = "47"
-convert_case = "0.8.0"
 thingbuf.version = "0.1"
 parquet.version = "55"
 parquet.optional = true

--- a/libs/db/eql/Cargo.toml
+++ b/libs/db/eql/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 # parse
 peg = "0.8.5"
 unicode-ident = "1.0.18"
+convert_case = "0.8.0"
 
 # data-structures
 smallvec = "1.15"

--- a/libs/db/eql/src/lib.rs
+++ b/libs/db/eql/src/lib.rs
@@ -7,12 +7,33 @@ use std::{
 };
 use unicode_ident::*;
 
+use convert_case::Casing;
 use impeller2::{
     schema::Schema,
     types::{ComponentId, Timestamp},
 };
 use impeller2_wkt::ComponentPath;
 use peg::error::ParseError;
+
+/// DataFusion table/column ident for a component name.
+///
+/// Must match `elodin-db` table registration: snake_case (digits are word
+/// boundaries) then replace non-alphanumeric characters with `_`.
+///
+/// `CANOPENMOTORMESSAGE3.ACTUAL_POSITION` → `canopenmotormessage_3_actual_position`
+pub fn sql_table_name(component_name: &str) -> String {
+    component_name
+        .to_case(convert_case::Case::Snake)
+        .chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
 
 pub mod formulas;
 
@@ -125,7 +146,7 @@ pub enum Expr {
 impl Expr {
     fn to_field(&self) -> Result<String, Error> {
         match self {
-            Expr::ComponentPart(component) => Ok(component.name.replace(".", "_")),
+            Expr::ComponentPart(component) => Ok(sql_table_name(&component.name)),
             Expr::Time(_) => Ok("time".to_string()),
             Expr::Formula(formula, expr) => formula.to_field(expr),
             Expr::BinaryOp(left, right, op) => Ok(format!(
@@ -137,7 +158,7 @@ impl Expr {
 
             Expr::ArrayAccess(inner_expr, index) => match inner_expr.as_ref() {
                 Expr::ComponentPart(part) if part.component.is_some() => {
-                    Ok(format!("{}[{}]", part.name.replace(".", "_"), index + 1))
+                    Ok(format!("{}[{}]", sql_table_name(&part.name), index + 1))
                 }
                 _ => Err(Error::InvalidFieldAccess(
                     "array access on non-component".to_string(),
@@ -153,9 +174,9 @@ impl Expr {
 
     fn to_table(&self) -> Result<String, Error> {
         match self {
-            Expr::ComponentPart(component) => Ok(component.name.replace(".", "_")),
+            Expr::ComponentPart(component) => Ok(sql_table_name(&component.name)),
 
-            Expr::Time(component) => Ok(component.name.replace(".", "_")),
+            Expr::Time(component) => Ok(sql_table_name(&component.name)),
             Expr::Formula(_, expr) => expr.to_table(),
             Expr::BinaryOp(left, right, _) => {
                 // Try left first, fall back to right if left is a literal
@@ -862,6 +883,36 @@ mod tests {
             Timestamp(0),    // earliest_timestamp
             Timestamp(1000), // last_timestamp
         )
+    }
+
+    #[test]
+    fn sql_table_name_splits_digits_like_datafusion_registration() {
+        assert_eq!(
+            sql_table_name("CANOPENMOTORMESSAGE3.ACTUAL_POSITION"),
+            "canopenmotormessage_3_actual_position"
+        );
+        assert_eq!(
+            sql_table_name("GpsPosMessage1.VACC"),
+            "gps_pos_message_1_vacc"
+        );
+        assert_eq!(sql_table_name("a.world_pos"), "a_world_pos");
+    }
+
+    #[test]
+    fn test_screaming_snake_component_sql() {
+        let component = Arc::new(Component::new(
+            "CANOPENMOTORMESSAGE3.ACTUAL_POSITION".to_string(),
+            ComponentId::new("CANOPENMOTORMESSAGE3.ACTUAL_POSITION"),
+            Schema::new(impeller2::types::PrimType::F64, Vec::<u64>::new()).unwrap(),
+        ));
+        let context = Context::from_leaves([component.clone()], Timestamp(0), Timestamp(1000));
+        let expr = context
+            .parse_str("CANOPENMOTORMESSAGE3.ACTUAL_POSITION")
+            .unwrap();
+        assert_eq!(
+            expr.to_sql(&context).unwrap(),
+            "select canopenmotormessage_3_actual_position.canopenmotormessage_3_actual_position as 'CANOPENMOTORMESSAGE3.ACTUAL_POSITION' from canopenmotormessage_3_actual_position"
+        );
     }
 
     #[test]

--- a/libs/db/src/arrow/mod.rs
+++ b/libs/db/src/arrow/mod.rs
@@ -8,7 +8,6 @@ use arrow::{
     compute,
     datatypes::*,
 };
-use convert_case::Casing;
 use datafusion::{
     catalog::streaming::StreamingTable, datasource::MemTable, execution::RecordBatchStream,
     physical_plan::streaming::PartitionStream, prelude::SessionContext,
@@ -354,9 +353,7 @@ impl DB {
                     .component_metadata
                     .get(&component.component_id)
                     .unwrap();
-                let component_name = sanitize_sql_table_name(
-                    &component_metadata.name.to_case(convert_case::Case::Snake),
-                );
+                let component_name = eql::sql_table_name(&component_metadata.name);
                 let name = component_name.clone();
                 let mem_table = component.as_mem_table_with_element_names(
                     &component_name,

--- a/libs/db/src/lib.rs
+++ b/libs/db/src/lib.rs
@@ -1,4 +1,3 @@
-use convert_case::Casing;
 use datafusion::common::HashSet;
 use futures_lite::StreamExt;
 use impeller2::registry::VTableRegistry;
@@ -59,6 +58,7 @@ const RESPONSE_PACKET_CAPACITY: usize = 8 * 1024 * 1024;
 pub mod append_log;
 mod arrow;
 pub use arrow::sanitize_sql_table_name;
+pub use eql::sql_table_name;
 #[cfg(feature = "axum")]
 pub mod assets;
 #[cfg(feature = "axum")]
@@ -2413,9 +2413,7 @@ async fn handle_packet<A: AsyncWrite + Send + Sync + 'static>(
                     else {
                         continue;
                     };
-                    let component_name = crate::arrow::sanitize_sql_table_name(
-                        &component_metadata.name.to_case(convert_case::Case::Snake),
-                    );
+                    let component_name = eql::sql_table_name(&component_metadata.name);
 
                     if component_name == table_name {
                         // Get the raw data as byte slices

--- a/libs/db/tests_query/eql_cast_query.rs
+++ b/libs/db/tests_query/eql_cast_query.rs
@@ -75,6 +75,22 @@ fn assert_query_success(output: std::process::Output) -> String {
 }
 
 #[test]
+fn eql_query_resolves_screaming_snake_component_with_trailing_digit() {
+    let dir = create_fixture(
+        "CANOPENMOTORMESSAGE3.ACTUAL_POSITION",
+        PrimType::F64,
+        &[
+            1.0f64.to_le_bytes().to_vec(),
+            2.0f64.to_le_bytes().to_vec(),
+            3.0f64.to_le_bytes().to_vec(),
+        ],
+    );
+    let output = run_eql_query(dir.path(), "CANOPENMOTORMESSAGE3.ACTUAL_POSITION");
+    let stdout = assert_query_success(output);
+    assert_eq!(csv_values(&stdout), vec!["1", "2", "3"]);
+}
+
+#[test]
 fn eql_cast_identifier_syntax_allows_u16_float_arithmetic() {
     let dir = create_fixture(
         "sensor.count",

--- a/libs/elodin-editor/Cargo.toml
+++ b/libs/elodin-editor/Cargo.toml
@@ -97,7 +97,6 @@ heapless.version = "0.8"
 arc-swap = "1.7.1"
 
 # helpers
-convert_case = "0.7"
 itertools = "0.12.1"
 opener = "0.7.1"
 hex = "0.4.3"

--- a/libs/elodin-editor/src/ui/data_overview/mod.rs
+++ b/libs/elodin-editor/src/ui/data_overview/mod.rs
@@ -13,7 +13,6 @@ use bevy::{
     prelude::*,
 };
 use bevy_egui::egui::{self, Color32, Pos2, Rect, Sense, Stroke, Vec2};
-use convert_case::{Case, Casing};
 use impeller2::types::{ComponentId, Timestamp};
 use impeller2_bevy::CommandsExt;
 use impeller2_wkt::{ArrowIPC, ErrorResponse, SQLQuery, SparklineQuery};
@@ -207,26 +206,10 @@ fn hue_to_rgb(p: f32, q: f32, mut t: f32) -> f32 {
 }
 
 /// Convert component name to SQL table name using the same conversion as the database.
-/// The database uses `to_case(Case::Snake)` followed by replacing invalid SQL characters.
 pub fn component_to_table_name(full_component_name: &str) -> String {
     // Full component name is like "GpsPosMessage1.VACC"
     // Table name is like "gps_pos_message_1_vacc"
-    // Must match the conversion in libs/db/src/arrow/mod.rs
-    sanitize_sql_table_name(&full_component_name.to_case(Case::Snake))
-}
-
-/// Sanitize a string to be a valid SQL table name.
-/// Replaces invalid characters with underscores.
-fn sanitize_sql_table_name(name: &str) -> String {
-    name.chars()
-        .map(|c| {
-            if c.is_alphanumeric() || c == '_' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect()
+    eql::sql_table_name(full_component_name)
 }
 
 /// Widget for rendering the Data Overview panel

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -830,22 +830,27 @@ fn collect_object_3d_mesh_component_ids(
     eql_ctx: &EqlContext,
     out: &mut HashSet<ComponentId>,
 ) {
-    let impeller2_wkt::Object3DMesh::Ellipsoid {
-        scale,
-        error_covariance_cholesky,
-        error_covariance,
-        ..
-    } = mesh
-    else {
-        return;
-    };
-
-    if let Some(cholesky) = error_covariance_cholesky {
-        collect_eql_component_ids(cholesky, eql_ctx, out);
-    } else if let Some(covariance) = error_covariance {
-        collect_eql_component_ids(covariance, eql_ctx, out);
-    } else {
-        collect_eql_component_ids(scale, eql_ctx, out);
+    match mesh {
+        impeller2_wkt::Object3DMesh::Glb { animations, .. } => {
+            for anim in animations {
+                collect_eql_component_ids(&anim.eql_expr, eql_ctx, out);
+            }
+        }
+        impeller2_wkt::Object3DMesh::Ellipsoid {
+            scale,
+            error_covariance_cholesky,
+            error_covariance,
+            ..
+        } => {
+            if let Some(cholesky) = error_covariance_cholesky {
+                collect_eql_component_ids(cholesky, eql_ctx, out);
+            } else if let Some(covariance) = error_covariance {
+                collect_eql_component_ids(covariance, eql_ctx, out);
+            } else {
+                collect_eql_component_ids(scale, eql_ctx, out);
+            }
+        }
+        impeller2_wkt::Object3DMesh::Mesh { .. } => {}
     }
 }
 
@@ -2586,6 +2591,62 @@ mod tests {
         ids.clear();
         collect_object_3d_mesh_component_ids(&mesh, &eql_ctx, &mut ids);
         assert_eq!(ids, [ComponentId::new("shape.scale")].into_iter().collect());
+    }
+
+    #[test]
+    fn glb_joint_animation_eql_components_are_allowlisted() {
+        use impeller2::schema::Schema;
+        use impeller2::types::PrimType;
+        use impeller2_wkt::{JointAnimation, Object3DMesh};
+
+        let components = [
+            "CANOPENMOTORMESSAGE3.ACTUAL_POSITION",
+            "CONTROLMESSAGE.FIN_DEFLECTION_DEG",
+        ]
+        .map(|name| {
+            Arc::new(eql::Component::new(
+                name.to_string(),
+                ComponentId::new(name),
+                Schema::new(PrimType::F64, vec![4_u64]).expect("valid schema"),
+            ))
+        });
+        let eql_ctx = EqlContext(eql::Context::from_leaves(
+            components,
+            Timestamp(0),
+            Timestamp(1),
+        ));
+        let mesh = Object3DMesh::Glb {
+            path: "models/fins.glb".into(),
+            scale: 1.0,
+            translate: (0.0, 0.0, 0.0),
+            rotate: (0.0, 0.0, 0.0),
+            animations: vec![
+                JointAnimation {
+                    joint_name: "Root.Fin_3".into(),
+                    eql_expr:
+                        "(0, CANOPENMOTORMESSAGE3.ACTUAL_POSITION.cast(f32)/1000.0 - 22.0, 0)"
+                            .into(),
+                },
+                JointAnimation {
+                    joint_name: "FinGhost_0".into(),
+                    eql_expr: "(0, CONTROLMESSAGE.FIN_DEFLECTION_DEG[0], 0)".into(),
+                },
+            ],
+            emissivity: 0.0,
+            glow: 0.0,
+            glow_color: None,
+        };
+
+        let mut ids = HashSet::new();
+        collect_object_3d_mesh_component_ids(&mesh, &eql_ctx, &mut ids);
+        assert!(
+            ids.contains(&ComponentId::new("CANOPENMOTORMESSAGE3.ACTUAL_POSITION")),
+            "missing motor position, ids={ids:?}"
+        );
+        assert!(
+            ids.contains(&ComponentId::new("CONTROLMESSAGE.FIN_DEFLECTION_DEG")),
+            "missing ghost deflection, ids={ids:?}"
+        );
     }
 
     #[test]

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -1175,7 +1175,14 @@ impl XYLine {
         }
     }
 
+    pub fn gpu_resident(&self) -> bool {
+        self.x_shard_alloc.is_some() || self.y_shard_alloc.is_some()
+    }
+
     pub fn unload_gpu(&mut self) {
+        if !self.gpu_resident() {
+            return;
+        }
         for buf in &self.x_values {
             buf.release_gpu();
         }
@@ -2130,7 +2137,14 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
         self.clear_raw();
     }
 
+    pub fn gpu_resident(&self) -> bool {
+        self.data_buffer_shard_alloc.is_some() || self.timestamp_buffer_shard_alloc.is_some()
+    }
+
     pub fn unload_gpu(&mut self) {
+        if !self.gpu_resident() {
+            return;
+        }
         for (_, chunk) in self.tree.overlapping_mut(ii(i64::MIN, i64::MAX)) {
             chunk.data.release_gpu();
             chunk.timestamps_float.release_gpu();
@@ -2152,11 +2166,6 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
         self.tree
             .iter()
             .all(|(_, chunk)| chunk.data.gpu_is_dirty() && chunk.timestamps_float.gpu_is_dirty())
-    }
-
-    #[cfg(test)]
-    fn has_gpu_allocs(&self) -> bool {
-        self.data_buffer_shard_alloc.is_some() || self.timestamp_buffer_shard_alloc.is_some()
     }
 }
 
@@ -3294,7 +3303,7 @@ mod tests {
     }
 
     #[test]
-    fn unload_gpu_drops_allocs_and_dirties_shards() {
+    fn unload_gpu_is_noop_when_already_cleared() {
         let mut tree = LineTree::<f32>::default();
         let chunk = Chunk::from_iter(
             &[Timestamp(10), Timestamp(20)],
@@ -3305,27 +3314,25 @@ mod tests {
         tree.insert(chunk);
         tree.mark_gpu_clean();
         assert!(!tree.all_gpu_dirty());
-        assert!(!tree.has_gpu_allocs());
+        assert!(!tree.gpu_resident());
 
         tree.unload_gpu();
-        assert!(tree.all_gpu_dirty());
-        assert!(!tree.has_gpu_allocs());
+        assert!(!tree.all_gpu_dirty());
+        assert!(!tree.gpu_resident());
     }
 
     #[test]
-    fn xy_unload_gpu_drops_allocs_and_dirties_shards() {
+    fn xy_unload_gpu_is_noop_when_already_cleared() {
         let mut xy = XYLine::default();
         xy.push_x_value(1.0);
         xy.push_y_value(2.0);
         xy.mark_gpu_clean();
         assert!(!xy.all_gpu_dirty());
-        assert!(xy.x_shard_alloc.is_none());
-        assert!(xy.y_shard_alloc.is_none());
+        assert!(!xy.gpu_resident());
 
         xy.unload_gpu();
-        assert!(xy.all_gpu_dirty());
-        assert!(xy.x_shard_alloc.is_none());
-        assert!(xy.y_shard_alloc.is_none());
+        assert!(!xy.all_gpu_dirty());
+        assert!(!xy.gpu_resident());
     }
 
     #[test]
@@ -3352,21 +3359,55 @@ mod tests {
         let a = LineHandle::Timeseries(handle.clone());
         let b = LineHandle::Timeseries(handle.clone());
         let cases = [
-            (true, false, false),
-            (false, true, false),
-            (true, true, false),
-            (false, false, true),
+            (true, false, true),
+            (false, true, true),
+            (true, true, true),
+            (false, false, false),
         ];
-        for (a_on, b_on, expect_unloaded) in cases {
+        for (a_on, b_on, expect_visible) in cases {
             lines.get_mut(&handle).expect("line").data.mark_gpu_clean();
             let (visible_ts, visible_xy) = visible_plot_gpu_asset_ids([(&a, a_on), (&b, b_on)]);
-            unload_plot_gpu_not_on_screen(&mut lines, &mut xy_lines, &visible_ts, &visible_xy);
-            let dirty = lines.get(&handle).expect("line").data.all_gpu_dirty();
             assert_eq!(
-                dirty, expect_unloaded,
-                "a_on={a_on} b_on={b_on} expect_unloaded={expect_unloaded}"
+                visible_ts.contains(&handle.id()),
+                expect_visible,
+                "a_on={a_on} b_on={b_on} expect_visible={expect_visible}"
             );
+            unload_plot_gpu_not_on_screen(&mut lines, &mut xy_lines, &visible_ts, &visible_xy);
+            // No shard allocs ⇒ already cleared; must not walk/lock or dirty shards.
+            assert!(!lines.get(&handle).expect("line").data.all_gpu_dirty());
+            assert!(!lines.get(&handle).expect("line").data.gpu_resident());
         }
+    }
+
+    #[test]
+    fn unload_plot_gpu_skips_already_cleared_assets() {
+        use crate::ui::plot::gpu::unload_plot_gpu_not_on_screen;
+
+        let mut lines = Assets::<Line>::default();
+        let mut xy_lines = Assets::<XYLine>::default();
+        let ts = lines.add(Line::default());
+        let xy = xy_lines.add(XYLine::default());
+        {
+            let mut line = lines.get_mut(&ts).expect("line");
+            let chunk = Chunk::from_iter(
+                &[Timestamp(1), Timestamp(2)],
+                Timestamp(0),
+                [0.0_f32, 1.0_f32].into_iter(),
+            )
+            .expect("chunk");
+            line.data.insert(chunk);
+            line.data.mark_gpu_clean();
+        }
+        {
+            let mut xy_line = xy_lines.get_mut(&xy).expect("xy");
+            xy_line.push_x_value(1.0);
+            xy_line.push_y_value(2.0);
+            xy_line.mark_gpu_clean();
+        }
+
+        unload_plot_gpu_not_on_screen(&mut lines, &mut xy_lines, &HashSet::new(), &HashSet::new());
+        assert!(!lines.get(&ts).expect("line").data.all_gpu_dirty());
+        assert!(!xy_lines.get(&xy).expect("xy").all_gpu_dirty());
     }
 }
 

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -1170,6 +1170,32 @@ impl XYLine {
         }
     }
 
+    pub fn unload_gpu(&mut self) {
+        for buf in &self.x_values {
+            buf.release_gpu();
+        }
+        for buf in &self.y_values {
+            buf.release_gpu();
+        }
+        self.x_shard_alloc = None;
+        self.y_shard_alloc = None;
+    }
+
+    #[cfg(test)]
+    fn mark_gpu_clean(&self) {
+        for buf in self.x_values.iter().chain(self.y_values.iter()) {
+            buf.mark_gpu_clean();
+        }
+    }
+
+    #[cfg(test)]
+    fn all_gpu_dirty(&self) -> bool {
+        self.x_values
+            .iter()
+            .chain(self.y_values.iter())
+            .all(|buf| buf.gpu_is_dirty())
+    }
+
     pub fn write_to_index_buffer(
         &mut self,
         index_buffer: &Buffer,
@@ -1300,6 +1326,21 @@ impl<T: IntoBytes + Immutable + Debug + Clone, const N: usize> SharedBuffer<T, N
 impl<T, const N: usize> SharedBuffer<T, N> {
     pub fn cpu(&self) -> &[T] {
         &self.cpu
+    }
+
+    fn release_gpu(&self) {
+        let _ = self.gpu.lock().take();
+        self.gpu_dirty.store(true, atomic::Ordering::SeqCst);
+    }
+
+    #[cfg(test)]
+    fn gpu_is_dirty(&self) -> bool {
+        self.gpu_dirty.load(atomic::Ordering::SeqCst)
+    }
+
+    #[cfg(test)]
+    fn mark_gpu_clean(&self) {
+        self.gpu_dirty.store(false, atomic::Ordering::SeqCst);
     }
 }
 
@@ -2082,6 +2123,35 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
             }
         }
         self.clear_raw();
+    }
+
+    pub fn unload_gpu(&mut self) {
+        for (_, chunk) in self.tree.overlapping_mut(ii(i64::MIN, i64::MAX)) {
+            chunk.data.release_gpu();
+            chunk.timestamps_float.release_gpu();
+        }
+        self.data_buffer_shard_alloc = None;
+        self.timestamp_buffer_shard_alloc = None;
+    }
+
+    #[cfg(test)]
+    fn mark_gpu_clean(&mut self) {
+        for (_, chunk) in self.tree.overlapping_mut(ii(i64::MIN, i64::MAX)) {
+            chunk.data.mark_gpu_clean();
+            chunk.timestamps_float.mark_gpu_clean();
+        }
+    }
+
+    #[cfg(test)]
+    fn all_gpu_dirty(&self) -> bool {
+        self.tree
+            .iter()
+            .all(|(_, chunk)| chunk.data.gpu_is_dirty() && chunk.timestamps_float.gpu_is_dirty())
+    }
+
+    #[cfg(test)]
+    fn has_gpu_allocs(&self) -> bool {
+        self.data_buffer_shard_alloc.is_some() || self.timestamp_buffer_shard_alloc.is_some()
     }
 }
 
@@ -3160,6 +3230,82 @@ mod tests {
         }
         // Timestamp(i64) = 8 bytes + f32 = 4 bytes => 12 bytes per sample.
         assert_eq!(tree.raw_archive_bytes(), 1_000 * 12);
+    }
+
+    #[test]
+    fn unload_gpu_drops_allocs_and_dirties_shards() {
+        let mut tree = LineTree::<f32>::default();
+        let chunk = Chunk::from_iter(
+            &[Timestamp(10), Timestamp(20)],
+            Timestamp(0),
+            [1.0_f32, 2.0_f32].into_iter(),
+        )
+        .expect("chunk");
+        tree.insert(chunk);
+        tree.mark_gpu_clean();
+        assert!(!tree.all_gpu_dirty());
+        assert!(!tree.has_gpu_allocs());
+
+        tree.unload_gpu();
+        assert!(tree.all_gpu_dirty());
+        assert!(!tree.has_gpu_allocs());
+    }
+
+    #[test]
+    fn xy_unload_gpu_drops_allocs_and_dirties_shards() {
+        let mut xy = XYLine::default();
+        xy.push_x_value(1.0);
+        xy.push_y_value(2.0);
+        xy.mark_gpu_clean();
+        assert!(!xy.all_gpu_dirty());
+        assert!(xy.x_shard_alloc.is_none());
+        assert!(xy.y_shard_alloc.is_none());
+
+        xy.unload_gpu();
+        assert!(xy.all_gpu_dirty());
+        assert!(xy.x_shard_alloc.is_none());
+        assert!(xy.y_shard_alloc.is_none());
+    }
+
+    #[test]
+    fn shared_line_stays_loaded_while_any_pane_is_on_screen() {
+        use crate::ui::plot::gpu::{
+            LineHandle, unload_plot_gpu_not_on_screen, visible_plot_gpu_asset_ids,
+        };
+
+        let mut lines = Assets::<Line>::default();
+        let mut xy_lines = Assets::<XYLine>::default();
+        let handle = lines.add(Line::default());
+        {
+            let mut line = lines.get_mut(&handle).expect("line");
+            let chunk = Chunk::from_iter(
+                &[Timestamp(1), Timestamp(2)],
+                Timestamp(0),
+                [0.0_f32, 1.0_f32].into_iter(),
+            )
+            .expect("chunk");
+            line.data.insert(chunk);
+            line.data.mark_gpu_clean();
+        }
+
+        let a = LineHandle::Timeseries(handle.clone());
+        let b = LineHandle::Timeseries(handle.clone());
+        let cases = [
+            (true, false, false),
+            (false, true, false),
+            (true, true, false),
+            (false, false, true),
+        ];
+        for (a_on, b_on, expect_unloaded) in cases {
+            lines.get_mut(&handle).expect("line").data.mark_gpu_clean();
+            let (visible_ts, visible_xy) = visible_plot_gpu_asset_ids([(&a, a_on), (&b, b_on)]);
+            unload_plot_gpu_not_on_screen(&mut lines, &mut xy_lines, &visible_ts, &visible_xy);
+            let dirty = lines.get(&handle).expect("line").data.all_gpu_dirty();
+            assert_eq!(
+                dirty, expect_unloaded,
+                "a_on={a_on} b_on={b_on} expect_unloaded={expect_unloaded}"
+            );
+        }
     }
 }
 

--- a/libs/elodin-editor/src/ui/plot/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot/gpu.rs
@@ -631,13 +631,34 @@ pub(crate) fn unload_plot_gpu_not_on_screen(
     visible_ts: &HashSet<AssetId<Line>>,
     visible_xy: &HashSet<AssetId<XYLine>>,
 ) {
-    for (id, line) in line_assets.iter_mut() {
-        if !visible_ts.contains(&id) {
+    let ts_unload: Vec<AssetId<Line>> = line_assets
+        .iter()
+        .filter_map(|(id, line)| {
+            if visible_ts.contains(&id) || !line.data.gpu_resident() {
+                None
+            } else {
+                Some(id)
+            }
+        })
+        .collect();
+    for id in ts_unload {
+        if let Some(mut line) = line_assets.get_mut(id) {
             line.data.unload_gpu();
         }
     }
-    for (id, xy_line) in xy_assets.iter_mut() {
-        if !visible_xy.contains(&id) {
+
+    let xy_unload: Vec<AssetId<XYLine>> = xy_assets
+        .iter()
+        .filter_map(|(id, xy_line)| {
+            if visible_xy.contains(&id) || !xy_line.gpu_resident() {
+                None
+            } else {
+                Some(id)
+            }
+        })
+        .collect();
+    for id in xy_unload {
+        if let Some(mut xy_line) = xy_assets.get_mut(id) {
             xy_line.unload_gpu();
         }
     }

--- a/libs/elodin-editor/src/ui/plot/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot/gpu.rs
@@ -1,11 +1,12 @@
 //! GPU rendering for plot data
 #![allow(dead_code)] // Shader struct fields appear unused to Rust but are used by GPU
 
-use bevy::asset::{AssetApp, Assets, uuid_handle};
+use bevy::asset::{AssetApp, AssetId, Assets, Handle, uuid_handle};
 use bevy::color::ColorToComponents;
 use bevy::core_pipeline::core_2d::CORE_2D_DEPTH_FORMAT;
 use bevy::ecs::bundle::Bundle;
 use bevy::ecs::entity::Entity;
+use bevy::ecs::hierarchy::ChildOf;
 use bevy::ecs::schedule::{IntoScheduleConfigs, SystemSet};
 use bevy::ecs::system::{Commands, Query, Res, ResMut, SystemState};
 use bevy::math::{FloatOrd, Vec4};
@@ -25,7 +26,7 @@ use bevy::shader::Shader;
 use bevy::sprite_render::{Mesh2dPipeline, SetMesh2dViewBindGroup, init_mesh_2d_pipeline};
 use bevy::{
     app::Plugin,
-    asset::{Handle, load_internal_asset},
+    asset::load_internal_asset,
     core_pipeline::core_2d::Transparent2d,
     ecs::{
         component::Component,
@@ -45,9 +46,11 @@ use bevy_render::sync_world::{MainEntity, SyncToRenderWorld, TemporaryRenderEnti
 use binding_types::storage_buffer_read_only_sized;
 use impeller2::types::Timestamp;
 use impeller2_wkt::GraphType;
+use std::collections::HashSet;
 use std::num::NonZeroU64;
 use std::ops::Range;
 
+use crate::ui::ViewportRect;
 use crate::ui::plot::{CHUNK_COUNT, CHUNK_LEN, Line, XYLine};
 
 use super::BufferShardAlloc;
@@ -554,6 +557,7 @@ type DrawLine2d = (
 type LineQueryMut = (
     Entity,
     &'static LineHandle,
+    Option<&'static ChildOf>,
     &'static LineConfig,
     &'static mut LineUniform,
     &'static mut LineVisibleRange,
@@ -564,6 +568,7 @@ type LineQueryMut = (
 
 type ExtractLinesParams = (
     Query<'static, 'static, LineQueryMut>,
+    Query<'static, 'static, &'static ViewportRect>,
     ResMut<'static, Assets<Line>>,
     ResMut<'static, Assets<XYLine>>,
     Res<'static, crate::SelectedTimeRange>,
@@ -585,6 +590,59 @@ impl bevy::prelude::FromWorld for ExtractLinesState {
     }
 }
 
+fn line_gpu_pane_on_screen(
+    child_of: Option<&ChildOf>,
+    viewport_rects: &Query<&ViewportRect>,
+) -> bool {
+    let Some(child) = child_of else {
+        return true;
+    };
+    viewport_rects
+        .get(child.parent())
+        .ok()
+        .and_then(|rect| rect.0)
+        .is_some()
+}
+
+pub(crate) fn visible_plot_gpu_asset_ids<'a>(
+    entries: impl IntoIterator<Item = (&'a LineHandle, bool)>,
+) -> (HashSet<AssetId<Line>>, HashSet<AssetId<XYLine>>) {
+    let mut timeseries = HashSet::new();
+    let mut xy = HashSet::new();
+    for (handle, on_screen) in entries {
+        if !on_screen {
+            continue;
+        }
+        match handle {
+            LineHandle::Timeseries(h) => {
+                timeseries.insert(h.id());
+            }
+            LineHandle::XY(h) => {
+                xy.insert(h.id());
+            }
+        }
+    }
+    (timeseries, xy)
+}
+
+pub(crate) fn unload_plot_gpu_not_on_screen(
+    line_assets: &mut Assets<Line>,
+    xy_assets: &mut Assets<XYLine>,
+    visible_ts: &HashSet<AssetId<Line>>,
+    visible_xy: &HashSet<AssetId<XYLine>>,
+) {
+    for (id, line) in line_assets.iter_mut() {
+        if !visible_ts.contains(&id) {
+            line.data.unload_gpu();
+        }
+    }
+    for (id, xy_line) in xy_assets.iter_mut() {
+        if !visible_xy.contains(&id) {
+            xy_line.unload_gpu();
+        }
+    }
+}
+
 fn extract_lines(
     mut main_world: ResMut<MainWorld>,
     mut commands: Commands,
@@ -594,14 +652,42 @@ fn extract_lines(
 ) {
     main_world.resource_scope(
         |world, mut cached_state: bevy::prelude::Mut<ExtractLinesState>| {
-            let (mut lines, mut line_assets, mut xy_lines, selected_range, mut main_commands) =
-                cached_state.state.params_mut(world);
+            let (
+                mut lines,
+                viewport_rects,
+                mut line_assets,
+                mut xy_lines,
+                selected_range,
+                mut main_commands,
+            ) = cached_state.state.params_mut(world);
             let selected = selected_range.0.clone();
             let selected_span_micros = selected.end.0.saturating_sub(selected.start.0);
             let short_window = crate::is_short_accuracy_window(&selected);
+
+            let mut on_screen_entries = Vec::new();
+            for (entity, line_handle, child_of, _, _, _, _, _, mut cache) in lines.iter_mut() {
+                let on_screen = line_gpu_pane_on_screen(child_of, &viewport_rects);
+                if !on_screen && let Some(ref mut cache) = cache {
+                    cache.0 = None;
+                }
+                on_screen_entries.push((entity, line_handle.clone(), on_screen));
+            }
+            let (visible_ts, visible_xy) = visible_plot_gpu_asset_ids(
+                on_screen_entries
+                    .iter()
+                    .map(|(_, handle, on_screen)| (handle, *on_screen)),
+            );
+            unload_plot_gpu_not_on_screen(
+                &mut line_assets,
+                &mut xy_lines,
+                &visible_ts,
+                &visible_xy,
+            );
+
             for (
                 entity,
                 line_handle,
+                child_of,
                 config,
                 uniform,
                 line_visible_range,
@@ -610,6 +696,9 @@ fn extract_lines(
                 mut cache,
             ) in lines.iter_mut()
             {
+                if !line_gpu_pane_on_screen(child_of, &viewport_rects) {
+                    continue;
+                }
                 let Some(mut line) = line_handle.get(&mut line_assets, &mut xy_lines) else {
                     continue;
                 };

--- a/libs/elodin-editor/src/ui/plot/widget.rs
+++ b/libs/elodin-editor/src/ui/plot/widget.rs
@@ -1576,14 +1576,17 @@ pub fn auto_y_bounds(
 
 #[allow(clippy::type_complexity)]
 pub fn sync_graphs(
-    mut graph_states: Query<&mut GraphState, Without<crate::ui::query_plot::QueryPlotData>>,
+    mut graph_states: Query<
+        (Entity, &mut GraphState),
+        Without<crate::ui::query_plot::QueryPlotData>,
+    >,
     metadata_store: Res<ComponentMetadataRegistry>,
     schema_store: Res<ComponentSchemaRegistry>,
     mut collected_graph_data: ResMut<CollectedGraphData>,
     mut lines: ResMut<Assets<Line>>,
     mut commands: Commands,
 ) {
-    for mut graph_state in graph_states.iter_mut() {
+    for (graph_entity, mut graph_state) in graph_states.iter_mut() {
         let graph_state = &mut *graph_state;
 
         for (component_path, component_values) in &graph_state.components {
@@ -1649,6 +1652,7 @@ pub fn sync_graphs(
                             })
                             .insert(Name::new("line"))
                             .insert(LineWidgetWidth(graph_state.widget_width as usize))
+                            .insert(ChildOf(graph_entity))
                             .id();
                         graph_state
                             .enabled_lines
@@ -1668,7 +1672,8 @@ pub fn sync_graphs(
                             .try_insert(graph_state.graph_type)
                             .try_insert(LineWidgetWidth(graph_state.widget_width as usize))
                             .try_insert(graph_state.visible_range.clone())
-                            .try_insert(LineHandle::Timeseries(line));
+                            .try_insert(LineHandle::Timeseries(line))
+                            .try_insert(ChildOf(graph_entity));
                     }
                     (None, false) => {}
                 }

--- a/libs/nox-py/src/db/mod.rs
+++ b/libs/nox-py/src/db/mod.rs
@@ -13,7 +13,6 @@
 //! Python-facing calls communicate over bounded std channels and release the
 //! GIL while blocking.
 
-use convert_case::Casing;
 use impeller2::types::PrimType;
 use pyo3::prelude::*;
 
@@ -88,7 +87,7 @@ pub(crate) fn format_prim_type(prim_type: PrimType) -> String {
 /// exact conversion the server uses, so it can never drift.
 #[pyfunction]
 fn sql_table_name(component_name: &str) -> String {
-    elodin_db::sanitize_sql_table_name(&component_name.to_case(convert_case::Case::Snake))
+    elodin_db::sql_table_name(component_name)
 }
 
 pub fn register(parent_module: &Bound<'_, PyModule>) -> PyResult<()> {


### PR DESCRIPTION
These issues were found during testing against a real telemetry DB:

1. GPU out of memory errors due to so many line graphs. Solution: Do not allocate GPU memory for offscreen lines.
2. `elodin-db query --eql` for certain expressions would fail. Specifically this one would fail: `elodin-db query --eql CANOPENMESSAGE0.ACTUAL_POSITION $REALDB`.
3. The fins would not animate. Solution: EQL expressions in animate have to be added to the telemetry list.

I would suggest looking at each commit in isolation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> SQL naming is shared across DB, EQL, editor, and Python—behavior change for some component names is intentional but must stay consistent everywhere; plot GPU unload touches render hot path and shared assets.
> 
> **Overview**
> **EQL / SQL table naming** — Adds shared `eql::sql_table_name` (snake_case with digit word boundaries, then sanitize) and routes EQL SQL generation, DataFusion registration, table lookup, editor data overview, and Python bindings through it instead of ad hoc dot→underscore or duplicated `convert_case` logic. Fixes queries like `CANOPENMOTORMESSAGE3.ACTUAL_POSITION` that previously pointed at the wrong table.
> 
> **Plot GPU memory** — Line entities are parented under graph panes via `ChildOf`; extract uses `ViewportRect` to detect on-screen panes, skips GPU work for off-screen lines, and calls new `unload_gpu` / `gpu_resident` on `LineTree` and `XYLine` so shared line assets stay loaded while any pane is visible.
> 
> **3D / telemetry** — `collect_object_3d_mesh_component_ids` now walks **GLB** `JointAnimation` EQL expressions so animated fins pull the right components into the allowlist/prefetch path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9868bcea0674e6c103a279638d05f54c3f6f1b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->