### PR TITLE
fix: Add protoc and protobuf for release jobs.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -367,7 +367,8 @@ jobs:
           sudo apt-get install -y \
             curl libssl-dev \
             g++ pkg-config libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0 \
-            libwayland-dev libxkbcommon-dev libopenblas-dev gfortran gfortran-12 libgfortran-12-dev
+            libwayland-dev libxkbcommon-dev libopenblas-dev gfortran gfortran-12 libgfortran-12-dev \
+            protobuf-compiler
       - name: Install Python dependencies
         run: |
           pip install patchelf jax typing_extensions
@@ -468,6 +469,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
+      - name: Install dependencies
+        run: |
+          brew install protobuf
       - name: Install Python dependencies
         run: |
           pip install jax typing_extensions

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -51,6 +51,10 @@ libxkbcommon-dev = '*'
 gfortran = '*'
 gfortran-12 = '*'
 libgfortran-12-dev = '*'
+protobuf-compiler = '*'
+
+[dist.dependencies.homebrew]
+protobuf = '*'
 
 [dist.dependencies.chocolatey]
 cmake = '*'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only dependency install for release builds; no application or security logic changes.
> 
> **Overview**
> Installs `protoc`/`protobuf` on Linux and macOS release jobs so Python wheel (and cargo-dist) builds can compile protobuf-dependent crates.
> 
> Adds `protobuf-compiler` to the Linux `linux-wheel` apt install list and a Homebrew `protobuf` step on `macos-wheel`. Mirrors the same packages in `dist-workspace.toml` for cargo-dist apt/homebrew dependency install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0ee58c847b45640b85d35cc586d96bc74881a97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->