### PR TITLE
fix(editor): keep Y-up GLBs and planar terrain level after frame→Bevy.

### DIFF
--- a/libs/bevy_geo_frames/src/geo.rs
+++ b/libs/bevy_geo_frames/src/geo.rs
@@ -320,6 +320,16 @@ impl GeoRotation {
         GeoRotation(frame, r_frame * q.conjugate(), RotationKind::Relative)
     }
 
+    /// Bevy / glTF Y-up → schematic Z-up.
+    ///
+    /// Viewport grids already store this as the local attitude so
+    /// `to_bevy(absolute(ENU, y_up_to_schematic()))` is identity (ground stays
+    /// horizontal). Y-up assets (GLB, planar terrain) need the same lift or
+    /// `bevy_R * att` pitches them 90°.
+    pub fn y_up_to_schematic() -> DQuat {
+        DQuat::from_rotation_x(std::f64::consts::FRAC_PI_2)
+    }
+
     /// Convert orientation to Bevy.
     ///
     /// Both [`RotationKind`]s compose the local→frame attitude with the
@@ -747,6 +757,18 @@ mod tests {
                 b
             );
         };
+    }
+
+    #[test]
+    fn y_up_to_schematic_nets_identity_in_enu_plane() {
+        let ctx = dummy_ctx();
+        let q =
+            GeoRotation::absolute(GeoFrame::ENU, GeoRotation::y_up_to_schematic()).to_bevy(&ctx);
+        assert_quat_eq!(
+            q,
+            DQuat::IDENTITY,
+            "ENU Y-up asset should sit level in Bevy"
+        );
     }
 
     #[test]

--- a/libs/bevy_geo_frames/src/geo.rs
+++ b/libs/bevy_geo_frames/src/geo.rs
@@ -320,14 +320,23 @@ impl GeoRotation {
         GeoRotation(frame, r_frame * q.conjugate(), RotationKind::Relative)
     }
 
-    /// Bevy / glTF Y-up → schematic Z-up.
+    /// Bevy / glTF Y-up → schematic Z-up (ENU / body convention).
     ///
-    /// Viewport grids already store this as the local attitude so
-    /// `to_bevy(absolute(ENU, y_up_to_schematic()))` is identity (ground stays
-    /// horizontal). Y-up assets (GLB, planar terrain) need the same lift or
-    /// `bevy_R * att` pitches them 90°.
+    /// Viewport grids and GLB children store this so a Z-up schematic/body
+    /// mesh stays level after `to_bevy`. Planar terrain should use
+    /// [`Self::y_up_level`]: `Rx(+π/2)` only cancels ENU `bevy_R`, so NED
+    /// heightfields would land with Bevy normal `-Y`.
     pub fn y_up_to_schematic() -> DQuat {
         DQuat::from_rotation_x(std::f64::consts::FRAC_PI_2)
+    }
+
+    /// Local attitude that cancels `bevy_R` for a Y-up mesh (normal `+Y`).
+    ///
+    /// `to_bevy(absolute(frame, y_up_level(frame, ctx)))` is identity, so
+    /// planar heightfields and fallback grids stay a Bevy XZ plane in every
+    /// frame — not only ENU.
+    pub fn y_up_level(frame: GeoFrame, context: &GeoContext) -> DQuat {
+        DQuat::from_mat3(&GeoFrame::bevy_R_(&frame, context)).conjugate()
     }
 
     /// Convert orientation to Bevy.
@@ -768,6 +777,25 @@ mod tests {
             q,
             DQuat::IDENTITY,
             "ENU Y-up asset should sit level in Bevy"
+        );
+    }
+
+    #[test]
+    fn y_up_level_nets_identity_in_every_plane_frame() {
+        let ctx = dummy_ctx();
+        for frame in [GeoFrame::ENU, GeoFrame::NED, GeoFrame::ECEF] {
+            let q =
+                GeoRotation::absolute(frame, GeoRotation::y_up_level(frame, &ctx)).to_bevy(&ctx);
+            assert_quat_eq!(
+                q,
+                DQuat::IDENTITY,
+                "{frame:?} Y-up surface should sit level in Bevy"
+            );
+        }
+        assert_quat_eq!(
+            GeoRotation::y_up_level(GeoFrame::ENU, &ctx),
+            GeoRotation::y_up_to_schematic(),
+            "ENU y_up_level is Rx(+π/2)"
         );
     }
 

