### PR TITLE
Fixes from running release QA test plan

### DIFF
--- a/.cursor/skills/elodin-editor-dev/SKILL.md
+++ b/.cursor/skills/elodin-editor-dev/SKILL.md
@@ -227,7 +227,7 @@ Env overrides: `ELODIN_BIN`, `ELODIN_SCREENSHOT_DELAY` (script default 20), `SCR
 
 - **Port 2240** — live `elodin editor` / `elodin run` binds the sim DB; do not parallelize with monte-carlo or another editor. Group-kill leftovers before the next case.
 - **RAM gauge** — status-bar RSS is read via platform APIs in `ui/status_bar.rs` (not Bevy `SystemInformationDiagnosticsPlugin`). On macOS Bevy's sysinfo is built with `apple-app-store` and always reports 0 GiB for the current process.
-- **video-stream** — clear `./video-stream-db` if the editor hangs or video never appears; `GST_PLUGIN_PATH=target/release` can make `gst-plugin-scanner` warn about `libelodin.dylib` (benign).
+- **video-stream** — clear `./video-stream-db` if the editor hangs or video never appears. `elodinsink` / `x264enc` / `srtsrc` come from `nix develop` or `nix develop .#run` (`GST_PLUGIN_PATH`). Do not prepend cargo `target/release` (`libelodin` makes `gst-plugin-scanner` abort the scan on GStreamer 1.26).
 - **voyager** — needs SPICE kernels under `examples/voyager/nasa_spice_data/` and a clean DB dir after interrupted runs.
 - **nix develop** — prefer it for CI-parity builds; for a tight screenshot loop, a warm `cargo build -p elodin --release` outside a full env rebuild is fine once the toolchain is already installed.
 

--- a/.cursor/skills/elodin-nix/SKILL.md
+++ b/.cursor/skills/elodin-nix/SKILL.md
@@ -65,6 +65,7 @@ This is configured in `flake.nix` and used automatically by `nix develop` and `n
 
 Provides:
 - **Dev shell**: `nix develop` — unified development environment
+- **Run shell**: `nix develop .#run` — packaged CLI/DB/Python plus GStreamer + `elodinsink`
 - **Packages**: `elodin-py`, `elodin-cli`, `elodin-db`, `elodinsink`
 - **Overlay**: `elodinOverlay` with all Elodin packages
 - **NixOS configs**: NixOS 25.11 based

