### PR TITLE
fix(examples): Put Apollo thruster particles in schematic Z-up.

### DIFF
--- a/docs/public/content/reference/schematic.md
+++ b/docs/public/content/reference/schematic.md
@@ -245,7 +245,7 @@ viewport hdr=#true {
 
 ```kdl
 thruster name="DPS" effect="effects/apollo-lander/descent_plume.effect" body_frame=#true \
-         position="(0, -1.9, 0)" direction="(0, -1, 0)" intensity="lander.main_thrust_viz[2]" {
+         position="(0, 0, -1.9)" direction="(0, 0, -1)" intensity="lander.main_thrust_viz[2]" {
     effect "effects/apollo-lander/descent_glow.effect"
     light color="(1.0, 0.95, 0.88)" intensity=3000000.0 range=40.0 offset=0.8 shadows=#true
 }

--- a/examples/apollo-lander/README.md
+++ b/examples/apollo-lander/README.md
@@ -302,8 +302,8 @@ Use `--dry-run` to only write the narrowed specs.
     intensity from `lander.dust_viz` (throttle × surface proximity) — the
     regolith sheet ramps in below ~12 m and dies at engine cutoff.
   Spawn rates come from the effect files and scale with intensity; nozzle
-  geometry lives in `apollo-lander.kdl` (RCS positions tuned to the visible
-  four-quad layout after the GLB mesh translate). The schematic
+  geometry lives in `apollo-lander.kdl` (schematic Z-up body offsets, tuned to
+  the four-quad layout after the Y-up GLB is lifted onto ENU). The schematic
   `environment` node (harsh sun + shadows, near-zero ambient, black sky) and
   the viewport's `hdr`/`ev100`/`bloom` reproduce the pyrotechnique lighting;
   effect assets are ingested into the DB and served like the GLBs. Reference

--- a/examples/apollo-lander/WHITEPAPER.md
+++ b/examples/apollo-lander/WHITEPAPER.md
@@ -418,7 +418,7 @@ Monte Carlo `attitude_gain` parameter.
 
 [`ground_contact`](sim.py) latches a landing the first time the entity altitude
 drops to `FOOTPAD_HEIGHT_M` (≈ 2.40 m). The LM GLB uses
-`translate="(0, -2.5, 0)"`, so pad bottoms sit that far below the entity origin;
+`translate="(0, 0, -2.5)"`, so pad bottoms sit that far below the entity origin;
 pinning at this height puts the pads on the moon mesh at `z ≈ 0`. On that contact
 tick — *before* the velocity is zeroed — it records the vertical impact speed
 `|v_z|` as `touchdown_speed` and the horizontal impact speed `‖v_xy‖` as
@@ -703,7 +703,7 @@ Earth atmosphere is active); raymarched Earth atmosphere for the blue limb.
 ### 8.1 Figuring out the model units
 
 - **Lunar Module** — meters, Y-up; `LANDER_GLB_SCALE = 1.0`. KDL
-  `translate="(0, -2.5, 0)"` puts pads ≈ `FOOTPAD_HEIGHT_M` (2.40 m) below the
+  `translate="(0, 0, -2.5)"` puts pads ≈ `FOOTPAD_HEIGHT_M` (2.40 m) below the
   entity origin; `ground_contact` pins there.
 - **Moon** — native radius ≈ 0.97, KDL `scale = 1,798,000` → lunar scale.
 - **Earth** — `earth.glb` is already Earth radius at `scale=1`.

--- a/examples/apollo-lander/apollo-lander.kdl
+++ b/examples/apollo-lander/apollo-lander.kdl
@@ -72,28 +72,30 @@ hsplit {
 }
 
 // Thruster exhaust: hanabi .effect files from pyrotechnique, driven by EQL.
+// Body-frame offsets are schematic Z-up (ENU). The GLB is Y-up and lifted
+// with y_up_to_schematic (Rx(+π/2)): mesh (x,y,z) → schematic (x,-z,y).
 object_3d lander.world_pos frame=ENU {
-    glb path=apollo-lunar-module.glb translate="(0, -2.5, 0)"
-    thruster name="DPS" effect="effects/apollo-lander/descent_plume.effect" body_frame=#true position="(0, -1.9, 0)" direction="(0, -1, 0)" intensity="lander.main_thrust_viz[2]" {
+    glb path=apollo-lunar-module.glb translate="(0, 0, -2.5)"
+    thruster name="DPS" effect="effects/apollo-lander/descent_plume.effect" body_frame=#true position="(0, 0, -1.9)" direction="(0, 0, -1)" intensity="lander.main_thrust_viz[2]" {
         effect "effects/apollo-lander/descent_glow.effect"
         light color="(1.0, 0.95, 0.88)" intensity=3000000.0 range=40.0 offset=0.8 shadows=#true
     }
-    thruster name="rcs_0" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(1.089, 0.870, -1.506)" direction="(0, 0, -1)" intensity="lander.rcs_thruster_viz[0]" cutoff=0.006
-    thruster name="rcs_1" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(1.388, 0.874, -1.361)" direction="(1, 0, 0)" intensity="lander.rcs_thruster_viz[1]" cutoff=0.006
-    thruster name="rcs_2" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(-1.180, 0.527, -1.369)" direction="(0, -1, 0)" intensity="lander.rcs_thruster_viz[2]" cutoff=0.006
-    thruster name="rcs_3" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(-1.360, 0.855, -1.361)" direction="(-1, 0, 0)" intensity="lander.rcs_thruster_viz[3]" cutoff=0.006
-    thruster name="rcs_4" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(-1.062, 0.858, -1.507)" direction="(0, 0, -1)" intensity="lander.rcs_thruster_viz[4]" cutoff=0.006
-    thruster name="rcs_5" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(-1.249, 1.127, 1.230)" direction="(0, 1, 0)" intensity="lander.rcs_thruster_viz[5]" cutoff=0.006
-    thruster name="rcs_6" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(-1.429, 0.916, 1.280)" direction="(-1, 0, 0)" intensity="lander.rcs_thruster_viz[6]" cutoff=0.006
-    thruster name="rcs_7" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(-1.232, 0.912, 1.428)" direction="(0, 0, 1)" intensity="lander.rcs_thruster_viz[7]" cutoff=0.006
-    thruster name="rcs_8" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(1.297, 1.127, 1.243)" direction="(0, 1, 0)" intensity="lander.rcs_thruster_viz[8]" cutoff=0.006
-    thruster name="rcs_9" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(1.296, 0.694, 1.243)" direction="(0, -1, 0)" intensity="lander.rcs_thruster_viz[9]" cutoff=0.006
-    thruster name="rcs_10" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(1.484, 0.905, 1.260)" direction="(1, 0, 0)" intensity="lander.rcs_thruster_viz[10]" cutoff=0.006
-    thruster name="rcs_11" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(1.314, 0.908, 1.442)" direction="(0, 0, 1)" intensity="lander.rcs_thruster_viz[11]" cutoff=0.006
-    thruster name="rcs_12" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(1.207, 1.201, -1.369)" direction="(0, 1, 0)" intensity="lander.rcs_thruster_viz[12]" cutoff=0.006
-    thruster name="rcs_13" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(1.207, 0.527, -1.369)" direction="(0, -1, 0)" intensity="lander.rcs_thruster_viz[13]" cutoff=0.006
-    thruster name="rcs_14" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(-1.249, 0.694, 1.230)" direction="(0, -1, 0)" intensity="lander.rcs_thruster_viz[14]" cutoff=0.006
-    thruster name="rcs_15" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(-1.180, 1.200, -1.369)" direction="(0, 1, 0)" intensity="lander.rcs_thruster_viz[15]" cutoff=0.006
+    thruster name="rcs_0" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(1.089, 1.506, 0.870)" direction="(0, 1, 0)" intensity="lander.rcs_thruster_viz[0]" cutoff=0.006
+    thruster name="rcs_1" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(1.388, 1.361, 0.874)" direction="(1, 0, 0)" intensity="lander.rcs_thruster_viz[1]" cutoff=0.006
+    thruster name="rcs_2" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(-1.180, 1.369, 0.527)" direction="(0, 0, -1)" intensity="lander.rcs_thruster_viz[2]" cutoff=0.006
+    thruster name="rcs_3" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(-1.360, 1.361, 0.855)" direction="(-1, 0, 0)" intensity="lander.rcs_thruster_viz[3]" cutoff=0.006
+    thruster name="rcs_4" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(-1.062, 1.507, 0.858)" direction="(0, 1, 0)" intensity="lander.rcs_thruster_viz[4]" cutoff=0.006
+    thruster name="rcs_5" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(-1.249, -1.230, 1.127)" direction="(0, 0, 1)" intensity="lander.rcs_thruster_viz[5]" cutoff=0.006
+    thruster name="rcs_6" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(-1.429, -1.280, 0.916)" direction="(-1, 0, 0)" intensity="lander.rcs_thruster_viz[6]" cutoff=0.006
+    thruster name="rcs_7" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(-1.232, -1.428, 0.912)" direction="(0, -1, 0)" intensity="lander.rcs_thruster_viz[7]" cutoff=0.006
+    thruster name="rcs_8" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(1.297, -1.243, 1.127)" direction="(0, 0, 1)" intensity="lander.rcs_thruster_viz[8]" cutoff=0.006
+    thruster name="rcs_9" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(1.296, -1.243, 0.694)" direction="(0, 0, -1)" intensity="lander.rcs_thruster_viz[9]" cutoff=0.006
+    thruster name="rcs_10" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(1.484, -1.260, 0.905)" direction="(1, 0, 0)" intensity="lander.rcs_thruster_viz[10]" cutoff=0.006
+    thruster name="rcs_11" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(1.314, -1.442, 0.908)" direction="(0, -1, 0)" intensity="lander.rcs_thruster_viz[11]" cutoff=0.006
+    thruster name="rcs_12" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(1.207, 1.369, 1.201)" direction="(0, 0, 1)" intensity="lander.rcs_thruster_viz[12]" cutoff=0.006
+    thruster name="rcs_13" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(1.207, 1.369, 0.527)" direction="(0, 0, -1)" intensity="lander.rcs_thruster_viz[13]" cutoff=0.006
+    thruster name="rcs_14" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(-1.249, -1.230, 0.694)" direction="(0, 0, -1)" intensity="lander.rcs_thruster_viz[14]" cutoff=0.006
+    thruster name="rcs_15" effect="effects/apollo-lander/rcs_puff.effect" body_frame=#true position="(-1.180, 1.369, 1.200)" direction="(0, 0, 1)" intensity="lander.rcs_thruster_viz[15]" cutoff=0.006
 }
 
 object_3d "(0,0,0,1, 0,0,0)" frame=ENU {

--- a/examples/apollo-lander/apollo-lander.kdl
+++ b/examples/apollo-lander/apollo-lander.kdl
@@ -74,6 +74,7 @@ hsplit {
 // Thruster exhaust: hanabi .effect files from pyrotechnique, driven by EQL.
 // Body-frame offsets are schematic Z-up (ENU). The GLB is Y-up and lifted
 // with y_up_to_schematic (Rx(+π/2)): mesh (x,y,z) → schematic (x,-z,y).
+// Keep RCS_THRUSTERS in rcs_geometry.py in lockstep with these nozzles.
 object_3d lander.world_pos frame=ENU {
     glb path=apollo-lunar-module.glb translate="(0, 0, -2.5)"
     thruster name="DPS" effect="effects/apollo-lander/descent_plume.effect" body_frame=#true position="(0, 0, -1.9)" direction="(0, 0, -1)" intensity="lander.main_thrust_viz[2]" {

--- a/examples/apollo-lander/rcs_geometry.py
+++ b/examples/apollo-lander/rcs_geometry.py
@@ -3,33 +3,57 @@
 The KDL thruster ``direction`` vectors are exhaust directions. The reaction
 force on the vehicle is therefore the opposite vector, and ``position x force``
 defines the body-axis torque sign each visible jet contributes.
+
+Offsets are schematic Z-up (ENU), matching ``apollo-lander.kdl`` after the
+Y-up GLB is lifted with ``y_up_to_schematic``: mesh (x, y, z) → schematic
+(x, -z, y).
 """
 
 from __future__ import annotations
 
-RCS_THRUSTER_AXIS = (1, 1, 0, 1, 1, 2, 1, 1, 2, 2, 1, 1, 0, 0, 2, 0)
-RCS_THRUSTER_SIGN = (
-    -1.0,
-    1.0,
-    1.0,
-    -1.0,
-    1.0,
-    1.0,
-    1.0,
-    -1.0,
-    -1.0,
-    1.0,
-    -1.0,
-    1.0,
-    -1.0,
-    1.0,
-    -1.0,
-    -1.0,
+# (position, exhaust direction) — same order and values as apollo-lander.kdl.
+RCS_THRUSTERS = (
+    ((1.089, 1.506, 0.870), (0.0, 1.0, 0.0)),
+    ((1.388, 1.361, 0.874), (1.0, 0.0, 0.0)),
+    ((-1.180, 1.369, 0.527), (0.0, 0.0, -1.0)),
+    ((-1.360, 1.361, 0.855), (-1.0, 0.0, 0.0)),
+    ((-1.062, 1.507, 0.858), (0.0, 1.0, 0.0)),
+    ((-1.249, -1.230, 1.127), (0.0, 0.0, 1.0)),
+    ((-1.429, -1.280, 0.916), (-1.0, 0.0, 0.0)),
+    ((-1.232, -1.428, 0.912), (0.0, -1.0, 0.0)),
+    ((1.297, -1.243, 1.127), (0.0, 0.0, 1.0)),
+    ((1.296, -1.243, 0.694), (0.0, 0.0, -1.0)),
+    ((1.484, -1.260, 0.905), (1.0, 0.0, 0.0)),
+    ((1.314, -1.442, 0.908), (0.0, -1.0, 0.0)),
+    ((1.207, 1.369, 1.201), (0.0, 0.0, 1.0)),
+    ((1.207, 1.369, 0.527), (0.0, 0.0, -1.0)),
+    ((-1.249, -1.230, 0.694), (0.0, 0.0, -1.0)),
+    ((-1.180, 1.369, 1.200), (0.0, 0.0, 1.0)),
 )
+
+
+def _torque_axis_sign(
+    position: tuple[float, float, float], direction: tuple[float, float, float]
+) -> tuple[int, float]:
+    px, py, pz = position
+    dx, dy, dz = direction
+    torque = (
+        py * (-dz) - pz * (-dy),
+        pz * (-dx) - px * (-dz),
+        px * (-dy) - py * (-dx),
+    )
+    axis = max(range(3), key=lambda i: abs(torque[i]))
+    return axis, 1.0 if torque[axis] >= 0.0 else -1.0
+
+
+RCS_THRUSTER_AXIS = tuple(_torque_axis_sign(p, d)[0] for p, d in RCS_THRUSTERS)
+RCS_THRUSTER_SIGN = tuple(_torque_axis_sign(p, d)[1] for p, d in RCS_THRUSTERS)
 RCS_THRUSTER_VIZ_MIN_RAW_LEVEL = 0.001
 
 if len(RCS_THRUSTER_AXIS) != len(RCS_THRUSTER_SIGN):
     raise RuntimeError("RCS thruster axis/sign tables must have the same length")
+if len(RCS_THRUSTERS) != 16:
+    raise RuntimeError("RCS thruster table must match the 16 KDL nozzles")
 
 
 def rcs_thruster_levels(torque_norm: tuple[float, float, float]) -> tuple[float, ...]:

--- a/examples/apollo-lander/sim.py
+++ b/examples/apollo-lander/sim.py
@@ -58,7 +58,7 @@ DEFAULT_MAX_TICKS = int(math.ceil((REFERENCE.t_end + 20.0) * SIMULATION_RATE_HZ)
 # The Apollo LM GLB is modeled in meters (world AABB ~6.4 m footprint, ~5.0 m
 # tall, Y-up), so render it at its modeled scale to be ~life-size.
 LANDER_GLB_SCALE = 1.0
-# KDL translate="(0, -2.5, 0)" puts footpads ≈ 2.40 m below the entity origin
+# KDL translate="(0, 0, -2.5)" puts footpads ≈ 2.40 m below the entity origin
 # (raw ymin≈0.10). Physics contact pins the origin at this height so pads sit
 # on the moon mesh at z ≈ 0. The Sea of Tranquility tile was removed; moon.glb
 # is seated with under-site surface at z = 0 (see apollo-lander.kdl).

--- a/libs/elodin-editor/src/object_3d.rs
+++ b/libs/elodin-editor/src/object_3d.rs
@@ -3045,6 +3045,20 @@ mod translate_body_frame_tests {
             "identity-att GLB should sit level in ENU Bevy, got {world:?}"
         );
     }
+
+    #[test]
+    fn glb_y_up_nozzle_offset_is_schematic_down() {
+        use bevy_geo_frames::GeoRotation;
+
+        // Thruster `position`/`direction` are schematic Z-up. A Y-up GLB
+        // nozzle at mesh (0, -1.9, 0) lands at schematic (0, 0, -1.9) after
+        // the same Rx(+π/2) lift applied to the GLB child.
+        let schematic = GeoRotation::y_up_to_schematic() * DVec3::new(0.0, -1.9, 0.0);
+        assert!(
+            (schematic - DVec3::new(0.0, 0.0, -1.9)).length() < 1e-9,
+            "mesh −Y nozzle must become schematic −Z, got {schematic:?}"
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The GLB Y-up lift left DPS/RCS offsets in mesh Y, so plumes sat beside the lander instead of the nozzles.

<img width="1163" height="722" alt="image" src="https://github.com/user-attachments/assets/b5655319-7d7f-49fb-8916-881080da887c" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visualization-only geometry and docs; RCS viz torque mapping is derived from the same table, with no change to physics or control.
> 
> **Overview**
> Fixes Apollo lander exhaust sitting beside the mesh after the Y-up GLB lift: thruster `position`/`direction` and the LM `glb` translate are now schematic Z-up (mesh `(x,y,z)` → `(x,-z,y)`).
> 
> DPS and all 16 RCS nozzles in `apollo-lander.kdl` are remapped so plumes attach at the bells. `rcs_geometry.py` stores the same nozzle table and derives torque axis/sign from `position × −exhaust`, so viz firing stays in lockstep with KDL. Docs and a unit test record that a mesh −Y nozzle becomes schematic −Z.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e2b17395d89a0c6e63d58cffa65f27c7d3342fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->