--- a/libs/elodin-editor/src/headless.rs
+++ b/libs/elodin-editor/src/headless.rs
@@ -348,6 +348,7 @@ fn load_headless_scene(
                     &mut materials,
                     &mut world_mesh_materials,
                     &world_mesh,
+                    &geo_context,
                 ));
             }
             _ => {}

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -2025,12 +2025,15 @@ pub fn spawn_mesh(
             let scene = assets.load(&url);
 
             let translation = Vec3::new(translate.0, translate.1, translate.2);
-            let rotation = Quat::from_euler(
+            let kdl_rotate = Quat::from_euler(
                 EulerRot::XYZ,
                 rotate.0.to_radians(),
                 rotate.1.to_radians(),
                 rotate.2.to_radians(),
             );
+            // glTF is Y-up; schematic / WorldPos is Z-up. Same lift the
+            // viewport grid applies so `bevy_R * att` does not pitch the mesh.
+            let rotation = GeoRotation::y_up_to_schematic().as_quat() * kdl_rotate;
             let offset_transform = Transform {
                 translation,
                 rotation,
@@ -3026,6 +3029,20 @@ mod translate_body_frame_tests {
         assert!(
             (cam_delta_bevy - rendered_aft).length() < 1e-6,
             "ECEF Absolute mesh aft must match body translate: Δ={cam_delta_bevy:?}, aft={rendered_aft:?}"
+        );
+    }
+
+    #[test]
+    fn glb_y_up_child_cancels_enu_frame_basis() {
+        use bevy_geo_frames::{GeoContext, GeoFrame, GeoRotation};
+
+        let ctx = GeoContext::default();
+        let parent = GeoRotation::relative(GeoFrame::ENU, DQuat::IDENTITY).to_bevy(&ctx);
+        let child = GeoRotation::y_up_to_schematic();
+        let world = parent * child;
+        assert!(
+            world.dot(DQuat::IDENTITY).abs() > 1.0 - 1e-9,
+            "identity-att GLB should sit level in ENU Bevy, got {world:?}"
         );
     }
 }

--- a/libs/elodin-editor/src/plugins/world_mesh/mod.rs
+++ b/libs/elodin-editor/src/plugins/world_mesh/mod.rs
@@ -4,7 +4,7 @@ use bevy::{
     pbr::wireframe::{Wireframe, WireframeColor},
     prelude::*,
 };
-use bevy_geo_frames::{GeoPosition, GeoRotation, OrDefault};
+use bevy_geo_frames::{GeoContext, GeoPosition, GeoRotation, OrDefault};
 use bevy_world_mesh::prelude::WorldMeshPlugin as BevyWorldMeshRendererPlugin;
 use bevy_world_mesh::terrain::{
     math::TerrainModel,
@@ -79,6 +79,7 @@ pub(crate) fn spawn_world_mesh_terrain(
     materials: &mut Assets<StandardMaterial>,
     world_mesh_materials: &mut Assets<bevy_world_mesh::prelude::WorldMeshMaterial>,
     world_mesh: &impeller2_wkt::WorldMesh,
+    geo_context: &GeoContext,
 ) -> Entity {
     let region = world_mesh.region.clone();
     let config = if region == "globe" {
@@ -109,11 +110,18 @@ pub(crate) fn spawn_world_mesh_terrain(
                 world_mesh,
                 &region,
                 region != "globe",
+                geo_context,
             )
         }
-        WorldMeshConfig::Fallback(fallback) => {
-            spawn_world_mesh_fallback(commands, meshes, materials, world_mesh, &region, fallback)
-        }
+        WorldMeshConfig::Fallback(fallback) => spawn_world_mesh_fallback(
+            commands,
+            meshes,
+            materials,
+            world_mesh,
+            &region,
+            fallback,
+            geo_context,
+        ),
     }
 }
 
@@ -134,6 +142,7 @@ fn spawn_world_mesh_terrain_bundle(
     world_mesh: &impeller2_wkt::WorldMesh,
     region: &str,
     y_up_surface: bool,
+    geo_context: &GeoContext,
 ) -> Entity {
     let anchor = commands
         .spawn((
@@ -152,7 +161,7 @@ fn spawn_world_mesh_terrain_bundle(
         Name::new(format!("world_mesh terrain renderer ({region})")),
     ));
 
-    insert_geo_components(commands, anchor, world_mesh, y_up_surface);
+    insert_geo_components(commands, anchor, world_mesh, y_up_surface, geo_context);
     insert_big_space_cell(commands, anchor);
     anchor
 }
@@ -177,15 +186,17 @@ fn insert_geo_components(
     entity: Entity,
     world_mesh: &impeller2_wkt::WorldMesh,
     y_up_surface: bool,
+    geo_context: &GeoContext,
 ) {
     let Some(frame) = world_mesh.frame.or_default() else {
         return;
     };
     let (x, y, z) = world_mesh.translate.unwrap_or_default();
     // Planar heightfields are Bevy Y-up (normal +Y), same as InfiniteGrid.
-    // Lift them to schematic Z-up so `to_bevy` leaves the ground horizontal.
+    // Cancel `bevy_R` so `to_bevy` leaves the ground a Bevy XZ plane in
+    // every frame — `y_up_to_schematic` only cancels ENU.
     let att = if y_up_surface {
-        GeoRotation::y_up_to_schematic()
+        GeoRotation::y_up_level(frame, geo_context)
     } else {
         DQuat::IDENTITY
     };
@@ -397,6 +408,7 @@ fn spawn_world_mesh_fallback(
     world_mesh: &impeller2_wkt::WorldMesh,
     region: &str,
     fallback: WorldMeshFallback,
+    geo_context: &GeoContext,
 ) -> Entity {
     let entity = match fallback {
         WorldMeshFallback::PlanarGrid => spawn_planar_fallback_grid(commands, world_mesh, region),
@@ -410,6 +422,7 @@ fn spawn_world_mesh_fallback(
         entity,
         world_mesh,
         matches!(fallback, WorldMeshFallback::PlanarGrid),
+        geo_context,
     );
     insert_big_space_cell(commands, entity);
     entity
@@ -662,6 +675,20 @@ mod tests {
     }
 
     #[test]
+    fn planar_ned_anchor_stays_level_in_bevy() {
+        let (mut app, anchor, _) = spawn_model_terrain(
+            TerrainModel::planar(DVec3::ZERO, 250.0, 0.0, 100.0),
+            world_mesh(Some(GeoFrame::NED), None),
+        );
+        apply_geo_transforms(&mut app);
+        let rotation = app.world().get::<Transform>(anchor).unwrap().rotation;
+        assert!(
+            rotation.dot(Quat::IDENTITY).abs() > 1.0 - 1e-5,
+            "planar NED terrain should sit level in Bevy, got {rotation:?}"
+        );
+    }
+
+    #[test]
     fn framed_world_mesh_anchor_stays_at_origin_for_geo_pipeline() {
         let world_mesh = world_mesh(Some(GeoFrame::NED), Some((1.0, 2.0, 3.0)));
 
@@ -694,6 +721,7 @@ mod tests {
                 &world_mesh,
                 &world_mesh.region,
                 true,
+                &GeoContext::default(),
             )
         };
         app.world_mut().flush();

--- a/libs/elodin-editor/src/plugins/world_mesh/mod.rs
+++ b/libs/elodin-editor/src/plugins/world_mesh/mod.rs
@@ -102,7 +102,14 @@ pub(crate) fn spawn_world_mesh_terrain(
             let material =
                 world_mesh_materials.add(bevy_world_mesh::prelude::WorldMeshMaterial::default());
 
-            spawn_world_mesh_terrain_bundle(commands, terrain_bundle, material, world_mesh, &region)
+            spawn_world_mesh_terrain_bundle(
+                commands,
+                terrain_bundle,
+                material,
+                world_mesh,
+                &region,
+                region != "globe",
+            )
         }
         WorldMeshConfig::Fallback(fallback) => {
             spawn_world_mesh_fallback(commands, meshes, materials, world_mesh, &region, fallback)
@@ -126,6 +133,7 @@ fn spawn_world_mesh_terrain_bundle(
     material: Handle<bevy_world_mesh::prelude::WorldMeshMaterial>,
     world_mesh: &impeller2_wkt::WorldMesh,
     region: &str,
+    y_up_surface: bool,
 ) -> Entity {
     let anchor = commands
         .spawn((
@@ -144,7 +152,7 @@ fn spawn_world_mesh_terrain_bundle(
         Name::new(format!("world_mesh terrain renderer ({region})")),
     ));
 
-    insert_geo_components(commands, anchor, world_mesh);
+    insert_geo_components(commands, anchor, world_mesh, y_up_surface);
     insert_big_space_cell(commands, anchor);
     anchor
 }
@@ -168,14 +176,22 @@ fn insert_geo_components(
     commands: &mut Commands,
     entity: Entity,
     world_mesh: &impeller2_wkt::WorldMesh,
+    y_up_surface: bool,
 ) {
     let Some(frame) = world_mesh.frame.or_default() else {
         return;
     };
     let (x, y, z) = world_mesh.translate.unwrap_or_default();
+    // Planar heightfields are Bevy Y-up (normal +Y), same as InfiniteGrid.
+    // Lift them to schematic Z-up so `to_bevy` leaves the ground horizontal.
+    let att = if y_up_surface {
+        GeoRotation::y_up_to_schematic()
+    } else {
+        DQuat::IDENTITY
+    };
     commands.entity(entity).insert((
         GeoPosition(frame, DVec3::new(x, y, z)),
-        GeoRotation::relative(frame, DQuat::IDENTITY),
+        GeoRotation::absolute(frame, att),
     ));
 }
 
@@ -389,7 +405,12 @@ fn spawn_world_mesh_fallback(
         }
     };
 
-    insert_geo_components(commands, entity, world_mesh);
+    insert_geo_components(
+        commands,
+        entity,
+        world_mesh,
+        matches!(fallback, WorldMeshFallback::PlanarGrid),
+    );
     insert_big_space_cell(commands, entity);
     entity
 }
@@ -627,6 +648,20 @@ mod tests {
     }
 
     #[test]
+    fn planar_enu_anchor_stays_level_in_bevy() {
+        let (mut app, anchor, _) = spawn_model_terrain(
+            TerrainModel::planar(DVec3::ZERO, 250.0, 0.0, 100.0),
+            world_mesh(Some(GeoFrame::ENU), None),
+        );
+        apply_geo_transforms(&mut app);
+        let rotation = app.world().get::<Transform>(anchor).unwrap().rotation;
+        assert!(
+            rotation.dot(Quat::IDENTITY).abs() > 1.0 - 1e-5,
+            "planar ENU terrain should sit level in Bevy, got {rotation:?}"
+        );
+    }
+
+    #[test]
     fn framed_world_mesh_anchor_stays_at_origin_for_geo_pipeline() {
         let world_mesh = world_mesh(Some(GeoFrame::NED), Some((1.0, 2.0, 3.0)));
 
@@ -658,6 +693,7 @@ mod tests {
                 Handle::default(),
                 &world_mesh,
                 &world_mesh.region,
+                true,
             )
         };
         app.world_mut().flush();

--- a/libs/elodin-editor/src/ui/schematic/load.rs
+++ b/libs/elodin-editor/src/ui/schematic/load.rs
@@ -1085,6 +1085,7 @@ impl LoadSchematicParams<'_, '_> {
             &mut self.materials,
             &mut self.world_mesh_materials,
             &world_mesh,
+            &self.geo_context,
         );
         let mut e = self.commands.entity(entity);
         e.insert((SchematicSpawned, world_mesh));


### PR DESCRIPTION
Identity attitude now composes with the ENU→Bevy basis, which pitched glTF meshes and Y-up heightfields 90° in every viewport. Lift those assets into schematic Z-up the same way the grid and plane primitive already do.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes geo orientation of GLBs and world-mesh terrain in every viewport/headless spawn path; wrong attitude would tilt ground or models, but globe meshes are left unchanged and tests cover ENU/NED identity.
> 
> **Overview**
> Stops identity-attitude glTF meshes and planar heightfields from pitching 90° when `to_bevy` composes with the frame basis.
> 
> Adds `y_up_to_schematic` (`Rx(+π/2)`) for GLB children so Y-up assets sit level in ENU after `bevy_R * att`. Planar world-mesh terrain and fallback grids use **`y_up_level`** (the conjugate of `bevy_R`) as an **absolute** attitude so the ground stays a Bevy XZ plane in ENU, NED, and ECEF — not only ENU. Globe meshes keep identity attitude.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87a718eaf10ab36a203f9163f4b94061384395a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->