### PR TITLE
feat(voyager): add heliocentric relative dynamics

### DIFF
--- a/examples/voyager/README.md
+++ b/examples/voyager/README.md
@@ -13,9 +13,10 @@ In this example it provides reference
 positions and velocities for the planets and the Voyager spacecraft
 from published files (aka SPICE kernels).
 
-This example is a work in progress. Right now the simulated probes do
-not make it to Saturn. Future work is needed to isolate the error
-sources and improve the simulation.
+This example is a work in progress. The simulated probes still do not
+reproduce the gravity assists or reach Saturn. Chapter 2 below fixes
+one real error in the Sun-centered force model; it does not turn this
+into a mission reconstruction.
 
 The editor exposes that divergence numerically as two telemetry signals
 for each simulated probe:
@@ -60,6 +61,25 @@ which `main.py` loads at startup.
 
 ## Run
 
+Chapter 1 is the original model and the default:
+
 ```bash
 python examples/voyager/main.py run
 ```
+
+Chapter 2 uses the same kernels, masses, RK4 integrator, and timestep,
+but subtracts each planet's acceleration of the Sun. The states are
+Sun-relative (`r = R_probe - R_sun`), so the force model needs
+
+```text
+mu_i * ((r_i - r) / |r_i - r|^3 - r_i / |r_i|^3)
+```
+
+```bash
+python examples/voyager/chapter_2.py run
+```
+
+That correction reduces long-span disagreement with the published
+supertrajectory, but the probes still do not slingshot correctly. This
+example does not reconstruct maneuvers or claim navigation-grade
+accuracy.

--- a/examples/voyager/README.md
+++ b/examples/voyager/README.md
@@ -13,10 +13,9 @@ In this example it provides reference
 positions and velocities for the planets and the Voyager spacecraft
 from published files (aka SPICE kernels).
 
-This example is a work in progress. The simulated probes still do not
-reproduce the gravity assists or reach Saturn. Chapter 2 below fixes
-one real error in the Sun-centered force model; it does not turn this
-into a mission reconstruction.
+This example is a work in progress. Right now the simulated probes do
+not make it to Saturn. Future work is needed to isolate the error
+sources and improve the simulation.
 
 The editor exposes that divergence numerically as two telemetry signals
 for each simulated probe:
@@ -61,25 +60,10 @@ which `main.py` loads at startup.
 
 ## Run
 
-Chapter 1 is the original model and the default:
-
 ```bash
 python examples/voyager/main.py run
 ```
 
-Chapter 2 uses the same kernels, masses, RK4 integrator, and timestep,
-but subtracts each planet's acceleration of the Sun. The states are
-Sun-relative (`r = R_probe - R_sun`), so the force model needs
-
-```text
-mu_i * ((r_i - r) / |r_i - r|^3 - r_i / |r_i|^3)
-```
-
-```bash
-python examples/voyager/chapter_2.py run
-```
-
-That correction reduces long-span disagreement with the published
-supertrajectory, but the probes still do not slingshot correctly. This
-example does not reconstruct maneuvers or claim navigation-grade
-accuracy.
+Chapter 2 (`python examples/voyager/chapter_2.py run`) subtracts each
+planet's acceleration of the Sun. Same kernels, masses, RK4, and
+timestep. It does not reproduce the gravity assists.

--- a/examples/voyager/chapter_2.py
+++ b/examples/voyager/chapter_2.py
@@ -1,0 +1,8 @@
+"""Run Voyager Chapter 2: heliocentric relative dynamics."""
+
+import os
+import runpy
+from pathlib import Path
+
+os.environ["VOYAGER_DYNAMICS_CHAPTER"] = "2"
+runpy.run_path(Path(__file__).with_name("main.py"), run_name="__main__")

