### PR TITLE
revert: fix: Try using protoc-bin-vendored. (#808)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5584,7 +5584,6 @@ dependencies = [
  "postcard-dyn",
  "postcard-schema",
  "prost 0.14.4",
- "protoc-bin-vendored",
  "rayon",
  "reflink-copy",
  "reqwest",
@@ -11724,70 +11723,6 @@ checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost 0.14.4",
 ]
-
-[[package]]
-name = "protoc-bin-vendored"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c381df33c98266b5f08186583660090a4ffa0889e76c7e9a5e175f645a67fa"
-dependencies = [
- "protoc-bin-vendored-linux-aarch_64",
- "protoc-bin-vendored-linux-ppcle_64",
- "protoc-bin-vendored-linux-s390_64",
- "protoc-bin-vendored-linux-x86_32",
- "protoc-bin-vendored-linux-x86_64",
- "protoc-bin-vendored-macos-aarch_64",
- "protoc-bin-vendored-macos-x86_64",
- "protoc-bin-vendored-win32",
-]
-
-[[package]]
-name = "protoc-bin-vendored-linux-aarch_64"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c350df4d49b5b9e3ca79f7e646fde2377b199e13cfa87320308397e1f37e1a4c"
-
-[[package]]
-name = "protoc-bin-vendored-linux-ppcle_64"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55a63e6c7244f19b5c6393f025017eb5d793fd5467823a099740a7a4222440c"
-
-[[package]]
-name = "protoc-bin-vendored-linux-s390_64"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dba5565db4288e935d5330a07c264a4ee8e4a5b4a4e6f4e83fad824cc32f3b0"
-
-[[package]]
-name = "protoc-bin-vendored-linux-x86_32"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8854774b24ee28b7868cd71dccaae8e02a2365e67a4a87a6cd11ee6cdbdf9cf5"
-
-[[package]]
-name = "protoc-bin-vendored-linux-x86_64"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b38b07546580df720fa464ce124c4b03630a6fb83e05c336fea2a241df7e5d78"
-
-[[package]]
-name = "protoc-bin-vendored-macos-aarch_64"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89278a9926ce312e51f1d999fee8825d324d603213344a9a706daa009f1d8092"
-
-[[package]]
-name = "protoc-bin-vendored-macos-x86_64"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81745feda7ccfb9471d7a4de888f0652e806d5795b61480605d4943176299756"
-
-[[package]]
-name = "protoc-bin-vendored-win32"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
 
 [[package]]
 name = "psm"

