### PR TITLE
Fix betaflight takeoff

### DIFF
--- a/examples/betaflight-sitl/README.md
+++ b/examples/betaflight-sitl/README.md
@@ -12,8 +12,8 @@ The simulation provides:
 - **6-DOF Physics**: Rigid body dynamics with motor thrust, drag, and gravity
 - **Betaflight Integration**: Real Betaflight flight controller running as SITL
 - **UDP Communication**: Bidirectional sensor/motor data exchange
-- **8kHz PID Loop**: High-performance control matching Betaflight's fastest rate
-- **Multi-Rate Sensors**: Realistic sensor update rates (gyro 8kHz, accel 4.8kHz, baro 480Hz, mag 200Hz)
+- **1kHz Lockstep Loop**: Real-time physics and Betaflight PID updates by default
+- **Multi-Rate Sensors**: Requested sensor rates are capped by the simulation rate
 
 ```
 ┌─────────────────────┐        UDP        ┌─────────────────────┐
@@ -76,7 +76,7 @@ This only needs to be done once - the config is saved to `eeprom.bin`.
    screen /tmp/bf
    ```
 
-3. **Configure Betaflight for 8kHz operation** (in screen session):
+3. **Configure arming and full-rate PID processing** (in screen session):
    ```
    #
    status
@@ -84,14 +84,15 @@ This only needs to be done once - the config is saved to `eeprom.bin`.
    # Configure ARM switch (AUX1 channel, activated when > 1700)
    aux 0 0 0 1700 2100 0 0
    
-   # Configure 8kHz gyro/PID loop rate
+   # Process every available gyro/PID update
    set gyro_hardware_lpf = NORMAL
    set pid_process_denom = 1
    
    save
    ```
    
-   This sets ARM mode on AUX1 channel and configures Betaflight for 8kHz PID loop operation.
+   This configures ARM on AUX1 and processes every lockstep update. The actual
+   lockstep rate is set by `simulation_rate` (1kHz by default).
 
 4. **Exit screen**: Press `Ctrl+A` then `K` then `Y`
 
@@ -263,11 +264,11 @@ DroneConfig(
     arm_length=0.12,             # meters
     motor_max_thrust=15.0,       # Newtons per motor
     motor_time_constant=0.02,    # seconds
-    simulation_rate=8000.0,      # 8kHz physics (matches Betaflight PID)
+    simulation_rate=1000.0,      # 1kHz physics/PID lockstep
     sensor_noise=True,           # Enable realistic sensor noise
-    # Sensor rates (Aleph hardware defaults)
-    gyro_rate=8000.0,            # 8kHz (BMI270 3x IMU)
-    accel_rate=4800.0,           # 4.8kHz (BMI270 3x IMU)
+    # Requested sensor rates (capped by the simulation rate)
+    gyro_rate=8000.0,            # Effective rate is 1kHz by default
+    accel_rate=4800.0,           # Effective rate is 1kHz by default
     baro_rate=480.0,             # 480Hz (BMP581)
     mag_rate=200.0,              # 200Hz (BMM350)
 )
@@ -285,9 +286,11 @@ The simulation includes a realistic sensor noise model based on the proven drone
 - **Accelerometer**: Gaussian noise
 - **Barometer**: Gaussian noise (~0.03m std dev)
 
-Noise levels are tuned for SITL stability (1e-7 covariance). Higher noise levels
-can cause Betaflight's attitude estimator to drift during the bootgrace period,
-leading to motor imbalance at liftoff.
+The gyro uses `1e-7 (rad/s)²` measurement covariance and `1e-8` bias-drift
+covariance. The measurement covariance corresponds to approximately
+`0.000316 rad/s` (`0.018 deg/s`) RMS noise per sample. This matches the
+original example's recommended stable SITL setting while keeping sensor noise
+enabled. Higher gyro noise can produce motor imbalance or destabilize liftoff.
 
 ### Ground Physics
 
@@ -515,11 +518,11 @@ lsof -i :5761
 
 ### Performance
 
-**Simulation too slow**: The simulation runs at 8kHz by default to match Betaflight's
-high-performance PID loop. For optimal performance:
-- `simulation_rate = 8000.0` (8kHz) is the default
-- Ensure sufficient CPU for both Elodin and Betaflight
-- 8kHz produces ~160,000 ticks for a 20-second simulation
+**Simulation too slow**: The default `simulation_rate = 1000.0` gives the
+Python/UDP lockstep bridge a 1ms budget per tick and is intended to run in real
+time on typical hosts. Higher rates remain available but may run slower than
+real time because every tick includes DB access and a synchronous Betaflight
+UDP round trip. The default 15-second run produces 15,000 simulation ticks.
 
 ## Development
 