--- a/examples/voyager/dynamics.py
+++ b/examples/voyager/dynamics.py
@@ -1,0 +1,41 @@
+"""Small, testable pieces of the Voyager gravity models."""
+
+from collections.abc import Iterable, Mapping
+
+import jax.numpy as jnp
+
+
+def direct_planetary_acceleration(
+    probe_position,
+    source_position,
+    gravitational_parameter,
+):
+    """Acceleration of a probe toward one gravity source, in m/s^2."""
+    source_to_probe = source_position - probe_position
+    distance = jnp.linalg.norm(source_to_probe)
+    return gravitational_parameter * source_to_probe / distance**3
+
+
+def planetary_acceleration_of_sun(source_position, gravitational_parameter):
+    """Acceleration of the heliocentric origin toward one planet, in m/s^2."""
+    source_distance = jnp.linalg.norm(source_position)
+    safe_distance = jnp.where(source_distance > 0.0, source_distance, 1.0)
+    return gravitational_parameter * source_position / safe_distance**3
+
+
+def heliocentric_relative_acceleration(
+    probe_position,
+    source_position,
+    gravitational_parameter,
+):
+    """Probe acceleration relative to the accelerating Sun, in m/s^2."""
+    direct_acceleration = direct_planetary_acceleration(
+        probe_position, source_position, gravitational_parameter
+    )
+    sun_acceleration = planetary_acceleration_of_sun(source_position, gravitational_parameter)
+    return direct_acceleration - sun_acceleration
+
+
+def gravity_source_entity_names(planets: Iterable[Mapping[str, object]]) -> tuple[str, ...]:
+    """Return the Sun and planet entities that may source probe gravity."""
+    return ("Sun", *(str(planet["entity_name"]) for planet in planets))

--- a/examples/voyager/dynamics.py
+++ b/examples/voyager/dynamics.py
@@ -1,41 +1,10 @@
-"""Small, testable pieces of the Voyager gravity models."""
-
-from collections.abc import Iterable, Mapping
-
 import jax.numpy as jnp
 
 
-def direct_planetary_acceleration(
-    probe_position,
-    source_position,
-    gravitational_parameter,
-):
-    """Acceleration of a probe toward one gravity source, in m/s^2."""
-    source_to_probe = source_position - probe_position
-    distance = jnp.linalg.norm(source_to_probe)
-    return gravitational_parameter * source_to_probe / distance**3
-
-
-def planetary_acceleration_of_sun(source_position, gravitational_parameter):
-    """Acceleration of the heliocentric origin toward one planet, in m/s^2."""
-    source_distance = jnp.linalg.norm(source_position)
-    safe_distance = jnp.where(source_distance > 0.0, source_distance, 1.0)
-    return gravitational_parameter * source_position / safe_distance**3
-
-
-def heliocentric_relative_acceleration(
-    probe_position,
-    source_position,
-    gravitational_parameter,
-):
-    """Probe acceleration relative to the accelerating Sun, in m/s^2."""
-    direct_acceleration = direct_planetary_acceleration(
-        probe_position, source_position, gravitational_parameter
-    )
-    sun_acceleration = planetary_acceleration_of_sun(source_position, gravitational_parameter)
-    return direct_acceleration - sun_acceleration
-
-
-def gravity_source_entity_names(planets: Iterable[Mapping[str, object]]) -> tuple[str, ...]:
-    """Return the Sun and planet entities that may source probe gravity."""
-    return ("Sun", *(str(planet["entity_name"]) for planet in planets))
+def heliocentric_relative_acceleration(probe_position, source_position, mu):
+    """Direct pull on the probe minus that source's acceleration of the Sun."""
+    to_probe = source_position - probe_position
+    direct = mu * to_probe / jnp.linalg.norm(to_probe) ** 3
+    r = jnp.linalg.norm(source_position)
+    sun = jnp.where(r > 0.0, mu * source_position / r**3, 0.0)
+    return direct - sun

--- a/examples/voyager/main.py
+++ b/examples/voyager/main.py
@@ -9,6 +9,11 @@ import spiceypy as spice
 import numpy as np
 from pathlib import Path
 
+from dynamics import (
+    gravity_source_entity_names,
+    heliocentric_relative_acceleration,
+)
+
 # SIM_TIME_STEP = 1.0 / 120.0
 SIM_TIME_STEP = 3600.0
 # SIM_TIME_STEP = 86400.0
