### PR TITLE
Fix: View-cube to bevy.

### DIFF
--- a/examples/rc-jet/main.py
+++ b/examples/rc-jet/main.py
@@ -133,7 +133,7 @@ def setup_world(config: BDXConfig) -> tuple[el.World, el.EntityId, el.EntityId]:
                 viewport name=Viewport pos="bdx.world_pos.translate_world(-8.0,-8.0,4.0)" look_at="bdx.world_pos" show_grid=#false show_frustums=#true active=#true far=100000
                 vsplit share=0.4 {
                     viewport name=TGTViewport pos="target.world_pos.translate_world(1,1,0.2)" look_at="bdx.world_pos" show_grid=#false
-                    viewport name=FPVViewport pos="bdx.world_pos.rotate_z(-90).translate_y(-2.0)" show_grid=#false
+                    viewport name=FPVViewport pos="bdx.world_pos.translate(1,0,0.1)" look_at="bdx.world_pos.translate(2,0,0.1)" up="bdx.world_pos.direction(0,0,1)" show_grid=#false
                     sensor_view "bdx.fpv_cam" name="FPV (sensor_camera)"
                 }
             }

--- a/libs/elodin-editor/src/plugins/view_cube/camera.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/camera.rs
@@ -23,8 +23,6 @@ use super::components::{
 };
 use super::config::ViewCubeConfig;
 use super::events::ViewCubeEvent;
-use crate::WorldPosExt;
-use crate::object_3d::ComponentArrayExt;
 use bevy_geo_frames::{GeoContext, GeoFrame, GeoPosition, GeoRotation, Present};
 
 const FACE_IN_SCREEN_PLANE_DOT_THRESHOLD: f32 = 0.999;