@@ -552,19 +555,24 @@ This simulation models realistic sensor update rates based on the Elodin Aleph f
 controller hardware. Different sensors update at different frequencies within the
 high-rate physics/PID loop.
 
-### Default Rates (Aleph Hardware)
+### Configured and Effective Rates
 
-| Sensor | Hardware | Rate | Datasheet |
-|--------|----------|------|-----------|
-| Gyroscope | BMI270 (3x with timing offset) | 8 kHz | [bst-bmi270-ds000.pdf](https://www.mouser.com/datasheet/3/1046/1/bst-bmi270-ds000.pdf) |
-| Accelerometer | BMI270 (3x with timing offset) | 4.8 kHz | [bst-bmi270-ds000.pdf](https://www.mouser.com/datasheet/3/1046/1/bst-bmi270-ds000.pdf) |
-| Barometer | BMP581 | 480 Hz | [bst_bmp581_ds004.pdf](https://www.mouser.com/datasheet/3/1046/1/bst_bmp581_ds004.pdf) |
-| Magnetometer | BMM350 | 200 Hz | [bst-bmm350-ds001.pdf](https://www.mouser.com/datasheet/3/1046/1/bst-bmm350-ds001.pdf) |
+Configured sensor rates represent hardware targets. A sensor cannot update more
+than once per physics tick, so its effective rate is capped by the 1kHz default
+simulation rate and rounded to a whole number of ticks.
+
+| Sensor | Hardware | Configured rate | Effective default rate | Datasheet |
+|--------|----------|-----------------|------------------------|-----------|
+| Gyroscope | BMI270 (3x with timing offset) | 8 kHz | 1 kHz | [bst-bmi270-ds000.pdf](https://www.mouser.com/datasheet/3/1046/1/bst-bmi270-ds000.pdf) |
+| Accelerometer | BMI270 (3x with timing offset) | 4.8 kHz | 1 kHz | [bst-bmi270-ds000.pdf](https://www.mouser.com/datasheet/3/1046/1/bst-bmi270-ds000.pdf) |
+| Barometer | BMP581 | 480 Hz | 500 Hz | [bst_bmp581_ds004.pdf](https://www.mouser.com/datasheet/3/1046/1/bst_bmp581_ds004.pdf) |
+| Magnetometer | BMM350 | 200 Hz | 200 Hz | [bst-bmm350-ds001.pdf](https://www.mouser.com/datasheet/3/1046/1/bst-bmm350-ds001.pdf) |
 
 ### Why Multi-Rate?
 
-Real sensors don't all sample at the same frequency. The PID loop runs at 8kHz driven
-by gyroscope data, but other sensors update less frequently:
+Real sensors don't all sample at the same frequency. The physics/PID lockstep
+runs at 1kHz by default. Gyroscope and accelerometer targets above that rate are
+therefore capped at 1kHz, while slower sensors update less frequently:
 
 - **Gyroscope (8 kHz)**: Drives the PID loop. The BMI270 supports up to 6.4 kHz per
   sensor; with 3 IMUs running with timing offsets, effective rate exceeds 8 kHz.
@@ -576,11 +584,11 @@ by gyroscope data, but other sensors update less frequently:
 
 ### How It Works
 
-The simulation uses tick decimation with `jax.lax.cond` to update sensors at their
-native rates while the physics/PID loop runs at 8kHz:
+The simulation uses tick decimation with `jax.lax.cond` to approximate requested
+sensor rates using whole physics ticks:
 
 ```python
-tick_interval = round(PID_RATE / SENSOR_RATE)
+tick_interval = max(1, round(PID_RATE / SENSOR_RATE))
 
 # Sensor updates only when tick is divisible by interval
 sensor_out = jax.lax.cond(
@@ -591,8 +599,8 @@ sensor_out = jax.lax.cond(
 )
 ```
 
-For example, with 8 kHz PID and 200 Hz magnetometer: `tick_interval = 40`
-(magnetometer updates every 40th physics tick).
+For example, with the default 1kHz PID rate and a 200Hz magnetometer,
+`tick_interval = 5` (the magnetometer updates every fifth physics tick).
 
 ### Customizing for Different Hardware
 
@@ -603,7 +611,7 @@ DroneConfig(
     # ... other parameters ...
     
     # Sensor update rates (Hz)
-    gyro_rate=8000.0,    # Must match PID loop rate
+    gyro_rate=8000.0,    # Requested rate; capped by the PID rate
     accel_rate=4800.0,   # BMI270: 1.6kHz × 3 IMUs
     baro_rate=480.0,     # BMP581 continuous mode
     mag_rate=200.0,      # BMM350

--- a/examples/betaflight-sitl/README.md
+++ b/examples/betaflight-sitl/README.md
@@ -61,6 +61,15 @@ This compiles the Betaflight firmware for SITL mode. The binary will be at:
 **IMPORTANT**: Before running the simulation, you must configure an ARM switch in Betaflight.
 This only needs to be done once - the config is saved to `eeprom.bin`.
 
+Run the initialization script from the repository root:
+
+```bash
+./examples/betaflight-sitl/init_eeprom.py
+```
+
+It starts SITL, sends the CLI commands, saves `eeprom.bin`, then restarts SITL
+and verifies the persisted settings. To do the same setup manually:
+
 1. **Start SITL** (in terminal 1):
    ```bash
    ./betaflight/obj/main/betaflight_SITL.elf
@@ -152,6 +161,7 @@ Phase 3: Raising throttle...
 ```
 examples/betaflight-sitl/
 ├── build.sh           # Build script for Betaflight SITL
+├── init_eeprom.py     # Create and configure eeprom.bin
 ├── main.py            # Main simulation entry point
 ├── config.py          # Drone physical parameters
 ├── sim.py             # Physics simulation systems

--- a/examples/betaflight-sitl/README.md
+++ b/examples/betaflight-sitl/README.md
@@ -344,11 +344,11 @@ sequenceDiagram
 
 #### 1. Betaflight Build with GYROPID_SYNC
 
-Modify [build.sh](examples/betaflight-sitl/build.sh) to enable lockstep mode:
+[build.sh](build.sh) enables lockstep mode through Betaflight's `OPTIONS`
+make variable without modifying the submodule:
 
-```c
-// In target.h - uncomment this line:
-#define SIMULATOR_GYROPID_SYNC
+```bash
+make TARGET=SITL OPTIONS=SIMULATOR_GYROPID_SYNC
 ```
 
 When enabled, Betaflight's main loop blocks on a mutex that is only released when a new FDM packet arrives. This provides synchronization without needing custom semaphores.

--- a/examples/betaflight-sitl/build.sh
+++ b/examples/betaflight-sitl/build.sh
@@ -14,6 +14,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BETAFLIGHT_DIR="$SCRIPT_DIR/betaflight"
+BETAFLIGHT_OPTIONS="SIMULATOR_GYROPID_SYNC"
 
 # Check if betaflight submodule is cloned (directory may exist as empty gitlink before update)
 if [ ! -f "$BETAFLIGHT_DIR/Makefile" ]; then
@@ -34,13 +35,14 @@ if [[ "$(uname)" == "Darwin" ]]; then
     MACOS_CFLAGS_DISABLED="-Werror -Wunsafe-loop-optimizations -fuse-linker-plugin"
 fi
 
-# Helper function to run make with proper flags
+# Helper function to run make with lockstep enabled and the proper platform flags
 run_make() {
     if [[ -n "$MACOS_OPTIMISATION_BASE" ]]; then
         # Use EXTRA_FLAGS to add -Wno-error which disables treating warnings as errors
-        make "OPTIMISATION_BASE=$MACOS_OPTIMISATION_BASE" "EXTRA_FLAGS=-Wno-error" "$@"
+        make "OPTIONS=$BETAFLIGHT_OPTIONS" \
+            "OPTIMISATION_BASE=$MACOS_OPTIMISATION_BASE" "EXTRA_FLAGS=-Wno-error" "$@"
     else
-        make "$@"
+        make "OPTIONS=$BETAFLIGHT_OPTIONS" "$@"
     fi
 }
 
@@ -76,20 +78,8 @@ case "${1:-build}" in
             make configs
         fi
         
-        # Enable SIMULATOR_GYROPID_SYNC for lockstep synchronization with Elodin
-        # This makes Betaflight block on FDM packets, allowing tight timing control
-        TARGET_H="$BETAFLIGHT_DIR/src/platform/SIMULATOR/target/SITL/target.h"
-        if grep -q "^//#define SIMULATOR_GYROPID_SYNC" "$TARGET_H"; then
-            echo "Enabling SIMULATOR_GYROPID_SYNC for lockstep mode..."
-            sed -i.bak 's|^//#define SIMULATOR_GYROPID_SYNC|#define SIMULATOR_GYROPID_SYNC|' "$TARGET_H"
-            rm -f "${TARGET_H}.bak"
-        elif grep -q "^#define SIMULATOR_GYROPID_SYNC" "$TARGET_H"; then
-            echo "SIMULATOR_GYROPID_SYNC already enabled."
-        else
-            echo "Warning: Could not find SIMULATOR_GYROPID_SYNC in target.h"
-        fi
-        
-        # Build SITL target
+        # Build SITL target with SIMULATOR_GYROPID_SYNC enabled through OPTIONS.
+        # This makes Betaflight block on FDM packets without modifying the submodule.
         JOBS=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
         
         # On macOS, we need to create stubs for missing SITL symbols and do a two-pass build
@@ -195,7 +185,7 @@ STUBS_EOF
         echo "Building Betaflight SITL with debug symbols..."
         # DEBUG=GDB uses simpler LTO flags that work on macOS
         JOBS=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
-        make TARGET=SITL DEBUG=GDB -j"$JOBS"
+        run_make TARGET=SITL DEBUG=GDB -j"$JOBS"
         echo "Debug build complete."
         ;;
     

--- a/examples/betaflight-sitl/config.py
+++ b/examples/betaflight-sitl/config.py
@@ -142,12 +142,13 @@ class DroneConfig:
 
     # --- Simulation Settings ---
 
-    # Physics simulation rate in Hz (8kHz for high-performance Betaflight PID loop)
+    # Physics/PID lockstep rate in Hz. 1kHz is the real-time default; higher
+    # rates may run slower than real time because each tick includes a UDP round trip.
     # simulation_rate: float = 8000.0  # 125µs
     # simulation_rate: float = 4000.0  # 250µs
-    simulation_rate: float = 2000.0  # 500µs
+    # simulation_rate: float = 2000.0  # 500µs
     # simulation_rate: float = 1500.0  # 667µs
-    # simulation_rate: float = 1000.0  # 1000µs
+    simulation_rate: float = 1000.0  # 1000µs
 
     # Total simulation time in seconds
     simulation_time: float = 15.0
@@ -159,10 +160,10 @@ class DroneConfig:
     # Based on Elodin Aleph flight controller hardware specifications.
     # See README.md "Sensor Simulation Rates" section for details.
 
-    # Gyroscope rate - drives PID loop (BMI270: 6.4kHz × 3 IMUs = ~19.2kHz effective)
-    gyro_rate: float = 8000.0  # Must match PID loop rate
+    # Gyroscope target rate (capped by the physics/PID rate)
+    gyro_rate: float = 8000.0  # Requested rate; capped by the physics/PID rate
 
-    # Accelerometer rate (BMI270: 1.6kHz × 3 IMUs = ~4.8kHz effective)
+    # Accelerometer target rate (capped by the physics/PID rate)
     accel_rate: float = 4800.0
 
     # Barometer rate (BMP581: up to 480Hz continuous mode)

--- a/examples/betaflight-sitl/init_eeprom.py
+++ b/examples/betaflight-sitl/init_eeprom.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+import socket
+import subprocess
+import time
+from pathlib import Path
+
+root = Path(__file__).resolve().parent
+binary = root / "betaflight/obj/main/betaflight_SITL.elf"
+
+
+def receive_until(cli, marker):
+    response = b""
+    while marker not in response:
+        chunk = cli.recv(4096)
+        if not chunk:
+            raise ConnectionError("Betaflight closed the CLI connection")
+        response += chunk
+    return response.decode(errors="replace")
+
+
+def start_sitl():
+    sitl = subprocess.Popen(
+        [binary],
+        cwd=root,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    for _ in range(50):
+        try:
+            cli = socket.create_connection(("localhost", 5761), timeout=0.2)
+            break
+        except OSError:
+            time.sleep(0.1)
+    else:
+        raise TimeoutError("Betaflight CLI did not start")
+    cli.settimeout(10)
+    cli.sendall(b"#")
+    receive_until(cli, b"# ")
+    return sitl, cli
+
+
+def command(cli, text):
+    cli.sendall(f"{text}\n".encode())
+    return receive_until(cli, b"# ")
+
+
+def initialize():
+    sitl, cli = start_sitl()
+    with cli:
+        for text in (
+            "aux 0 0 0 1700 2100 0 0",
+            "set gyro_hardware_lpf = NORMAL",
+            "set pid_process_denom = 1",
+        ):
+            command(cli, text)
+        cli.sendall(b"save\n")
+        receive_until(cli, b"Rebooting")
+    sitl.wait()
+
+
+def verify():
+    sitl, cli = start_sitl()
+    expected = (
+        ("get gyro_hardware_lpf", "gyro_hardware_lpf = NORMAL"),
+        ("get pid_process_denom", "pid_process_denom = 1"),
+        ("aux", "aux 0 0 0 1700 2100 0 0"),
+    )
+
+    missing = []
+    with cli:
+        for query, value in expected:
+            if value not in command(cli, query):
+                missing.append(value)
+        cli.sendall(b"exit\n")
+        receive_until(cli, b"Rebooting")
+    sitl.wait()
+
+    if missing:
+        raise RuntimeError("EEPROM verification failed: " + ", ".join(missing))
+
+
+initialize()
+verify()
+print(f"Initialized and verified {root / 'eeprom.bin'}")

--- a/examples/betaflight-sitl/main.py
+++ b/examples/betaflight-sitl/main.py
@@ -143,7 +143,7 @@ world.recipe(betaflight_recipe)
 print(f"Betaflight SITL: {BETAFLIGHT_PATH.name}")
 print(f"Simulation: {config.simulation_time}s at {config.pid_rate:.0f}Hz PID loop")
 print(
-    f"Sensor rates: gyro={config.gyro_rate:.0f}Hz, accel={config.accel_rate:.0f}Hz, baro={config.baro_rate:.0f}Hz, mag={config.mag_rate:.0f}Hz"
+    f"Requested sensor rates: gyro={config.gyro_rate:.0f}Hz, accel={config.accel_rate:.0f}Hz, baro={config.baro_rate:.0f}Hz, mag={config.mag_rate:.0f}Hz"
 )
 
 

--- a/examples/betaflight-sitl/sensors.py
+++ b/examples/betaflight-sitl/sensors.py
@@ -4,17 +4,17 @@ Sensor Simulation for Betaflight SITL
 This module simulates the IMU (Inertial Measurement Unit) and other sensors
 that provide data to Betaflight's flight controller algorithms.
 
-Sensor Models:
-- Gyroscope: Measures angular velocity in body frame (8 kHz - drives PID)
-- Accelerometer: Measures linear acceleration in body frame (4.8 kHz)
-- Barometer: Measures altitude via pressure (480 Hz)
-- Magnetometer: Measures heading reference (200 Hz)
+Sensor Models (configured targets; effective rates are capped by the physics rate):
+- Gyroscope: Measures angular velocity in body frame (8 kHz target, 1 kHz default)
+- Accelerometer: Measures linear acceleration in body frame (4.8 kHz target, 1 kHz default)
+- Barometer: Measures altitude via pressure (480 Hz target, 500 Hz default)
+- Magnetometer: Measures heading reference (200 Hz target and default)
 
 Multi-Rate Simulation:
-Sensors update at their realistic hardware rates based on Aleph flight controller
-specs (BMI270 IMU, BMP581 barometer, BMM350 magnetometer). The simulation runs
-at 8kHz to match Betaflight's high-performance PID loop, but slower sensors
-only update at their native rates using tick decimation.
+Sensors request rates based on the Elodin Aleph flight controller hardware
+(BMI270 IMU, BMP581 barometer, BMM350 magnetometer). The physics/PID lockstep
+runs at 1kHz by default, so faster sensor targets are capped at 1kHz and slower
+sensors use tick decimation.
 
 Noise Model (from proven drone example):
 - Gaussian measurement noise on each sample
@@ -93,7 +93,7 @@ class Noise:
 # Note: Betaflight's attitude estimator is sensitive to noise during the
 # bootgrace/calibration period. High noise causes attitude drift and
 # motor imbalance at liftoff.
-gyro_noise = Noise(0, 0, 0.01, 0.001)  # Gyro noise + bias drift
+gyro_noise = Noise(0, 0, 1e-7, 1e-8)  # Gyro noise + bias drift
 accel_noise = Noise(0, 1, 0.01, 0.001)  # Accel noise (no drift)
 baro_noise = Noise(0, 2, 0.01, 0.001)  # ~0.03m std dev
 mag_noise = Noise(0, 3, 0.01, 0.001)  # Magnetometer noise (very low)
@@ -296,8 +296,8 @@ def create_accel_system(config: DroneConfig):
     in body frame. Applies noise and bias when enabled.
     No filtering - Betaflight handles that.
 
-    Multi-rate: Updates at ~4.8kHz (BMI270 1.6kHz × 3 IMUs). Between updates,
-    the previous reading is held.
+    Multi-rate: Requests ~4.8kHz (BMI270 1.6kHz × 3 IMUs), capped by the
+    physics/PID rate. Between updates, the previous reading is held.
 
     Detects ground contact to correctly report +g when at rest (the ground
     constraint zeros velocity but doesn't add normal force to the Force component).
@@ -364,7 +364,7 @@ def create_accel_system(config: DroneConfig):
         """
         Compute accelerometer reading with multi-rate decimation.
 
-        Updates at accel_tick_interval (e.g., every 2 ticks for 4.8kHz at 8kHz PID).
+        Updates at accel_tick_interval, capped at one update per physics tick.
         Returns previous reading when not updating.
         """
         new_reading = _compute_accel_reading(tick, pos, vel, force, inertia, bias)
@@ -427,7 +427,7 @@ def create_baro_system(config: DroneConfig):
         """
         Compute barometer reading with multi-rate decimation.
 
-        Updates at baro_tick_interval (e.g., every 17 ticks for 480Hz at 8kHz PID).
+        Updates at baro_tick_interval (every 2 ticks at the default 1kHz rate).
         Returns previous reading when not updating.
         """
         new_reading = _compute_baro_reading(tick, pos)
@@ -482,7 +482,7 @@ def create_mag_system(config: DroneConfig):
         """
         Compute magnetometer reading with multi-rate decimation.
 
-        Updates at mag_tick_interval (e.g., every 40 ticks for 200Hz at 8kHz PID).
+        Updates at mag_tick_interval (every 5 ticks at the default 1kHz rate).
         Returns previous reading when not updating.
         """
         new_reading = _compute_mag_reading(tick, pos)
@@ -533,11 +533,11 @@ def create_sensor_system(config: DroneConfig) -> el.System:
     """
     Create the complete sensor system with multi-rate simulation.
 
-    Combines sensors at their realistic hardware rates:
-    - Gyroscope: 8 kHz (matches PID loop, driven by 3x BMI270)
-    - Accelerometer: 4.8 kHz (3x BMI270 @ 1.6 kHz each)
-    - Barometer: 480 Hz (BMP581 continuous mode)
-    - Magnetometer: 200 Hz (BMM350)
+    Combines sensors at their configured target rates, capped by the physics rate:
+    - Gyroscope: 8 kHz target (1 kHz at the default physics rate)
+    - Accelerometer: 4.8 kHz target (1 kHz at the default physics rate)
+    - Barometer: 480 Hz target (500 Hz after whole-tick rounding at 1 kHz)
+    - Magnetometer: 200 Hz target and effective rate
 
     Args:
         config: Drone configuration


### PR DESCRIPTION
betaflight wasn't taking off for me. The core fix was changing the gyro noise setting.

Added a few other changes as well:

* It wasn't running realtime at 2kHz, so I switched to 1kHz for now
* Added a python script that takes care of programming the EEPROM
* Instead of using `sed` to change the betaflight submodule to enable lockstep mode, passed a `-D` to `make` instead

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the betaflight-sitl example (sim tuning, build script, and docs); no production services or security-sensitive paths.
> 
> **Overview**
> Fixes Betaflight SITL liftoff by **lowering simulated gyro noise** in `sensors.py` to `1e-7` / `1e-8` bias drift (from much higher values that destabilized attitude and motors during bootgrace).
> 
> Sets the default **physics/PID lockstep to 1kHz** in `config.py` so the Python/UDP bridge can run in real time; docs and comments now treat high gyro/accel rates as **targets capped by** `simulation_rate`.
> 
> Adds **`init_eeprom.py`** to program and verify `eeprom.bin` (ARM aux, gyro LPF, `pid_process_denom`) over the CLI instead of manual `screen` only.
> 
> **`build.sh`** enables `SIMULATOR_GYROPID_SYNC` via `OPTIONS=` on `make` and drops `sed` edits inside the Betaflight submodule; debug builds use the same helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aefc2f50881e6427f027dedd6cdd94505784c66e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->