@@ -18,6 +23,7 @@ G = 6.6743e-11
 DEFAULT_DB_PATH = "dbs/voyager"
 DB_PATH_ENV = "DB_PATH"
 MAX_TICKS_ENV = "MAX_TICKS"
+DYNAMICS_CHAPTER_ENV = "VOYAGER_DYNAMICS_CHAPTER"
 
 SPICE_DIR = Path(__file__).resolve().parent / "nasa_spice_data"
 SPICE_KERNELS = [
@@ -288,9 +294,35 @@ def gravity(
     )
 
 
+@el.system
+def heliocentric_gravity(
+    graph: el.GraphQuery[GravityEdge],
+    query: el.Query[el.WorldPos, el.Inertia],
+) -> el.Query[el.Force]:
+    """Chapter 2 gravity in a nonrotating frame with a Sun-centered origin."""
+
+    def gravity_fn(force, probe_pos, probe_inertia, source_pos, source_inertia):
+        probe_mass = probe_inertia.mass()
+        gravitational_parameter = G * source_inertia.mass()
+
+        relative_acceleration = heliocentric_relative_acceleration(
+            probe_pos.linear(), source_pos.linear(), gravitational_parameter
+        )
+
+        return el.Force(linear=force.force() + probe_mass * relative_acceleration)
+
+    return graph.edge_fold(
+        left_query=query,
+        right_query=query,
+        return_type=el.Force,
+        init_value=el.Force(),
+        fold_fn=gravity_fn,
+    )
+
+
 for probe in PROBES:
     probe_id = body_entity_ids[probe["entity_name"]]
-    for source_name in ["Sun", *[planet["entity_name"] for planet in PLANETS]]:
+    for source_name in gravity_source_entity_names(PLANETS):
         w.spawn(
             GravityConstraint(probe_id, body_entity_ids[source_name]),
             name=f"{probe['entity_name']} -> {source_name}",
@@ -336,7 +368,12 @@ w.schematic(
 """.format(body_objects=body_objects)
 )
 
-sys = el.six_dof(sys=gravity)
+dynamics_chapter = os.environ.get(DYNAMICS_CHAPTER_ENV, "1")
+if dynamics_chapter not in ("1", "2"):
+    raise ValueError(f"{DYNAMICS_CHAPTER_ENV} must be '1' or '2'")
+
+gravity_system = gravity if dynamics_chapter == "1" else heliocentric_gravity
+sys = el.six_dof(sys=gravity_system)
 db_path = Path(os.environ.get(DB_PATH_ENV, DEFAULT_DB_PATH))
 max_ticks_env = os.environ.get(MAX_TICKS_ENV)
 max_ticks = int(max_ticks_env) if max_ticks_env is not None else None

--- a/examples/voyager/main.py
+++ b/examples/voyager/main.py
@@ -9,10 +9,7 @@ import spiceypy as spice
 import numpy as np
 from pathlib import Path
 
-from dynamics import (
-    gravity_source_entity_names,
-    heliocentric_relative_acceleration,
-)
+from dynamics import heliocentric_relative_acceleration
 
 # SIM_TIME_STEP = 1.0 / 120.0
 SIM_TIME_STEP = 3600.0
@@ -299,17 +296,11 @@ def heliocentric_gravity(
     graph: el.GraphQuery[GravityEdge],
     query: el.Query[el.WorldPos, el.Inertia],
 ) -> el.Query[el.Force]:
-    """Chapter 2 gravity in a nonrotating frame with a Sun-centered origin."""
-
     def gravity_fn(force, probe_pos, probe_inertia, source_pos, source_inertia):
-        probe_mass = probe_inertia.mass()
-        gravitational_parameter = G * source_inertia.mass()
-
-        relative_acceleration = heliocentric_relative_acceleration(
-            probe_pos.linear(), source_pos.linear(), gravitational_parameter
+        acc = heliocentric_relative_acceleration(
+            probe_pos.linear(), source_pos.linear(), G * source_inertia.mass()
         )
-
-        return el.Force(linear=force.force() + probe_mass * relative_acceleration)
+        return el.Force(linear=force.force() + probe_inertia.mass() * acc)
 
     return graph.edge_fold(
         left_query=query,
@@ -322,7 +313,7 @@ def heliocentric_gravity(
 
 for probe in PROBES:
     probe_id = body_entity_ids[probe["entity_name"]]
-    for source_name in gravity_source_entity_names(PLANETS):
+    for source_name in ["Sun", *[planet["entity_name"] for planet in PLANETS]]:
         w.spawn(
             GravityConstraint(probe_id, body_entity_ids[source_name]),
             name=f"{probe['entity_name']} -> {source_name}",

--- a/examples/voyager/test_dynamics.py
+++ b/examples/voyager/test_dynamics.py
@@ -1,0 +1,109 @@
+"""Focused checks for the Voyager Chapter 2 force equation."""
+
+import ast
+from pathlib import Path
+
+import jax.numpy as jnp
+import numpy as np
+from dynamics import (
+    direct_planetary_acceleration,
+    gravity_source_entity_names,
+    heliocentric_relative_acceleration,
+    planetary_acceleration_of_sun,
+)
+
+
+def test_direct_planetary_acceleration_points_toward_source():
+    probe_position = jnp.array([2.0, 0.0, 0.0])
+    source_position = jnp.array([5.0, 0.0, 0.0])
+
+    acceleration = direct_planetary_acceleration(
+        probe_position,
+        source_position,
+        gravitational_parameter=18.0,
+    )
+
+    np.testing.assert_allclose(acceleration, [2.0, 0.0, 0.0])
+
+
+def test_sun_acceleration_is_subtracted_from_direct_acceleration():
+    probe_position = jnp.array([5.0, 0.0, 0.0])
+    source_position = jnp.array([3.0, 0.0, 0.0])
+    gravitational_parameter = 9.0
+
+    direct_acceleration = direct_planetary_acceleration(
+        probe_position, source_position, gravitational_parameter
+    )
+    sun_acceleration = planetary_acceleration_of_sun(source_position, gravitational_parameter)
+    relative_acceleration = heliocentric_relative_acceleration(
+        probe_position, source_position, gravitational_parameter
+    )
+
+    np.testing.assert_allclose(direct_acceleration, [-2.25, 0.0, 0.0])
+    np.testing.assert_allclose(sun_acceleration, [1.0, 0.0, 0.0])
+    np.testing.assert_allclose(relative_acceleration, [-3.25, 0.0, 0.0])
+
+
+def test_relative_acceleration_accumulates_over_multiple_sources():
+    probe_position = jnp.array([4.0, 0.0, 0.0])
+    sources = (
+        (jnp.array([2.0, 0.0, 0.0]), 8.0),
+        (jnp.array([-2.0, 0.0, 0.0]), 18.0),
+    )
+
+    relative_acceleration = sum(
+        (
+            heliocentric_relative_acceleration(probe_position, source_position, mu)
+            for source_position, mu in sources
+        ),
+        start=jnp.zeros(3),
+    )
+
+    # The two independently hand-computed contributions are -4 and +4 m/s^2.
+    np.testing.assert_allclose(relative_acceleration, [0.0, 0.0, 0.0])
+
+
+def test_source_at_origin_has_no_indirect_acceleration():
+    probe_position = jnp.array([2.0, 0.0, 0.0])
+    source_position = jnp.zeros(3)
+
+    direct_acceleration = direct_planetary_acceleration(
+        probe_position, source_position, gravitational_parameter=16.0
+    )
+    sun_acceleration = planetary_acceleration_of_sun(source_position, gravitational_parameter=16.0)
+
+    relative_acceleration = heliocentric_relative_acceleration(
+        probe_position, source_position, gravitational_parameter=16.0
+    )
+
+    np.testing.assert_allclose(sun_acceleration, jnp.zeros(3))
+    np.testing.assert_allclose(relative_acceleration, direct_acceleration)
+    np.testing.assert_allclose(relative_acceleration, [-4.0, 0.0, 0.0])
+
+
+def test_truth_probes_are_not_wired_into_chapter_2_gravity():
+    planets = (
+        {"entity_name": "earth"},
+        {"entity_name": "jupiter"},
+    )
+    assert gravity_source_entity_names(planets) == ("Sun", "earth", "jupiter")
+
+    main_tree = ast.parse(Path(__file__).with_name("main.py").read_text())
+    gravity_source_calls = [
+        node
+        for node in ast.walk(main_tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "gravity_source_entity_names"
+    ]
+    assert len(gravity_source_calls) == 1
+    assert ast.unparse(gravity_source_calls[0].args[0]) == "PLANETS"
+
+    relative_acceleration_calls = [
+        node
+        for node in ast.walk(main_tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "heliocentric_relative_acceleration"
+    ]
+    assert len(relative_acceleration_calls) == 1

--- a/examples/voyager/test_dynamics.py
+++ b/examples/voyager/test_dynamics.py
@@ -1,109 +1,26 @@
-"""Focused checks for the Voyager Chapter 2 force equation."""
-
-import ast
-from pathlib import Path
-
 import jax.numpy as jnp
 import numpy as np
-from dynamics import (
-    direct_planetary_acceleration,
-    gravity_source_entity_names,
-    heliocentric_relative_acceleration,
-    planetary_acceleration_of_sun,
-)
+from dynamics import heliocentric_relative_acceleration
 
 
-def test_direct_planetary_acceleration_points_toward_source():
-    probe_position = jnp.array([2.0, 0.0, 0.0])
-    source_position = jnp.array([5.0, 0.0, 0.0])
-
-    acceleration = direct_planetary_acceleration(
-        probe_position,
-        source_position,
-        gravitational_parameter=18.0,
-    )
-
-    np.testing.assert_allclose(acceleration, [2.0, 0.0, 0.0])
-
-
-def test_sun_acceleration_is_subtracted_from_direct_acceleration():
-    probe_position = jnp.array([5.0, 0.0, 0.0])
-    source_position = jnp.array([3.0, 0.0, 0.0])
-    gravitational_parameter = 9.0
-
-    direct_acceleration = direct_planetary_acceleration(
-        probe_position, source_position, gravitational_parameter
-    )
-    sun_acceleration = planetary_acceleration_of_sun(source_position, gravitational_parameter)
-    relative_acceleration = heliocentric_relative_acceleration(
-        probe_position, source_position, gravitational_parameter
-    )
-
-    np.testing.assert_allclose(direct_acceleration, [-2.25, 0.0, 0.0])
-    np.testing.assert_allclose(sun_acceleration, [1.0, 0.0, 0.0])
-    np.testing.assert_allclose(relative_acceleration, [-3.25, 0.0, 0.0])
-
-
-def test_relative_acceleration_accumulates_over_multiple_sources():
-    probe_position = jnp.array([4.0, 0.0, 0.0])
-    sources = (
-        (jnp.array([2.0, 0.0, 0.0]), 8.0),
-        (jnp.array([-2.0, 0.0, 0.0]), 18.0),
-    )
-
-    relative_acceleration = sum(
-        (
-            heliocentric_relative_acceleration(probe_position, source_position, mu)
-            for source_position, mu in sources
+def test_heliocentric_relative_acceleration():
+    # planet at +3, probe at +5, mu=9: direct=-2.25, sun=+1
+    np.testing.assert_allclose(
+        heliocentric_relative_acceleration(
+            jnp.array([5.0, 0.0, 0.0]), jnp.array([3.0, 0.0, 0.0]), 9.0
         ),
-        start=jnp.zeros(3),
+        [-3.25, 0.0, 0.0],
     )
 
-    # The two independently hand-computed contributions are -4 and +4 m/s^2.
-    np.testing.assert_allclose(relative_acceleration, [0.0, 0.0, 0.0])
-
-
-def test_source_at_origin_has_no_indirect_acceleration():
-    probe_position = jnp.array([2.0, 0.0, 0.0])
-    source_position = jnp.zeros(3)
-
-    direct_acceleration = direct_planetary_acceleration(
-        probe_position, source_position, gravitational_parameter=16.0
-    )
-    sun_acceleration = planetary_acceleration_of_sun(source_position, gravitational_parameter=16.0)
-
-    relative_acceleration = heliocentric_relative_acceleration(
-        probe_position, source_position, gravitational_parameter=16.0
+    # source at the origin has no indirect term
+    np.testing.assert_allclose(
+        heliocentric_relative_acceleration(jnp.array([2.0, 0.0, 0.0]), jnp.zeros(3), 16.0),
+        [-4.0, 0.0, 0.0],
     )
 
-    np.testing.assert_allclose(sun_acceleration, jnp.zeros(3))
-    np.testing.assert_allclose(relative_acceleration, direct_acceleration)
-    np.testing.assert_allclose(relative_acceleration, [-4.0, 0.0, 0.0])
-
-
-def test_truth_probes_are_not_wired_into_chapter_2_gravity():
-    planets = (
-        {"entity_name": "earth"},
-        {"entity_name": "jupiter"},
+    probe = jnp.array([4.0, 0.0, 0.0])
+    np.testing.assert_allclose(
+        heliocentric_relative_acceleration(probe, jnp.array([2.0, 0.0, 0.0]), 8.0)
+        + heliocentric_relative_acceleration(probe, jnp.array([-2.0, 0.0, 0.0]), 18.0),
+        [0.0, 0.0, 0.0],
     )
-    assert gravity_source_entity_names(planets) == ("Sun", "earth", "jupiter")
-
-    main_tree = ast.parse(Path(__file__).with_name("main.py").read_text())
-    gravity_source_calls = [
-        node
-        for node in ast.walk(main_tree)
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Name)
-        and node.func.id == "gravity_source_entity_names"
-    ]
-    assert len(gravity_source_calls) == 1
-    assert ast.unparse(gravity_source_calls[0].args[0]) == "PLANETS"
-
-    relative_acceleration_calls = [
-        node
-        for node in ast.walk(main_tree)
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Name)
-        and node.func.id == "heliocentric_relative_acceleration"
-    ]
-    assert len(relative_acceleration_calls) == 1


### PR DESCRIPTION
This resubmits the previously approved Chapter 2 slice from #776 as the smallest independently useful Voyager change.

The Voyager example integrates Sun-relative states but only applies direct planetary gravity. That misses the planets’ acceleration of the Sun, which is the origin of the frame.

This PR adds an optional Chapter 2 gravity model:

```text
mu_i * ((r_i - r) / |r_i - r|^3 - r_i / |r_i|^3)
```

Chapter 1 stays the default. `python examples/voyager/chapter_2.py run` selects the new model. The same kernels, masses, RK4 integrator, and timestep are used.

The change is limited to:

- `examples/voyager/dynamics.py`
- `examples/voyager/test_dynamics.py`
- `examples/voyager/chapter_2.py`
- `examples/voyager/main.py`
- `examples/voyager/README.md`

Reconstructed-arc validation, generated results, extra kernels, long tutorial/docs changes, and benchmark campaigns are intentionally deferred.

This does not reproduce the gravity assists or claim navigation-grade accuracy. It also does not add reconstructed-encounter validation.

Tests: `pytest examples/voyager/test_dynamics.py -v` — 1 passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only physics switch behind an env var; default Chapter 1 gravity is unchanged.
> 
> **Overview**
> Adds an optional **heliocentric relative** gravity model for the Voyager example so Sun-relative integration also subtracts each planet’s acceleration of the Sun (`μ((r_i−r)/|r_i−r|³ − r_i/|r_i|³)`).
> 
> Chapter 1 (direct gravity only) remains the default. `python examples/voyager/chapter_2.py run` sets `VOYAGER_DYNAMICS_CHAPTER=2` and reuses the same kernels, masses, RK4, and timestep. Unit tests cover the new acceleration helper. This does not claim gravity-assist or navigation-grade accuracy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b70284e0c7f9b1c9bfcfffc3823ccbc50b569219. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->