@@ -422,6 +420,7 @@ impl<'w, 's> ViewCubeEditorLookup<'w, 's> {
 pub fn handle_view_cube_editor(
     mut events: MessageReader<ViewCubeEvent>,
     overlay_cameras: Query<(&ViewCubeLink, &ViewCubeFrameRef), With<ViewCubeCamera>>,
+    cubes: Query<(&ViewCubeFrame, &GlobalTransform), With<ViewCubeRoot>>,
     mut camera_query: ViewCubeCameraQuery,
     mut lookup: ViewCubeEditorLookup,
     config: Res<ViewCubeConfig>,
@@ -437,6 +436,11 @@ pub fn handle_view_cube_editor(
         let Ok((entity, mut transform, parent, mut editor_cam)) = camera_query.get_mut(cam) else {
             continue;
         };
+        let cube_world_rotation = cubes
+            .iter()
+            .find(|(frame, _)| frame.0 == cube_frame)
+            .map(|(_, global)| global.rotation())
+            .unwrap_or(Quat::IDENTITY);
 
         let origin_world = lookup.origin();
         let camera_pose = lookup.current_camera_pose(transform.as_ref(), parent, origin_world);
@@ -461,12 +465,7 @@ pub fn handle_view_cube_editor(
 
         let global_rotation = camera_pose.rotation;
         let parent_rotation = camera_pose.parent_rotation;
-        let cube_rotation = if config.sync_with_camera {
-            global_rotation.conjugate() * config.axis_correction
-        } else {
-            Quat::IDENTITY
-        };
-        let camera_dir_cube = cube_rotation.inverse() * Vec3::Z;
+        let camera_dir_cube = camera_dir_in_cube_local(cube_world_rotation, global_rotation);
 
         if let ViewCubeEvent::FaceClicked { direction, .. } = event {
             let clicked_face_dot = direction.to_look_direction().dot(camera_dir_cube);
@@ -835,6 +834,13 @@ fn direction_target_camera_dir_world(
     frame_dir_to_bevy(frame, local, geo)
 }
 
+pub(super) fn camera_dir_in_cube_local(
+    cube_world_rotation: Quat,
+    camera_world_rotation: Quat,
+) -> Vec3 {
+    cube_world_rotation.inverse() * (camera_world_rotation * Vec3::Z)
+}
+
 fn sphere_radial_up(geo: &GeoContext, look_at_bevy: Option<DVec3>) -> Option<Vec3> {
     if geo.present != Present::Sphere {
         return None;
@@ -1143,13 +1149,14 @@ fn view_cube_orbit_target(
 ) -> Option<DVec3> {
     let viewport = viewports.get(camera).ok()?;
     let frame = viewport.frame.unwrap_or_default();
+    // Same 3-vector / WorldPos rule as viewport follow (`POS_ECEF` is 3 elems).
     let resolved = viewport
         .look_at
         .compiled_expr
         .as_ref()
         .and_then(|compiled_expr| compiled_expr.execute(entity_map, values).ok())
-        .and_then(|val| val.as_world_pos())
-        .map(|world_pos| GeoPosition(frame, world_pos.pos()).to_bevy(geo_context));
+        .and_then(|val| crate::ui::gauges::component_value_to_position(&val))
+        .map(|pos| GeoPosition(frame, pos).to_bevy(geo_context));
     match resolved {
         Some(target) => Some(orbit_cache.remember(camera, target)),
         None => orbit_cache.last(camera),

--- a/libs/elodin-editor/src/plugins/view_cube/camera.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/camera.rs
@@ -10,7 +10,7 @@ use bevy::log::warn;
 use bevy::math::{DVec3, Dir3};
 use bevy::prelude::*;
 use bevy::world_serialization::{WorldInstance, WorldInstanceSpawner};
-use bevy_editor_cam::controller::component::{EditorCam, OrbitConstraint};
+use bevy_editor_cam::controller::component::EditorCam;
 use bevy_editor_cam::controller::motion::CurrentMotion;
 use bevy_editor_cam::extensions::look_to::LookToTrigger;
 use impeller2_bevy::EntityMap;
@@ -23,7 +23,7 @@ use super::components::{
 };
 use super::config::ViewCubeConfig;
 use super::events::ViewCubeEvent;
-use bevy_geo_frames::{GeoContext, GeoFrame, GeoPosition, GeoRotation, Present};
+use bevy_geo_frames::{GeoContext, GeoFrame, GeoPosition, GeoRotation};
 
 const FACE_IN_SCREEN_PLANE_DOT_THRESHOLD: f32 = 0.999;
 const CORNER_IN_SCREEN_AXIS_DOT_THRESHOLD: f32 = 0.998;
@@ -648,30 +648,15 @@ pub fn handle_view_cube_editor(
             let base_up_world = parent_rotation * base_up_local;
             let base_right_world = parent_rotation * base_right_local;
 
-            // Left/Right is a turntable azimuth: yaw around the orbit's fixed up
-            // (world vertical) like a drag-orbit, so the horizon stays level.
-            // Falls back to the camera up only when the orbit is unconstrained.
-            let orbit_target = view_cube_orbit_target(
-                entity,
-                &lookup.viewports,
-                lookup.entity_map.as_ref(),
-                &lookup.values,
-                &lookup.geo_context,
-                &mut lookup.orbit_cache,
-            );
-            let orbit_up_world = sphere_radial_up(&lookup.geo_context, orbit_target).unwrap_or(
-                match editor_cam.orbit_constraint {
-                    OrbitConstraint::Fixed { up, .. } => up.as_vec3(),
-                    OrbitConstraint::Free => base_up_world,
-                },
-            );
-
+            // Screen-space pairs: Left/Right yaw around camera up, Up/Down
+            // pitch around camera right. World-up yaw collapsed onto pitch
+            // after a side-face snap (NED E/W): camera right became Bevy Y.
             let (step_axis_world, signed_angle, _) = arrow_camera_axis_angle(
                 *arrow,
                 angle,
                 base_right_world,
                 base_forward_world,
-                orbit_up_world,
+                base_up_world,
             );
             let step_rotation_world = Quat::from_axis_angle(*step_axis_world, signed_angle);
 
@@ -684,12 +669,19 @@ pub fn handle_view_cube_editor(
             let new_world_rotation = step_rotation_world * (parent_rotation * base_rotation);
             let new_rotation_local = parent_inv * new_world_rotation;
 
-            let focus_world = orbit_target
-                .map(|target| (target - origin_world).as_vec3())
-                .unwrap_or_else(|| {
-                    camera_pose.translation
-                        + base_forward_world * (editor_cam.last_anchor_depth.abs() as f32)
-                });
+            let focus_world = view_cube_orbit_target(
+                entity,
+                &lookup.viewports,
+                lookup.entity_map.as_ref(),
+                &lookup.values,
+                &lookup.geo_context,
+                &mut lookup.orbit_cache,
+            )
+            .map(|target| (target - origin_world).as_vec3())
+            .unwrap_or_else(|| {
+                camera_pose.translation
+                    + base_forward_world * (editor_cam.last_anchor_depth.abs() as f32)
+            });
 
             // Yaw/pitch orbit the focus object so it stays framed; roll is about
             // the view axis and must spin in place (pivot on the camera itself),
@@ -841,34 +833,23 @@ pub(super) fn camera_dir_in_cube_local(
     cube_world_rotation.inverse() * (camera_world_rotation * Vec3::Z)
 }
 
-fn sphere_radial_up(geo: &GeoContext, look_at_bevy: Option<DVec3>) -> Option<Vec3> {
-    if geo.present != Present::Sphere {
-        return None;
-    }
-    let up = look_at_bevy?.normalize();
-    if !up.is_finite() || up.length_squared() <= 1.0e-12 {
-        return None;
-    }
-    Some(up.as_vec3())
-}
-
 fn arrow_camera_axis_angle(
     arrow: RotationArrow,
     angle: f32,
     camera_right_world: Vec3,
     camera_forward_world: Vec3,
-    orbit_up_world: Vec3,
+    camera_up_world: Vec3,
 ) -> (Dir3, f32, &'static str) {
     match arrow {
         RotationArrow::Left => (
-            Dir3::new(orbit_up_world).unwrap_or(Dir3::new_unchecked(Vec3::Y)),
+            Dir3::new(camera_up_world).unwrap_or(Dir3::new_unchecked(Vec3::Y)),
             angle,
-            "orbit_up",
+            "camera_up",
         ),
         RotationArrow::Right => (
-            Dir3::new(orbit_up_world).unwrap_or(Dir3::new_unchecked(Vec3::Y)),
+            Dir3::new(camera_up_world).unwrap_or(Dir3::new_unchecked(Vec3::Y)),
             -angle,
-            "orbit_up",
+            "camera_up",
         ),
         RotationArrow::Up => (
             Dir3::new(camera_right_world).unwrap_or(Dir3::new_unchecked(Vec3::X)),
@@ -1169,6 +1150,7 @@ mod tests {
     use crate::plugins::render_layer_alloc::view_cube_render_layers;
     use bevy::asset::AssetPlugin;
     use bevy::world_serialization::{WorldAsset, WorldAssetRoot, WorldSerializationPlugin};
+    use bevy_geo_frames::Present;
 
     #[test]
     fn angle_to_target_rotation_default_is_zero() {
@@ -1318,45 +1300,74 @@ mod tests {
         let angle = 0.25;
         let right = Vec3::Y;
         let forward = Vec3::X;
-        // Distinct from the camera up so we can assert yaw uses the orbit axis.
-        let orbit_up = Vec3::Z;
+        let camera_up = Vec3::Z;
 
-        // Left/Right yaw around the orbit (world) up, not the camera up.
         let (axis, signed_angle, source) =
-            arrow_camera_axis_angle(RotationArrow::Left, angle, right, forward, orbit_up);
-        assert_eq!(*axis, orbit_up);
+            arrow_camera_axis_angle(RotationArrow::Left, angle, right, forward, camera_up);
+        assert_eq!(*axis, camera_up);
         assert_eq!(signed_angle, angle);
-        assert_eq!(source, "orbit_up");
+        assert_eq!(source, "camera_up");
 
         let (axis, signed_angle, source) =
-            arrow_camera_axis_angle(RotationArrow::Right, angle, right, forward, orbit_up);
-        assert_eq!(*axis, orbit_up);
+            arrow_camera_axis_angle(RotationArrow::Right, angle, right, forward, camera_up);
+        assert_eq!(*axis, camera_up);
         assert_eq!(signed_angle, -angle);
-        assert_eq!(source, "orbit_up");
+        assert_eq!(source, "camera_up");
 
         let (axis, signed_angle, source) =
-            arrow_camera_axis_angle(RotationArrow::Up, angle, right, forward, orbit_up);
+            arrow_camera_axis_angle(RotationArrow::Up, angle, right, forward, camera_up);
         assert_eq!(*axis, right);
         assert_eq!(signed_angle, angle);
         assert_eq!(source, "camera_right");
 
         let (axis, signed_angle, source) =
-            arrow_camera_axis_angle(RotationArrow::Down, angle, right, forward, orbit_up);
+            arrow_camera_axis_angle(RotationArrow::Down, angle, right, forward, camera_up);
         assert_eq!(*axis, right);
         assert_eq!(signed_angle, -angle);
         assert_eq!(source, "camera_right");
 
         let (axis, signed_angle, source) =
-            arrow_camera_axis_angle(RotationArrow::RollLeft, angle, right, forward, orbit_up);
+            arrow_camera_axis_angle(RotationArrow::RollLeft, angle, right, forward, camera_up);
         assert_eq!(*axis, forward);
         assert_eq!(signed_angle, angle);
         assert_eq!(source, "camera_forward");
 
         let (axis, signed_angle, source) =
-            arrow_camera_axis_angle(RotationArrow::RollRight, angle, right, forward, orbit_up);
+            arrow_camera_axis_angle(RotationArrow::RollRight, angle, right, forward, camera_up);
         assert_eq!(*axis, forward);
         assert_eq!(signed_angle, -angle);
         assert_eq!(source, "camera_forward");
+    }
+
+    #[test]
+    fn side_face_snap_keeps_yaw_orthogonal_to_pitch() {
+        let geo = mojave_geo(Present::Plane);
+        let config = ViewCubeConfig::default();
+        let face = crate::plugins::view_cube::FaceDirection::Up;
+        let look = face_target_camera_dir_world(face, GeoFrame::NED, &geo, &config);
+        let facing = Dir3::new(-look).expect("ned +Y facing");
+        let up = choose_face_upright_up(face, Quat::IDENTITY, facing).expect("up");
+        let rotation = Transform::default().looking_to(*facing, *up).rotation;
+        let right = rotation * Vec3::X;
+        let camera_up = rotation * Vec3::Y;
+        let forward = rotation * Vec3::NEG_Z;
+        assert!(
+            Vec3::Y.dot(right).abs() > 0.9,
+            "NED E-face snap banks camera right onto world up, got {}",
+            Vec3::Y.dot(right)
+        );
+
+        let (yaw, _, yaw_src) =
+            arrow_camera_axis_angle(RotationArrow::Left, 0.2, right, forward, camera_up);
+        let (pitch, _, pitch_src) =
+            arrow_camera_axis_angle(RotationArrow::Up, 0.2, right, forward, camera_up);
+        assert_eq!(yaw_src, "camera_up");
+        assert_eq!(pitch_src, "camera_right");
+        assert!(
+            yaw.dot(*pitch).abs() < 0.15,
+            "Left/Right must stay off the Up/Down axis after an E-face snap, got {}",
+            yaw.dot(*pitch)
+        );
     }
 
     #[test]
@@ -1428,16 +1439,6 @@ mod tests {
             (as_ecef - as_enu).length() > 1.0e3,
             "ECEF vs ENU interpretation of the same metres must diverge at Mojave"
         );
-    }
-
-    #[test]
-    fn sphere_radial_up_is_look_at_direction() {
-        let geo = mojave_geo(Present::Sphere);
-        let look_at = DVec3::new(3.0, 0.0, 4.0);
-        let up = sphere_radial_up(&geo, Some(look_at)).expect("sphere up");
-        let expected = look_at.normalize().as_vec3();
-        assert!((up - expected).length() < 1.0e-5);
-        assert!(sphere_radial_up(&mojave_geo(Present::Plane), Some(look_at)).is_none());
     }
 
     #[test]

--- a/libs/elodin-editor/src/plugins/view_cube/camera.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/camera.rs
@@ -482,7 +482,7 @@ pub fn handle_view_cube_editor(
             let facing_local_vec = parent_rotation.inverse() * facing_world;
 
             if let Ok(facing_local) = Dir3::new(facing_local_vec) {
-                let chosen_up = choose_face_upright_up(*direction, parent_rotation, facing_local)
+                let chosen_up = choose_face_upright_up(parent_rotation, facing_local)
                     .or_else(|| choose_continuous_up(transform.as_ref(), facing_local))
                     .unwrap_or_else(|| {
                         choose_min_rotation_up(transform.as_ref(), parent_rotation, facing_local).0
@@ -578,7 +578,7 @@ pub fn handle_view_cube_editor(
             let facing_local_vec = parent_rotation.inverse() * facing_world;
 
             if let Ok(facing_local) = Dir3::new(facing_local_vec) {
-                let chosen_up = choose_face_upright_up(*target_face, parent_rotation, facing_local)
+                let chosen_up = choose_face_upright_up(parent_rotation, facing_local)
                     .or_else(|| choose_continuous_up(transform.as_ref(), facing_local))
                     .unwrap_or_else(|| {
                         choose_min_rotation_up(transform.as_ref(), parent_rotation, facing_local).0
@@ -897,23 +897,12 @@ fn choose_continuous_up(transform: &Transform, facing_local: Dir3) -> Option<Dir
     None
 }
 
-fn choose_face_upright_up(
-    target_face: super::components::FaceDirection,
-    parent_rotation: Quat,
-    facing_local: Dir3,
-) -> Option<Dir3> {
+fn choose_face_upright_up(parent_rotation: Quat, facing_local: Dir3) -> Option<Dir3> {
     let parent_inverse = parent_rotation.inverse();
-    let world_candidates: &[Vec3] = match target_face {
-        super::components::FaceDirection::East
-        | super::components::FaceDirection::West
-        | super::components::FaceDirection::North
-        | super::components::FaceDirection::South => &[Vec3::Y, Vec3::Z, Vec3::X],
-        super::components::FaceDirection::Up => &[Vec3::Z, Vec3::X, Vec3::Y],
-        super::components::FaceDirection::Down => &[Vec3::NEG_Z, Vec3::X, Vec3::Y],
-    };
-
+    // Local vertical first. FaceDirection names are Bevy-era (Up = cube +Y)
+    // and no longer match geo labels (ENU N / NED E sit on +Y).
     let facing = *facing_local;
-    for world_up in world_candidates.iter().copied() {
+    for world_up in [Vec3::Y, Vec3::Z, Vec3::X] {
         let local_up_candidate = parent_inverse * world_up;
         let projected = local_up_candidate - facing * local_up_candidate.dot(facing);
         if projected.length_squared() <= 1.0e-6 {
@@ -1221,52 +1210,47 @@ mod tests {
         let parent = Quat::IDENTITY;
         let east_facing = Dir3::new(Vec3::NEG_X).expect("unit vector");
         let west_facing = Dir3::new(Vec3::X).expect("unit vector");
-        let east_up = choose_face_upright_up(
-            crate::plugins::view_cube::FaceDirection::East,
-            parent,
-            east_facing,
-        )
-        .expect("upright up for east");
-        let west_up = choose_face_upright_up(
-            crate::plugins::view_cube::FaceDirection::West,
-            parent,
-            west_facing,
-        )
-        .expect("upright up for west");
+        let east_up = choose_face_upright_up(parent, east_facing).expect("upright up for east");
+        let west_up = choose_face_upright_up(parent, west_facing).expect("upright up for west");
         assert!(east_up.dot(Vec3::Y) > 0.99, "east up should be +Y");
         assert!(west_up.dot(Vec3::Y) > 0.99, "west up should be +Y");
     }
 
     #[test]
-    fn choose_face_upright_up_prefers_backward_on_down_face() {
+    fn choose_face_upright_up_uses_north_when_looking_along_vertical() {
         let parent = Quat::IDENTITY;
-        let down_facing = Dir3::new(Vec3::Y).expect("unit vector");
-        let up = choose_face_upright_up(
-            crate::plugins::view_cube::FaceDirection::Down,
-            parent,
-            down_facing,
-        )
-        .expect("upright up for down");
+        let looking_up = choose_face_upright_up(parent, Dir3::new(Vec3::Y).expect("unit vector"))
+            .expect("upright when looking up");
+        let looking_down =
+            choose_face_upright_up(parent, Dir3::new(Vec3::NEG_Y).expect("unit vector"))
+                .expect("upright when looking down");
         assert!(
-            up.dot(Vec3::NEG_Z) > 0.99,
-            "down-face up should align with -Z, got {:?}",
-            *up
+            looking_up.dot(Vec3::Z) > 0.99,
+            "looking up should use +Z, got {:?}",
+            *looking_up
+        );
+        assert!(
+            looking_down.dot(Vec3::Z) > 0.99,
+            "looking down should use +Z, got {:?}",
+            *looking_down
         );
     }
 
     #[test]
-    fn choose_face_upright_up_prefers_forward_on_up_face() {
-        let parent = Quat::IDENTITY;
-        let up_facing = Dir3::new(Vec3::NEG_Y).expect("unit vector");
-        let up = choose_face_upright_up(
+    fn choose_face_upright_up_keeps_world_y_on_ned_east_snap() {
+        let geo = mojave_geo(Present::Plane);
+        let config = ViewCubeConfig::default();
+        let look = face_target_camera_dir_world(
             crate::plugins::view_cube::FaceDirection::Up,
-            parent,
-            up_facing,
-        )
-        .expect("upright up for up-face");
+            GeoFrame::NED,
+            &geo,
+            &config,
+        );
+        let facing = Dir3::new(-look).expect("ned +Y facing");
+        let up = choose_face_upright_up(Quat::IDENTITY, facing).expect("up");
         assert!(
-            up.dot(Vec3::Z) > 0.99,
-            "up-face up should align with +Z, got {:?}",
+            up.dot(Vec3::Y) > 0.9,
+            "NED E (cube +Y) must keep world Y up, got {:?}",
             *up
         );
     }
@@ -1346,14 +1330,18 @@ mod tests {
         let face = crate::plugins::view_cube::FaceDirection::Up;
         let look = face_target_camera_dir_world(face, GeoFrame::NED, &geo, &config);
         let facing = Dir3::new(-look).expect("ned +Y facing");
-        let up = choose_face_upright_up(face, Quat::IDENTITY, facing).expect("up");
+        let up = choose_face_upright_up(Quat::IDENTITY, facing).expect("up");
         let rotation = Transform::default().looking_to(*facing, *up).rotation;
         let right = rotation * Vec3::X;
         let camera_up = rotation * Vec3::Y;
         let forward = rotation * Vec3::NEG_Z;
         assert!(
-            Vec3::Y.dot(right).abs() > 0.9,
-            "NED E-face snap banks camera right onto world up, got {}",
+            camera_up.dot(Vec3::Y) > 0.9,
+            "NED E-face snap should keep camera up on world Y, got {camera_up:?}"
+        );
+        assert!(
+            Vec3::Y.dot(right).abs() < 0.15,
+            "NED E-face snap must not bank camera right onto world up, got {}",
             Vec3::Y.dot(right)
         );
 

--- a/libs/elodin-editor/src/plugins/view_cube/camera.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/camera.rs
@@ -23,10 +23,9 @@ use super::components::{
 };
 use super::config::ViewCubeConfig;
 use super::events::ViewCubeEvent;
-use crate::Coordinate;
 use crate::WorldPosExt;
 use crate::object_3d::ComponentArrayExt;
-use bevy_geo_frames::{GeoContext, GeoPosition};
+use bevy_geo_frames::{GeoContext, GeoFrame, GeoPosition, GeoRotation, Present};
 
 const FACE_IN_SCREEN_PLANE_DOT_THRESHOLD: f32 = 0.999;
 const CORNER_IN_SCREEN_AXIS_DOT_THRESHOLD: f32 = 0.998;
@@ -79,6 +78,28 @@ pub struct ViewCubeArrowTargetCache {
     entries: HashMap<Entity, ArrowTargetState>,
 }
 
+#[derive(Resource, Default)]
+pub struct ViewCubeOrbitTargetCache {
+    entries: HashMap<Entity, DVec3>,
+}
+
+impl ViewCubeOrbitTargetCache {
+    fn remember(&mut self, camera: Entity, target: DVec3) -> DVec3 {
+        self.entries.insert(camera, target);
+        target
+    }
+
+    fn last(&self, camera: Entity) -> Option<DVec3> {
+        self.entries.get(&camera).copied()
+    }
+}
+
+/// Cube-local axis → Bevy world. Same `to_bevy` the mesh uses.
+pub fn frame_dir_to_bevy(frame: GeoFrame, local_dir: Vec3, geo: &GeoContext) -> Vec3 {
+    let q = GeoRotation::absolute(frame, bevy::math::DQuat::IDENTITY).to_bevy(geo);
+    (q * local_dir.as_dvec3()).as_vec3().normalize_or_zero()
+}
+
 impl ViewCubeArrowTargetCache {
     const TTL_SECS: f64 = 1.5;
 
@@ -116,14 +137,14 @@ impl ViewCubeArrowTargetCache {
     }
 }
 
-fn main_camera_for_event(
+fn overlay_for_event(
     event: &ViewCubeEvent,
-    overlay_cameras: &Query<&ViewCubeLink, With<ViewCubeCamera>>,
-) -> Option<Entity> {
+    overlay_cameras: &Query<(&ViewCubeLink, &ViewCubeFrameRef), With<ViewCubeCamera>>,
+) -> Option<(Entity, GeoFrame)> {
     overlay_cameras
         .get(event_source(event))
         .ok()
-        .map(|link| link.main_camera)
+        .map(|(link, frame_ref)| (link.main_camera, frame_ref.0))
 }
 
 fn event_source(event: &ViewCubeEvent) -> Entity {
@@ -308,6 +329,7 @@ pub(super) struct ViewCubeEditorLookup<'w, 's> {
     geo_context: Res<'w, GeoContext>,
     time: Res<'w, Time>,
     arrow_cache: ResMut<'w, ViewCubeArrowTargetCache>,
+    orbit_cache: ResMut<'w, ViewCubeOrbitTargetCache>,
     camera_parents: CameraParentQuery<'w, 's>,
     #[cfg(feature = "big_space")]
     floating_origin: FloatingOriginQuery<'w, 's>,
@@ -399,19 +421,17 @@ impl<'w, 's> ViewCubeEditorLookup<'w, 's> {
 #[allow(clippy::too_many_arguments)]
 pub fn handle_view_cube_editor(
     mut events: MessageReader<ViewCubeEvent>,
-    overlay_cameras: Query<&ViewCubeLink, With<ViewCubeCamera>>,
+    overlay_cameras: Query<(&ViewCubeLink, &ViewCubeFrameRef), With<ViewCubeCamera>>,
     mut camera_query: ViewCubeCameraQuery,
     mut lookup: ViewCubeEditorLookup,
     config: Res<ViewCubeConfig>,
     mut look_to: MessageWriter<LookToTrigger>,
-    geo_context: Res<GeoContext>,
-    coordinate: Res<Coordinate>,
 ) {
     for event in events.read() {
         let now_secs = lookup.time.elapsed_secs_f64();
         lookup.arrow_cache.prune(now_secs);
 
-        let Some(cam) = main_camera_for_event(event, &overlay_cameras) else {
+        let Some((cam, cube_frame)) = overlay_for_event(event, &overlay_cameras) else {
             continue;
         };
         let Ok((entity, mut transform, parent, mut editor_cam)) = camera_query.get_mut(cam) else {
@@ -431,7 +451,7 @@ pub fn handle_view_cube_editor(
                 lookup.entity_map.as_ref(),
                 &lookup.values,
                 &lookup.geo_context,
-                &coordinate,
+                &mut lookup.orbit_cache,
                 origin_world,
             );
         }
@@ -454,7 +474,8 @@ pub fn handle_view_cube_editor(
                 continue;
             }
 
-            let raw_look_dir_world = face_target_camera_dir_world(*direction, &config);
+            let raw_look_dir_world =
+                face_target_camera_dir_world(*direction, cube_frame, &lookup.geo_context, &config);
             if raw_look_dir_world.length_squared() <= 1.0e-6 {
                 continue;
             }
@@ -502,7 +523,12 @@ pub fn handle_view_cube_editor(
             if clicked_corner_dot >= CORNER_IN_SCREEN_AXIS_DOT_THRESHOLD {
                 continue;
             }
-            let raw_look_dir_world = direction_target_camera_dir_world(*local_direction, &config);
+            let raw_look_dir_world = direction_target_camera_dir_world(
+                *local_direction,
+                cube_frame,
+                &lookup.geo_context,
+                &config,
+            );
             if raw_look_dir_world.length_squared() <= 1.0e-6 {
                 continue;
             }
@@ -543,7 +569,12 @@ pub fn handle_view_cube_editor(
             ..
         } = event
         {
-            let raw_look_dir_world = face_target_camera_dir_world(*target_face, &config);
+            let raw_look_dir_world = face_target_camera_dir_world(
+                *target_face,
+                cube_frame,
+                &lookup.geo_context,
+                &config,
+            );
             let facing_world = -raw_look_dir_world;
             let facing_local_vec = parent_rotation.inverse() * facing_world;
 
@@ -587,7 +618,7 @@ pub fn handle_view_cube_editor(
                 lookup.entity_map.as_ref(),
                 &lookup.values,
                 &lookup.geo_context,
-                &coordinate,
+                &mut lookup.orbit_cache,
                 origin_world,
             );
 
@@ -621,10 +652,20 @@ pub fn handle_view_cube_editor(
             // Left/Right is a turntable azimuth: yaw around the orbit's fixed up
             // (world vertical) like a drag-orbit, so the horizon stays level.
             // Falls back to the camera up only when the orbit is unconstrained.
-            let orbit_up_world = match editor_cam.orbit_constraint {
-                OrbitConstraint::Fixed { up, .. } => up.as_vec3(),
-                OrbitConstraint::Free => base_up_world,
-            };
+            let orbit_target = view_cube_orbit_target(
+                entity,
+                &lookup.viewports,
+                lookup.entity_map.as_ref(),
+                &lookup.values,
+                &lookup.geo_context,
+                &mut lookup.orbit_cache,
+            );
+            let orbit_up_world = sphere_radial_up(&lookup.geo_context, orbit_target).unwrap_or(
+                match editor_cam.orbit_constraint {
+                    OrbitConstraint::Fixed { up, .. } => up.as_vec3(),
+                    OrbitConstraint::Free => base_up_world,
+                },
+            );
 
             let (step_axis_world, signed_angle, _) = arrow_camera_axis_angle(
                 *arrow,
@@ -644,19 +685,12 @@ pub fn handle_view_cube_editor(
             let new_world_rotation = step_rotation_world * (parent_rotation * base_rotation);
             let new_rotation_local = parent_inv * new_world_rotation;
 
-            let focus_world = view_cube_orbit_target(
-                entity,
-                &lookup.viewports,
-                lookup.entity_map.as_ref(),
-                &lookup.values,
-                &geo_context,
-                &coordinate,
-            )
-            .map(|target| (target - origin_world).as_vec3())
-            .unwrap_or_else(|| {
-                camera_pose.translation
-                    + base_forward_world * (editor_cam.last_anchor_depth.abs() as f32)
-            });
+            let focus_world = orbit_target
+                .map(|target| (target - origin_world).as_vec3())
+                .unwrap_or_else(|| {
+                    camera_pose.translation
+                        + base_forward_world * (editor_cam.last_anchor_depth.abs() as f32)
+                });
 
             // Yaw/pitch orbit the focus object so it stays framed; roll is about
             // the view axis and must spin in place (pivot on the camera itself),
@@ -708,8 +742,8 @@ pub fn handle_view_cube_editor(
                         &lookup.viewports,
                         lookup.entity_map.as_ref(),
                         &lookup.values,
-                        &geo_context,
-                        &coordinate,
+                        &lookup.geo_context,
+                        &mut lookup.orbit_cache,
                         origin_world,
                     );
                     if let Ok(facing) = Dir3::new(Vec3::NEG_Z) {
@@ -768,27 +802,48 @@ fn apply_viewport_zoom(out: bool, transform: &mut Transform, editor_cam: &mut Ed
 
 fn face_target_camera_dir_world(
     direction: super::components::FaceDirection,
+    frame: GeoFrame,
+    geo: &GeoContext,
     config: &ViewCubeConfig,
 ) -> Vec3 {
     let local_dir = direction.to_look_direction();
-    direction_target_camera_dir_world(local_dir, config)
+    direction_target_camera_dir_world(local_dir, frame, geo, config)
 }
 
 #[cfg(test)]
 fn corner_target_camera_dir_world(
     position: super::components::CornerPosition,
+    frame: GeoFrame,
+    geo: &GeoContext,
     config: &ViewCubeConfig,
 ) -> Vec3 {
     let local_dir = position.to_look_direction();
-    direction_target_camera_dir_world(local_dir, config)
+    direction_target_camera_dir_world(local_dir, frame, geo, config)
 }
 
-fn direction_target_camera_dir_world(local_dir: Vec3, config: &ViewCubeConfig) -> Vec3 {
-    if config.sync_with_camera {
-        (config.axis_correction * local_dir).normalize_or_zero()
+fn direction_target_camera_dir_world(
+    local_dir: Vec3,
+    frame: GeoFrame,
+    geo: &GeoContext,
+    config: &ViewCubeConfig,
+) -> Vec3 {
+    let local = if config.sync_with_camera {
+        config.axis_correction * local_dir
     } else {
-        local_dir.normalize_or_zero()
+        local_dir
+    };
+    frame_dir_to_bevy(frame, local, geo)
+}
+
+fn sphere_radial_up(geo: &GeoContext, look_at_bevy: Option<DVec3>) -> Option<Vec3> {
+    if geo.present != Present::Sphere {
+        return None;
     }
+    let up = look_at_bevy?.normalize();
+    if !up.is_finite() || up.length_squared() <= 1.0e-12 {
+        return None;
+    }
+    Some(up.as_vec3())
 }
 
 fn arrow_camera_axis_angle(
@@ -1025,7 +1080,7 @@ fn update_anchor_depth_for_view_cube(
     entity_map: &EntityMap,
     values: &Query<&'static ComponentValue>,
     geo_context: &GeoContext,
-    coordinate: &Coordinate,
+    orbit_cache: &mut ViewCubeOrbitTargetCache,
     origin_world: DVec3,
 ) {
     let Some(orbit_target_world) = view_cube_orbit_target(
@@ -1034,7 +1089,7 @@ fn update_anchor_depth_for_view_cube(
         entity_map,
         values,
         geo_context,
-        coordinate,
+        orbit_cache,
     ) else {
         return;
     };
@@ -1054,7 +1109,7 @@ fn refresh_anchor_depth_for_arrow(
     entity_map: &EntityMap,
     values: &Query<&'static ComponentValue>,
     geo_context: &GeoContext,
-    coordinate: &Coordinate,
+    orbit_cache: &mut ViewCubeOrbitTargetCache,
     origin_world: DVec3,
 ) -> Option<(f32, f32)> {
     let orbit_target_world = view_cube_orbit_target(
@@ -1063,7 +1118,7 @@ fn refresh_anchor_depth_for_arrow(
         entity_map,
         values,
         geo_context,
-        coordinate,
+        orbit_cache,
     )?;
     let orbit_target = (orbit_target_world - origin_world).as_vec3();
     let measured_distance = (orbit_target - camera_translation).length();
@@ -1084,13 +1139,21 @@ fn view_cube_orbit_target(
     entity_map: &EntityMap,
     values: &Query<&'static ComponentValue>,
     geo_context: &GeoContext,
-    coordinate: &Coordinate,
+    orbit_cache: &mut ViewCubeOrbitTargetCache,
 ) -> Option<DVec3> {
     let viewport = viewports.get(camera).ok()?;
-    let compiled_expr = viewport.look_at.compiled_expr.as_ref()?;
-    let val = compiled_expr.execute(entity_map, values).ok()?;
-    let world_pos = val.as_world_pos()?;
-    Some(GeoPosition(coordinate.0.unwrap_or_default(), world_pos.pos()).to_bevy(geo_context))
+    let frame = viewport.frame.unwrap_or_default();
+    let resolved = viewport
+        .look_at
+        .compiled_expr
+        .as_ref()
+        .and_then(|compiled_expr| compiled_expr.execute(entity_map, values).ok())
+        .and_then(|val| val.as_world_pos())
+        .map(|world_pos| GeoPosition(frame, world_pos.pos()).to_bevy(geo_context));
+    match resolved {
+        Some(target) => Some(orbit_cache.remember(camera, target)),
+        None => orbit_cache.last(camera),
+    }
 }
 
 #[cfg(test)]
@@ -1293,9 +1356,91 @@ mod tests {
     fn corner_target_camera_dir_world_applies_axis_correction() {
         let corner = crate::plugins::view_cube::CornerPosition::TopFrontRight;
         let config = ViewCubeConfig::default();
-        let world = corner_target_camera_dir_world(corner, &config);
-        let expected = Vec3::new(1.0, 1.0, 1.0).normalize();
+        let geo = GeoContext::default();
+        let world = corner_target_camera_dir_world(corner, GeoFrame::ENU, &geo, &config);
+        let expected = frame_dir_to_bevy(GeoFrame::ENU, Vec3::new(1.0, 1.0, 1.0), &geo);
         assert!((world - expected).length() < 1.0e-5);
+    }
+
+    fn mojave_geo(present: Present) -> GeoContext {
+        GeoContext::from(bevy_geo_frames::GeoOrigin::new_from_degrees(
+            35.3506640, -117.80902, 589.2740,
+        ))
+        .with_present(present)
+    }
+
+    fn assert_click_matches_to_bevy(frame: GeoFrame, local: Vec3, geo: &GeoContext) {
+        let config = ViewCubeConfig::default();
+        let world = direction_target_camera_dir_world(local, frame, geo, &config);
+        let expected = frame_dir_to_bevy(frame, local, geo);
+        assert!(
+            (world - expected).length() < 1.0e-5,
+            "{frame:?} click {local:?} = {world:?}, expected {expected:?}"
+        );
+        assert!(
+            world.length() > 0.5,
+            "{frame:?} click produced a near-zero direction"
+        );
+    }
+
+    #[test]
+    fn face_click_plus_x_matches_to_bevy_in_every_frame_plane() {
+        let geo = mojave_geo(Present::Plane);
+        let local = Vec3::X;
+        for frame in [GeoFrame::ENU, GeoFrame::NED, GeoFrame::ECEF] {
+            assert_click_matches_to_bevy(frame, local, &geo);
+        }
+        let ecef = frame_dir_to_bevy(GeoFrame::ECEF, local, &geo);
+        assert!(
+            (ecef - local).length() > 0.25,
+            "Mojave ECEF +X must not be raw Bevy +X, got {ecef:?}"
+        );
+        let enu = frame_dir_to_bevy(GeoFrame::ENU, local, &geo);
+        assert!(
+            (enu - Vec3::X).length() < 1.0e-5,
+            "ENU +X (East) stays Bevy +X, got {enu:?}"
+        );
+    }
+
+    #[test]
+    fn face_click_plus_x_matches_to_bevy_in_every_frame_sphere() {
+        let geo = mojave_geo(Present::Sphere);
+        let local = Vec3::X;
+        for frame in [GeoFrame::ENU, GeoFrame::NED, GeoFrame::ECEF] {
+            assert_click_matches_to_bevy(frame, local, &geo);
+        }
+    }
+
+    #[test]
+    fn orbit_target_uses_viewport_frame_not_default_enu() {
+        let geo = mojave_geo(Present::Plane);
+        let ecef = DVec3::new(1.0, 2.0, 3.0);
+        let as_ecef = GeoPosition(GeoFrame::ECEF, ecef).to_bevy(&geo);
+        let as_enu = GeoPosition(GeoFrame::ENU, ecef).to_bevy(&geo);
+        assert!(
+            (as_ecef - as_enu).length() > 1.0e3,
+            "ECEF vs ENU interpretation of the same metres must diverge at Mojave"
+        );
+    }
+
+    #[test]
+    fn sphere_radial_up_is_look_at_direction() {
+        let geo = mojave_geo(Present::Sphere);
+        let look_at = DVec3::new(3.0, 0.0, 4.0);
+        let up = sphere_radial_up(&geo, Some(look_at)).expect("sphere up");
+        let expected = look_at.normalize().as_vec3();
+        assert!((up - expected).length() < 1.0e-5);
+        assert!(sphere_radial_up(&mojave_geo(Present::Plane), Some(look_at)).is_none());
+    }
+
+    #[test]
+    fn orbit_cache_keeps_last_target_when_eql_empty() {
+        let mut cache = ViewCubeOrbitTargetCache::default();
+        let camera = Entity::from_bits(9);
+        let target = DVec3::new(10.0, 20.0, 30.0);
+        cache.remember(camera, target);
+        assert_eq!(cache.last(camera), Some(target));
+        assert_eq!(cache.last(Entity::from_bits(10)), None);
     }
 
     #[test]

--- a/libs/elodin-editor/src/plugins/view_cube/camera.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/camera.rs
@@ -486,11 +486,16 @@ pub fn handle_view_cube_editor(
             let facing_local_vec = parent_rotation.inverse() * facing_world;
 
             if let Ok(facing_local) = Dir3::new(facing_local_vec) {
-                let chosen_up = choose_face_upright_up(parent_rotation, facing_local)
-                    .or_else(|| choose_continuous_up(transform.as_ref(), facing_local))
-                    .unwrap_or_else(|| {
-                        choose_min_rotation_up(transform.as_ref(), parent_rotation, facing_local).0
-                    });
+                let chosen_up = choose_face_upright_up(
+                    parent_rotation,
+                    facing_local,
+                    cube_frame,
+                    &lookup.geo_context,
+                )
+                .or_else(|| choose_continuous_up(transform.as_ref(), facing_local))
+                .unwrap_or_else(|| {
+                    choose_min_rotation_up(transform.as_ref(), parent_rotation, facing_local).0
+                });
                 let trigger = LookToTrigger {
                     target_facing_direction: facing_local.as_dvec3(),
                     target_up_direction: chosen_up.as_dvec3(),
@@ -582,11 +587,16 @@ pub fn handle_view_cube_editor(
             let facing_local_vec = parent_rotation.inverse() * facing_world;
 
             if let Ok(facing_local) = Dir3::new(facing_local_vec) {
-                let chosen_up = choose_face_upright_up(parent_rotation, facing_local)
-                    .or_else(|| choose_continuous_up(transform.as_ref(), facing_local))
-                    .unwrap_or_else(|| {
-                        choose_min_rotation_up(transform.as_ref(), parent_rotation, facing_local).0
-                    });
+                let chosen_up = choose_face_upright_up(
+                    parent_rotation,
+                    facing_local,
+                    cube_frame,
+                    &lookup.geo_context,
+                )
+                .or_else(|| choose_continuous_up(transform.as_ref(), facing_local))
+                .unwrap_or_else(|| {
+                    choose_min_rotation_up(transform.as_ref(), parent_rotation, facing_local).0
+                });
                 let trigger = LookToTrigger {
                     target_facing_direction: facing_local.as_dvec3(),
                     target_up_direction: chosen_up.as_dvec3(),
@@ -901,12 +911,28 @@ fn choose_continuous_up(transform: &Transform, facing_local: Dir3) -> Option<Dir
     None
 }
 
-fn choose_face_upright_up(parent_rotation: Quat, facing_local: Dir3) -> Option<Dir3> {
+/// Frame-local "sky": ENU/ECEF +Z, NED −Z (up). Mapped through the same `to_bevy`
+/// the look direction uses, so ECEF snaps stay on the equatorial plane.
+fn frame_camera_up_bevy(frame: GeoFrame, geo: &GeoContext) -> Vec3 {
+    let local = match frame {
+        GeoFrame::NED => Vec3::NEG_Z,
+        GeoFrame::ENU | GeoFrame::ECEF => Vec3::Z,
+    };
+    frame_dir_to_bevy(frame, local, geo)
+}
+
+fn choose_face_upright_up(
+    parent_rotation: Quat,
+    facing_local: Dir3,
+    frame: GeoFrame,
+    geo: &GeoContext,
+) -> Option<Dir3> {
     let parent_inverse = parent_rotation.inverse();
-    // Local vertical first. FaceDirection names are Bevy-era (Up = cube +Y)
-    // and no longer match geo labels (ENU N / NED E sit on +Y).
+    // Frame up first (ECEF Z, not Bevy Y / local vertical). Then Bevy axes
+    // when looking along that up. FaceDirection names are Bevy-era.
     let facing = *facing_local;
-    for world_up in [Vec3::Y, Vec3::Z, Vec3::X] {
+    let frame_up = frame_camera_up_bevy(frame, geo);
+    for world_up in [frame_up, Vec3::Y, Vec3::Z, Vec3::X] {
         let local_up_candidate = parent_inverse * world_up;
         let projected = local_up_candidate - facing * local_up_candidate.dot(facing);
         if projected.length_squared() <= 1.0e-6 {
@@ -1234,25 +1260,34 @@ mod tests {
         );
     }
 
+    fn upright_up(facing: Dir3, frame: GeoFrame, geo: &GeoContext) -> Dir3 {
+        choose_face_upright_up(Quat::IDENTITY, facing, frame, geo).expect("upright up")
+    }
+
     #[test]
     fn choose_face_upright_up_keeps_east_west_consistent() {
-        let parent = Quat::IDENTITY;
+        let geo = GeoContext::default();
         let east_facing = Dir3::new(Vec3::NEG_X).expect("unit vector");
         let west_facing = Dir3::new(Vec3::X).expect("unit vector");
-        let east_up = choose_face_upright_up(parent, east_facing).expect("upright up for east");
-        let west_up = choose_face_upright_up(parent, west_facing).expect("upright up for west");
+        let east_up = upright_up(east_facing, GeoFrame::ENU, &geo);
+        let west_up = upright_up(west_facing, GeoFrame::ENU, &geo);
         assert!(east_up.dot(Vec3::Y) > 0.99, "east up should be +Y");
         assert!(west_up.dot(Vec3::Y) > 0.99, "west up should be +Y");
     }
 
     #[test]
     fn choose_face_upright_up_uses_north_when_looking_along_vertical() {
-        let parent = Quat::IDENTITY;
-        let looking_up = choose_face_upright_up(parent, Dir3::new(Vec3::Y).expect("unit vector"))
-            .expect("upright when looking up");
-        let looking_down =
-            choose_face_upright_up(parent, Dir3::new(Vec3::NEG_Y).expect("unit vector"))
-                .expect("upright when looking down");
+        let geo = GeoContext::default();
+        let looking_up = upright_up(
+            Dir3::new(Vec3::Y).expect("unit vector"),
+            GeoFrame::ENU,
+            &geo,
+        );
+        let looking_down = upright_up(
+            Dir3::new(Vec3::NEG_Y).expect("unit vector"),
+            GeoFrame::ENU,
+            &geo,
+        );
         assert!(
             looking_up.dot(Vec3::Z) > 0.99,
             "looking up should use +Z, got {:?}",
@@ -1276,7 +1311,7 @@ mod tests {
             &config,
         );
         let facing = Dir3::new(-look).expect("ned +Y facing");
-        let up = choose_face_upright_up(Quat::IDENTITY, facing).expect("up");
+        let up = upright_up(facing, GeoFrame::NED, &geo);
         assert!(
             up.dot(Vec3::Y) > 0.9,
             "NED E (cube +Y) must keep world Y up, got {:?}",
@@ -1359,7 +1394,7 @@ mod tests {
         let face = crate::plugins::view_cube::FaceDirection::Up;
         let look = face_target_camera_dir_world(face, GeoFrame::NED, &geo, &config);
         let facing = Dir3::new(-look).expect("ned +Y facing");
-        let up = choose_face_upright_up(Quat::IDENTITY, facing).expect("up");
+        let up = upright_up(facing, GeoFrame::NED, &geo);
         let rotation = Transform::default().looking_to(*facing, *up).rotation;
         let right = rotation * Vec3::X;
         let camera_up = rotation * Vec3::Y;
@@ -1444,6 +1479,34 @@ mod tests {
         for frame in [GeoFrame::ENU, GeoFrame::NED, GeoFrame::ECEF] {
             assert_click_matches_to_bevy(frame, local, &geo);
         }
+    }
+
+    #[test]
+    fn ecef_plus_x_snap_keeps_equator_level_in_plane() {
+        let origin = bevy_geo_frames::GeoOrigin::new_from_degrees(34.72, -86.64, 180.5);
+        let geo = GeoContext::from(origin).with_present(Present::Plane);
+        let config = ViewCubeConfig::default();
+        let look = face_target_camera_dir_world(
+            crate::plugins::view_cube::FaceDirection::East,
+            GeoFrame::ECEF,
+            &geo,
+            &config,
+        );
+        let facing = Dir3::new(-look).expect("ecef +X facing");
+        let up = upright_up(facing, GeoFrame::ECEF, &geo);
+        let rotation = Transform::default().looking_to(*facing, *up).rotation;
+        let right = rotation * Vec3::X;
+        let ecef_z = frame_dir_to_bevy(GeoFrame::ECEF, Vec3::Z, &geo);
+        assert!(
+            right.dot(ecef_z).abs() < 0.05,
+            "ECEF +X snap must keep ECEF Z in the screen vertical, got right·ecefZ={}",
+            right.dot(ecef_z)
+        );
+        assert!(
+            (rotation * Vec3::Y).dot(ecef_z) > 0.9,
+            "ECEF +X snap must use ECEF Z as camera up, got {:?}",
+            rotation * Vec3::Y
+        );
     }
 
     #[test]

--- a/libs/elodin-editor/src/plugins/view_cube/camera.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/camera.rs
@@ -90,6 +90,10 @@ impl ViewCubeOrbitTargetCache {
     fn last(&self, camera: Entity) -> Option<DVec3> {
         self.entries.get(&camera).copied()
     }
+
+    fn forget(&mut self, camera: Entity) {
+        self.entries.remove(&camera);
+    }
 }
 
 /// Cube-local axis → Bevy world. Same `to_bevy` the mesh uses.
@@ -1120,16 +1124,41 @@ fn view_cube_orbit_target(
     let viewport = viewports.get(camera).ok()?;
     let frame = viewport.frame.unwrap_or_default();
     // Same 3-vector / WorldPos rule as viewport follow (`POS_ECEF` is 3 elems).
-    let resolved = viewport
-        .look_at
-        .compiled_expr
-        .as_ref()
-        .and_then(|compiled_expr| compiled_expr.execute(entity_map, values).ok())
-        .and_then(|val| crate::ui::gauges::component_value_to_position(&val))
-        .map(|pos| GeoPosition(frame, pos).to_bevy(geo_context));
-    match resolved {
-        Some(target) => Some(orbit_cache.remember(camera, target)),
-        None => orbit_cache.last(camera),
+    // Missing compiled expr = cleared (don't aim). Execute error = sample gap.
+    let Some(compiled_expr) = viewport.look_at.compiled_expr.as_ref() else {
+        return apply_orbit_look_at(orbit_cache, camera, OrbitLookAt::Cleared);
+    };
+    match compiled_expr.execute(entity_map, values) {
+        Err(_) => apply_orbit_look_at(orbit_cache, camera, OrbitLookAt::Gap),
+        Ok(val) => match crate::ui::gauges::component_value_to_position(&val) {
+            Some(pos) => {
+                let target = GeoPosition(frame, pos).to_bevy(geo_context);
+                apply_orbit_look_at(orbit_cache, camera, OrbitLookAt::Target(target))
+            }
+            None => apply_orbit_look_at(orbit_cache, camera, OrbitLookAt::NotAPosition),
+        },
+    }
+}
+
+enum OrbitLookAt {
+    Cleared,
+    Gap,
+    NotAPosition,
+    Target(DVec3),
+}
+
+fn apply_orbit_look_at(
+    cache: &mut ViewCubeOrbitTargetCache,
+    camera: Entity,
+    look_at: OrbitLookAt,
+) -> Option<DVec3> {
+    match look_at {
+        OrbitLookAt::Cleared | OrbitLookAt::NotAPosition => {
+            cache.forget(camera);
+            None
+        }
+        OrbitLookAt::Gap => cache.last(camera),
+        OrbitLookAt::Target(target) => Some(cache.remember(camera, target)),
     }
 }
 
@@ -1430,13 +1459,36 @@ mod tests {
     }
 
     #[test]
-    fn orbit_cache_keeps_last_target_when_eql_empty() {
+    fn orbit_cache_keeps_last_target_on_gap() {
         let mut cache = ViewCubeOrbitTargetCache::default();
         let camera = Entity::from_bits(9);
         let target = DVec3::new(10.0, 20.0, 30.0);
-        cache.remember(camera, target);
-        assert_eq!(cache.last(camera), Some(target));
+        apply_orbit_look_at(&mut cache, camera, OrbitLookAt::Target(target));
+        assert_eq!(
+            apply_orbit_look_at(&mut cache, camera, OrbitLookAt::Gap),
+            Some(target)
+        );
         assert_eq!(cache.last(Entity::from_bits(10)), None);
+    }
+
+    #[test]
+    fn orbit_cache_forgets_when_look_at_cleared() {
+        let mut cache = ViewCubeOrbitTargetCache::default();
+        let camera = Entity::from_bits(9);
+        apply_orbit_look_at(
+            &mut cache,
+            camera,
+            OrbitLookAt::Target(DVec3::new(10.0, 20.0, 30.0)),
+        );
+        assert_eq!(
+            apply_orbit_look_at(&mut cache, camera, OrbitLookAt::Cleared),
+            None
+        );
+        assert_eq!(cache.last(camera), None);
+        assert_eq!(
+            apply_orbit_look_at(&mut cache, camera, OrbitLookAt::NotAPosition),
+            None
+        );
     }
 
     #[test]

--- a/libs/elodin-editor/src/plugins/view_cube/config.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/config.rs
@@ -34,13 +34,11 @@ pub struct AxisDefinition {
 impl CoordinateSystem {
     /// Get the three axis definitions for XYZ in this coordinate system.
     pub fn get_axes(&self) -> [AxisDefinition; 3] {
+        // Directions are frame-local cube axes. `GeoRotation::absolute`
+        // on the mesh root is what places them in Bevy.
         match self.0 {
             GeoFrame::ENU =>
-            // ENU mapped to Bevy's Y-up coordinate system:
-            // East (red)    -> Bevy +X
-            // North (green) -> Bevy -Z
-            // Up (blue)     -> Bevy +Y
-            // See: https://docs.elodin.systems/reference/coords/
+            // East / North / Up on cube +X / +Y / +Z.
             {
                 [
                     AxisDefinition {
@@ -53,54 +51,48 @@ impl CoordinateSystem {
                     AxisDefinition {
                         positive_label: "N",
                         negative_label: "S",
-                        direction: Vec3::NEG_Z,
+                        direction: Vec3::Y,
                         color: Color::srgb(0.2, 0.8, 0.2), // Green
                         color_dim: Color::srgb(0.15, 0.5, 0.15),
                     },
                     AxisDefinition {
                         positive_label: "U",
                         negative_label: "D",
-                        direction: Vec3::Y,
+                        direction: Vec3::Z,
                         color: Color::srgb(0.2, 0.4, 0.9), // Blue
                         color_dim: Color::srgb(0.15, 0.3, 0.6),
                     },
                 ]
             }
             GeoFrame::NED =>
-            // NED mapped to Bevy's Y-up coordinate system:
-            // North (red)  -> Bevy -Z
-            // East (green) -> Bevy +X
-            // Down (blue)  -> Bevy -Y
+            // North / East / Down on cube +X / +Y / +Z.
             {
                 [
                     AxisDefinition {
                         positive_label: "N",
                         negative_label: "S",
-                        direction: Vec3::NEG_Z,
+                        direction: Vec3::X,
                         color: Color::srgb(0.9, 0.2, 0.2), // Red
                         color_dim: Color::srgb(0.6, 0.15, 0.15),
                     },
                     AxisDefinition {
                         positive_label: "E",
                         negative_label: "W",
-                        direction: Vec3::X,
+                        direction: Vec3::Y,
                         color: Color::srgb(0.2, 0.8, 0.2), // Green
                         color_dim: Color::srgb(0.15, 0.5, 0.15),
                     },
                     AxisDefinition {
                         positive_label: "D",
                         negative_label: "U",
-                        direction: Vec3::NEG_Y,
+                        direction: Vec3::Z,
                         color: Color::srgb(0.2, 0.4, 0.9), // Blue
                         color_dim: Color::srgb(0.15, 0.3, 0.6),
                     },
                 ]
             }
             GeoFrame::ECEF =>
-            // NED mapped to Bevy's Y-up coordinate system:
-            // North (red)  -> Bevy -Z
-            // East (green) -> Bevy +X
-            // Down (blue)  -> Bevy -Y
+            // ECEF +X / +Y / +Z on cube +X / +Y / +Z.
             {
                 [
                     AxisDefinition {
@@ -260,20 +252,20 @@ mod tests {
     }
 
     #[test]
-    fn enu_face_labels_keep_semantic_direction_and_flip_east_west_visual_side() {
+    fn enu_face_labels_sit_on_frame_local_axes() {
         let labels = CoordinateSystem(GeoFrame::ENU).get_face_labels(1.0);
 
         let east = label_by_text(&labels, "E");
         let west = label_by_text(&labels, "W");
+        let north = label_by_text(&labels, "N");
         let up = label_by_text(&labels, "U");
-        let south = label_by_text(&labels, "S");
 
         assert_eq!(east.direction, FaceDirection::East);
         assert_eq!(west.direction, FaceDirection::West);
         assert_eq!(east.position, Vec3::X);
         assert_eq!(west.position, Vec3::NEG_X);
-        assert_eq!(up.position, Vec3::Y);
-        assert_eq!(south.position, Vec3::Z);
+        assert_eq!(north.position, Vec3::Y);
+        assert_eq!(up.position, Vec3::Z);
     }
 
     #[test]

--- a/libs/elodin-editor/src/plugins/view_cube/interactions.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/interactions.rs
@@ -394,18 +394,15 @@ fn edge_interaction_context(
     root_query: &Query<Entity, With<ViewCubeRoot>>,
     main_camera: Entity,
     camera_globals: &Query<&GlobalTransform, With<ViewCubeTargetCamera>>,
-    config: &ViewCubeConfig,
+    root_globals: &Query<&GlobalTransform, With<ViewCubeRoot>>,
+    _config: &ViewCubeConfig,
 ) -> Option<(Entity, EdgeInteractionContext)> {
     let root = find_root_ancestor(target, parents_query, root_query)?;
     let camera_global = camera_globals.get(main_camera).ok()?;
+    let cube_global = root_globals.get(root).ok()?;
 
-    let (_, cam_rotation, _) = camera_global.to_scale_rotation_translation();
-    let cube_rotation = if config.sync_with_camera {
-        cam_rotation.conjugate() * config.axis_correction
-    } else {
-        Quat::IDENTITY
-    };
-    let camera_dir_cube = cube_rotation.inverse() * Vec3::Z;
+    let camera_dir_cube =
+        super::camera::camera_dir_in_cube_local(cube_global.rotation(), camera_global.rotation());
     let (front_face, front_dot) = front_face(camera_dir_cube);
 
     Some((
@@ -704,6 +701,7 @@ fn compute_hover_targets(
     parents_query: &Query<&ChildOf>,
     root_query: &Query<Entity, With<ViewCubeRoot>>,
     camera_globals: &Query<&GlobalTransform, With<ViewCubeTargetCamera>>,
+    root_globals: &Query<&GlobalTransform, With<ViewCubeRoot>>,
     config: &ViewCubeConfig,
 ) -> Vec<Entity> {
     let Ok((_, element)) = cube_elements.get(target) else {
@@ -718,6 +716,7 @@ fn compute_hover_targets(
                 root_query,
                 main_camera,
                 camera_globals,
+                root_globals,
                 config,
             ) else {
                 return vec![];
@@ -858,6 +857,7 @@ pub fn on_cube_hover_start(
     parents_query: Query<&ChildOf>,
     root_query: Query<Entity, With<ViewCubeRoot>>,
     camera_globals: Query<&GlobalTransform, With<ViewCubeTargetCamera>>,
+    root_globals: Query<&GlobalTransform, With<ViewCubeRoot>>,
     config: Res<ViewCubeConfig>,
     children_query: Query<&Children>,
     material_query: Query<&MeshMaterial3d<StandardMaterial>>,
@@ -888,6 +888,7 @@ pub fn on_cube_hover_start(
         &parents_query,
         &root_query,
         &camera_globals,
+        &root_globals,
         &config,
     );
 
@@ -1013,6 +1014,7 @@ fn frame_hover_swap_target(
     main_camera: Entity,
     overlay_camera: Entity,
     camera_globals: &Query<&GlobalTransform, With<ViewCubeTargetCamera>>,
+    root_globals: &Query<&GlobalTransform, With<ViewCubeRoot>>,
     config: &ViewCubeConfig,
 ) -> Option<(FaceDirection, Entity)> {
     if !hovered.entities.contains(&target_entity) {
@@ -1035,6 +1037,7 @@ fn frame_hover_swap_target(
         root_query,
         main_camera,
         camera_globals,
+        root_globals,
         config,
     )?;
     if !is_face_on(context) {
@@ -1130,6 +1133,7 @@ pub fn on_cube_click(
                 main_camera,
                 source,
                 &lookup.camera_globals,
+                &lookup.root_globals,
                 &lookup.config,
             ) {
                 events.write(ViewCubeEvent::FaceClicked { direction, source });
@@ -1142,6 +1146,7 @@ pub fn on_cube_click(
                 &lookup.root_query,
                 main_camera,
                 &lookup.camera_globals,
+                &lookup.root_globals,
                 &lookup.config,
             ) else {
                 return;

--- a/libs/elodin-editor/src/plugins/view_cube/mod.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/mod.rs
@@ -75,6 +75,7 @@ impl Plugin for ViewCubePlugin {
             .add_observer(interactions::on_action_button_click);
 
         app.init_resource::<camera::ViewCubeArrowTargetCache>()
+            .init_resource::<camera::ViewCubeOrbitTargetCache>()
             .add_systems(Update, camera::handle_view_cube_editor)
             .add_systems(Update, camera::snap_initial_camera);
 

--- a/libs/elodin-editor/src/plugins/view_cube/spawn.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/spawn.rs
@@ -83,14 +83,12 @@ fn spawn_frame_view_cubes(
             frame,
             render_layers.clone(),
         );
-        if frame == GeoFrame::ECEF {
-            commands
-                .entity(cube_root)
-                .insert(bevy_geo_frames::GeoRotation::absolute(
-                    frame,
-                    bevy::math::DQuat::IDENTITY,
-                ));
-        }
+        commands
+            .entity(cube_root)
+            .insert(bevy_geo_frames::GeoRotation::absolute(
+                frame,
+                bevy::math::DQuat::IDENTITY,
+            ));
         frames.cubes.insert(frame, cube_root);
     }
 }
@@ -372,9 +370,9 @@ mod tests {
 
         assert_eq!(axis_configs[0].0, Vec3::X);
         assert_eq!(axis_configs[0].2, "X");
-        assert_eq!(axis_configs[1].0, Vec3::NEG_Z);
+        assert_eq!(axis_configs[1].0, Vec3::Y);
         assert_eq!(axis_configs[1].2, "Y");
-        assert_eq!(axis_configs[2].0, Vec3::Y);
+        assert_eq!(axis_configs[2].0, Vec3::Z);
         assert_eq!(axis_configs[2].2, "Z");
     }
 
@@ -404,13 +402,13 @@ mod tests {
             .find(|a| a.positive_label == "D")
             .expect("Down axis");
 
-        assert_eq!(north_axis.direction, Vec3::NEG_Z);
+        assert_eq!(north_axis.direction, Vec3::X);
         assert_eq!(north_axis.negative_label, "S");
 
-        assert_eq!(east_axis.direction, Vec3::X);
+        assert_eq!(east_axis.direction, Vec3::Y);
         assert_eq!(east_axis.negative_label, "W");
 
-        assert_eq!(down_axis.direction, Vec3::NEG_Y);
+        assert_eq!(down_axis.direction, Vec3::Z);
         assert_eq!(down_axis.negative_label, "U");
     }
 }

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -1889,9 +1889,18 @@ impl ViewportPane {
             };
         };
 
-        commands
-            .entity(camera)
-            .insert((ViewCubeTargetCamera, NeedsInitialSnap));
+        commands.entity(camera).insert(ViewCubeTargetCamera);
+        let has_kdl_pose = viewport
+            .pos
+            .as_ref()
+            .is_some_and(|eql| !eql.trim().is_empty())
+            || viewport
+                .look_at
+                .as_ref()
+                .is_some_and(|eql| !eql.trim().is_empty());
+        if !has_kdl_pose {
+            commands.entity(camera).insert(NeedsInitialSnap);
+        }
 
         let mut view_cube_config = ViewCubeConfig::editor_mode();
         view_cube_config.system = CoordinateSystem(cube_frame);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core 3D viewport camera, view-cube snaps, and orbit framing across ENU/NED/ECEF; behavior changes are broad but localized to editor view code plus one example.
> 
> **Overview**
> **View cube navigation** now maps cube clicks and snaps through **`bevy_geo_frames`** (`frame_dir_to_bevy`, per-frame `GeoRotation` on every cube root) instead of hard-coded Bevy axis remaps. ENU/NED/ECEF labels and axes sit on cube **+X/+Y/+Z**; face “up” prefers each frame’s vertical (e.g. ECEF **Z** on equatorial snaps). Edge/hover logic derives view direction from the **cube root** transform.
> 
> **Orbit / look-at** uses the viewport’s **`frame`** and `component_value_to_position`, with a **`ViewCubeOrbitTargetCache`** to hold the last target on telemetry gaps and clear when look-at is empty or non-positional. Rotation arrows yaw around **camera up** (not fixed world/orbit up). KDL viewports with **`pos`/`look_at`** no longer get **`NeedsInitialSnap`**.
> 
> The RC jet example **FPV viewport** is updated to body-relative `pos`/`look_at`/`up`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0348a364d60e70370c548dfa46aff92f033f0ebe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->