### PR TITLE
Release v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 ## unreleased
 
+## v0.19
+
+### v0.19.0
+- **(feat)** Add a native Earth environment. (#778, #795)
+- **(feat)** Add heliocentric relative dynamics to Voyager. (#789)
+- **(feat)** Add Voyager trajectory error telemetry. (#769)
+- **(feat)** Add viewport follow-camera smoothing. (#764)
+- **(feat)** Add an artificial horizon gauge. (#753)
+- **(feat)** Add headless video capture. (#754, #757)
+- **(feat)** Add --kdl to allow local KDL and asset development. (#763)
+- **(feat:aleph)** Add initrd-based one-shot Aleph UEFI and OS flashing over USB-C. (#748)
+- **(feat:db)** Add Elodin DB gRPC. (#772)
+- **(feat:db)** Add `elodin-db export --format mcap`. (#746)
+- **(fix)** Fix view-cube ECEF face labels, zoom in/out. (#796, #790, #758)
+- **(fix)** Fix Betaflight takeoff. (#791)
+- **(fix)** Fix GPU OOM and fins animation. (#788)
+- **(fix)** Generate schematic planes in Z-up so identity pose is ground. (#786, #793)
+- **(fix)** Fix ECEF translate and add `ned_to_ecef()`. (#774)
+- **(fix)** Prevent an editor crash when scrubbing with particles. (#777)
+- **(fix)** Fix reconnect replay time travel. (#775)
+- **(fix)** Fix the Ctrl-P command palette panic. (#770)
+- **(fix)** Capture headless video on hybrid Intel + NVIDIA hosts. (#768)
+- **(fix)** Fix `line_3d` f32 quantization. (#766)
+- **(fix)** Make `elodin_capture.sh` work on Ubuntu. (#767)
+- **(fix)** Restore minimal terrain rendering. (#761)
+- **(fix:examples)** Put Apollo thruster particles in schematic Z-up. (#797)
+- **(fix:impeller2)** Skip and log malformed fields instead of dropping the table. (#762)
+- **(perf)** Improve editor FPS on DB playback. (#771)
+- **(chore)** Bump Bevy Hanabi. (#773)
+
 ## v0.18
 
 ### v0.18.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-serial-bridge"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "blackbox",
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-setup"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "fastrand 1.9.0",
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-status"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "db-macros",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_ai_skybox"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "bevy",
  "chrono",
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "blackbox"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "zerocopy",
 ]
@@ -4244,7 +4244,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-mlir"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "blake3",
  "cranelift-codegen",
@@ -5211,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "db-macros"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "convert_case 0.6.0",
  "darling 0.20.11",
@@ -5515,7 +5515,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elodin"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "base64 0.22.1",
  "bevy",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "elodin-db"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5640,7 +5640,7 @@ dependencies = [
 
 [[package]]
 name = "elodin-db-tests"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "arrow",
  "elodin-db",
@@ -5663,7 +5663,7 @@ dependencies = [
 
 [[package]]
 name = "elodin-editor"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "ab_glyph",
  "arc-swap",
@@ -5748,7 +5748,7 @@ dependencies = [
 
 [[package]]
 name = "elodin-macros"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "convert_case 0.6.0",
  "darling 0.20.11",
@@ -5968,7 +5968,7 @@ checksum = "f8970033a4282a7bcf899b38b5ed3a58b732fe093d03785d58648515d8d309da"
 
 [[package]]
 name = "eql"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "bevy_geo_frames",
  "bevy_math",
@@ -7088,7 +7088,7 @@ checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
 
 [[package]]
 name = "gst-elodin-plugin"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "gst-plugin-version-helper",
@@ -7282,7 +7282,7 @@ dependencies = [
 
 [[package]]
 name = "hamann-chen-line"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "clap 4.6.1",
@@ -7951,7 +7951,7 @@ checksum = "40fac9d56ed6437b198fddba683305e8e2d651aa42647f00f5ae542e7f5c94a2"
 
 [[package]]
 name = "impeller2"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "bevy",
  "const-fnv1a-hash",
@@ -7974,7 +7974,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-bbq"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "bbqueue",
  "impeller2",
@@ -7983,7 +7983,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-bevy"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "bbqueue",
  "bevy",
@@ -8007,7 +8007,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-cli"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -8036,7 +8036,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-frame"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "cobs 0.2.3",
  "impeller2",
@@ -8044,7 +8044,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-kdl"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "bevy_geo_frames",
  "impeller2",
@@ -8059,7 +8059,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-stellar"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "bbqueue",
  "fastrand 2.4.1",
@@ -8080,7 +8080,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-wkt"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "bevy",
  "bevy_geo_frames",
@@ -8237,7 +8237,7 @@ checksum = "d57a1694cff80cdd6c8a4cae63984578e2617528d3c266e53f56dfd3e279e9f7"
 
 [[package]]
 name = "inscriber"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "clap 4.6.1",
@@ -8912,7 +8912,7 @@ dependencies = [
 
 [[package]]
 name = "lqr"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "clap 4.6.1",
@@ -9223,7 +9223,7 @@ dependencies = [
 
 [[package]]
 name = "mekf"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "clap 4.6.1",
@@ -9424,7 +9424,7 @@ dependencies = [
 
 [[package]]
 name = "monte-carlo"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "chrono",
  "csv",
@@ -9970,7 +9970,7 @@ dependencies = [
 
 [[package]]
 name = "nox"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "approx",
  "bevy_math",
@@ -9999,14 +9999,14 @@ dependencies = [
 
 [[package]]
 name = "nox-array"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "zerocopy",
 ]
 
 [[package]]
 name = "nox-frames"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "approx",
  "hifitime",
@@ -10016,7 +10016,7 @@ dependencies = [
 
 [[package]]
 name = "nox-py"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "approx",
  "arrow",
@@ -11349,7 +11349,7 @@ dependencies = [
 
 [[package]]
 name = "postcard-c-codegen"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "clap 4.6.1",
  "convert_case 0.6.0",
@@ -12230,7 +12230,7 @@ dependencies = [
 
 [[package]]
 name = "rc-jet-controller"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "clap 4.6.1",
@@ -12600,7 +12600,7 @@ dependencies = [
 
 [[package]]
 name = "roci"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "bbqueue",
@@ -12626,7 +12626,7 @@ dependencies = [
 
 [[package]]
 name = "roci-adcs"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "approx",
  "nox",
@@ -12699,14 +12699,14 @@ dependencies = [
 
 [[package]]
 name = "rtsp-ingest"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "rtsp-streamer"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "clap 4.6.1",
@@ -12894,7 +12894,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s10"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "async-watcher",
  "cargo_metadata",
@@ -13659,7 +13659,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stellarator"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "blocking",
  "futures",
@@ -13687,11 +13687,11 @@ dependencies = [
 
 [[package]]
 name = "stellarator-buf"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 
 [[package]]
 name = "stellarator-macros"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -14105,7 +14105,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tegrastats-bridge"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "db-macros",
@@ -15326,7 +15326,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "video-streamer"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -15345,7 +15345,7 @@ dependencies = [
 
 [[package]]
 name = "video-toolbox"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "bitflags 2.11.1",
  "block2 0.6.2",
@@ -16701,7 +16701,7 @@ dependencies = [
 
 [[package]]
 name = "wmm"
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 dependencies = [
  "approx",
  "bindgen 0.70.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ members = [
 exclude = ["fsw/sensor-fw", "fsw/blackbox", "docs/memserve"]
 
 [workspace.package]
-version = "0.18.1-alpha.0"
+version = "0.19.0"
 edition = "2024"
 repository = "https://github.com/elodin-sys/elodin"
 

--- a/docs/public/config.toml
+++ b/docs/public/config.toml
@@ -38,7 +38,7 @@ github = "https://github.com/elodin-sys"
 twitter = "https://twitter.com/elodinsystems"
 email = "info@elodin.systems"
 ganalytics = ""
-version = "v0.18.0"
+version = "v0.19.0"
 
 # If running on netlify.app site, set to true
 is_netlify = false

--- a/docs/public/content/releases/changelog.md
+++ b/docs/public/content/releases/changelog.md
@@ -13,6 +13,36 @@ order = 1
 +++
 
 
+## v0.19
+
+### v0.19.0
+- **(feat)** Add a native Earth environment. (#778, #795)
+- **(feat)** Add heliocentric relative dynamics to Voyager. (#789)
+- **(feat)** Add Voyager trajectory error telemetry. (#769)
+- **(feat)** Add viewport follow-camera smoothing. (#764)
+- **(feat)** Add an artificial horizon gauge. (#753)
+- **(feat)** Add headless video capture. (#754, #757)
+- **(feat)** Add --kdl to allow local KDL and asset development. (#763)
+- **(feat:aleph)** Add initrd-based one-shot Aleph UEFI and OS flashing over USB-C. (#748)
+- **(feat:db)** Add Elodin DB gRPC. (#772)
+- **(feat:db)** Add `elodin-db export --format mcap`. (#746)
+- **(fix)** Fix view-cube ECEF face labels, zoom in/out. (#796, #790, #758)
+- **(fix)** Fix Betaflight takeoff. (#791)
+- **(fix)** Fix GPU OOM and fins animation. (#788)
+- **(fix)** Generate schematic planes in Z-up so identity pose is ground. (#786, #793)
+- **(fix)** Fix ECEF translate and add `ned_to_ecef()`. (#774)
+- **(fix)** Prevent an editor crash when scrubbing with particles. (#777)
+- **(fix)** Fix reconnect replay time travel. (#775)
+- **(fix)** Fix the Ctrl-P command palette panic. (#770)
+- **(fix)** Capture headless video on hybrid Intel + NVIDIA hosts. (#768)
+- **(fix)** Fix `line_3d` f32 quantization. (#766)
+- **(fix)** Make `elodin_capture.sh` work on Ubuntu. (#767)
+- **(fix)** Restore minimal terrain rendering. (#761)
+- **(fix:examples)** Put Apollo thruster particles in schematic Z-up. (#797)
+- **(fix:impeller2)** Skip and log malformed fields instead of dropping the table. (#762)
+- **(perf)** Improve editor FPS on DB playback. (#771)
+- **(chore)** Bump Bevy Hanabi. (#773)
+
 ## v0.18
 
 ### v0.18.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version and changelog-only release bump; no runtime or API code changes in this PR.
> 
> **Overview**
> Cuts **v0.19.0** by bumping `[workspace.package]` (and lockfile crate versions) from `0.18.1-alpha.0` to `0.19.0`, and setting docs `version` to `v0.19.0`.
> 
> Adds the **v0.19.0** notes to `CHANGELOG.md` and the public docs changelog: Earth environment, Voyager dynamics/telemetry, editor camera/gauges/headless capture, Aleph USB flashing, DB gRPC and MCAP export, plus assorted editor/DB fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48bf58fd42b9e87f6ba969f3c1252314d8e6ec52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->