--- a/.cursor/skills/qa-test-plan/SKILL.md
+++ b/.cursor/skills/qa-test-plan/SKILL.md
@@ -13,17 +13,19 @@ Everything for this skill lives in this directory (`.cursor/skills/qa-test-plan/
 - **Ready-to-run plan — examples smoke/feature test:** [examples/test-plan.md](examples/test-plan.md) (24 cases: `SDK-001` build + one per `examples/` project). Shared helpers live alongside it in [examples/](examples/) (`run_probe.sh`, `probe.py`).
 - **Ready-to-run plan — Elodin-DB deep suite:** [elodin-db/test-plan.md](elodin-db/test-plan.md) (23 cases: generate realistic DBs from the examples — drone, logstream, video-stream, sensor-camera, apollo-lander, rc-jet — then exercise every `elodin-db` subcommand, serving mode, replication, exports, and clients on them). Helper: [elodin-db/serve_probe.py](elodin-db/serve_probe.py); reuses the examples probes.
 - **Ready-to-run plan — Elodin Editor deep suite:** [elodin-editor/test-plan.md](elodin-editor/test-plan.md) (19 cases: release build, live/recorded DB connect, screenshot gallery across examples covering feature-catalog §16–17, `--kdl` preload, inspector feature check; helpers [elodin-editor/capture.sh](elodin-editor/capture.sh)). Visual cases use `ELODIN_SCREENSHOT*` (see [elodin-editor-dev](../elodin-editor-dev/SKILL.md)).
-- New instantiated plans use the same focused-folder pattern: `<yyyy-mm-dd>-<release>/test-plan.md` plus evidence artifacts in that folder.
+- Dated run reports and instantiated plans live under gitignored `ai-context/qa-test-plan/<yyyy-mm-dd>-<release>/` (not in this skill folder).
+
+**Source files are never the report.** Do not write Results, Evidence, Notes, Summary ticks, or Plan Header run metadata into `template.md`, `examples/test-plan.md`, `elodin-db/test-plan.md`, or `elodin-editor/test-plan.md`. Those keep AUTHOR-VALIDATED baselines and blank Results. Every execution (and every new custom plan) works on a **dated copy** under `ai-context/`.
 
 ## Agent entry point
 
-- **"Run/execute the examples QA plan" (or "smoke-test the examples for a release")** → open [examples/test-plan.md](examples/test-plan.md), set the Plan Header (commit, branch, date, environment, executor), then execute cases top-to-bottom following that document's own **Execution Rules**. It is self-contained and every `agent` case has an `AUTHOR-VALIDATED` baseline. Run from the repo root inside `nix develop`. Note the two hard-won prerequisites baked into [examples/run_probe.sh](examples/run_probe.sh): live-run cases bind port `2240` exclusively (never parallelize them), and tearing a run down requires a **process-group kill** (the s10 child restarts on a plain kill).
-- **"Run/execute the Elodin-DB QA plan" (or "put elodin-db through its paces")** → open [elodin-db/test-plan.md](elodin-db/test-plan.md) and execute the same way. It first generates a stable of realistic DBs under `/tmp/qa-db/` from the examples, then runs the full `elodin-db` command surface over them; its **Hard-won operational rules** section (group-kill teardown, the `tcp+1` asset-server port collision) is required reading before touching live servers.
-- **"Run/execute the Elodin Editor QA plan" (or "screenshot / visual-regression the editor")** → open [elodin-editor/test-plan.md](elodin-editor/test-plan.md) and execute the same way. Prefer a warm `target/release/elodin` (EDITOR-100). Never parallelize live-editor cases (port 2240). For `agent+visual` criteria, **Read the PNG** — file existence alone is insufficient. Stale `video-stream-db` / voyager DB dirs must be deleted before those captures (handled by [elodin-editor/capture.sh](elodin-editor/capture.sh)).
-- **"Create/author a new plan for `<release>`"** → follow *Instantiating a Plan for a Release* below (copy `template.md` into this folder).
-- **"Add/edit a test case"** → follow *Authoring Test Cases* below and the case anatomy rules.
+- **"Run/execute the examples QA plan" (or "smoke-test the examples for a release")** → copy [examples/test-plan.md](examples/test-plan.md) into a dated folder (see *Executing a Plan*), then fill the **copy's** header and run cases top-to-bottom using that document's **Execution Rules**. It is self-contained and every `agent` case has an `AUTHOR-VALIDATED` baseline. Run from the repo root inside `nix develop`. Note the two hard-won prerequisites baked into [examples/run_probe.sh](examples/run_probe.sh): live-run cases bind port `2240` exclusively (never parallelize them), and tearing a run down requires a **process-group kill** (the s10 child restarts on a plain kill).
+- **"Run/execute the Elodin-DB QA plan" (or "put elodin-db through its paces")** → copy [elodin-db/test-plan.md](elodin-db/test-plan.md) the same way, then execute the copy. It first generates a stable of realistic DBs under `/tmp/qa-db/` from the examples, then runs the full `elodin-db` command surface over them; its **Hard-won operational rules** section (group-kill teardown, the `tcp+1` asset-server port collision) is required reading before touching live servers.
+- **"Run/execute the Elodin Editor QA plan" (or "screenshot / visual-regression the editor")** → copy [elodin-editor/test-plan.md](elodin-editor/test-plan.md) the same way, then execute the copy. Prefer a warm `target/release/elodin` (EDITOR-100). Never parallelize live-editor cases (port 2240). For `agent+visual` criteria, **Read the PNG** — file existence alone is insufficient. Stale `video-stream-db` / voyager DB dirs must be deleted before those captures (handled by [elodin-editor/capture.sh](elodin-editor/capture.sh)).
+- **"Create/author a new plan for `<release>`"** → follow *Instantiating a Plan for a Release* below (copy `template.md` into `ai-context/qa-test-plan/`).
+- **"Add/edit a test case"** → follow *Authoring Test Cases* below and the case anatomy rules. Persist new cases on the **source** ready-to-run plan and/or `template.md`, not on a dated run report.
 
-There are three workflows: **authoring** test cases, **instantiating** a plan for a release, and **executing** a plan. The execution rules themselves live inside the template (and every copied plan) so a plan is self-contained.
+There are three workflows: **authoring** test cases (edit sources), **instantiating** a custom plan from `template.md` (dated copy), and **executing** a ready-to-run suite (dated copy of that suite). The execution rules themselves live inside the plan so a copy is self-contained.
 
 ## Authoring Test Cases
 
@@ -79,27 +81,39 @@ Add new areas as needed; record them in this table so IDs stay consistent.
 
 ## Instantiating a Plan for a Release
 
-1. Copy the template:
+Use this when the user wants a **new custom plan** (not one of the ready-to-run suites). Copy `template.md` into gitignored `ai-context/`, never edit it in place:
 
 ```bash
-PLAN_DIR=".cursor/skills/qa-test-plan/$(date +%F)-<release>"
+PLAN_DIR="ai-context/qa-test-plan/$(date +%F)-<release>"
 mkdir -p "$PLAN_DIR"
 cp .cursor/skills/qa-test-plan/template.md "$PLAN_DIR/test-plan.md"
 ```
 
-2. Fill the Plan Header: release name, `git rev-parse --short HEAD`, `git branch --show-current`, date, environment (note whether a display is available), executor.
-3. Scope the plan: delete cases irrelevant to this release, add release-specific cases following the authoring rules. Keep the Summary table in sync with the case blocks — same IDs, same order.
-4. If new cases were added that future releases should keep, also add them to [template.md](template.md) so the template stays the source of truth.
+1. Fill the **copy's** Plan Header: release name, `git rev-parse --short HEAD`, `git branch --show-current`, date, environment (note whether a display is available), executor.
+2. Scope the copy: delete cases irrelevant to this release, add release-specific cases following the authoring rules. Keep the Summary table in sync with the case blocks — same IDs, same order.
+3. If new cases were added that future releases should keep, also add them to [template.md](template.md) (and the relevant ready-to-run suite) so the sources stay the source of truth.
 
 ## Executing a Plan
 
-The binding rules are in the plan document itself ("Execution Rules" section) — read them first; they travel with every copy. Operationally:
+**First action: dated copy. Do not skip this.** Ready-to-run suites (`examples/`, `elodin-db/`, `elodin-editor/`) and `template.md` are templates. Filling Results into them is a bug.
 
-1. Set the header Status to IN PROGRESS.
+```bash
+# <suite> is examples | elodin-db | elodin-editor
+# <release> is a short slug the user named, or the suite name if they did not
+PLAN_DIR="ai-context/qa-test-plan/$(date +%F)-<release>"
+mkdir -p "$PLAN_DIR"
+cp ".cursor/skills/qa-test-plan/<suite>/test-plan.md" "$PLAN_DIR/test-plan.md"
+```
+
+Work **only** on `$PLAN_DIR/test-plan.md`. Leave the source plan's Status, Summary Results, and case Result/Evidence blank (AUTHOR-VALIDATED notes stay on the source).
+
+The binding rules are in the copied plan itself ("Execution Rules" section) — read them first. Operationally:
+
+1. On the **copy**, set the header Status to IN PROGRESS (commit, branch, date, environment, executor).
 2. Work through cases strictly in Summary-table order, one at a time. For each case: check Requires, run the steps, verify every pass criterion, write Evidence (exit codes, matching output lines, artifact paths), then set Result in the case block and mirror it in the Summary row.
 3. Long builds are normal (SDK-001 up to 30 min, RUST-001 up to 40 min) — use the case's Expected duration to size timeouts instead of assuming a hang.
 4. On FAIL, save output to `<artifacts>/<case-id>-fail.log`, diagnose briefly in Notes, and move on. Never fix code mid-run; a QA run measures the release as it is.
-5. When all cases have a result: fill the Run Summary counts, list notable issues and follow-ups, set Status to COMPLETE, and report to the user — lead with FAIL/BLOCKED cases and anything a human must do (`manual` cases marked SKIPPED).
+5. When all cases have a result: fill the Run Summary counts, list notable issues and follow-ups, set Status to COMPLETE, and report to the user — lead with FAIL/BLOCKED cases and anything a human must do (`manual` cases marked SKIPPED). Point them at the dated copy path, not the source suite.
 
 ## Example: well-formed vs poor case
 

--- a/.cursor/skills/qa-test-plan/elodin-db/test-plan.md
+++ b/.cursor/skills/qa-test-plan/elodin-db/test-plan.md
@@ -280,7 +280,7 @@ grep -E "first frame seen|verification:" /tmp/qa-db/sc-gen.log
 ```bash
 rm -rf /tmp/qa-db/apollo
 nix develop --command sh -c '
-  ELODIN_DB_PATH=/tmp/qa-db/apollo ELODIN_APOLLO_MAX_TICKS=3600 timeout 240 \
+  ELODIN_DB_PATH=/tmp/qa-db/apollo ELODIN_APOLLO_MAX_TICKS=3600 ELODIN_NON_INTERACTIVE=1 timeout 240 \
     setsid elodin run examples/apollo-lander/main.py > /tmp/qa-db/apollo-gen.log 2>&1
   pkill -9 -f "apollo" 2>/dev/null
   for i in $(seq 1 40); do ss -ltn 2>/dev/null | grep -q ":2240 " || break; sleep 0.5; done; true'

--- a/.cursor/skills/qa-test-plan/elodin-db/test-plan.md
+++ b/.cursor/skills/qa-test-plan/elodin-db/test-plan.md
@@ -69,6 +69,8 @@ then runs the **whole `elodin-db` command surface** over them. Coverage map (eve
 
 ## Execution Rules
 
+If this file is still the suite template (`elodin-db/test-plan.md`), copy it to `ai-context/qa-test-plan/<yyyy-mm-dd>-<release>/test-plan.md` and fill results **only on the copy**. Never write run metadata into this file.
+
 1. Run every command from the repository root, inside the Nix shell (`nix develop --command <cmd>`).
 2. Execute cases in Summary order, one at a time. Never parallelize live-server cases — they bind fixed ports (2240/2241 source + asset, 2242 follower, 2250 Lua case, 2360 HTTP API).
 3. Check **Requires** first. Generator DBs under `/tmp/qa-db/` are this plan's declared cross-case artifacts: generators create them, later cases consume them read-only (serving/surgery cases work on **copies**). If a required DB is missing, mark the case BLOCKED.

--- a/.cursor/skills/qa-test-plan/elodin-editor/test-plan.md
+++ b/.cursor/skills/qa-test-plan/elodin-editor/test-plan.md
@@ -58,6 +58,8 @@ Coverage map (feature-catalog §16–17 → cases):
 
 ## Execution Rules
 
+If this file is still the suite template (`elodin-editor/test-plan.md`), copy it to `ai-context/qa-test-plan/<yyyy-mm-dd>-<release>/test-plan.md` and fill results **only on the copy**. Never write run metadata into this file.
+
 1. Run every command from the repository root, inside the Nix shell when possible (`nix develop --command <cmd>`). A warm `./target/release/elodin` is acceptable for screenshot cases once EDITOR-100 has built it.
 2. Execute cases in Summary order, one at a time. Never parallelize live-editor cases.
 3. Check **Requires** first. If unmet, mark BLOCKED.

--- a/.cursor/skills/qa-test-plan/examples/test-plan.md
+++ b/.cursor/skills/qa-test-plan/examples/test-plan.md
@@ -683,17 +683,17 @@ nix develop --command bash .cursor/skills/qa-test-plan/examples/run_probe.sh exa
 #### - [ ] EX-021 — video-stream: H.264 GStreamer pipeline
 
 - **Priority:** P2 | **Mode:** manual | **Requires:** SDK-001
-- **Description:** Ingests H.264 video into the DB via the custom `elodinsink` GStreamer plugin (test-pattern, plus optional OBS SRT / RTSP) alongside a rolling-ball sim, shown in editor `video_stream` tiles (README: `elodin editor examples/video-stream/main.py`). The headline path needs the GStreamer plugin build + a real-time (non-terminating) sim + the editor to decode/display the video — not agent-verifiable headlessly, so `manual`. The plugin **build** is an agent-checkable prerequisite (below).
+- **Description:** Ingests H.264 video into the DB via the custom `elodinsink` GStreamer plugin (test-pattern, plus optional OBS SRT / RTSP) alongside a rolling-ball sim, shown in editor `video_stream` tiles (README: `elodin editor examples/video-stream/main.py`). The headline path needs the Nix-provided GStreamer plugin + a real-time (non-terminating) sim + the editor to decode/display the video — not agent-verifiable headlessly, so `manual`. Plugin availability is an agent-checkable prerequisite (below).
 - **Expected duration:** manual
 
 **Agent prerequisite check (validated):**
 
 ```bash
-nix develop --command cargo build --release --manifest-path fsw/gstreamer/Cargo.toml
-ls target/release/libgstelodin.so
+nix develop --command gst-inspect-1.0 elodinsink
+nix develop --command gst-inspect-1.0 x264enc
 ```
 
-- [ ] Builds `target/release/libgstelodin.so` (exit 0)
+- [ ] `gst-inspect-1.0` lists `elodinsink` and `x264enc` (exit 0)
 
 **Manual (full pipeline — human, needs display):**
 1. `nix develop --command elodin editor examples/video-stream/main.py` (s10 auto-runs `stream-video.sh`: `videotestsrc → x264enc → h264parse → elodinsink msg-name="test-video"`).
@@ -701,7 +701,7 @@ ls target/release/libgstelodin.so
 
 **Result:**
 **Evidence:**
-**Notes:** Prerequisite AUTHOR-VALIDATED 2026-07-10 @822eb89a9: `libgstelodin.so` built (cargo release, 1m01s). Live pipeline not agent-validated — the s10 group front-loads the plugin build and the pipeline is a non-terminating real-time stream whose payoff is the decoded video in the editor tile (needs display); left `manual`.
+**Notes:** Prerequisite AUTHOR-VALIDATED 2026-07-10 @822eb89a9: `libgstelodin.so` built (cargo release, 1m01s). Live pipeline not agent-validated — the s10 group front-loads the plugin build and the pipeline is a non-terminating real-time stream whose payoff is the decoded video in the editor tile (needs display); left `manual`. The cargo `target/release` plugin path was replaced by the Nix `elodinsink` package on `GST_PLUGIN_PATH` (`nix develop` / `nix develop .#run`).
 
 ---
 

--- a/.cursor/skills/qa-test-plan/examples/test-plan.md
+++ b/.cursor/skills/qa-test-plan/examples/test-plan.md
@@ -34,6 +34,8 @@ Usage (inside `nix develop`, from repo root):
 
 ## Execution Rules
 
+If this file is still the suite template (`examples/test-plan.md`), copy it to `ai-context/qa-test-plan/<yyyy-mm-dd>-<release>/test-plan.md` and fill results **only on the copy**. Never write run metadata into this file.
+
 1. Run every command from the repository root, inside the Nix shell (`nix develop --command <cmd>`).
 2. Execute cases in Summary order, one at a time. Do not parallelize — every live-run case binds port 2240 exclusively.
 3. Check **Requires** first. If a required case did not PASS, mark this case BLOCKED and record which requirement failed.

--- a/.cursor/skills/qa-test-plan/feature-catalog.md
+++ b/.cursor/skills/qa-test-plan/feature-catalog.md
@@ -198,7 +198,7 @@
 
 ## 17. Video Streaming & Decoding
 
-- **`elodinsink` GStreamer element** — Streams Annex-B H.264 NAL units to the DB (`db-address`, `msg-name`/`msg-id`); keyframe guidance (~12-frame interval, SPS/PPS with every IDR via `h264parse config-interval=-1`); documented pipelines: `videotestsrc`, file playback, V4L2 webcams (JPEG/raw + `nvv4l2h264enc`), macOS `avfvideosrc ! vtenc_h264_hw`, GenICam via `aravissrc`; `GST_PLUGIN_PATH` for local testing.
+- **`elodinsink` GStreamer element** — Streams Annex-B H.264 NAL units to the DB (`db-address`, `msg-name`/`msg-id`); keyframe guidance (~12-frame interval, SPS/PPS with every IDR via `h264parse config-interval=-1`); documented pipelines: `videotestsrc`, file playback, V4L2 webcams (JPEG/raw + `nvv4l2h264enc`), macOS `avfvideosrc ! vtenc_h264_hw`, GenICam via `aravissrc`; `GST_PLUGIN_PATH` is set by `nix develop` / `nix develop .#run` (and the Aleph `elodinsink` module).
 - **OBS ingestion** — SRT listener pipeline (port 9000, OBS in caller mode; recommended H.264 CBR settings) or obs-gstreamer direct-to-elodinsink; H.264 only (no HEVC).
 - **RTSP ingestion** — `rtsp-streamer` standalone Rust producer (`RTSP_URL`, auto-reconnect, Nix-packaged).
 - **File streaming** — `video-streamer` FFmpeg utility re-encodes files to AV1 OBUs into the DB (bitrate/keyframe/speed-preset options); ffmpeg-based live-or-preserved timestamp modes.

--- a/.cursor/skills/qa-test-plan/template.md
+++ b/.cursor/skills/qa-test-plan/template.md
@@ -1,6 +1,6 @@
 # QA Test Plan: <release or milestone>
 
-> Copy this file to `.cursor/skills/qa-test-plan/<yyyy-mm-dd>-<release>/test-plan.md` before filling it out.
+> Copy this file to `ai-context/qa-test-plan/<yyyy-mm-dd>-<release>/test-plan.md` before filling it out.
 > Evidence artifacts go in the same folder (see the curated [examples/](examples/) plan for the pattern).
 
 ## Plan Header
@@ -18,6 +18,8 @@
 ## Execution Rules
 
 These rules travel with the plan so any agent can execute it without extra context.
+
+If this file is still `template.md`, copy it to `ai-context/qa-test-plan/<yyyy-mm-dd>-<release>/test-plan.md` and fill results **only on the copy**. Never write run metadata into the template.
 
 1. Run every command from the repository root, inside the Nix shell (`nix develop --command <cmd>` or an activated shell).
 2. Execute cases in the order listed, one at a time. Do not parallelize cases.

--- a/aleph/pkgs/elodin-examples.nix
+++ b/aleph/pkgs/elodin-examples.nix
@@ -8,13 +8,4 @@ pkgs.runCommand "elodin-examples" {} ''
   cp -R ${../../examples/three-body} "$out/three-body"
 
   chmod -R u+w "$out"
-
-  for script in "$out/video-stream/stream-video.sh" "$out/video-stream/receive-obs-stream.sh"; do
-    substituteInPlace "$script" \
-      --replace-fail "Builds the elodinsink GStreamer plugin from source" "Uses the system elodinsink GStreamer plugin" \
-      --replace-fail "The plugin is built automatically - no manual prerequisite steps required." "The plugin is provided by the Aleph elodinsink module." \
-      --replace-fail 'echo "Building elodinsink GStreamer plugin..."' 'echo "Using system elodinsink GStreamer plugin..."' \
-      --replace-fail 'cargo build --release --manifest-path="$REPO_ROOT/fsw/gstreamer/Cargo.toml"' ':' \
-      --replace-fail 'export GST_PLUGIN_PATH="$REPO_ROOT/target/release:''${GST_PLUGIN_PATH}"' ':'
-  done
 ''

--- a/docs/public/content/reference/replays.md
+++ b/docs/public/content/reference/replays.md
@@ -21,7 +21,7 @@ so replaying a recording does not require a separate `elodin-db` process.
 Set `ELODIN_DB_PATH` when running a simulation to keep its database:
 
 ```bash
-ELODIN_DB_PATH=dbs/apollo elodin run examples/apollo-lander/main.py
+ELODIN_DB_PATH=dbs/apollo ELODIN_NON_INTERACTIVE=1 elodin run examples/apollo-lander/main.py
 ```
 
 The recording includes a `db_state` file, component data, and an `assets/`

--- a/examples/apollo-lander/README.md
+++ b/examples/apollo-lander/README.md
@@ -106,6 +106,11 @@ For a single editor run:
 elodin editor examples/apollo-lander/main.py
 ```
 
+The editor stays interactive after `max_ticks`. Monte Carlo workers flip that
+off automatically via `ELODIN_MONTE_CARLO_CONTEXT`. Headless `elodin run` /
+QA should set `ELODIN_NON_INTERACTIVE=1` so the process exits and prints
+`elodin simulation summary`.
+
 Single editor/headless runs launch the Rust LGC controller in
 `examples/apollo-lander/controller` via an `s10` cargo recipe. Monte Carlo runs
 build the controller once using the campaign `[[build]]` step, then each run

--- a/examples/apollo-lander/main.py
+++ b/examples/apollo-lander/main.py
@@ -277,7 +277,7 @@ world.run(
     max_ticks=max_ticks,
     db_path=params.db_path or os.environ.get("ELODIN_DB_PATH"),
     post_step=post_step,
-    interactive=False,
+    interactive=True,
     start_timestamp=START_TIMESTAMP_US,
     log_level="warn",
 )

--- a/examples/apollo-lander/main.py
+++ b/examples/apollo-lander/main.py
@@ -36,6 +36,16 @@ DEFAULT_COMMAND_PORT = 9012
 MAX_TICKS_ENV = "ELODIN_APOLLO_MAX_TICKS"
 
 
+def _interactive() -> bool:
+    # Editor stays alive after max_ticks. Monte Carlo injects
+    # ELODIN_MONTE_CARLO_CONTEXT (same as ELODIN_DB_PATH) and must exit.
+    # elodin run / QA set ELODIN_NON_INTERACTIVE=1 (same as rc-jet).
+    return (
+        os.environ.get("ELODIN_MONTE_CARLO_CONTEXT") is None
+        and os.environ.get("ELODIN_NON_INTERACTIVE") != "1"
+    )
+
+
 class SitlBridge:
     def __init__(self, throttle: float, attitude: list[float]) -> None:
         self.state_port = el.monte_carlo.port("state", DEFAULT_STATE_PORT)
@@ -277,7 +287,7 @@ world.run(
     max_ticks=max_ticks,
     db_path=params.db_path or os.environ.get("ELODIN_DB_PATH"),
     post_step=post_step,
-    interactive=True,
+    interactive=_interactive(),
     start_timestamp=START_TIMESTAMP_US,
     log_level="warn",
 )

--- a/examples/video-stream/README.md
+++ b/examples/video-stream/README.md
@@ -59,8 +59,7 @@ This example demonstrates streaming video into Elodin DB and displaying it in th
 
 ## Requirements
 
-- Nix development shell (`nix develop`) which provides GStreamer, SRT, and x264
-- Rust toolchain (for building the elodinsink plugin)
+- Nix shell (`nix develop` or `nix develop .#run`) — provides GStreamer, x264, SRT, and `elodinsink` on `GST_PLUGIN_PATH`
 - OBS Studio (optional, for the OBS Camera stream)
 
 ## Walkthrough
@@ -71,9 +70,10 @@ This walkthrough takes you through the full lifecycle: running the example, opti
 
 ```bash
 nix develop
+# or: nix develop .#run
 ```
 
-This provides GStreamer, x264, SRT, and all other dependencies needed by the example.
+Both shells put GStreamer, x264, SRT, and `elodinsink` on `GST_PLUGIN_PATH`. Do not override that path with cargo `target/`.
 
 ### Step 2: Build the Elodin Tools
 
@@ -94,7 +94,7 @@ The editor opens with a 3D viewport (showing a rolling ball) and three video str
 - **OBS Camera**: Shows "Initializing..." until OBS connects
 - **RTSP Camera**: Shows "No video at this time" until an RTSP source feeds the `rtsp-camera` message (see [RTSP Camera](#rtsp-camera))
 
-The GStreamer plugin (`elodinsink`) is built automatically on first run.
+The `elodinsink` GStreamer plugin comes from the Nix shell — no cargo plugin build.
 
 ### Step 4: Connect OBS Studio (Optional)
 
@@ -219,7 +219,7 @@ If you install the [obs-gstreamer](https://github.com/fzwoch/obs-gstreamer) plug
 ### Setup
 
 1. Install `obs-gstreamer` following its [installation instructions](https://github.com/fzwoch/obs-gstreamer#installation)
-2. Build `elodinsink` on the OBS machine (requires the Elodin repo and nix shell)
+2. On the OBS machine, use a Nix shell (`nix develop` or `nix develop .#run`) so `elodinsink` is on `GST_PLUGIN_PATH`
 3. In OBS, go to **Settings** -> **Output** -> **Output Mode: Advanced**
 4. Under the **Streaming** tab, set **Encoder** to **GStreamer**
 5. Set the pipeline to:
@@ -295,10 +295,11 @@ This is normal - the video stream tile defers connection for about 0.5 seconds d
 - Use hardware encoding (NVENC/QSV) instead of x264 for lower encoding latency
 - Reduce resolution and bitrate in OBS
 
-### Plugin build fails
+### `elodinsink` / `x264enc` / `srtsrc` not found
 
-- Make sure you're in a nix develop shell
-- Check that GStreamer development libraries are available: `pkg-config --libs gstreamer-1.0`
+- Re-enter `nix develop` or `nix develop .#run` — those shells set `GST_PLUGIN_PATH`
+- Confirm with `gst-inspect-1.0 elodinsink` (and `x264enc` / `srtsrc` as needed)
+- Do not set `GST_PLUGIN_PATH` to cargo `target/release` (it also contains `libelodin`, which breaks the GStreamer 1.26 plugin scanner)
 
 ### "Loss of Signal" overlay
 

--- a/examples/video-stream/receive-obs-stream.sh
+++ b/examples/video-stream/receive-obs-stream.sh
@@ -2,12 +2,11 @@
 # OBS Studio SRT Receiver for Elodin
 #
 # This script:
-# 1. Builds the elodinsink GStreamer plugin from source
-# 2. Waits for Elodin DB to be ready
-# 3. Listens for an SRT stream (e.g. from OBS Studio) and forwards
+# 1. Waits for Elodin DB to be ready
+# 2. Listens for an SRT stream (e.g. from OBS Studio) and forwards
 #    the H.264 video into Elodin DB via elodinsink
 #
-# The plugin is built automatically - no manual prerequisite steps required.
+# Requires `nix develop` or `nix develop .#run` (elodinsink, srtsrc, gst-launch).
 #
 # Usage:
 #   ./receive-obs-stream.sh [OPTIONS]
@@ -73,19 +72,11 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# =============================================================================
-# Build elodinsink Plugin
-# =============================================================================
-
-# Get the repository root (this script is in examples/video-stream/)
-REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-
-# Build the GStreamer plugin (cargo will skip if already up-to-date)
-echo "Building elodinsink GStreamer plugin..."
-cargo build --release --manifest-path="$REPO_ROOT/fsw/gstreamer/Cargo.toml"
-
-# Set plugin path to include our built plugin (prepend so local build overrides nix)
-export GST_PLUGIN_PATH="$REPO_ROOT/target/release:${GST_PLUGIN_PATH}"
+if ! command -v gst-inspect-1.0 >/dev/null 2>&1 || ! gst-inspect-1.0 elodinsink >/dev/null 2>&1; then
+    echo "ERROR: GStreamer element elodinsink is not available." >&2
+    echo "Run from \`nix develop\` or \`nix develop .#run\` — those shells set GST_PLUGIN_PATH." >&2
+    exit 1
+fi
 
 # =============================================================================
 # Wait for Elodin DB

--- a/examples/video-stream/stream-video.sh
+++ b/examples/video-stream/stream-video.sh
@@ -2,23 +2,18 @@
 # Video streaming script for Elodin
 #
 # This script:
-# 1. Builds the elodinsink GStreamer plugin from source
-# 2. Waits for Elodin DB to be ready
-# 3. Runs a GStreamer pipeline to stream H.264 video to Elodin DB
+# 1. Waits for Elodin DB to be ready
+# 2. Runs a GStreamer pipeline to stream H.264 video to Elodin DB
 #
-# The plugin is built automatically - no manual prerequisite steps required.
+# Requires `nix develop` or `nix develop .#run` (elodinsink, x264enc, gst-launch).
 
 set -e
 
-# Get the repository root (this script is in examples/video-stream/)
-REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-
-# Build the GStreamer plugin (cargo will skip if already up-to-date)
-echo "Building elodinsink GStreamer plugin..."
-cargo build --release --manifest-path="$REPO_ROOT/fsw/gstreamer/Cargo.toml"
-
-# Set plugin path to include our built plugin (prepend so local build overrides nix)
-export GST_PLUGIN_PATH="$REPO_ROOT/target/release:${GST_PLUGIN_PATH}"
+if ! command -v gst-inspect-1.0 >/dev/null 2>&1 || ! gst-inspect-1.0 elodinsink >/dev/null 2>&1; then
+    echo "ERROR: GStreamer element elodinsink is not available." >&2
+    echo "Run from \`nix develop\` or \`nix develop .#run\` — those shells set GST_PLUGIN_PATH." >&2
+    exit 1
+fi
 
 echo "Waiting for elodin-db on 127.0.0.1:2240..."
 

--- a/fsw/gstreamer/README.md
+++ b/fsw/gstreamer/README.md
@@ -22,19 +22,23 @@ brew install gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plu
 
 ## Installation
 
+`elodinsink` is a flake package. `nix develop` and `nix develop .#run` put it on
+`GST_PLUGIN_PATH` automatically (same pattern as `x264enc` / `srtsrc`).
+
 ```
-cd elodin/fsw/gstreamer
-cargo build --release
+nix build .#elodinsink
 ```
 
-The compiled plugin will be available at `target/release/libgstelodin.so`
+The plugin lands at `result/lib/gstreamer-1.0/libgstelodin.{so,dylib}`.
+
+Do not add cargo `target/release` to `GST_PLUGIN_PATH`. That directory also
+contains `libelodin`, and `gst-plugin-scanner` will try to dlopen every dylib
+there — on GStreamer 1.26 a failed scan can hide the rest of the plugin set.
 
 ## Usage
 
-For local testing set the `GST_PLUGIN_PATH` env var to `target/release`:
-```sh
-GST_PLUGIN_PATH=./target/release
-```
+Run pipelines from `nix develop` or `nix develop .#run`. Aleph sets the same
+path via the `elodinsink` NixOS module.
 
 The plugin provides a new GStreamer element called `elodinsink`. elodin-db expects the h264 stream to be made up of annex-b NAL units. For best results it is important to send frequency keyframes -- 12 seems to provide good results.
 Further you will want to ensure that SPS and PPS are sent with every IDR frame. You can do that with `h264 parse config-interva=-1`

--- a/nix/pkgs/common.nix
+++ b/nix/pkgs/common.nix
@@ -133,7 +133,7 @@
     eval "$(${gpuDetectScript})"
   '';
 
-  linuxGstreamerPackages = with pkgs; [
+  gstreamerPackages = with pkgs; [
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
     gst_all_1.gst-plugins-good
@@ -141,12 +141,14 @@
     gst_all_1.gst-plugins-ugly
   ];
 
+  # Isolated `lib/gstreamer-1.0` dirs only. Never point GST_PLUGIN_PATH at
+  # cargo `target/` — gst-plugin-scanner dlopens every dylib there.
   makeGstPluginPath = {
     pkgs,
     extra ? [],
   }:
     lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" (
-      linuxGstreamerPackages
+      gstreamerPackages
       ++ lib.optionals pkgs.stdenv.isLinux [pkgs.pipewire]
       ++ extra
     );
@@ -179,7 +181,7 @@ in {
     asoundConf
     mesaVulkanIcdPath
     nvidiaHookScript
-    linuxGstreamerPackages
+    gstreamerPackages
     makeGstPluginPath
     linuxEditorShellHook
     ;

--- a/nix/run.nix
+++ b/nix/run.nix
@@ -24,7 +24,6 @@
   linuxAttrs = lib.optionalAttrs pkgs.stdenv.isLinux (
     (common.linuxGraphicsEnv {inherit pkgs;})
     // {
-      GST_PLUGIN_PATH = common.makeGstPluginPath {inherit pkgs;};
       LD_LIBRARY_PATH = common.makeLinuxLibraryPath {inherit pkgs;};
     }
   );
@@ -36,13 +35,18 @@ in
         basePackages
         ++ common.commonNativeBuildInputs
         ++ common.commonBuildInputs
+        ++ common.gstreamerPackages
+        ++ [pkgs.elodin.elodinsink]
         ++ lib.optionals pkgs.stdenv.isLinux (
           common.linuxGraphicsAudioDeps
           ++ common.linuxCaptureTools
-          ++ common.linuxGstreamerPackages
           ++ [pkgs.ffmpeg-full]
         )
         ++ lib.optionals pkgs.stdenv.isDarwin common.darwinDeps;
+      GST_PLUGIN_PATH = common.makeGstPluginPath {
+        inherit pkgs;
+        extra = [pkgs.elodin.elodinsink];
+      };
       TOKTX = "${common.ktxTools}/bin/toktx";
       shellHook = lib.optionalString pkgs.stdenv.isLinux common.linuxEditorShellHook;
     })

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -140,7 +140,8 @@ with pkgs; let
     # the surplus so Python can import the extension without ENOMEM.
     GLIBC_TUNABLES = "glibc.rtld.optional_static_tls=16384";
 
-    # GStreamer plugin path for capture and elodinsink
+    # GStreamer + elodinsink for video-stream and capture. Example scripts
+    # inherit this; do not prepend cargo `target/` (see makeGstPluginPath).
     GST_PLUGIN_PATH = common.makeGstPluginPath {
       inherit pkgs;
       extra = [config.packages.elodinsink];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how video-stream and the run/dev shells locate GStreamer plugins, and how Apollo `elodin run` exits. Wrong GST_PLUGIN_PATH or interactive flags can break video ingest and QA generators.
> 
> **Overview**
> Stops video-stream scripts from `cargo build`ing `elodinsink` and prepending cargo `target/release` to `GST_PLUGIN_PATH` (that path also contains `libelodin`, which aborts GStreamer 1.26’s plugin scanner). Pipelines now require `nix develop` / `nix develop .#run`, which put isolated `lib/gstreamer-1.0` dirs plus the `elodinsink` package on `GST_PLUGIN_PATH`. The `.#run` shell now includes GStreamer plugins and `elodinsink` on all platforms, not only Linux.
> 
> Apollo lander `world.run` is interactive by default so the editor stays up after `max_ticks`. Monte Carlo still exits via `ELODIN_MONTE_CARLO_CONTEXT`; headless/QA must set `ELODIN_NON_INTERACTIVE=1` (wired into DB-104 and replay docs).
> 
> QA skill/plans: execute on dated copies under gitignored `ai-context/qa-test-plan/`; never write Results into the source suites. EX-021 checks `gst-inspect-1.0` instead of a cargo plugin build. Aleph example packaging no longer rewrites those scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 229df1aecc80e8fbbc10ba3d2cff3d949d881f0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->