--- a/libs/db/Cargo.toml
+++ b/libs/db/Cargo.toml
@@ -38,7 +38,6 @@ grpc = [
     "dep:tonic-health",
     "dep:tonic-prost",
     "dep:tonic-prost-build",
-    "dep:protoc-bin-vendored",
     "dep:tonic-reflection",
     "dep:tonic-types",
     "tokio/macros",
@@ -213,4 +212,3 @@ scuffle-h264 = "0.2"
 
 [build-dependencies]
 tonic-prost-build = { version = "=0.14.6", optional = true }
-protoc-bin-vendored = { version = "3.2.0", optional = true }

--- a/libs/db/build.rs
+++ b/libs/db/build.rs
@@ -1,9 +1,26 @@
 #[path = "../build-common/git_inspect.rs"]
 mod git_inspect;
-
 fn main() {
     #[cfg(feature = "grpc")]
-    compile_grpc_protos();
+    {
+        let protos = [
+            "proto/elodin/db/v1/common.proto",
+            "proto/elodin/db/v1/ingest.proto",
+            "proto/elodin/db/v1/query.proto",
+            "proto/elodin/db/v1/stream.proto",
+            "proto/elodin/db/v1/msg.proto",
+            "proto/elodin/db/v1/admin.proto",
+        ];
+        for proto in protos {
+            println!("cargo:rerun-if-changed={proto}");
+        }
+        let descriptor = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap())
+            .join("elodin_db_descriptor.bin");
+        tonic_prost_build::configure()
+            .file_descriptor_set_path(descriptor)
+            .compile_protos(&protos, &["proto"])
+            .expect("failed to compile gRPC protobufs");
+    }
 
     let hash = git_inspect::short_hash();
     println!(
@@ -12,86 +29,5 @@ fn main() {
     );
     if let Some(git_head_path) = git_inspect::head_path() {
         println!("cargo:rerun-if-changed={}", &git_head_path);
-    }
-}
-
-#[cfg(feature = "grpc")]
-fn compile_grpc_protos() {
-    use std::path::{Path, PathBuf};
-    use std::process::Command;
-
-    println!("cargo:rerun-if-env-changed=PROTOC");
-    let protos = [
-        "proto/elodin/db/v1/common.proto",
-        "proto/elodin/db/v1/ingest.proto",
-        "proto/elodin/db/v1/query.proto",
-        "proto/elodin/db/v1/stream.proto",
-        "proto/elodin/db/v1/msg.proto",
-        "proto/elodin/db/v1/admin.proto",
-    ];
-    for proto in protos {
-        println!("cargo:rerun-if-changed={proto}");
-    }
-    let descriptor =
-        PathBuf::from(std::env::var("OUT_DIR").unwrap()).join("elodin_db_descriptor.bin");
-    let mut config = tonic_prost_build::Config::new();
-    config.protoc_executable(resolve_protoc());
-    tonic_prost_build::configure()
-        .file_descriptor_set_path(descriptor)
-        .compile_with_config(config, &protos, &["proto"])
-        .expect("failed to compile gRPC protobufs");
-
-    fn resolve_protoc() -> PathBuf {
-        if let Some(path) = std::env::var_os("PROTOC")
-            .filter(|v| !v.is_empty())
-            .map(PathBuf::from)
-        {
-            if proto3_optional_supported(&path) {
-                return path;
-            }
-            println!(
-                "cargo:warning=PROTOC ({}) is too old for proto3 optional; using vendored protoc",
-                path.display()
-            );
-        } else if let Some(path) = find_protoc_on_path() {
-            if proto3_optional_supported(&path) {
-                return path;
-            }
-            println!(
-                "cargo:warning={} is too old for proto3 optional; using vendored protoc",
-                path.display()
-            );
-        }
-        protoc_bin_vendored::protoc_bin_path().expect("vendored protoc for this host")
-    }
-
-    fn find_protoc_on_path() -> Option<PathBuf> {
-        let path_var = std::env::var_os("PATH")?;
-        std::env::split_paths(&path_var).find_map(|dir| {
-            let unix = dir.join("protoc");
-            if unix.is_file() {
-                return Some(unix);
-            }
-            let windows = dir.join("protoc.exe");
-            windows.is_file().then_some(windows)
-        })
-    }
-
-    fn proto3_optional_supported(protoc: &Path) -> bool {
-        let Ok(output) = Command::new(protoc).arg("--version").output() else {
-            return false;
-        };
-        if !output.status.success() {
-            return false;
-        }
-        let Ok(stdout) = String::from_utf8(output.stdout) else {
-            return false;
-        };
-        // proto3 optional is stable in 3.15+. After 3.21 Google jumped to 22+.
-        let version = stdout.split_whitespace().last().unwrap_or("");
-        let mut parts = version.split('.');
-        let major: u32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
-        let minor: u32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
-        major > 3 || (major == 3 && minor >= 15)
     }
 }


### PR DESCRIPTION
This reverts commit 71a61e7b7f7582a171bc7e300e328fcad32b9c4e.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build-time gRPC codegen now depends on whatever `protoc` is on PATH (or PROTOC), which can fail on old or missing compilers. No runtime behavior change.
> 
> **Overview**
> Reverts the `protoc-bin-vendored` fallback and custom `PROTOC`/PATH version checks in `elodin-db`’s gRPC build.
> 
> `build.rs` again uses `tonic_prost_build::configure().compile_protos(...)` without pinning a vendored binary. Builds with the `grpc` feature need a compatible `protoc` available at compile time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d661610c75b56d7c4fd2ea1c5cdd434480f71fa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->