### PR TITLE
fix: View-cube ecef face labels.

### DIFF
--- a/examples/geo-frames/main.py
+++ b/examples/geo-frames/main.py
@@ -112,9 +112,12 @@ def world() -> el.World:
         f"""
         coordinate frame=NED lat={LAT_DEG} lon={LON_DEG} alt={ALT_M}
         hsplit {{
+            vsplit {{
+                viewport name="ECEF Equator" frame="ECEF" pos="(0,0,0,1, 8000000,-80000000, 0)" look_at="(0,0,0,1, 0,0,0)" up="(0,0,1)" far=15000000.0 hdr=#true show_grid=#true active=#true
+                viewport name="ECEF Oblique" frame="ECEF" pos="(0,0,0,1, 46000000,-46000000, 46000000)" look_at="(0,0,0,1, 0,0,0)" up="(0,0,1)" far=15000000.0 hdr=#true show_grid=#true active=#true
+            }}
             tabs {{
                 viewport name=Frames frame="NED" pos="(0,0,0,1, 4000000,4000000,-3000000)" look_at="(0,0,0,1, 0,0,0)" far=15000000.0 hdr=#true show_grid=#false active=#true
-                viewport name=Frames frame="ECEF" pos="(0,0,0,1, 8000000,-80000000, 0)" look_at="(0,0,0,1, 0,0,0)" up="(0,0,1)" far=15000000.0 hdr=#true show_grid=#true active=#true 
                 inspector
                 hierarchy
             }}

--- a/libs/elodin-editor/src/plugins/view_cube/camera.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/camera.rs
@@ -1710,6 +1710,147 @@ mod tests {
         );
     }
 
+    /// Per-viewport labels hang under the shared cube, so the cube's layer must
+    /// not be forced onto them — otherwise every viewport draws every copy.
+    #[test]
+    fn per_viewport_face_label_subtrees_keep_their_own_render_layers() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.init_resource::<WorldInstanceSpawner>();
+        app.add_systems(Update, apply_render_layers_to_scene);
+
+        let frame_layers = view_cube_render_layers(GeoFrame::ECEF);
+        let viewport_a = RenderLayers::layer(24);
+        let viewport_b = RenderLayers::layer(25);
+
+        let root = app
+            .world_mut()
+            .spawn((ViewCubeRoot, Visibility::Hidden, frame_layers.clone()))
+            .id();
+        let label_a = app
+            .world_mut()
+            .spawn((ChildOf(root), KeepsRenderLayers, viewport_a.clone()))
+            .id();
+        let glyph_a = app
+            .world_mut()
+            .spawn((ChildOf(label_a), RenderLayers::layer(0)))
+            .id();
+        let label_b = app
+            .world_mut()
+            .spawn((ChildOf(root), KeepsRenderLayers, viewport_b.clone()))
+            .id();
+        let glyph_b = app
+            .world_mut()
+            .spawn((ChildOf(label_b), RenderLayers::layer(0)))
+            .id();
+        let shared_axis = app
+            .world_mut()
+            .spawn((ChildOf(root), RenderLayers::layer(0)))
+            .id();
+
+        app.update();
+
+        assert_eq!(app.world().get::<RenderLayers>(label_a), Some(&viewport_a));
+        assert_eq!(app.world().get::<RenderLayers>(label_b), Some(&viewport_b));
+        assert_eq!(
+            app.world().get::<RenderLayers>(glyph_a),
+            Some(&viewport_a),
+            "glyphs follow their own label, not the shared cube",
+        );
+        assert_eq!(app.world().get::<RenderLayers>(glyph_b), Some(&viewport_b));
+        assert_eq!(
+            app.world().get::<RenderLayers>(shared_axis),
+            Some(&frame_layers),
+            "cube parts that are not per-viewport still take the frame layer",
+        );
+    }
+
+    /// Two viewports on the same frame share one cube, so each has to own its
+    /// copy of the labels and spin it for its own camera.
+    #[test]
+    fn two_viewports_sharing_a_cube_orient_their_own_labels() {
+        let geo = geo_frames_geo();
+        let cube = ecef_cube_rotation(&geo);
+        let label = ecef_face_label("+X");
+        let equator = camera_looking(Vec3::new(0.0, -8.0, 0.0), Vec3::Z);
+        let oblique = camera_looking(Vec3::new(4.6, -4.6, 4.6), Vec3::Z);
+
+        let mut app = App::new();
+        app.add_systems(Update, orient_face_labels_to_view);
+
+        let cube_root = app
+            .world_mut()
+            .spawn((
+                ViewCubeRoot,
+                GlobalTransform::from(Transform::from_rotation(cube)),
+            ))
+            .id();
+
+        let mut spawn_viewport_copy = |camera_rotation: Quat| {
+            let camera = app
+                .world_mut()
+                .spawn((
+                    ViewCubeCamera,
+                    GlobalTransform::from(Transform::from_rotation(camera_rotation)),
+                ))
+                .id();
+            app.world_mut()
+                .spawn((
+                    ChildOf(cube_root),
+                    FaceLabel {
+                        base_rotation: label.rotation,
+                        camera,
+                        last_angle: 0.0,
+                        last_view: None,
+                    },
+                    Transform::from_rotation(label.rotation),
+                ))
+                .id()
+        };
+        let label_equator = spawn_viewport_copy(equator);
+        let label_oblique = spawn_viewport_copy(oblique);
+
+        app.update();
+
+        for (entity, camera, name) in [
+            (label_equator, equator, "equator"),
+            (label_oblique, oblique, "oblique"),
+        ] {
+            let expected = face_label_in_plane_angle(label.rotation, cube, camera)
+                .unwrap_or_else(|| panic!("+X should be visible from the {name} camera"));
+            let solved = app.world().get::<FaceLabel>(entity).expect("label");
+            assert!(
+                (solved.last_angle - expected).abs() <= FACE_LABEL_ANGLE_EPS,
+                "{name} copy should be solved for its own camera, \
+                 got {} expected {expected}",
+                solved.last_angle,
+            );
+            let applied = app.world().get::<Transform>(entity).expect("transform");
+            let wanted = label.rotation * Quat::from_rotation_z(expected);
+            assert!(
+                applied.rotation.abs_diff_eq(wanted, 1.0e-5),
+                "{name} copy should carry its spin: applied={:?} wanted={wanted:?}",
+                applied.rotation,
+            );
+        }
+
+        let angle_equator = app
+            .world()
+            .get::<FaceLabel>(label_equator)
+            .expect("label")
+            .last_angle;
+        let angle_oblique = app
+            .world()
+            .get::<FaceLabel>(label_oblique)
+            .expect("label")
+            .last_angle;
+        assert!(
+            (angle_equator - angle_oblique).abs() > 1.0e-3,
+            "the two viewports look from different angles, so their labels \
+             must not end up sharing one orientation",
+        );
+    }
+
     #[test]
     fn view_cube_scene_root_is_revealed_after_scene_instance_is_ready() {
         let mut app = App::new();

--- a/libs/elodin-editor/src/plugins/view_cube/camera.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/camera.rs
@@ -294,6 +294,31 @@ pub(super) fn face_label_in_plane_angle(
     (baseline.length_squared() > FACE_LABEL_EPS * FACE_LABEL_EPS).then_some(angle)
 }
 
+type FaceLabelOrientQuery<'w, 's> = Query<
+    'w,
+    's,
+    (
+        &'static mut FaceLabel,
+        &'static mut Transform,
+        &'static mut GlobalTransform,
+    ),
+    (Without<ViewCubeCamera>, Without<ViewCubeRoot>),
+>;
+
+type ViewCubeRootGlobalQuery<'w, 's> = Query<
+    'w,
+    's,
+    (&'static ViewCubeFrame, &'static GlobalTransform),
+    (With<ViewCubeRoot>, Without<FaceLabel>),
+>;
+
+type ViewCubeOverlayGlobalQuery<'w, 's> = Query<
+    'w,
+    's,
+    (&'static ViewCubeFrameRef, &'static GlobalTransform),
+    (With<ViewCubeCamera>, Without<FaceLabel>),
+>;
+
 /// Spins each face label so its word reads horizontally in the viewport
 /// that owns it.
 ///
@@ -301,15 +326,9 @@ pub(super) fn face_label_in_plane_angle(
 /// GLB instance can reparent children. After propagation we also write
 /// `GlobalTransform`, otherwise extract still sees the baked pose.
 pub fn orient_face_labels_to_view(
-    mut labels: Query<
-        (&mut FaceLabel, &mut Transform, &mut GlobalTransform),
-        (Without<ViewCubeCamera>, Without<ViewCubeRoot>),
-    >,
-    cubes: Query<(&ViewCubeFrame, &GlobalTransform), (With<ViewCubeRoot>, Without<FaceLabel>)>,
-    cube_cameras: Query<
-        (&ViewCubeFrameRef, &GlobalTransform),
-        (With<ViewCubeCamera>, Without<FaceLabel>),
-    >,
+    mut labels: FaceLabelOrientQuery<'_, '_>,
+    cubes: ViewCubeRootGlobalQuery<'_, '_>,
+    cube_cameras: ViewCubeOverlayGlobalQuery<'_, '_>,
 ) {
     for (mut face_label, mut label_transform, mut label_global) in labels.iter_mut() {
         let Ok((frame_ref, camera_global)) = cube_cameras.get(face_label.camera) else {

--- a/libs/elodin-editor/src/plugins/view_cube/camera.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/camera.rs
@@ -19,8 +19,8 @@ use std::collections::HashMap;
 use std::f32::consts::PI;
 
 use super::components::{
-    AxisLabelBillboard, FaceLabel, RotationArrow, ViewCubeCamera, ViewCubeFrame, ViewCubeFrameRef,
-    ViewCubeLink, ViewCubeRoot, ViewportActionButton,
+    AxisLabelBillboard, FaceLabel, KeepsRenderLayers, RotationArrow, ViewCubeCamera, ViewCubeFrame,
+    ViewCubeFrameRef, ViewCubeLink, ViewCubeRoot, ViewportActionButton,
 };
 use super::config::ViewCubeConfig;
 use super::events::ViewCubeEvent;
@@ -289,78 +289,35 @@ pub(super) fn face_label_in_plane_angle(
     (baseline.length_squared() > FACE_LABEL_EPS * FACE_LABEL_EPS).then_some(angle)
 }
 
-/// Per-coordinate-frame view state, kept between runs to detect a still view.
-pub struct FaceLabelView {
-    frame: GeoFrame,
-    cube_rotation: Quat,
-    camera_rotation: Quat,
-    moved: bool,
-}
-
-/// Spins each face label so its word reads horizontally in its own cube's
-/// viewport.
+/// Spins each face label so its word reads horizontally in the viewport that
+/// owns it.
 ///
-/// Only recomputes for cubes whose view actually moved, and leaves the label
-/// transform untouched when the angle is unchanged, so a still viewport costs a
-/// couple of quaternion compares and no transform propagation.
+/// Every label knows the overlay camera it belongs to, so two viewports on the
+/// same frame — which share a single cube — each orient their own copy. Reading
+/// through `Mut` does not flag a change, so a still viewport costs one
+/// comparison per label and triggers no transform propagation.
 pub fn orient_face_labels_to_view(
     mut labels: Query<(&ChildOf, &mut FaceLabel, &mut Transform)>,
-    cubes: Query<(&ViewCubeFrame, &GlobalTransform), With<ViewCubeRoot>>,
-    cube_cameras: Query<(&ViewCubeFrameRef, &GlobalTransform), With<ViewCubeCamera>>,
-    mut views: Local<Vec<FaceLabelView>>,
+    cubes: Query<&GlobalTransform, With<ViewCubeRoot>>,
+    cube_cameras: Query<&GlobalTransform, With<ViewCubeCamera>>,
 ) {
-    if labels.is_empty() {
-        return;
-    }
-
-    // Reused across runs: a handful of frames, so a linear scan beats a map and
-    // never allocates after the first few runs.
-    for view in views.iter_mut() {
-        view.moved = false;
-    }
-
-    for (frame_ref, camera_global) in cube_cameras.iter() {
-        let camera_rotation = camera_global.rotation();
-        let Some((_, cube_global)) = cubes.iter().find(|(frame, _)| frame.0 == frame_ref.0) else {
-            continue;
-        };
-        let cube_rotation = cube_global.rotation();
-
-        match views.iter_mut().find(|view| view.frame == frame_ref.0) {
-            Some(view) => {
-                view.moved =
-                    view.cube_rotation != cube_rotation || view.camera_rotation != camera_rotation;
-                view.cube_rotation = cube_rotation;
-                view.camera_rotation = camera_rotation;
-            }
-            None => views.push(FaceLabelView {
-                frame: frame_ref.0,
-                cube_rotation,
-                camera_rotation,
-                moved: true,
-            }),
-        }
-    }
-
-    if views.iter().all(|view| !view.moved) {
-        return;
-    }
-
     for (parent, mut face_label, mut label_transform) in labels.iter_mut() {
-        let Ok((cube_frame, _)) = cubes.get(parent.0) else {
+        let Ok(cube_global) = cubes.get(parent.0) else {
             continue;
         };
-        let Some(view) = views
-            .iter()
-            .find(|view| view.frame == cube_frame.0 && view.moved)
-        else {
+        let Ok(camera_global) = cube_cameras.get(face_label.camera) else {
             continue;
         };
+
+        let view = (cube_global.rotation(), camera_global.rotation());
+        if face_label.last_view == Some(view) {
+            continue;
+        }
+        face_label.last_view = Some(view);
 
         let base_rotation = face_label.base_rotation;
-        let angle =
-            face_label_in_plane_angle(base_rotation, view.cube_rotation, view.camera_rotation)
-                .unwrap_or(face_label.last_angle);
+        let angle = face_label_in_plane_angle(base_rotation, view.0, view.1)
+            .unwrap_or(face_label.last_angle);
         if (angle - face_label.last_angle).abs() <= FACE_LABEL_ANGLE_EPS {
             continue;
         }
@@ -375,6 +332,7 @@ pub fn apply_render_layers_to_scene(
     scene_instances: Query<&WorldInstance>,
     scene_spawner: Res<WorldInstanceSpawner>,
     view_cube_entities: Query<Entity, Without<ViewCubeCamera>>,
+    own_layers: Query<&RenderLayers, With<KeepsRenderLayers>>,
     mut commands: Commands,
 ) {
     for (cube_root, render_layers, visibility) in view_cube_query.iter() {
@@ -382,6 +340,7 @@ pub fn apply_render_layers_to_scene(
             cube_root,
             &children_query,
             &view_cube_entities,
+            &own_layers,
             render_layers,
             &mut commands,
         );
@@ -399,12 +358,22 @@ fn apply_layers_recursive(
     entity: Entity,
     children_query: &Query<&Children>,
     view_cube_entities: &Query<Entity, Without<ViewCubeCamera>>,
+    own_layers: &Query<&RenderLayers, With<KeepsRenderLayers>>,
     render_layers: &RenderLayers,
     commands: &mut Commands,
 ) {
-    if view_cube_entities.get(entity).is_ok() {
-        commands.entity(entity).insert(render_layers.clone());
-    }
+    // A per-viewport subtree keeps its own layer and hands it down, otherwise
+    // the shared cube's layer would leak in and every viewport would see every
+    // copy of the face labels.
+    let render_layers = match own_layers.get(entity) {
+        Ok(own) => own,
+        Err(_) => {
+            if view_cube_entities.get(entity).is_ok() {
+                commands.entity(entity).insert(render_layers.clone());
+            }
+            render_layers
+        }
+    };
 
     if let Ok(children) = children_query.get(entity) {
         for child in children.iter() {
@@ -412,6 +381,7 @@ fn apply_layers_recursive(
                 child,
                 children_query,
                 view_cube_entities,
+                own_layers,
                 render_layers,
                 commands,
             );

--- a/libs/elodin-editor/src/plugins/view_cube/camera.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/camera.rs
@@ -178,11 +178,16 @@ pub fn sync_view_cube_camera_orientation(
         };
 
         let (_, rotation, _) = main_camera_transform.to_scale_rotation_translation();
-        // Mirror the camera's global rotation.
+        let translation = rotation * Vec3::new(0.0, 0.0, config.camera_distance);
+        if camera_transform.rotation.abs_diff_eq(rotation, 1.0e-6)
+            && camera_transform
+                .translation
+                .abs_diff_eq(translation, 1.0e-5)
+        {
+            continue;
+        }
         camera_transform.rotation = rotation;
-        // Keep it at its given distance.
-        camera_transform.translation =
-            camera_transform.rotation * Vec3::new(0.0, 0.0, config.camera_distance);
+        camera_transform.translation = translation;
     }
 }
 
@@ -289,23 +294,28 @@ pub(super) fn face_label_in_plane_angle(
     (baseline.length_squared() > FACE_LABEL_EPS * FACE_LABEL_EPS).then_some(angle)
 }
 
-/// Spins each face label so its word reads horizontally in the viewport that
-/// owns it.
+/// Spins each face label so its word reads horizontally in the viewport
+/// that owns it.
 ///
-/// Every label knows the overlay camera it belongs to, so two viewports on the
-/// same frame — which share a single cube — each orient their own copy. Reading
-/// through `Mut` does not flag a change, so a still viewport costs one
-/// comparison per label and triggers no transform propagation.
+/// Cube pose comes from the overlay camera's frame, not `ChildOf` — the
+/// GLB instance can reparent children. After propagation we also write
+/// `GlobalTransform`, otherwise extract still sees the baked pose.
 pub fn orient_face_labels_to_view(
-    mut labels: Query<(&ChildOf, &mut FaceLabel, &mut Transform)>,
-    cubes: Query<&GlobalTransform, With<ViewCubeRoot>>,
-    cube_cameras: Query<&GlobalTransform, With<ViewCubeCamera>>,
+    mut labels: Query<
+        (&mut FaceLabel, &mut Transform, &mut GlobalTransform),
+        (Without<ViewCubeCamera>, Without<ViewCubeRoot>),
+    >,
+    cubes: Query<(&ViewCubeFrame, &GlobalTransform), (With<ViewCubeRoot>, Without<FaceLabel>)>,
+    cube_cameras: Query<
+        (&ViewCubeFrameRef, &GlobalTransform),
+        (With<ViewCubeCamera>, Without<FaceLabel>),
+    >,
 ) {
-    for (parent, mut face_label, mut label_transform) in labels.iter_mut() {
-        let Ok(cube_global) = cubes.get(parent.0) else {
+    for (mut face_label, mut label_transform, mut label_global) in labels.iter_mut() {
+        let Ok((frame_ref, camera_global)) = cube_cameras.get(face_label.camera) else {
             continue;
         };
-        let Ok(camera_global) = cube_cameras.get(face_label.camera) else {
+        let Some((_, cube_global)) = cubes.iter().find(|(frame, _)| frame.0 == frame_ref.0) else {
             continue;
         };
 
@@ -318,11 +328,11 @@ pub fn orient_face_labels_to_view(
         let base_rotation = face_label.base_rotation;
         let angle = face_label_in_plane_angle(base_rotation, view.0, view.1)
             .unwrap_or(face_label.last_angle);
-        if (angle - face_label.last_angle).abs() <= FACE_LABEL_ANGLE_EPS {
-            continue;
+        if (angle - face_label.last_angle).abs() > FACE_LABEL_ANGLE_EPS {
+            face_label.last_angle = angle;
+            label_transform.rotation = base_rotation * Quat::from_rotation_z(angle);
         }
-        face_label.last_angle = angle;
-        label_transform.rotation = base_rotation * Quat::from_rotation_z(angle);
+        *label_global = cube_global.mul_transform(*label_transform);
     }
 }
 
@@ -332,7 +342,7 @@ pub fn apply_render_layers_to_scene(
     scene_instances: Query<&WorldInstance>,
     scene_spawner: Res<WorldInstanceSpawner>,
     view_cube_entities: Query<Entity, Without<ViewCubeCamera>>,
-    own_layers: Query<&RenderLayers, With<KeepsRenderLayers>>,
+    current_layers: Query<(&RenderLayers, Has<KeepsRenderLayers>)>,
     mut commands: Commands,
 ) {
     for (cube_root, render_layers, visibility) in view_cube_query.iter() {
@@ -340,7 +350,7 @@ pub fn apply_render_layers_to_scene(
             cube_root,
             &children_query,
             &view_cube_entities,
-            &own_layers,
+            &current_layers,
             render_layers,
             &mut commands,
         );
@@ -358,15 +368,22 @@ fn apply_layers_recursive(
     entity: Entity,
     children_query: &Query<&Children>,
     view_cube_entities: &Query<Entity, Without<ViewCubeCamera>>,
-    own_layers: &Query<&RenderLayers, With<KeepsRenderLayers>>,
+    current_layers: &Query<(&RenderLayers, Has<KeepsRenderLayers>)>,
     render_layers: &RenderLayers,
     commands: &mut Commands,
 ) {
     // A per-viewport subtree keeps its own layer and hands it down, otherwise
     // the shared cube's layer would leak in and every viewport would see every
-    // copy of the face labels.
-    let render_layers = match own_layers.get(entity) {
-        Ok(own) => own,
+    // copy of the face labels. Rewriting an unchanged layer still trips Bevy
+    // change detection, so skip the insert when the mask is already right.
+    let render_layers = match current_layers.get(entity) {
+        Ok((own, true)) => own,
+        Ok((current, false)) => {
+            if view_cube_entities.get(entity).is_ok() && current != render_layers {
+                commands.entity(entity).insert(render_layers.clone());
+            }
+            render_layers
+        }
         Err(_) => {
             if view_cube_entities.get(entity).is_ok() {
                 commands.entity(entity).insert(render_layers.clone());
@@ -381,7 +398,7 @@ fn apply_layers_recursive(
                 child,
                 children_query,
                 view_cube_entities,
-                own_layers,
+                current_layers,
                 render_layers,
                 commands,
             );
@@ -1782,6 +1799,8 @@ mod tests {
             .world_mut()
             .spawn((
                 ViewCubeRoot,
+                ViewCubeFrame(GeoFrame::ECEF),
+                Transform::from_rotation(cube),
                 GlobalTransform::from(Transform::from_rotation(cube)),
             ))
             .id();
@@ -1791,6 +1810,8 @@ mod tests {
                 .world_mut()
                 .spawn((
                     ViewCubeCamera,
+                    ViewCubeFrameRef(GeoFrame::ECEF),
+                    Transform::from_rotation(camera_rotation),
                     GlobalTransform::from(Transform::from_rotation(camera_rotation)),
                 ))
                 .id();
@@ -1804,6 +1825,7 @@ mod tests {
                         last_view: None,
                     },
                     Transform::from_rotation(label.rotation),
+                    GlobalTransform::from(Transform::from_rotation(label.rotation)),
                 ))
                 .id()
         };
@@ -2123,6 +2145,46 @@ mod tests {
         assert!(
             face_label_in_plane_angle(label.rotation, Quat::IDENTITY, camera).is_none(),
             "an edge-on face has no meaningful in-plane angle"
+        );
+    }
+
+    /// geo-frames' two ECEF cameras: look-at in ECEF, converted the same way
+    /// the viewport does. +X on the oblique view must actually spin — baked
+    /// orientation leaves it vertical on screen.
+    #[test]
+    fn geo_frames_ecef_cameras_spin_plus_x_off_its_baked_pose() {
+        let geo = geo_frames_geo();
+        let cube = ecef_cube_rotation(&geo);
+        let label = ecef_face_label("+X");
+
+        let equator = GeoRotation::look_at(
+            GeoFrame::ECEF,
+            DVec3::new(-8_000_000.0, 80_000_000.0, 0.0),
+            Some(DVec3::Z),
+            &geo,
+        )
+        .to_bevy(&geo)
+        .as_quat();
+        let oblique = GeoRotation::look_at(
+            GeoFrame::ECEF,
+            DVec3::new(-46_000_000.0, 46_000_000.0, -46_000_000.0),
+            Some(DVec3::Z),
+            &geo,
+        )
+        .to_bevy(&geo)
+        .as_quat();
+
+        assert_reads_horizontally("+X", cube, equator);
+        assert_reads_horizontally("+X", cube, oblique);
+        assert_reads_horizontally("+Z", cube, oblique);
+        assert_reads_horizontally("-Y", cube, equator);
+
+        let baked = 0.0;
+        let spun = face_label_in_plane_angle(label.rotation, cube, oblique)
+            .expect("+X visible from the oblique ECEF camera");
+        assert!(
+            (spun - baked).abs() > 15.0_f32.to_radians(),
+            "oblique +X must leave its baked pose, got {spun} rad"
         );
     }
 }

--- a/libs/elodin-editor/src/plugins/view_cube/camera.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/camera.rs
@@ -16,9 +16,10 @@ use bevy_editor_cam::extensions::look_to::LookToTrigger;
 use impeller2_bevy::EntityMap;
 use impeller2_wkt::ComponentValue;
 use std::collections::HashMap;
+use std::f32::consts::PI;
 
 use super::components::{
-    AxisLabelBillboard, RotationArrow, ViewCubeCamera, ViewCubeFrame, ViewCubeFrameRef,
+    AxisLabelBillboard, FaceLabel, RotationArrow, ViewCubeCamera, ViewCubeFrame, ViewCubeFrameRef,
     ViewCubeLink, ViewCubeRoot, ViewportActionButton,
 };
 use super::config::ViewCubeConfig;
@@ -227,6 +228,144 @@ pub fn orient_axis_labels_to_screen_plane(
         label_transform.translation =
             label_meta.base_position + gap_dir_local * AXIS_LABEL_SCREEN_GAP;
         label_transform.rotation = cube_rotation.inverse() * *camera_rotation;
+    }
+}
+
+const FACE_LABEL_EPS: f32 = 1.0e-5;
+/// Angle change below which rewriting the label transform is not worth the
+/// change-detection and transform propagation it would trigger.
+const FACE_LABEL_ANGLE_EPS: f32 = 1.0e-4;
+
+/// Screen-space (x right, y up) baseline and glyph-up axes of a label spun by
+/// `angle` inside its face plane.
+#[cfg(test)]
+fn face_label_screen_axes(
+    base_rotation: Quat,
+    cube_rotation: Quat,
+    camera_rotation: Quat,
+    angle: f32,
+) -> (Vec2, Vec2) {
+    let to_camera = camera_rotation.inverse() * cube_rotation * base_rotation;
+    let (c1, c2) = (to_camera * Vec3::X, to_camera * Vec3::Y);
+    let (sin, cos) = angle.sin_cos();
+    let right = cos * c1 + sin * c2;
+    let up = cos * c2 - sin * c1;
+    (Vec2::new(right.x, right.y), Vec2::new(up.x, up.y))
+}
+
+/// In-plane spin (radians) that lays a face label's baseline flat on the screen
+/// horizontal.
+///
+/// Quantizing to 90° cannot do this: on an obliquely viewed face both in-plane
+/// axes can sit ~60° off horizontal, so every quarter turn reads sideways.
+/// Solving `cos·c1.y + sin·c2.y = 0` is exact for any pose instead, where `c1`
+/// and `c2` are the face plane axes in camera space.
+///
+/// Returns `None` for an edge-on face, whose whole plane projects to a line.
+pub(super) fn face_label_in_plane_angle(
+    base_rotation: Quat,
+    cube_rotation: Quat,
+    camera_rotation: Quat,
+) -> Option<f32> {
+    let to_camera = camera_rotation.inverse() * cube_rotation * base_rotation;
+    let c1 = to_camera * Vec3::X;
+    let c2 = to_camera * Vec3::Y;
+
+    // Both axes already project horizontally: nothing to solve.
+    let mut angle = if c1.y.abs() <= FACE_LABEL_EPS && c2.y.abs() <= FACE_LABEL_EPS {
+        0.0
+    } else {
+        (-c1.y).atan2(c2.y)
+    };
+
+    let (sin, cos) = angle.sin_cos();
+    let mut baseline = Vec2::new(cos * c1.x + sin * c2.x, cos * c1.y + sin * c2.y);
+    // Both halves of the solution are horizontal; take the one running left to
+    // right. Adding π only negates the baseline, so no need to solve again.
+    if baseline.x < 0.0 {
+        angle += PI;
+        baseline = -baseline;
+    }
+    (baseline.length_squared() > FACE_LABEL_EPS * FACE_LABEL_EPS).then_some(angle)
+}
+
+/// Per-coordinate-frame view state, kept between runs to detect a still view.
+pub struct FaceLabelView {
+    frame: GeoFrame,
+    cube_rotation: Quat,
+    camera_rotation: Quat,
+    moved: bool,
+}
+
+/// Spins each face label so its word reads horizontally in its own cube's
+/// viewport.
+///
+/// Only recomputes for cubes whose view actually moved, and leaves the label
+/// transform untouched when the angle is unchanged, so a still viewport costs a
+/// couple of quaternion compares and no transform propagation.
+pub fn orient_face_labels_to_view(
+    mut labels: Query<(&ChildOf, &mut FaceLabel, &mut Transform)>,
+    cubes: Query<(&ViewCubeFrame, &GlobalTransform), With<ViewCubeRoot>>,
+    cube_cameras: Query<(&ViewCubeFrameRef, &GlobalTransform), With<ViewCubeCamera>>,
+    mut views: Local<Vec<FaceLabelView>>,
+) {
+    if labels.is_empty() {
+        return;
+    }
+
+    // Reused across runs: a handful of frames, so a linear scan beats a map and
+    // never allocates after the first few runs.
+    for view in views.iter_mut() {
+        view.moved = false;
+    }
+
+    for (frame_ref, camera_global) in cube_cameras.iter() {
+        let camera_rotation = camera_global.rotation();
+        let Some((_, cube_global)) = cubes.iter().find(|(frame, _)| frame.0 == frame_ref.0) else {
+            continue;
+        };
+        let cube_rotation = cube_global.rotation();
+
+        match views.iter_mut().find(|view| view.frame == frame_ref.0) {
+            Some(view) => {
+                view.moved =
+                    view.cube_rotation != cube_rotation || view.camera_rotation != camera_rotation;
+                view.cube_rotation = cube_rotation;
+                view.camera_rotation = camera_rotation;
+            }
+            None => views.push(FaceLabelView {
+                frame: frame_ref.0,
+                cube_rotation,
+                camera_rotation,
+                moved: true,
+            }),
+        }
+    }
+
+    if views.iter().all(|view| !view.moved) {
+        return;
+    }
+
+    for (parent, mut face_label, mut label_transform) in labels.iter_mut() {
+        let Ok((cube_frame, _)) = cubes.get(parent.0) else {
+            continue;
+        };
+        let Some(view) = views
+            .iter()
+            .find(|view| view.frame == cube_frame.0 && view.moved)
+        else {
+            continue;
+        };
+
+        let base_rotation = face_label.base_rotation;
+        let angle =
+            face_label_in_plane_angle(base_rotation, view.cube_rotation, view.camera_rotation)
+                .unwrap_or(face_label.last_angle);
+        if (angle - face_label.last_angle).abs() <= FACE_LABEL_ANGLE_EPS {
+            continue;
+        }
+        face_label.last_angle = angle;
+        label_transform.rotation = base_rotation * Quat::from_rotation_z(angle);
     }
 }
 
@@ -1192,6 +1331,7 @@ fn apply_orbit_look_at(
 mod tests {
     use super::*;
     use crate::plugins::render_layer_alloc::view_cube_render_layers;
+    use crate::plugins::view_cube::config::CoordinateSystem;
     use bevy::asset::AssetPlugin;
     use bevy::world_serialization::{WorldAsset, WorldAssetRoot, WorldSerializationPlugin};
     use bevy_geo_frames::Present;
@@ -1731,5 +1871,147 @@ mod tests {
 
         assert!((transform.translation - start.translation).length() < 1.0e-5);
         assert!((editor_cam.last_anchor_depth + 4.0).abs() < 1.0e-5);
+    }
+
+    fn ecef_face_label(text: &str) -> crate::plugins::view_cube::config::FaceLabelConfig {
+        CoordinateSystem(GeoFrame::ECEF)
+            .get_face_labels(1.0)
+            .into_iter()
+            .find(|label| label.text == text)
+            .unwrap_or_else(|| panic!("missing ECEF face label {text}"))
+    }
+
+    fn camera_looking(from: Vec3, up: Vec3) -> Quat {
+        Transform::from_translation(from)
+            .looking_at(Vec3::ZERO, up)
+            .rotation
+    }
+
+    fn geo_frames_geo() -> GeoContext {
+        GeoContext::from(bevy_geo_frames::GeoOrigin::new_from_degrees(
+            34.72, -86.64, 180.5,
+        ))
+        .with_present(Present::Plane)
+    }
+
+    /// Real ECEF cube pose: the root carries `GeoRotation::absolute(ECEF, I)`.
+    /// Testing against `Quat::IDENTITY` instead hides the oblique faces entirely.
+    fn ecef_cube_rotation(geo: &GeoContext) -> Quat {
+        GeoRotation::absolute(GeoFrame::ECEF, bevy::math::DQuat::IDENTITY)
+            .to_bevy(geo)
+            .as_quat()
+    }
+
+    fn assert_reads_horizontally(text: &str, cube: Quat, camera: Quat) {
+        let label = ecef_face_label(text);
+        let angle = face_label_in_plane_angle(label.rotation, cube, camera)
+            .unwrap_or_else(|| panic!("{text} should not be edge-on for this pose"));
+        let (baseline, _) = face_label_screen_axes(label.rotation, cube, camera, angle);
+        assert!(
+            baseline.y.abs() <= 1.0e-4 * baseline.length().max(1.0e-6) + 1.0e-5,
+            "{text} should read horizontally, screen baseline={baseline:?}"
+        );
+        assert!(
+            baseline.x > 0.0,
+            "{text} should run left to right, screen baseline={baseline:?}"
+        );
+    }
+
+    /// The ECEF cube carries `bevy_R_ecef`, so its faces are viewed obliquely and
+    /// their in-plane axes never line up with the screen. Every visible face has
+    /// to read horizontally anyway.
+    #[test]
+    fn ecef_visible_face_labels_read_horizontally_over_a_camera_sweep() {
+        let geo = geo_frames_geo();
+        let cube = ecef_cube_rotation(&geo);
+        let labels = CoordinateSystem(GeoFrame::ECEF).get_face_labels(1.0);
+
+        for yaw_deg in (0..360).step_by(5) {
+            for pitch_deg in (-85..=85).step_by(5) {
+                let camera = Quat::from_euler(
+                    EulerRot::YXZ,
+                    (yaw_deg as f32).to_radians(),
+                    (pitch_deg as f32).to_radians(),
+                    0.0,
+                );
+                for label in &labels {
+                    let normal_cam = camera.inverse() * cube * label.position.normalize_or_zero();
+                    // Only faces actually turned toward the viewer must be readable.
+                    if normal_cam.z < 0.2 {
+                        continue;
+                    }
+                    let angle = face_label_in_plane_angle(label.rotation, cube, camera)
+                        .unwrap_or_else(|| {
+                            panic!(
+                                "{} is visible (n.z={:.3}) at yaw={yaw_deg} pitch={pitch_deg} but was treated as edge-on",
+                                label.text, normal_cam.z
+                            )
+                        });
+                    let (baseline, _) = face_label_screen_axes(label.rotation, cube, camera, angle);
+                    assert!(
+                        baseline.y.abs() <= 1.0e-4 * baseline.length() + 1.0e-5,
+                        "{} reads sideways at yaw={yaw_deg} pitch={pitch_deg}: baseline={baseline:?}",
+                        label.text
+                    );
+                    assert!(
+                        baseline.x > 0.0,
+                        "{} runs right to left at yaw={yaw_deg} pitch={pitch_deg}: baseline={baseline:?}",
+                        label.text
+                    );
+                }
+            }
+        }
+    }
+
+    /// Regression: a 90°-quantized roll leaves this oblique `+X` face ~63° off
+    /// horizontal, because none of its four quarter turns is horizontal.
+    #[test]
+    fn ecef_oblique_side_face_is_horizontal_where_quantized_rolls_fail() {
+        let geo = geo_frames_geo();
+        let cube = ecef_cube_rotation(&geo);
+        let camera = Quat::from_euler(
+            EulerRot::YXZ,
+            150.0_f32.to_radians(),
+            30.0_f32.to_radians(),
+            0.0,
+        );
+        assert_reads_horizontally("+X", cube, camera);
+    }
+
+    #[test]
+    fn ecef_plus_z_label_is_untouched_when_face_on() {
+        let camera = camera_looking(Vec3::Z, Vec3::Y);
+        let label = ecef_face_label("+Z");
+        let angle = face_label_in_plane_angle(label.rotation, Quat::IDENTITY, camera)
+            .expect("+Z is face-on, not edge-on");
+        assert!(
+            angle.abs() < 1.0e-5,
+            "a face-on label is already horizontal and must not spin, got {angle}"
+        );
+    }
+
+    #[test]
+    fn ecef_plus_z_label_flips_when_camera_is_upside_down() {
+        let camera = camera_looking(Vec3::Z, Vec3::NEG_Y);
+        let label = ecef_face_label("+Z");
+        let angle = face_label_in_plane_angle(label.rotation, Quat::IDENTITY, camera)
+            .expect("+Z stays face-on when the camera rolls");
+        assert!(
+            (angle.abs() - PI).abs() < 1.0e-5,
+            "upside-down view should spin the label 180°, got {angle}"
+        );
+        assert_reads_horizontally("+Z", Quat::IDENTITY, camera);
+    }
+
+    #[test]
+    fn face_label_has_no_angle_when_face_is_edge_on() {
+        // Camera in the +X face plane, screen-up along the face: the whole face
+        // projects to a vertical line, so no angle can be horizontal.
+        let label = ecef_face_label("+X");
+        let camera = camera_looking(Vec3::Y, Vec3::Z);
+        assert!(
+            face_label_in_plane_angle(label.rotation, Quat::IDENTITY, camera).is_none(),
+            "an edge-on face has no meaningful in-plane angle"
+        );
     }
 }

--- a/libs/elodin-editor/src/plugins/view_cube/components.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/components.rs
@@ -190,14 +190,30 @@ pub struct AxisLabelBillboard {
     pub base_position: Vec3,
 }
 
-/// Face label painted on the cube: the baked face pose plus the in-plane spin
-/// that keeps the word horizontal on screen. `last_angle` is both the fallback
-/// for edge-on faces and the guard that avoids rewriting an unchanged transform.
+/// Face label painted on a cube face, owned by one viewport's overlay camera.
+///
+/// A cube is shared by every viewport on its frame, so each viewport spawns its
+/// own copy of the labels on its own render layer; `camera` is what ties a copy
+/// back to the view it has to stay readable in.
 #[derive(Component, Clone, Copy)]
 pub struct FaceLabel {
     pub base_rotation: Quat,
+    pub camera: Entity,
+    /// Fallback spin for edge-on faces, and the guard against rewriting an
+    /// unchanged transform.
     pub last_angle: f32,
+    /// Cube and camera rotations the spin was last solved for.
+    pub last_view: Option<(Quat, Quat)>,
 }
+
+/// Marks a view-cube subtree that keeps its own render layers instead of
+/// inheriting the shared cube's.
+#[derive(Component, Clone, Copy)]
+pub struct KeepsRenderLayers;
+
+/// Marks an overlay camera whose face labels have been spawned.
+#[derive(Component, Clone, Copy)]
+pub struct ViewportFaceLabels;
 
 // ============================================================================
 // Resources

--- a/libs/elodin-editor/src/plugins/view_cube/components.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/components.rs
@@ -190,6 +190,15 @@ pub struct AxisLabelBillboard {
     pub base_position: Vec3,
 }
 
+/// Face label painted on the cube: the baked face pose plus the in-plane spin
+/// that keeps the word horizontal on screen. `last_angle` is both the fallback
+/// for edge-on faces and the guard that avoids rewriting an unchanged transform.
+#[derive(Component, Clone, Copy)]
+pub struct FaceLabel {
+    pub base_rotation: Quat,
+    pub last_angle: f32,
+}
+
 // ============================================================================
 // Resources
 // ============================================================================

--- a/libs/elodin-editor/src/plugins/view_cube/mod.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/mod.rs
@@ -18,6 +18,7 @@ pub use theme::ViewCubeColors;
 
 use bevy::picking::prelude::*;
 use bevy::prelude::*;
+use bevy::transform::TransformSystems;
 use bevy_fontmesh::prelude::*;
 
 #[derive(Resource)]
@@ -82,23 +83,18 @@ impl Plugin for ViewCubePlugin {
         if self.config.sync_with_camera {
             app.add_systems(
                 PostUpdate,
-                (
-                    camera::sync_view_cube_camera_orientation,
-                    camera::orient_axis_labels_to_screen_plane,
-                    camera::orient_face_labels_to_view,
-                )
-                    .chain(),
-            );
-        } else {
-            app.add_systems(
-                PostUpdate,
-                (
-                    camera::orient_axis_labels_to_screen_plane,
-                    camera::orient_face_labels_to_view,
-                )
-                    .chain(),
+                camera::sync_view_cube_camera_orientation.before(TransformSystems::Propagate),
             );
         }
+        app.add_systems(
+            PostUpdate,
+            (
+                camera::orient_axis_labels_to_screen_plane,
+                camera::orient_face_labels_to_view,
+            )
+                .chain()
+                .after(TransformSystems::Propagate),
+        );
 
         app.add_systems(Update, camera::apply_render_layers_to_scene);
     }

--- a/libs/elodin-editor/src/plugins/view_cube/mod.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/mod.rs
@@ -85,11 +85,19 @@ impl Plugin for ViewCubePlugin {
                 (
                     camera::sync_view_cube_camera_orientation,
                     camera::orient_axis_labels_to_screen_plane,
+                    camera::orient_face_labels_to_view,
                 )
                     .chain(),
             );
         } else {
-            app.add_systems(PostUpdate, camera::orient_axis_labels_to_screen_plane);
+            app.add_systems(
+                PostUpdate,
+                (
+                    camera::orient_axis_labels_to_screen_plane,
+                    camera::orient_face_labels_to_view,
+                )
+                    .chain(),
+            );
         }
 
         app.add_systems(Update, camera::apply_render_layers_to_scene);

--- a/libs/elodin-editor/src/plugins/view_cube/spawn.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/spawn.rs
@@ -24,6 +24,10 @@ pub(crate) fn plugin(app: &mut App) {
     app.init_resource::<ViewCubeFrames>()
         .add_systems(Startup, spawn_frame_view_cubes)
         .add_systems(
+            Update,
+            (spawn_viewport_face_labels, despawn_orphaned_face_labels),
+        )
+        .add_systems(
             PreUpdate,
             // Reads keyboard state and is read back by the picking observers, so
             // it has to be pinned between the two.
@@ -127,16 +131,60 @@ fn spawn_frame_view_cube_mesh(
         Some(&render_layers),
     );
 
-    spawn_face_labels(
-        commands,
-        asset_server,
-        materials,
-        config,
-        Some(&render_layers),
-        cube_root,
-    );
+    // Face labels are not spawned here: they are per-viewport, see
+    // `spawn_viewport_face_labels`.
 
     cube_root
+}
+
+type LabellessOverlayCameras<'w, 's> = Query<
+    'w,
+    's,
+    (Entity, &'static ViewCubeFrameRef, &'static RenderLayerLease),
+    (With<ViewCubeCamera>, Without<ViewportFaceLabels>),
+>;
+
+/// Give every overlay camera its own copy of the face labels, on its own render
+/// layer, so two viewports on the same frame can orient them independently.
+fn spawn_viewport_face_labels(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+    config: Res<ViewCubeConfig>,
+    frames: Res<ViewCubeFrames>,
+    cameras: LabellessOverlayCameras,
+) {
+    for (camera, frame_ref, ui_lease) in cameras.iter() {
+        let Some(cube_root) = frames.get(frame_ref.0) else {
+            continue;
+        };
+        let mut frame_config = config.clone();
+        frame_config.system = CoordinateSystem(frame_ref.0);
+        spawn_face_labels(
+            &mut commands,
+            &asset_server,
+            &mut materials,
+            &frame_config,
+            &ui_lease.render_layers(),
+            cube_root,
+            camera,
+        );
+        commands.entity(camera).insert(ViewportFaceLabels);
+    }
+}
+
+/// Viewports come and go with the tile layout, and their render layer is
+/// recycled, so a closed viewport's labels have to go with it.
+fn despawn_orphaned_face_labels(
+    mut commands: Commands,
+    labels: Query<(Entity, &FaceLabel)>,
+    cameras: Query<(), With<ViewCubeCamera>>,
+) {
+    for (entity, label) in labels.iter() {
+        if cameras.get(label.camera).is_err() {
+            commands.entity(entity).despawn();
+        }
+    }
 }
 
 /// Spawn a per-viewport overlay camera that renders the shared frame cube.
@@ -424,8 +472,9 @@ fn spawn_face_labels(
     asset_server: &AssetServer,
     materials: &mut Assets<StandardMaterial>,
     config: &ViewCubeConfig,
-    render_layers: Option<&RenderLayers>,
+    render_layers: &RenderLayers,
     parent: Entity,
+    camera: Entity,
 ) {
     let font: Handle<Font> =
         asset_server.load("embedded://elodin_editor/assets/fonts/Roboto-Bold.ttf");
@@ -445,7 +494,7 @@ fn spawn_face_labels(
             ..default()
         });
 
-        let mut label_cmd = commands.spawn((
+        commands.spawn((
             TextMesh {
                 text: label.text.to_string(),
                 font: font.clone(),
@@ -462,14 +511,15 @@ fn spawn_face_labels(
             Pickable::IGNORE,
             FaceLabel {
                 base_rotation: label.rotation,
+                camera,
                 last_angle: 0.0,
+                last_view: None,
             },
+            KeepsRenderLayers,
+            render_layers.clone(),
             ChildOf(parent),
             Name::new(format!("label_{}", label.text)),
         ));
-        if let Some(layers) = render_layers {
-            label_cmd.insert(layers.clone());
-        }
     }
 }
 

--- a/libs/elodin-editor/src/plugins/view_cube/spawn.rs
+++ b/libs/elodin-editor/src/plugins/view_cube/spawn.rs
@@ -460,6 +460,10 @@ fn spawn_face_labels(
                 .with_rotation(label.rotation)
                 .with_scale(Vec3::splat(label_scale)),
             Pickable::IGNORE,
+            FaceLabel {
+                base_rotation: label.rotation,
+                last_angle: 0.0,
+            },
             ChildOf(parent),
             Name::new(format!("label_{}", label.text)),
         ));


### PR DESCRIPTION
## Video
geo-frames example:

https://github.com/user-attachments/assets/e0d63f37-5aa4-476c-832e-83e8d3687c99


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches view-cube transform, render-layer inheritance, and per-viewport spawning—easy to leak labels across cameras or fight Bevy extract if scheduling is wrong. Logic is well-tested and isolated to the overlay widget.
> 
> **Overview**
> View-cube face labels now stay **screen-horizontal** at any camera pose, including oblique ECEF views where 90° rolls left text ~60° off.
> 
> Each overlay camera gets its **own copy** of the labels on its own render layer (`KeepsRenderLayers`), so two viewports sharing a cube can spin independently without leaking copies into every view. `orient_face_labels_to_view` solves an exact in-plane angle after transform propagation and writes `GlobalTransform` so extract sees the spin.
> 
> The geo-frames example splits ECEF into equator and oblique viewports so this is easy to check. Overlay camera sync also skips no-op writes to cut change detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51f3323dc0debcd798b9f7b556d03e7cc9ac4f23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->