### PR TITLE
Fix: GPU OOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ## v0.19
 
 ### v0.19.0
+- **(feat)** Report CPU, GPU, and plot-buffer usage in the status bar, with a `Dump GPU Allocations` command. (#817)
+- **(feat)** Open a recorded database directly with `elodin editor <path-to-db-folder>`. (#807)
 - **(feat)** Add a native Earth environment. (#778, #795)
 - **(feat)** Add heliocentric relative dynamics to Voyager. (#789)
 - **(feat)** Add Voyager trajectory error telemetry. (#769)
@@ -12,12 +14,17 @@
 - **(feat)** Add an artificial horizon gauge. (#753)
 - **(feat)** Add headless video capture. (#754, #757)
 - **(feat)** Add --kdl to allow local KDL and asset development. (#763)
+- **(feat:examples)** Update Betaflight SITL to 2026.6.1 with 8 kHz real-time lockstep. (#815, #818)
 - **(feat:aleph)** Add initrd-based one-shot Aleph UEFI and OS flashing over USB-C. (#748)
 - **(feat:db)** Add Elodin DB gRPC. (#772)
 - **(feat:db)** Add `elodin-db export --format mcap`. (#746)
+- **(fix)** Fix video-stream GStreamer plugin discovery and Apollo `elodin run` exit. (#812)
+- **(fix)** Fix cinematic viewport lighting and overlays leaking into regular panes. (#811)
+- **(fix)** Limit viewport `far` to frustum visualization only. (#802)
+- **(fix)** Scale the viewport grid from camera distance. (#800)
 - **(fix)** Fix view-cube ECEF face labels, zoom in/out. (#796, #790, #758)
 - **(fix)** Fix Betaflight takeoff. (#791)
-- **(fix)** Fix GPU OOM and fins animation. (#788)
+- **(fix)** Fix GPU OOM and fins animation. (#788, #817)
 - **(fix)** Generate schematic planes in Z-up so identity pose is ground. (#786, #793)
 - **(fix)** Fix ECEF translate and add `ned_to_ecef()`. (#774)
 - **(fix)** Prevent an editor crash when scrubbing with particles. (#777)
@@ -29,8 +36,10 @@
 - **(fix)** Restore minimal terrain rendering. (#761)
 - **(fix:examples)** Put Apollo thruster particles in schematic Z-up. (#797)
 - **(fix:impeller2)** Skip and log malformed fields instead of dropping the table. (#762)
+- **(perf)** Bump to Rust 1.98 and use algebraic float methods on hot paths. (#798)
 - **(perf)** Improve editor FPS on DB playback. (#771)
 - **(chore)** Bump Bevy Hanabi. (#773)
+- **(doc)** Index the examples by domain and by Elodin object. (#819)
 
 ## v0.18
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5714,6 +5714,7 @@ dependencies = [
  "miette 7.6.0",
  "nodit",
  "nox",
+ "nvml-wrapper",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
@@ -10242,6 +10243,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1e13adea6de269faa0724df58f43f6fe2a81af7094f1dcb8b5b968eb2103cb3"
 dependencies = [
  "scuffle-workspace-hack",
+]
+
+[[package]]
+name = "nvml-wrapper"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f049ae562349fefb8e837eb15443da1e7c6dcbd8a11f52a228f92220c2e5c85e"
+dependencies = [
+ "bitflags 2.11.1",
+ "libloading",
+ "nvml-wrapper-sys",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "wrapcenum-derive",
+]
+
+[[package]]
+name = "nvml-wrapper-sys"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4d594420fcda43b1c2c4bd44d48974aa3c7a9ab2cbf10dc18e35265767bf0b"
+dependencies = [
+ "libloading",
 ]
 
 [[package]]
@@ -16709,6 +16733,18 @@ dependencies = [
  "bindgen 0.70.1",
  "cc",
  "hifitime",
+]
+
+[[package]]
+name = "wrapcenum-derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76ff259533532054cfbaefb115c613203c73707017459206380f03b3b3f266e"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/libs/elodin-editor/Cargo.toml
+++ b/libs/elodin-editor/Cargo.toml
@@ -34,7 +34,7 @@ bevy = { workspace = true, features = [
 bevy_render.version = "0.19"
 # Same wgpu major as bevy_render 0.19; needed for `WriteOnly` staging-buffer
 # views which bevy_render does not re-export.
-wgpu = { version = "29", default-features = false }
+wgpu = { version = "29", default-features = false, features = ["counters"] }
 bevy_color.version = "0.19"
 bevy_egui.version = "0.40.1"
 bevy_picking = "0.19"
@@ -157,6 +157,7 @@ impeller2-bevy.default-features = false
 
 # 3D text for ViewCube labels
 bevy_fontmesh = "0.6"
+nvml-wrapper = "0.12.1"
 
 # macos
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -10,7 +10,9 @@ use bevy::{
     DefaultPlugins,
     asset::{UnapprovedPathMode, embedded_asset},
     camera::RenderTarget,
-    diagnostic::{DiagnosticsPlugin, FrameTimeDiagnosticsPlugin},
+    diagnostic::{
+        DiagnosticsPlugin, FrameTimeDiagnosticsPlugin, SystemInformationDiagnosticsPlugin,
+    },
     ecs::observer::Observer,
     ecs::system::{NonSendMarker, SystemParam},
     light::DirectionalLightShadowMap,
@@ -273,8 +275,10 @@ impl Plugin for EditorPlugin {
                     .disable::<bevy::dev_tools::render_debug::RenderDebugOverlayPlugin>()
                     .build(),
             )
-            .add_plugins(plugins::gpu_info::GpuInfoPlugin)
-            .add_plugins(plugins::kdl_document::plugin)
+            .add_plugins(plugins::gpu_info::GpuInfoPlugin);
+        #[cfg(not(target_family = "wasm"))]
+        app.add_plugins(plugins::hw_stats::HardwareStatsPlugin);
+        app.add_plugins(plugins::kdl_document::plugin)
             .add_plugins(skybox_asset_plugin())
             .add_plugins(skybox_generation_plugin())
             .init_resource::<skybox_db_assets::DbSkyboxAssetMirror>()
@@ -325,6 +329,7 @@ impl Plugin for EditorPlugin {
         app.add_plugins(plugins::fps_log::EnvFpsLogPlugin);
         app.add_plugins(ui::UiPlugin)
             .add_plugins(FrameTimeDiagnosticsPlugin::default())
+            .add_plugins(SystemInformationDiagnosticsPlugin)
             .add_plugins(WireframePlugin::default())
             .add_plugins(editor_cam_touch::EditorCamTouchPlugin)
             .add_plugins(crate::ui::plot::PlotPlugin)

--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -20,6 +20,7 @@ use bevy::{
     math::{DQuat, DVec3},
     pbr::wireframe::{WireframeConfig, WireframePlugin},
     prelude::*,
+    render::{RenderPlugin, settings::WgpuSettings},
     window::{PrimaryWindow, WindowRef, WindowResolution},
     winit::{WINIT_WINDOWS, WinitSettings},
 };
@@ -65,6 +66,17 @@ use ui::{
 #[derive(Resource, Default, Clone, Copy, Debug, Reflect)]
 #[reflect(Resource)]
 pub struct Coordinate(pub Option<GeoFrame>);
+
+pub(crate) fn editor_wgpu_settings() -> WgpuSettings {
+    WgpuSettings {
+        instance_memory_budget_thresholds: wgpu::MemoryBudgetThresholds {
+            for_resource_creation: Some(99),
+            for_device_loss: None,
+        },
+        memory_hints: wgpu::MemoryHints::MemoryUsage,
+        ..default()
+    }
+}
 
 mod embedded_lfs;
 pub mod icon_rasterizer;
@@ -240,6 +252,10 @@ impl Plugin for EditorPlugin {
             .add_plugins(plugins::kdl_asset_source::plugin)
             .add_plugins(
                 DefaultPlugins
+                    .set(RenderPlugin {
+                        render_creation: editor_wgpu_settings().into(),
+                        ..default()
+                    })
                     .set(WindowPlugin {
                         primary_window: Some(Window {
                             title: "Elodin".into(),

--- a/libs/elodin-editor/src/plugins/hw_stats.rs
+++ b/libs/elodin-editor/src/plugins/hw_stats.rs
@@ -1,19 +1,26 @@
-use std::time::Duration;
+use std::{
+    collections::BTreeMap,
+    fmt::Write as _,
+    path::PathBuf,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
 
 use bevy::{
     app::{App, AppExit, Plugin, Update},
     ecs::schedule::IntoScheduleConfigs,
     render::{
-        error_handler::{RenderError, RenderErrorHandler, RenderErrorPolicy},
+        error_handler::{ErrorType, RenderError, RenderErrorHandler, RenderErrorPolicy},
         renderer::{RenderAdapterInfo, RenderDevice},
     },
     time::common_conditions::on_timer,
 };
 use nvml_wrapper::Nvml;
 
-use crate::ui::plot::PlotGpuBufferPool;
+use crate::ui::plot::{PlotGpuBufferPool, gpu::evict_all_plot_gpu};
 
 const NVIDIA_VENDOR_ID: u32 = 0x10de;
+const GPU_MEMORY_PRESSURE_TRIM_PERCENT: u64 = 90;
+const OOM_RECOVERY_COOLDOWN: Duration = Duration::from_secs(10);
 
 #[derive(Clone, Copy, Debug, Default)]
 pub struct DeviceMemoryStats {
@@ -25,7 +32,8 @@ pub struct DeviceMemoryStats {
 pub struct HardwareStats {
     pub app_buffer_bytes: u64,
     pub app_texture_bytes: u64,
-    pub app_memory_allocations: u64,
+    pub app_buffer_count: Option<u64>,
+    pub app_texture_count: Option<u64>,
     pub device_memory: Option<DeviceMemoryStats>,
     pub gpu_utilization_percent: Option<u32>,
 }
@@ -49,12 +57,26 @@ struct NvmlSampler {
     state: NvmlState,
 }
 
+#[derive(bevy::prelude::Resource, Default)]
+struct OomRecoveryState {
+    last_oom: Option<Instant>,
+}
+
+fn allow_oom_recovery(state: &mut OomRecoveryState, now: Instant) -> bool {
+    let repeated = state
+        .last_oom
+        .is_some_and(|last| now.duration_since(last) < OOM_RECOVERY_COOLDOWN);
+    state.last_oom = Some(now);
+    !repeated
+}
+
 pub struct HardwareStatsPlugin;
 
 impl Plugin for HardwareStatsPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<HardwareStats>()
             .init_resource::<NvmlSampler>()
+            .init_resource::<OomRecoveryState>()
             .insert_resource(RenderErrorHandler(log_render_error))
             .add_systems(
                 Update,
@@ -68,12 +90,16 @@ fn sample_hardware_stats(
     adapter: Option<bevy::prelude::Res<RenderAdapterInfo>>,
     mut sampler: bevy::prelude::ResMut<NvmlSampler>,
     mut stats: bevy::prelude::ResMut<HardwareStats>,
+    mut plot_pool: Option<bevy::prelude::ResMut<PlotGpuBufferPool>>,
 ) {
     if let Some(render_device) = render_device {
         let counters = render_device.wgpu_device().get_internal_counters();
         stats.app_buffer_bytes = counter_u64(counters.hal.buffer_memory.read());
         stats.app_texture_bytes = counter_u64(counters.hal.texture_memory.read());
-        stats.app_memory_allocations = counter_u64(counters.hal.memory_allocations.read());
+        stats.app_buffer_count =
+            supported_counter(counters.hal.buffers.read(), stats.app_buffer_bytes);
+        stats.app_texture_count =
+            supported_counter(counters.hal.textures.read(), stats.app_texture_bytes);
     }
 
     stats.device_memory = None;
@@ -97,6 +123,25 @@ fn sample_hardware_stats(
         total_bytes: memory.total,
     });
     stats.gpu_utilization_percent = device.utilization_rates().ok().map(|rates| rates.gpu);
+
+    if let (Some(memory), Some(pool)) = (stats.device_memory, plot_pool.as_deref_mut())
+        && memory.total_bytes > 0
+        && memory.used_bytes.saturating_mul(100)
+            >= memory
+                .total_bytes
+                .saturating_mul(GPU_MEMORY_PRESSURE_TRIM_PERCENT)
+    {
+        let trim = pool.trim_ready();
+        if trim.values > 0 || trim.indices > 0 {
+            tracing::info!(
+                value_buffers = trim.values,
+                index_buffers = trim.indices,
+                used_bytes = memory.used_bytes,
+                total_bytes = memory.total_bytes,
+                "Trimmed ready plot GPU buffers under memory pressure"
+            );
+        }
+    }
 }
 
 impl NvmlSampler {
@@ -126,11 +171,146 @@ fn counter_u64(value: isize) -> u64 {
     value.max(0) as u64
 }
 
+fn supported_counter(value: isize, attributed_bytes: u64) -> Option<u64> {
+    let value = counter_u64(value);
+    (value > 0 || attributed_bytes == 0).then_some(value)
+}
+
+pub(crate) struct GpuAllocatorDump {
+    pub path: PathBuf,
+    pub total_allocated_bytes: u64,
+    pub total_reserved_bytes: u64,
+    pub block_count: usize,
+    pub allocation_count: usize,
+    pub largest_groups: String,
+}
+
+pub(crate) fn dump_gpu_allocations(
+    render_device: &RenderDevice,
+    reason: &str,
+) -> Result<GpuAllocatorDump, String> {
+    let report = render_device
+        .wgpu_device()
+        .generate_allocator_report()
+        .ok_or_else(|| "GPU allocator reporting is unavailable on this backend".to_string())?;
+
+    let mut groups: BTreeMap<(String, u64), usize> = BTreeMap::new();
+    for allocation in &report.allocations {
+        let label = if allocation.name.is_empty() {
+            "(unlabeled)".to_string()
+        } else {
+            allocation.name.clone()
+        };
+        *groups.entry((label, allocation.size)).or_default() += 1;
+    }
+    let mut groups: Vec<_> = groups.into_iter().collect();
+    groups.sort_by_key(|((_, size), count)| std::cmp::Reverse(size.saturating_mul(*count as u64)));
+    let mut largest_groups = String::new();
+    for ((label, size), count) in groups.iter().take(25) {
+        let total = size.saturating_mul(*count as u64);
+        let _ = writeln!(
+            largest_groups,
+            "{label}: {count} × {} = {}",
+            format_bytes(*size),
+            format_bytes(total)
+        );
+    }
+
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    #[cfg(unix)]
+    let dump_dir = PathBuf::from("/tmp");
+    #[cfg(not(unix))]
+    let dump_dir = std::env::temp_dir();
+    let path = dump_dir.join(format!("elodin-gpu-{reason}-{timestamp}.txt"));
+    let mut full = String::new();
+    let _ = writeln!(full, "reason: {reason}");
+    let _ = writeln!(
+        full,
+        "allocated: {} ({})",
+        report.total_allocated_bytes,
+        format_bytes(report.total_allocated_bytes)
+    );
+    let _ = writeln!(
+        full,
+        "reserved: {} ({})",
+        report.total_reserved_bytes,
+        format_bytes(report.total_reserved_bytes)
+    );
+    let _ = writeln!(full, "blocks: {}", report.blocks.len());
+    let _ = writeln!(full, "allocations: {}", report.allocations.len());
+    let _ = writeln!(full, "\naggregated by label and size:\n{largest_groups}");
+    let _ = writeln!(full, "memory blocks:");
+    for (index, block) in report.blocks.iter().enumerate() {
+        let _ = writeln!(
+            full,
+            "  block {index}: size={} allocations={:?}",
+            block.size, block.allocations
+        );
+    }
+    let _ = writeln!(full, "\nall allocations:");
+    for (index, allocation) in report.allocations.iter().enumerate() {
+        let label = if allocation.name.is_empty() {
+            "(unlabeled)"
+        } else {
+            &allocation.name
+        };
+        let _ = writeln!(
+            full,
+            "  {index}: size={} offset={} label={label:?}",
+            allocation.size, allocation.offset
+        );
+    }
+    std::fs::write(&path, full)
+        .map_err(|error| format!("failed to write {}: {error}", path.display()))?;
+
+    Ok(GpuAllocatorDump {
+        path,
+        total_allocated_bytes: report.total_allocated_bytes,
+        total_reserved_bytes: report.total_reserved_bytes,
+        block_count: report.blocks.len(),
+        allocation_count: report.allocations.len(),
+        largest_groups,
+    })
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const GIB: f64 = 1024.0 * 1024.0 * 1024.0;
+    const MIB: f64 = 1024.0 * 1024.0;
+    if bytes >= 1024 * 1024 * 1024 {
+        format!("{:.2} GiB", bytes as f64 / GIB)
+    } else if bytes >= 1024 * 1024 {
+        format!("{:.2} MiB", bytes as f64 / MIB)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
 fn log_render_error(
     error: &RenderError,
     main_world: &mut bevy::prelude::World,
-    _render_world: &mut bevy::prelude::World,
+    render_world: &mut bevy::prelude::World,
 ) -> RenderErrorPolicy {
+    if error.ty == ErrorType::OutOfMemory
+        && let Some(render_device) = main_world.get_resource::<RenderDevice>()
+    {
+        match dump_gpu_allocations(render_device, "oom") {
+            Ok(dump) => {
+                tracing::error!(
+                    path = %dump.path.display(),
+                    total_allocated_bytes = dump.total_allocated_bytes,
+                    total_reserved_bytes = dump.total_reserved_bytes,
+                    block_count = dump.block_count,
+                    allocation_count = dump.allocation_count,
+                    largest_groups = %dump.largest_groups,
+                    "GPU allocator report"
+                );
+            }
+            Err(error) => tracing::error!(%error, "GPU allocator report unavailable"),
+        }
+    }
     if let Some(pool) = main_world.get_resource::<PlotGpuBufferPool>() {
         tracing::error!(
             error_type = ?error.ty,
@@ -143,12 +323,35 @@ fn log_render_error(
             error_type = ?error.ty,
             app_buffer_bytes = stats.app_buffer_bytes,
             app_texture_bytes = stats.app_texture_bytes,
-            app_memory_allocations = stats.app_memory_allocations,
+            app_buffer_count = ?stats.app_buffer_count,
+            app_texture_count = ?stats.app_texture_count,
             device_memory = ?stats.device_memory,
             gpu_utilization_percent = ?stats.gpu_utilization_percent,
             "Render failure hardware state"
         );
     }
+
+    if error.ty == ErrorType::OutOfMemory {
+        let now = Instant::now();
+        let repeated = main_world
+            .get_resource_mut::<OomRecoveryState>()
+            .is_some_and(|mut state| !allow_oom_recovery(&mut state, now));
+        if !repeated {
+            let trim = if main_world.contains_resource::<PlotGpuBufferPool>() {
+                evict_all_plot_gpu(main_world, render_world)
+            } else {
+                Default::default()
+            };
+            tracing::error!(
+                value_buffers = trim.values,
+                index_buffers = trim.indices,
+                "Evicted plot GPU caches and recreating renderer after OutOfMemory"
+            );
+            return RenderErrorPolicy::Recover(crate::editor_wgpu_settings().into());
+        }
+        tracing::error!("Repeated OutOfMemory during recovery window");
+    }
+
     tracing::error!("Quitting the application due to {:?} RenderError", error.ty);
     main_world.write_message(AppExit::error());
     RenderErrorPolicy::StopRendering
@@ -156,11 +359,29 @@ fn log_render_error(
 
 #[cfg(test)]
 mod tests {
-    use super::counter_u64;
+    use super::{OomRecoveryState, allow_oom_recovery, counter_u64, supported_counter};
+    use std::time::{Duration, Instant};
 
     #[test]
     fn negative_backend_counters_are_clamped() {
         assert_eq!(counter_u64(-1), 0);
         assert_eq!(counter_u64(42), 42);
+        assert_eq!(supported_counter(0, 1024), None);
+        assert_eq!(supported_counter(3, 1024), Some(3));
+    }
+
+    #[test]
+    fn oom_recovery_allows_one_attempt_per_window() {
+        let start = Instant::now();
+        let mut state = OomRecoveryState::default();
+        assert!(allow_oom_recovery(&mut state, start));
+        assert!(!allow_oom_recovery(
+            &mut state,
+            start + Duration::from_secs(1)
+        ));
+        assert!(allow_oom_recovery(
+            &mut state,
+            start + Duration::from_secs(12)
+        ));
     }
 }

--- a/libs/elodin-editor/src/plugins/hw_stats.rs
+++ b/libs/elodin-editor/src/plugins/hw_stats.rs
@@ -1,0 +1,166 @@
+use std::time::Duration;
+
+use bevy::{
+    app::{App, AppExit, Plugin, Update},
+    ecs::schedule::IntoScheduleConfigs,
+    render::{
+        error_handler::{RenderError, RenderErrorHandler, RenderErrorPolicy},
+        renderer::{RenderAdapterInfo, RenderDevice},
+    },
+    time::common_conditions::on_timer,
+};
+use nvml_wrapper::Nvml;
+
+use crate::ui::plot::PlotGpuBufferPool;
+
+const NVIDIA_VENDOR_ID: u32 = 0x10de;
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct DeviceMemoryStats {
+    pub used_bytes: u64,
+    pub total_bytes: u64,
+}
+
+#[derive(bevy::prelude::Resource, Clone, Copy, Debug, Default)]
+pub struct HardwareStats {
+    pub app_buffer_bytes: u64,
+    pub app_texture_bytes: u64,
+    pub app_memory_allocations: u64,
+    pub device_memory: Option<DeviceMemoryStats>,
+    pub gpu_utilization_percent: Option<u32>,
+}
+
+impl HardwareStats {
+    pub fn app_gpu_bytes(&self) -> u64 {
+        self.app_buffer_bytes.saturating_add(self.app_texture_bytes)
+    }
+}
+
+#[derive(Default)]
+enum NvmlState {
+    #[default]
+    Uninitialized,
+    Ready(Nvml),
+    Unavailable,
+}
+
+#[derive(bevy::prelude::Resource, Default)]
+struct NvmlSampler {
+    state: NvmlState,
+}
+
+pub struct HardwareStatsPlugin;
+
+impl Plugin for HardwareStatsPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<HardwareStats>()
+            .init_resource::<NvmlSampler>()
+            .insert_resource(RenderErrorHandler(log_render_error))
+            .add_systems(
+                Update,
+                sample_hardware_stats.run_if(on_timer(Duration::from_millis(500))),
+            );
+    }
+}
+
+fn sample_hardware_stats(
+    render_device: Option<bevy::prelude::Res<RenderDevice>>,
+    adapter: Option<bevy::prelude::Res<RenderAdapterInfo>>,
+    mut sampler: bevy::prelude::ResMut<NvmlSampler>,
+    mut stats: bevy::prelude::ResMut<HardwareStats>,
+) {
+    if let Some(render_device) = render_device {
+        let counters = render_device.wgpu_device().get_internal_counters();
+        stats.app_buffer_bytes = counter_u64(counters.hal.buffer_memory.read());
+        stats.app_texture_bytes = counter_u64(counters.hal.texture_memory.read());
+        stats.app_memory_allocations = counter_u64(counters.hal.memory_allocations.read());
+    }
+
+    stats.device_memory = None;
+    stats.gpu_utilization_percent = None;
+
+    let Some(adapter) = adapter else {
+        return;
+    };
+    let Some(nvml) = sampler.nvml(adapter.vendor) else {
+        return;
+    };
+    let device = nvml
+        .device_by_pci_bus_id(adapter.device_pci_bus_id.as_str())
+        .or_else(|_| nvml.device_by_index(0));
+    let Ok(device) = device else {
+        return;
+    };
+
+    stats.device_memory = device.memory_info().ok().map(|memory| DeviceMemoryStats {
+        used_bytes: memory.used,
+        total_bytes: memory.total,
+    });
+    stats.gpu_utilization_percent = device.utilization_rates().ok().map(|rates| rates.gpu);
+}
+
+impl NvmlSampler {
+    fn nvml(&mut self, vendor_id: u32) -> Option<&Nvml> {
+        if matches!(self.state, NvmlState::Uninitialized) {
+            self.state = if vendor_id == NVIDIA_VENDOR_ID {
+                match Nvml::init() {
+                    Ok(nvml) => NvmlState::Ready(nvml),
+                    Err(error) => {
+                        tracing::debug!(%error, "NVML GPU metrics unavailable");
+                        NvmlState::Unavailable
+                    }
+                }
+            } else {
+                NvmlState::Unavailable
+            };
+        }
+
+        match &self.state {
+            NvmlState::Ready(nvml) => Some(nvml),
+            NvmlState::Uninitialized | NvmlState::Unavailable => None,
+        }
+    }
+}
+
+fn counter_u64(value: isize) -> u64 {
+    value.max(0) as u64
+}
+
+fn log_render_error(
+    error: &RenderError,
+    main_world: &mut bevy::prelude::World,
+    _render_world: &mut bevy::prelude::World,
+) -> RenderErrorPolicy {
+    if let Some(pool) = main_world.get_resource::<PlotGpuBufferPool>() {
+        tracing::error!(
+            error_type = ?error.ty,
+            plot_gpu_pool = ?pool.snapshot(),
+            "Render failure GPU state"
+        );
+    }
+    if let Some(stats) = main_world.get_resource::<HardwareStats>() {
+        tracing::error!(
+            error_type = ?error.ty,
+            app_buffer_bytes = stats.app_buffer_bytes,
+            app_texture_bytes = stats.app_texture_bytes,
+            app_memory_allocations = stats.app_memory_allocations,
+            device_memory = ?stats.device_memory,
+            gpu_utilization_percent = ?stats.gpu_utilization_percent,
+            "Render failure hardware state"
+        );
+    }
+    tracing::error!("Quitting the application due to {:?} RenderError", error.ty);
+    main_world.write_message(AppExit::error());
+    RenderErrorPolicy::StopRendering
+}
+
+#[cfg(test)]
+mod tests {
+    use super::counter_u64;
+
+    #[test]
+    fn negative_backend_counters_are_clamped() {
+        assert_eq!(counter_u64(-1), 0);
+        assert_eq!(counter_u64(42), 42);
+    }
+}

--- a/libs/elodin-editor/src/plugins/hw_stats.rs
+++ b/libs/elodin-editor/src/plugins/hw_stats.rs
@@ -48,7 +48,7 @@ impl HardwareStats {
 enum NvmlState {
     #[default]
     Uninitialized,
-    Ready(Nvml),
+    Ready(Box<Nvml>),
     Unavailable,
 }
 
@@ -149,7 +149,7 @@ impl NvmlSampler {
         if matches!(self.state, NvmlState::Uninitialized) {
             self.state = if vendor_id == NVIDIA_VENDOR_ID {
                 match Nvml::init() {
-                    Ok(nvml) => NvmlState::Ready(nvml),
+                    Ok(nvml) => NvmlState::Ready(Box::new(nvml)),
                     Err(error) => {
                         tracing::debug!(%error, "NVML GPU metrics unavailable");
                         NvmlState::Unavailable

--- a/libs/elodin-editor/src/plugins/hw_stats.rs
+++ b/libs/elodin-editor/src/plugins/hw_stats.rs
@@ -16,7 +16,7 @@ use bevy::{
 };
 use nvml_wrapper::Nvml;
 
-use crate::ui::plot::{PlotGpuBufferPool, gpu::evict_all_plot_gpu};
+use crate::ui::plot::{PlotGpuBufferPool, data::PlotGpuPoolSnapshot, gpu::evict_all_plot_gpu};
 
 const NVIDIA_VENDOR_ID: u32 = 0x10de;
 const GPU_MEMORY_PRESSURE_TRIM_PERCENT: u64 = 90;
@@ -171,6 +171,10 @@ fn counter_u64(value: isize) -> u64 {
     value.max(0) as u64
 }
 
+fn requires_renderer_recovery(error_type: ErrorType) -> bool {
+    matches!(error_type, ErrorType::OutOfMemory | ErrorType::DeviceLost)
+}
+
 fn supported_counter(value: isize, attributed_bytes: u64) -> Option<u64> {
     let value = counter_u64(value);
     (value > 0 || attributed_bytes == 0).then_some(value)
@@ -188,6 +192,7 @@ pub(crate) struct GpuAllocatorDump {
 pub(crate) fn dump_gpu_allocations(
     render_device: &RenderDevice,
     reason: &str,
+    plot_snapshot: Option<PlotGpuPoolSnapshot>,
 ) -> Result<GpuAllocatorDump, String> {
     let report = render_device
         .wgpu_device()
@@ -241,6 +246,16 @@ pub(crate) fn dump_gpu_allocations(
     );
     let _ = writeln!(full, "blocks: {}", report.blocks.len());
     let _ = writeln!(full, "allocations: {}", report.allocations.len());
+    if let Some(snapshot) = plot_snapshot {
+        let _ = writeln!(full, "plot pool: {snapshot:?}");
+        let _ = writeln!(
+            full,
+            "plot shard occupancy: {} / {} ({:.1}%)",
+            snapshot.value_shards_used,
+            snapshot.value_shards_capacity,
+            snapshot.shard_occupancy_percent().unwrap_or(0.0)
+        );
+    }
     let _ = writeln!(full, "\naggregated by label and size:\n{largest_groups}");
     let _ = writeln!(full, "memory blocks:");
     for (index, block) in report.blocks.iter().enumerate() {
@@ -293,10 +308,17 @@ fn log_render_error(
     main_world: &mut bevy::prelude::World,
     render_world: &mut bevy::prelude::World,
 ) -> RenderErrorPolicy {
-    if error.ty == ErrorType::OutOfMemory
-        && let Some(render_device) = main_world.get_resource::<RenderDevice>()
-    {
-        match dump_gpu_allocations(render_device, "oom") {
+    let recoverable = requires_renderer_recovery(error.ty);
+    let mut dump_path = None;
+    let plot_snapshot = main_world
+        .get_resource::<PlotGpuBufferPool>()
+        .map(|pool| pool.snapshot());
+    if recoverable && let Some(render_device) = main_world.get_resource::<RenderDevice>() {
+        let reason = match error.ty {
+            ErrorType::DeviceLost => "device-lost",
+            _ => "oom",
+        };
+        match dump_gpu_allocations(render_device, reason, plot_snapshot) {
             Ok(dump) => {
                 tracing::error!(
                     path = %dump.path.display(),
@@ -307,10 +329,15 @@ fn log_render_error(
                     largest_groups = %dump.largest_groups,
                     "GPU allocator report"
                 );
+                dump_path = Some(dump.path);
             }
             Err(error) => tracing::error!(%error, "GPU allocator report unavailable"),
         }
     }
+    let dump_path_label = dump_path
+        .as_deref()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|| "unavailable".to_string());
     if let Some(pool) = main_world.get_resource::<PlotGpuBufferPool>() {
         tracing::error!(
             error_type = ?error.ty,
@@ -331,7 +358,7 @@ fn log_render_error(
         );
     }
 
-    if error.ty == ErrorType::OutOfMemory {
+    if recoverable {
         let now = Instant::now();
         let repeated = main_world
             .get_resource_mut::<OomRecoveryState>()
@@ -345,21 +372,31 @@ fn log_render_error(
             tracing::error!(
                 value_buffers = trim.values,
                 index_buffers = trim.indices,
-                "Evicted plot GPU caches and recreating renderer after OutOfMemory"
+                error_type = ?error.ty,
+                "Evicted plot GPU caches and recreating renderer; GPU allocation report: {}",
+                dump_path_label
             );
             return RenderErrorPolicy::Recover(crate::editor_wgpu_settings().into());
         }
-        tracing::error!("Repeated OutOfMemory during recovery window");
+        tracing::error!(error_type = ?error.ty, "Repeated GPU failure during recovery window");
     }
 
-    tracing::error!("Quitting the application due to {:?} RenderError", error.ty);
+    tracing::error!(
+        "Quitting the application due to {:?} RenderError; GPU allocation report: {}",
+        error.ty,
+        dump_path_label
+    );
     main_world.write_message(AppExit::error());
     RenderErrorPolicy::StopRendering
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{OomRecoveryState, allow_oom_recovery, counter_u64, supported_counter};
+    use super::{
+        OomRecoveryState, allow_oom_recovery, counter_u64, requires_renderer_recovery,
+        supported_counter,
+    };
+    use bevy::render::error_handler::ErrorType;
     use std::time::{Duration, Instant};
 
     #[test]
@@ -368,6 +405,13 @@ mod tests {
         assert_eq!(counter_u64(42), 42);
         assert_eq!(supported_counter(0, 1024), None);
         assert_eq!(supported_counter(3, 1024), Some(3));
+    }
+
+    #[test]
+    fn oom_and_device_loss_require_renderer_recovery() {
+        assert!(requires_renderer_recovery(ErrorType::OutOfMemory));
+        assert!(requires_renderer_recovery(ErrorType::DeviceLost));
+        assert!(!requires_renderer_recovery(ErrorType::Validation));
     }
 
     #[test]

--- a/libs/elodin-editor/src/plugins/hw_stats.rs
+++ b/libs/elodin-editor/src/plugins/hw_stats.rs
@@ -313,25 +313,30 @@ fn log_render_error(
     let plot_snapshot = main_world
         .get_resource::<PlotGpuBufferPool>()
         .map(|pool| pool.snapshot());
-    if recoverable && let Some(render_device) = main_world.get_resource::<RenderDevice>() {
-        let reason = match error.ty {
-            ErrorType::DeviceLost => "device-lost",
-            _ => "oom",
-        };
-        match dump_gpu_allocations(render_device, reason, plot_snapshot) {
-            Ok(dump) => {
-                tracing::error!(
-                    path = %dump.path.display(),
-                    total_allocated_bytes = dump.total_allocated_bytes,
-                    total_reserved_bytes = dump.total_reserved_bytes,
-                    block_count = dump.block_count,
-                    allocation_count = dump.allocation_count,
-                    largest_groups = %dump.largest_groups,
-                    "GPU allocator report"
-                );
-                dump_path = Some(dump.path);
+    if recoverable {
+        match render_world.get_resource::<RenderDevice>() {
+            Some(render_device) => {
+                let reason = match error.ty {
+                    ErrorType::DeviceLost => "device-lost",
+                    _ => "oom",
+                };
+                match dump_gpu_allocations(render_device, reason, plot_snapshot) {
+                    Ok(dump) => {
+                        tracing::error!(
+                            path = %dump.path.display(),
+                            total_allocated_bytes = dump.total_allocated_bytes,
+                            total_reserved_bytes = dump.total_reserved_bytes,
+                            block_count = dump.block_count,
+                            allocation_count = dump.allocation_count,
+                            largest_groups = %dump.largest_groups,
+                            "GPU allocator report"
+                        );
+                        dump_path = Some(dump.path);
+                    }
+                    Err(error) => tracing::error!(%error, "GPU allocator report unavailable"),
+                }
             }
-            Err(error) => tracing::error!(%error, "GPU allocator report unavailable"),
+            None => tracing::error!("GPU allocator report unavailable: RenderDevice not found"),
         }
     }
     let dump_path_label = dump_path

--- a/libs/elodin-editor/src/plugins/mod.rs
+++ b/libs/elodin-editor/src/plugins/mod.rs
@@ -12,6 +12,8 @@ pub(crate) mod frustum_common;
 pub mod frustum_intersection;
 pub mod gizmos;
 pub(crate) mod gpu_info;
+#[cfg(not(target_family = "wasm"))]
+pub(crate) mod hw_stats;
 pub(crate) mod kdl_asset_source;
 pub(crate) mod kdl_document;
 mod logical_key;

--- a/libs/elodin-editor/src/ui/command_palette/palette_items.rs
+++ b/libs/elodin-editor/src/ui/command_palette/palette_items.rs
@@ -48,6 +48,8 @@ use nox::ArrayBuf;
 #[cfg(not(target_family = "wasm"))]
 use crate::plugins::hw_stats::dump_gpu_allocations;
 #[cfg(not(target_family = "wasm"))]
+use crate::ui::plot::PlotGpuBufferPool;
+#[cfg(not(target_family = "wasm"))]
 use bevy::render::renderer::RenderDevice;
 
 use crate::{
@@ -361,23 +363,22 @@ fn dump_gpu_allocations_item() -> PaletteItem {
     PaletteItem::new(
         "Dump GPU Allocations",
         DIAGNOSTICS_LABEL,
-        |_: In<String>, render_device: Res<RenderDevice>| match dump_gpu_allocations(
-            &render_device,
-            "manual",
-        ) {
-            Ok(dump) => {
-                tracing::info!(
-                    path = %dump.path.display(),
-                    total_allocated_bytes = dump.total_allocated_bytes,
-                    total_reserved_bytes = dump.total_reserved_bytes,
-                    block_count = dump.block_count,
-                    allocation_count = dump.allocation_count,
-                    largest_groups = %dump.largest_groups,
-                    "GPU allocator report"
-                );
-                PaletteEvent::Exit
+        |_: In<String>, render_device: Res<RenderDevice>, plot_pool: Res<PlotGpuBufferPool>| {
+            match dump_gpu_allocations(&render_device, "manual", Some(plot_pool.snapshot())) {
+                Ok(dump) => {
+                    tracing::info!(
+                        path = %dump.path.display(),
+                        total_allocated_bytes = dump.total_allocated_bytes,
+                        total_reserved_bytes = dump.total_reserved_bytes,
+                        block_count = dump.block_count,
+                        allocation_count = dump.allocation_count,
+                        largest_groups = %dump.largest_groups,
+                        "GPU allocator report"
+                    );
+                    PaletteEvent::Exit
+                }
+                Err(error) => PaletteEvent::Error(error),
             }
-            Err(error) => PaletteEvent::Error(error),
         },
     )
 }

--- a/libs/elodin-editor/src/ui/command_palette/palette_items.rs
+++ b/libs/elodin-editor/src/ui/command_palette/palette_items.rs
@@ -45,6 +45,11 @@ use impeller2_wkt::{
 };
 use nox::ArrayBuf;
 
+#[cfg(not(target_family = "wasm"))]
+use crate::plugins::hw_stats::dump_gpu_allocations;
+#[cfg(not(target_family = "wasm"))]
+use bevy::render::renderer::RenderDevice;
+
 use crate::{
     EqlContext, GridHandle, MainCamera, Offset, SelectedTimeRange, TimeRangeBehavior,
     TimeRangeError,
@@ -348,6 +353,34 @@ const HELP_LABEL: &str = "Help";
 const PRESETS_LABEL: &str = "Presets";
 const SCHEMATIC_LABEL: &str = "Schematic";
 const SKYBOX_LABEL: &str = "Skybox";
+#[cfg(not(target_family = "wasm"))]
+const DIAGNOSTICS_LABEL: &str = "Diagnostics";
+
+#[cfg(not(target_family = "wasm"))]
+fn dump_gpu_allocations_item() -> PaletteItem {
+    PaletteItem::new(
+        "Dump GPU Allocations",
+        DIAGNOSTICS_LABEL,
+        |_: In<String>, render_device: Res<RenderDevice>| match dump_gpu_allocations(
+            &render_device,
+            "manual",
+        ) {
+            Ok(dump) => {
+                tracing::info!(
+                    path = %dump.path.display(),
+                    total_allocated_bytes = dump.total_allocated_bytes,
+                    total_reserved_bytes = dump.total_reserved_bytes,
+                    block_count = dump.block_count,
+                    allocation_count = dump.allocation_count,
+                    largest_groups = %dump.largest_groups,
+                    "GPU allocator report"
+                );
+                PaletteEvent::Exit
+            }
+            Err(error) => PaletteEvent::Error(error),
+        },
+    )
+}
 
 struct ViewportEntry {
     label: String,
@@ -2238,6 +2271,8 @@ impl Default for PalettePage {
                     PaletteEvent::Exit
                 },
             ),
+            #[cfg(not(target_family = "wasm"))]
+            dump_gpu_allocations_item(),
             reset_cameras(),
             PaletteItem::new(
                 "Toggle Recording",

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -3772,18 +3772,34 @@ mod tests {
     #[test]
     fn resident_line_defers_when_index_pool_is_quarantined() {
         assert!(
-            defer_new_plot_gpu_allocs(true, false, 0, 0, 0, 4),
+            defer_new_plot_gpu_allocs(0, false, 0, 0, 0, 4),
             "shared/resident values still need a recycled index buffer"
         );
         assert!(
-            !defer_new_plot_gpu_allocs(true, true, 0, 0, 0, 4),
+            !defer_new_plot_gpu_allocs(0, true, 0, 0, 0, 4),
             "cached index must keep drawing while the pool cools down"
         );
         assert!(
-            !defer_new_plot_gpu_allocs(false, false, 0, 0, 0, 0),
+            !defer_new_plot_gpu_allocs(2, false, 0, 0, 0, 0),
             "empty pools are a first load, not a tab-switch leak"
         );
-        assert!(defer_new_plot_gpu_allocs(false, false, 0, 4, 0, 0));
+        assert!(defer_new_plot_gpu_allocs(2, false, 0, 4, 0, 0));
+    }
+
+    #[test]
+    fn xy_line_uses_actual_value_buffer_need_when_deferring() {
+        assert!(
+            !defer_new_plot_gpu_allocs(1, true, 1, 4, 1, 0),
+            "one ready value buffer is enough when only one is needed"
+        );
+        assert!(
+            defer_new_plot_gpu_allocs(2, true, 1, 4, 1, 0),
+            "two-buffer uploads still wait for a second ready value buffer"
+        );
+        assert!(
+            defer_new_plot_gpu_allocs(1, true, 0, 4, 1, 0),
+            "a single needed buffer still waits while candidates are quarantined"
+        );
     }
 }
 
@@ -3920,15 +3936,15 @@ pub(crate) fn plot_gpu_upload_blocked(ready: usize, quarantined: usize, need: us
 }
 
 pub(crate) fn defer_new_plot_gpu_allocs(
-    value_resident: bool,
+    value_buffers_needed: usize,
     has_index_cache: bool,
     value_ready: usize,
     value_quarantined: usize,
     index_ready: usize,
     index_quarantined: usize,
 ) -> bool {
-    let values_blocked =
-        !value_resident && plot_gpu_upload_blocked(value_ready, value_quarantined, 2);
+    let values_blocked = value_buffers_needed > 0
+        && plot_gpu_upload_blocked(value_ready, value_quarantined, value_buffers_needed);
     let index_blocked =
         !has_index_cache && plot_gpu_upload_blocked(index_ready, index_quarantined, 1);
     values_blocked || index_blocked
@@ -4091,13 +4107,13 @@ impl PlotGpuBufferPool {
 
     pub fn defer_new_allocs(
         &self,
-        value_resident: bool,
+        value_buffers_needed: usize,
         has_index_cache: bool,
         min_value_shards: usize,
     ) -> bool {
         let class = value_shard_class(min_value_shards);
         defer_new_plot_gpu_allocs(
-            value_resident,
+            value_buffers_needed,
             has_index_cache,
             self.value_count(class, true),
             self.value_count(class, false),

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -3526,14 +3526,55 @@ mod tests {
     }
 
     #[test]
+    fn ready_pool_items_are_evicted_after_idle_limit() {
+        let mut pool = QuarantinePool::default();
+        pool.release(1u32);
+        for _ in 0..PLOT_GPU_QUARANTINE_FRAMES {
+            assert_eq!(pool.tick(), 0);
+        }
+        assert_eq!(pool.ready_count(), 1);
+        for _ in 1..PLOT_GPU_POOL_IDLE_EVICT_FRAMES {
+            assert_eq!(pool.tick(), 0);
+        }
+        assert_eq!(pool.ready_count(), 1);
+        assert_eq!(pool.tick(), 1);
+        assert_eq!(pool.ready_count(), 0);
+    }
+
+    #[test]
+    fn pressure_trim_keeps_quarantined_items() {
+        let mut pool = QuarantinePool::default();
+        pool.release(1u32);
+        assert_eq!(pool.trim_ready(), 0);
+        assert_eq!(pool.quarantined_count(), 1);
+        for _ in 0..PLOT_GPU_QUARANTINE_FRAMES {
+            pool.tick();
+        }
+        assert_eq!(pool.trim_ready(), 1);
+        assert_eq!(pool.ready_count(), 0);
+    }
+
+    #[test]
+    fn recovery_pause_blocks_immediate_plot_reallocation() {
+        let mut pause = PlotGpuAllocationPause::default();
+        assert!(!pause.is_active());
+        pause.pause_for_recovery();
+        assert!(pause.is_active());
+    }
+
+    #[test]
     fn plot_gpu_snapshot_accounts_for_resident_and_pooled_buffers() {
         let snapshot = PlotGpuPoolSnapshot {
             value_live: 2,
             value_ready: 1,
             value_quarantined: 2,
+            value_allocations: 8,
+            value_destroyed: 3,
             index_live: 3,
             index_ready: 2,
             index_quarantined: 1,
+            index_allocations: 10,
+            index_destroyed: 4,
             ..Default::default()
         };
         assert_eq!(
@@ -3543,6 +3584,20 @@ mod tests {
         assert_eq!(
             snapshot.pooled_bytes(),
             3 * PLOT_VALUE_BUFFER_BYTES + 3 * PLOT_INDEX_BUFFER_BYTES
+        );
+        assert_eq!(
+            snapshot.value_allocations,
+            snapshot.value_live as u64
+                + snapshot.value_ready as u64
+                + snapshot.value_quarantined as u64
+                + snapshot.value_destroyed
+        );
+        assert_eq!(
+            snapshot.index_allocations,
+            snapshot.index_live as u64
+                + snapshot.index_ready as u64
+                + snapshot.index_quarantined as u64
+                + snapshot.index_destroyed
         );
     }
 
@@ -3603,9 +3658,30 @@ impl BoundOrd for f32 {
 /// wgpu/Bevy keep 1–3 frames in flight. Value buffers released on a tab
 /// switch must not be rewritten until those bind groups are gone.
 pub(crate) const PLOT_GPU_QUARANTINE_FRAMES: u8 = 3;
+pub(crate) const PLOT_GPU_POOL_IDLE_EVICT_FRAMES: u16 = 300;
+const PLOT_GPU_RECOVERY_PAUSE: Duration = Duration::from_secs(2);
+
+#[derive(Resource, Default)]
+pub struct PlotGpuAllocationPause {
+    until: Option<Instant>,
+}
+
+impl PlotGpuAllocationPause {
+    pub fn pause_for_recovery(&mut self) {
+        self.until = Some(Instant::now() + PLOT_GPU_RECOVERY_PAUSE);
+    }
+
+    pub fn is_active(&mut self) -> bool {
+        let active = self.until.is_some_and(|until| Instant::now() < until);
+        if !active {
+            self.until = None;
+        }
+        active
+    }
+}
 
 pub(crate) struct QuarantinePool<T> {
-    items: Vec<(T, u8)>,
+    items: Vec<(T, u8, u16)>,
 }
 
 impl<T> Default for QuarantinePool<T> {
@@ -3615,27 +3691,58 @@ impl<T> Default for QuarantinePool<T> {
 }
 
 impl<T> QuarantinePool<T> {
-    fn tick(&mut self) {
-        for (_, frames) in &mut self.items {
-            *frames = frames.saturating_sub(1);
+    fn tick(&mut self) -> usize {
+        for (_, quarantine_frames, idle_frames) in &mut self.items {
+            if *quarantine_frames > 0 {
+                *quarantine_frames -= 1;
+            } else {
+                *idle_frames = idle_frames.saturating_add(1);
+            }
         }
+        let before = self.items.len();
+        self.items.retain(|(_, quarantine_frames, idle_frames)| {
+            *quarantine_frames > 0 || *idle_frames < PLOT_GPU_POOL_IDLE_EVICT_FRAMES
+        });
+        before - self.items.len()
     }
 
     fn release(&mut self, item: T) {
-        self.items.push((item, PLOT_GPU_QUARANTINE_FRAMES));
+        self.items.push((item, PLOT_GPU_QUARANTINE_FRAMES, 0));
     }
 
     fn try_acquire(&mut self) -> Option<T> {
-        let idx = self.items.iter().position(|(_, frames)| *frames == 0)?;
+        let idx = self
+            .items
+            .iter()
+            .position(|(_, quarantine_frames, _)| *quarantine_frames == 0)?;
         Some(self.items.swap_remove(idx).0)
     }
 
     fn ready_count(&self) -> usize {
-        self.items.iter().filter(|(_, frames)| *frames == 0).count()
+        self.items
+            .iter()
+            .filter(|(_, quarantine_frames, _)| *quarantine_frames == 0)
+            .count()
     }
 
     fn quarantined_count(&self) -> usize {
-        self.items.iter().filter(|(_, frames)| *frames > 0).count()
+        self.items
+            .iter()
+            .filter(|(_, quarantine_frames, _)| *quarantine_frames > 0)
+            .count()
+    }
+
+    fn trim_ready(&mut self) -> usize {
+        let before = self.items.len();
+        self.items
+            .retain(|(_, quarantine_frames, _)| *quarantine_frames > 0);
+        before - self.items.len()
+    }
+
+    fn clear(&mut self) -> usize {
+        let count = self.items.len();
+        self.items.clear();
+        count
     }
 }
 
@@ -3668,11 +3775,13 @@ pub struct PlotGpuPoolSnapshot {
     pub value_quarantined: usize,
     pub value_allocations: u64,
     pub value_reuses: u64,
+    pub value_destroyed: u64,
     pub index_live: usize,
     pub index_ready: usize,
     pub index_quarantined: usize,
     pub index_allocations: u64,
     pub index_reuses: u64,
+    pub index_destroyed: u64,
 }
 
 impl PlotGpuPoolSnapshot {
@@ -3704,12 +3813,14 @@ pub struct PlotGpuBufferPool {
     index_live: usize,
     index_allocations: u64,
     index_reuses: u64,
+    value_destroyed: u64,
+    index_destroyed: u64,
 }
 
 impl PlotGpuBufferPool {
     pub fn tick(&mut self) {
-        self.value.tick();
-        self.index.tick();
+        self.value_destroyed += self.value.tick() as u64;
+        self.index_destroyed += self.index.tick() as u64;
     }
 
     pub fn release_value(&mut self, buffer: Buffer) {
@@ -3731,12 +3842,34 @@ impl PlotGpuBufferPool {
             value_quarantined: self.value.quarantined_count(),
             value_allocations: self.value_allocations,
             value_reuses: self.value_reuses,
+            value_destroyed: self.value_destroyed,
             index_live: self.index_live,
             index_ready: self.index.ready_count(),
             index_quarantined: self.index.quarantined_count(),
             index_allocations: self.index_allocations,
             index_reuses: self.index_reuses,
+            index_destroyed: self.index_destroyed,
         }
+    }
+
+    pub fn trim_ready(&mut self) -> PlotGpuPoolTrim {
+        let trim = PlotGpuPoolTrim {
+            values: self.value.trim_ready(),
+            indices: self.index.trim_ready(),
+        };
+        self.value_destroyed += trim.values as u64;
+        self.index_destroyed += trim.indices as u64;
+        trim
+    }
+
+    pub fn drain(&mut self) -> PlotGpuPoolTrim {
+        let trim = PlotGpuPoolTrim {
+            values: self.value.clear(),
+            indices: self.index.clear(),
+        };
+        self.value_destroyed += trim.values as u64;
+        self.index_destroyed += trim.indices as u64;
+        trim
     }
 
     pub fn defer_new_allocs(&self, value_resident: bool, has_index_cache: bool) -> bool {
@@ -3783,6 +3916,12 @@ impl PlotGpuBufferPool {
             mapped_at_creation: false,
         }))
     }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct PlotGpuPoolTrim {
+    pub values: usize,
+    pub indices: usize,
 }
 
 pub struct BufferShardAlloc {

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -1160,13 +1160,25 @@ impl XYLine {
         self.x_values.iter().map(|c| c.cpu().len()).sum()
     }
 
-    pub fn queue_load(&mut self, render_queue: &RenderQueue, render_device: &RenderDevice) {
-        let x_shard_alloc = self.x_shard_alloc.get_or_insert_with(|| {
-            BufferShardAlloc::with_nan_chunk(CHUNK_COUNT, CHUNK_LEN, render_device, render_queue)
-        });
-        let y_shard_alloc = self.y_shard_alloc.get_or_insert_with(|| {
-            BufferShardAlloc::with_nan_chunk(CHUNK_COUNT, CHUNK_LEN, render_device, render_queue)
-        });
+    pub fn has_samples(&self) -> bool {
+        self.x_values.iter().any(|c| c.cpu().len() > 0)
+    }
+
+    pub fn queue_load(
+        &mut self,
+        render_queue: &RenderQueue,
+        render_device: &RenderDevice,
+        pool: &mut PlotGpuBufferPool,
+    ) {
+        if !self.has_samples() {
+            return;
+        }
+        let x_shard_alloc = self
+            .x_shard_alloc
+            .get_or_insert_with(|| pool.take_value(render_device, render_queue));
+        let y_shard_alloc = self
+            .y_shard_alloc
+            .get_or_insert_with(|| pool.take_value(render_device, render_queue));
         for buf in &mut self.x_values {
             buf.queue_load(render_queue, x_shard_alloc);
         }
@@ -1179,7 +1191,7 @@ impl XYLine {
         self.x_shard_alloc.is_some() || self.y_shard_alloc.is_some()
     }
 
-    pub fn unload_gpu(&mut self) {
+    pub fn unload_gpu(&mut self, pool: &mut PlotGpuBufferPool) {
         if !self.gpu_resident() {
             return;
         }
@@ -1189,8 +1201,12 @@ impl XYLine {
         for buf in &self.y_values {
             buf.release_gpu();
         }
-        self.x_shard_alloc = None;
-        self.y_shard_alloc = None;
+        if let Some(alloc) = self.x_shard_alloc.take() {
+            pool.release_value(alloc.into_buffer());
+        }
+        if let Some(alloc) = self.y_shard_alloc.take() {
+            pool.release_value(alloc.into_buffer());
+        }
     }
 
     #[cfg(test)]
@@ -1594,6 +1610,10 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
         self.tree.iter().map(|(_, c)| c.summary.len).sum()
     }
 
+    pub fn has_samples(&self) -> bool {
+        self.tree.iter().any(|(_, c)| c.summary.len > 0)
+    }
+
     /// Identity for GPU index-cache invalidation when the view is rebuilt in place.
     pub fn content_gen(&self) -> u64 {
         self.content_gen
@@ -1808,13 +1828,17 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
         range: Range<Timestamp>,
         render_queue: &RenderQueue,
         render_device: &RenderDevice,
+        pool: &mut PlotGpuBufferPool,
     ) {
-        let data_buffer_alloc = self.data_buffer_shard_alloc.get_or_insert_with(|| {
-            BufferShardAlloc::with_nan_chunk(CHUNK_COUNT, CHUNK_LEN, render_device, render_queue)
-        });
-        let timestamp_buffer_alloc = self.timestamp_buffer_shard_alloc.get_or_insert_with(|| {
-            BufferShardAlloc::with_nan_chunk(CHUNK_COUNT, CHUNK_LEN, render_device, render_queue)
-        });
+        if !self.has_samples() {
+            return;
+        }
+        let data_buffer_alloc = self
+            .data_buffer_shard_alloc
+            .get_or_insert_with(|| pool.take_value(render_device, render_queue));
+        let timestamp_buffer_alloc = self
+            .timestamp_buffer_shard_alloc
+            .get_or_insert_with(|| pool.take_value(render_device, render_queue));
         for (_, chunk) in self.tree.overlapping_mut(ii(range.start.0, range.end.0)) {
             chunk.queue_load(render_queue, data_buffer_alloc, timestamp_buffer_alloc);
         }
@@ -2141,7 +2165,7 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
         self.data_buffer_shard_alloc.is_some() || self.timestamp_buffer_shard_alloc.is_some()
     }
 
-    pub fn unload_gpu(&mut self) {
+    pub fn unload_gpu(&mut self, pool: &mut PlotGpuBufferPool) {
         if !self.gpu_resident() {
             return;
         }
@@ -2149,8 +2173,12 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
             chunk.data.release_gpu();
             chunk.timestamps_float.release_gpu();
         }
-        self.data_buffer_shard_alloc = None;
-        self.timestamp_buffer_shard_alloc = None;
+        if let Some(alloc) = self.data_buffer_shard_alloc.take() {
+            pool.release_value(alloc.into_buffer());
+        }
+        if let Some(alloc) = self.timestamp_buffer_shard_alloc.take() {
+            pool.release_value(alloc.into_buffer());
+        }
     }
 
     #[cfg(test)]
@@ -3303,6 +3331,35 @@ mod tests {
     }
 
     #[test]
+    fn empty_line_has_no_samples() {
+        assert!(!LineTree::<f32>::default().has_samples());
+        assert!(!XYLine::default().has_samples());
+    }
+
+    #[test]
+    fn line_reports_samples_after_insert() {
+        let mut tree = LineTree::<f32>::default();
+        let chunk = Chunk::from_iter(
+            &[Timestamp(10), Timestamp(20)],
+            Timestamp(0),
+            [1.0_f32, 2.0_f32].into_iter(),
+        )
+        .expect("chunk");
+        tree.insert(chunk);
+        assert!(tree.has_samples());
+        assert_eq!(tree.total_points(), 2);
+    }
+
+    #[test]
+    fn xy_line_reports_samples_after_push() {
+        let mut xy = XYLine::default();
+        xy.push_x_value(1.0);
+        xy.push_y_value(2.0);
+        assert!(xy.has_samples());
+        assert_eq!(xy.point_count(), 1);
+    }
+
+    #[test]
     fn unload_gpu_is_noop_when_already_cleared() {
         let mut tree = LineTree::<f32>::default();
         let chunk = Chunk::from_iter(
@@ -3316,7 +3373,7 @@ mod tests {
         assert!(!tree.all_gpu_dirty());
         assert!(!tree.gpu_resident());
 
-        tree.unload_gpu();
+        tree.unload_gpu(&mut PlotGpuBufferPool::default());
         assert!(!tree.all_gpu_dirty());
         assert!(!tree.gpu_resident());
     }
@@ -3330,7 +3387,7 @@ mod tests {
         assert!(!xy.all_gpu_dirty());
         assert!(!xy.gpu_resident());
 
-        xy.unload_gpu();
+        xy.unload_gpu(&mut PlotGpuBufferPool::default());
         assert!(!xy.all_gpu_dirty());
         assert!(!xy.gpu_resident());
     }
@@ -3372,7 +3429,13 @@ mod tests {
                 expect_visible,
                 "a_on={a_on} b_on={b_on} expect_visible={expect_visible}"
             );
-            unload_plot_gpu_not_on_screen(&mut lines, &mut xy_lines, &visible_ts, &visible_xy);
+            unload_plot_gpu_not_on_screen(
+                &mut lines,
+                &mut xy_lines,
+                &visible_ts,
+                &visible_xy,
+                &mut PlotGpuBufferPool::default(),
+            );
             // No shard allocs ⇒ already cleared; must not walk/lock or dirty shards.
             assert!(!lines.get(&handle).expect("line").data.all_gpu_dirty());
             assert!(!lines.get(&handle).expect("line").data.gpu_resident());
@@ -3405,9 +3468,61 @@ mod tests {
             xy_line.mark_gpu_clean();
         }
 
-        unload_plot_gpu_not_on_screen(&mut lines, &mut xy_lines, &HashSet::new(), &HashSet::new());
+        unload_plot_gpu_not_on_screen(
+            &mut lines,
+            &mut xy_lines,
+            &HashSet::new(),
+            &HashSet::new(),
+            &mut PlotGpuBufferPool::default(),
+        );
         assert!(!lines.get(&ts).expect("line").data.all_gpu_dirty());
         assert!(!xy_lines.get(&xy).expect("xy").all_gpu_dirty());
+    }
+
+    #[test]
+    fn quarantine_pool_is_unusable_until_ticks_elapse() {
+        let mut pool = QuarantinePool::default();
+        pool.release(1u32);
+        pool.release(2u32);
+        assert_eq!(pool.ready_count(), 0);
+        assert_eq!(pool.quarantined_count(), 2);
+        assert!(plot_gpu_upload_blocked(
+            pool.ready_count(),
+            pool.quarantined_count(),
+            2
+        ));
+
+        pool.tick();
+        assert_eq!(pool.ready_count(), 0);
+        assert!(plot_gpu_upload_blocked(
+            pool.ready_count(),
+            pool.quarantined_count(),
+            2
+        ));
+
+        pool.tick();
+        assert_eq!(pool.ready_count(), 0);
+
+        pool.tick();
+        assert_eq!(pool.ready_count(), 2);
+        assert_eq!(pool.quarantined_count(), 0);
+        assert!(!plot_gpu_upload_blocked(
+            pool.ready_count(),
+            pool.quarantined_count(),
+            2
+        ));
+        assert_eq!(pool.try_acquire(), Some(1));
+        assert_eq!(pool.try_acquire(), Some(2));
+        assert_eq!(pool.try_acquire(), None);
+    }
+
+    #[test]
+    fn new_plot_gpu_upload_is_blocked_only_while_value_buffers_are_quarantined() {
+        assert!(!plot_gpu_upload_blocked(0, 0, 2));
+        assert!(plot_gpu_upload_blocked(0, 4, 2));
+        assert!(plot_gpu_upload_blocked(1, 4, 2));
+        assert!(!plot_gpu_upload_blocked(2, 4, 2));
+        assert!(!plot_gpu_upload_blocked(2, 0, 2));
     }
 }
 
@@ -3447,6 +3562,106 @@ impl BoundOrd for f32 {
     }
 }
 
+/// wgpu/Bevy keep 1–3 frames in flight. Value buffers released on a tab
+/// switch must not be rewritten until those bind groups are gone.
+pub(crate) const PLOT_GPU_QUARANTINE_FRAMES: u8 = 3;
+
+pub(crate) struct QuarantinePool<T> {
+    items: Vec<(T, u8)>,
+}
+
+impl<T> Default for QuarantinePool<T> {
+    fn default() -> Self {
+        Self { items: Vec::new() }
+    }
+}
+
+impl<T> QuarantinePool<T> {
+    fn tick(&mut self) {
+        for (_, frames) in &mut self.items {
+            *frames = frames.saturating_sub(1);
+        }
+    }
+
+    fn release(&mut self, item: T) {
+        self.items.push((item, PLOT_GPU_QUARANTINE_FRAMES));
+    }
+
+    fn try_acquire(&mut self) -> Option<T> {
+        let idx = self.items.iter().position(|(_, frames)| *frames == 0)?;
+        Some(self.items.swap_remove(idx).0)
+    }
+
+    fn ready_count(&self) -> usize {
+        self.items.iter().filter(|(_, frames)| *frames == 0).count()
+    }
+
+    fn quarantined_count(&self) -> usize {
+        self.items.iter().filter(|(_, frames)| *frames > 0).count()
+    }
+}
+
+pub(crate) fn plot_gpu_upload_blocked(ready: usize, quarantined: usize, need: usize) -> bool {
+    ready < need && quarantined > 0
+}
+
+/// Recycles plot value/index buffers across tab switches so hidden-graph
+/// unload does not immediately allocate a second full set (GPU OOM).
+#[derive(Resource, Default)]
+pub struct PlotGpuBufferPool {
+    value: QuarantinePool<Buffer>,
+    index: QuarantinePool<Buffer>,
+}
+
+impl PlotGpuBufferPool {
+    pub fn tick(&mut self) {
+        self.value.tick();
+        self.index.tick();
+    }
+
+    pub fn release_value(&mut self, buffer: Buffer) {
+        self.value.release(buffer);
+    }
+
+    pub fn release_index(&mut self, buffer: Buffer) {
+        self.index.release(buffer);
+    }
+
+    pub fn ready_value_count(&self) -> usize {
+        self.value.ready_count()
+    }
+
+    pub fn defer_new_value_upload(&self, already_resident: bool) -> bool {
+        !already_resident
+            && plot_gpu_upload_blocked(self.ready_value_count(), self.value.quarantined_count(), 2)
+    }
+
+    pub fn take_value(
+        &mut self,
+        render_device: &RenderDevice,
+        render_queue: &RenderQueue,
+    ) -> BufferShardAlloc {
+        if let Some(buffer) = self.value.try_acquire() {
+            BufferShardAlloc::from_pooled_value(buffer, CHUNK_COUNT, CHUNK_LEN, render_queue)
+        } else {
+            BufferShardAlloc::with_nan_chunk(CHUNK_COUNT, CHUNK_LEN, render_device, render_queue)
+        }
+    }
+
+    pub fn take_index(&mut self, render_device: &RenderDevice) -> Buffer {
+        if let Some(buffer) = self.index.try_acquire() {
+            buffer
+        } else {
+            render_device.create_buffer(&BufferDescriptor {
+                label: Some("Line index Buffer"),
+                size: (INDEX_BUFFER_LEN * size_of::<u32>()) as u64,
+                usage: BufferUsages::STORAGE | BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            })
+        }
+    }
+}
+
 pub struct BufferShardAlloc {
     buffer: Buffer,
     chunk_size: usize,
@@ -3464,6 +3679,31 @@ impl BufferShardAlloc {
         let shard = this.alloc().expect("couldn't alloc nan");
         render_queue.write_buffer_shard(&shard, &f32::NAN.to_le_bytes());
         this
+    }
+
+    fn from_pooled_value(
+        buffer: Buffer,
+        chunks: usize,
+        chunk_len: usize,
+        render_queue: &RenderQueue,
+    ) -> Self {
+        let chunk_size = size_of::<f32>() * chunk_len;
+        let mut free_map = RoaringBitmap::new();
+        for i in 0..=chunks as u32 {
+            free_map.insert(i);
+        }
+        let mut this = Self {
+            buffer,
+            free_map,
+            chunk_size,
+        };
+        let shard = this.alloc().expect("couldn't alloc nan");
+        render_queue.write_buffer_shard(&shard, &f32::NAN.to_le_bytes());
+        this
+    }
+
+    fn into_buffer(self) -> Buffer {
+        self.buffer
     }
 
     pub fn new<T: Sized>(chunks: usize, chunk_len: usize, render_device: &RenderDevice) -> Self {

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -3526,6 +3526,27 @@ mod tests {
     }
 
     #[test]
+    fn plot_gpu_snapshot_accounts_for_resident_and_pooled_buffers() {
+        let snapshot = PlotGpuPoolSnapshot {
+            value_live: 2,
+            value_ready: 1,
+            value_quarantined: 2,
+            index_live: 3,
+            index_ready: 2,
+            index_quarantined: 1,
+            ..Default::default()
+        };
+        assert_eq!(
+            snapshot.resident_bytes(),
+            2 * PLOT_VALUE_BUFFER_BYTES + 3 * PLOT_INDEX_BUFFER_BYTES
+        );
+        assert_eq!(
+            snapshot.pooled_bytes(),
+            3 * PLOT_VALUE_BUFFER_BYTES + 3 * PLOT_INDEX_BUFFER_BYTES
+        );
+    }
+
+    #[test]
     fn resident_line_defers_when_index_pool_is_quarantined() {
         assert!(
             defer_new_plot_gpu_allocs(true, false, 0, 0, 0, 4),
@@ -3637,12 +3658,52 @@ pub(crate) fn defer_new_plot_gpu_allocs(
     values_blocked || index_blocked
 }
 
+pub const PLOT_VALUE_BUFFER_BYTES: u64 = ((CHUNK_COUNT + 1) * CHUNK_LEN * size_of::<f32>()) as u64;
+pub const PLOT_INDEX_BUFFER_BYTES: u64 = (INDEX_BUFFER_LEN * size_of::<u32>()) as u64;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct PlotGpuPoolSnapshot {
+    pub value_live: usize,
+    pub value_ready: usize,
+    pub value_quarantined: usize,
+    pub value_allocations: u64,
+    pub value_reuses: u64,
+    pub index_live: usize,
+    pub index_ready: usize,
+    pub index_quarantined: usize,
+    pub index_allocations: u64,
+    pub index_reuses: u64,
+}
+
+impl PlotGpuPoolSnapshot {
+    pub fn resident_bytes(self) -> u64 {
+        (self.value_live as u64)
+            .saturating_mul(PLOT_VALUE_BUFFER_BYTES)
+            .saturating_add((self.index_live as u64).saturating_mul(PLOT_INDEX_BUFFER_BYTES))
+    }
+
+    pub fn pooled_bytes(self) -> u64 {
+        ((self.value_ready + self.value_quarantined) as u64)
+            .saturating_mul(PLOT_VALUE_BUFFER_BYTES)
+            .saturating_add(
+                ((self.index_ready + self.index_quarantined) as u64)
+                    .saturating_mul(PLOT_INDEX_BUFFER_BYTES),
+            )
+    }
+}
+
 /// Recycles plot value/index buffers across tab switches so hidden-graph
 /// unload does not immediately allocate a second full set (GPU OOM).
 #[derive(Resource, Default)]
 pub struct PlotGpuBufferPool {
     value: QuarantinePool<Buffer>,
     index: QuarantinePool<Buffer>,
+    value_live: usize,
+    value_allocations: u64,
+    value_reuses: u64,
+    index_live: usize,
+    index_allocations: u64,
+    index_reuses: u64,
 }
 
 impl PlotGpuBufferPool {
@@ -3652,11 +3713,30 @@ impl PlotGpuBufferPool {
     }
 
     pub fn release_value(&mut self, buffer: Buffer) {
+        debug_assert!(self.value_live > 0);
+        self.value_live = self.value_live.saturating_sub(1);
         self.value.release(buffer);
     }
 
     pub fn release_index(&mut self, buffer: Buffer) {
+        debug_assert!(self.index_live > 0);
+        self.index_live = self.index_live.saturating_sub(1);
         self.index.release(buffer);
+    }
+
+    pub fn snapshot(&self) -> PlotGpuPoolSnapshot {
+        PlotGpuPoolSnapshot {
+            value_live: self.value_live,
+            value_ready: self.value.ready_count(),
+            value_quarantined: self.value.quarantined_count(),
+            value_allocations: self.value_allocations,
+            value_reuses: self.value_reuses,
+            index_live: self.index_live,
+            index_ready: self.index.ready_count(),
+            index_quarantined: self.index.quarantined_count(),
+            index_allocations: self.index_allocations,
+            index_reuses: self.index_reuses,
+        }
     }
 
     pub fn defer_new_allocs(&self, value_resident: bool, has_index_cache: bool) -> bool {
@@ -3675,20 +3755,27 @@ impl PlotGpuBufferPool {
         render_device: &RenderDevice,
         render_queue: &RenderQueue,
     ) -> BufferShardAlloc {
+        self.value_live += 1;
         if let Some(buffer) = self.value.try_acquire() {
+            self.value_reuses += 1;
             BufferShardAlloc::from_pooled_value(buffer, CHUNK_COUNT, CHUNK_LEN, render_queue)
         } else {
+            self.value_allocations += 1;
             BufferShardAlloc::with_nan_chunk(CHUNK_COUNT, CHUNK_LEN, render_device, render_queue)
         }
     }
 
     pub fn take_index(&mut self, render_device: &RenderDevice) -> Option<Buffer> {
         if let Some(buffer) = self.index.try_acquire() {
+            self.index_live += 1;
+            self.index_reuses += 1;
             return Some(buffer);
         }
         if self.index.quarantined_count() > 0 {
             return None;
         }
+        self.index_live += 1;
+        self.index_allocations += 1;
         Some(render_device.create_buffer(&BufferDescriptor {
             label: Some("Line index Buffer"),
             size: (INDEX_BUFFER_LEN * size_of::<u32>()) as u64,

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -238,6 +238,10 @@ impl PlotLineUsers {
         remaining
     }
 
+    pub fn is_used(&self, key: PlotLineKey) -> bool {
+        self.counts.contains_key(&key)
+    }
+
     #[cfg(test)]
     pub fn count(&self, key: PlotLineKey) -> usize {
         self.counts.get(&key).copied().unwrap_or(0)

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -1948,12 +1948,18 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
                 chunk.data.release_gpu();
                 chunk.timestamps_float.release_gpu();
             }
-            if let Some(alloc) = self.data_buffer_shard_alloc.take() {
-                pool.release_value(alloc);
-            }
-            if let Some(alloc) = self.timestamp_buffer_shard_alloc.take() {
-                pool.release_value(alloc);
-            }
+            reclaim_or_release(
+                &mut self.data_buffer_shard_alloc,
+                value_class,
+                pool,
+                render_queue,
+            );
+            reclaim_or_release(
+                &mut self.timestamp_buffer_shard_alloc,
+                value_class,
+                pool,
+                render_queue,
+            );
         }
         let data_buffer_alloc = self
             .data_buffer_shard_alloc
@@ -3965,6 +3971,26 @@ pub fn value_shard_class(required: usize) -> usize {
         .unwrap_or(CHUNK_COUNT)
 }
 
+/// Hand a value buffer whose shards were all just released back to its owner or
+/// to the pool. An unchanged class means the buffer only ran out of free shards,
+/// so reclaim it in place: the pool would keep it quarantined and hand out a
+/// second buffer of the same size in its place.
+fn reclaim_or_release(
+    slot: &mut Option<BufferShardAlloc>,
+    value_class: usize,
+    pool: &mut PlotGpuBufferPool,
+    render_queue: &RenderQueue,
+) {
+    match slot.take() {
+        Some(mut alloc) if alloc.capacity_shards() == value_class => {
+            alloc.reset_shards(render_queue);
+            *slot = Some(alloc);
+        }
+        Some(alloc) => pool.release_value(alloc),
+        None => {}
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct PlotGpuPoolSnapshot {
     pub value_live: usize,
@@ -4305,6 +4331,17 @@ impl BufferShardAlloc {
     pub fn used_shards(&self) -> usize {
         self.data_capacity
             .saturating_sub(self.free_map.len() as usize)
+    }
+
+    /// Free every shard at once. Callers must have released the GPU copies that
+    /// referenced them, since `release_gpu` drops a shard without deallocating it.
+    pub fn reset_shards(&mut self, render_queue: &RenderQueue) {
+        self.free_map = RoaringBitmap::new();
+        for i in 0..=self.data_capacity as u32 {
+            self.free_map.insert(i);
+        }
+        let shard = self.alloc().expect("couldn't alloc nan");
+        render_queue.write_buffer_shard(&shard, &f32::NAN.to_le_bytes());
     }
 
     pub fn dealloc(&mut self, shard: BufferShard) {

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -3,7 +3,7 @@ use bevy::log::warn_once;
 use bevy::prelude::{InRef, Res, ResMut};
 use bevy::reflect::TypePath;
 use bevy::{
-    asset::{Assets, Handle},
+    asset::{AssetId, Assets, Handle},
     ecs::system::{Commands, Query},
     prelude::Resource,
 };
@@ -24,7 +24,7 @@ use roaring::bitmap::RoaringBitmap;
 use zerocopy::{Immutable, IntoBytes};
 
 use std::any::type_name;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::num::NonZeroU64;
 use std::ops::RangeInclusive;
 use std::sync::Arc;
@@ -199,6 +199,48 @@ impl CollectedGraphData {
         self.components
             .get(component_id)
             .and_then(|component| component.lines.get(&index))
+    }
+
+    pub fn remove_line_handle(&mut self, id: AssetId<Line>) {
+        for component in self.components.values_mut() {
+            component.lines.retain(|_, handle| handle.id() != id);
+        }
+    }
+}
+
+/// Live `LineHandle` entities per plot asset. Last user unloads GPU and
+/// drops the `CollectedGraphData` handle so unused `Assets<Line>` can go.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum PlotLineKey {
+    Timeseries(AssetId<Line>),
+    XY(AssetId<XYLine>),
+}
+
+#[derive(Resource, Default)]
+pub struct PlotLineUsers {
+    counts: HashMap<PlotLineKey, usize>,
+}
+
+impl PlotLineUsers {
+    pub fn retain(&mut self, key: PlotLineKey) {
+        *self.counts.entry(key).or_insert(0) += 1;
+    }
+
+    pub fn release(&mut self, key: PlotLineKey) -> usize {
+        let Some(count) = self.counts.get_mut(&key) else {
+            return 0;
+        };
+        *count = count.saturating_sub(1);
+        let remaining = *count;
+        if remaining == 0 {
+            self.counts.remove(&key);
+        }
+        remaining
+    }
+
+    #[cfg(test)]
+    pub fn count(&self, key: PlotLineKey) -> usize {
+        self.counts.get(&key).copied().unwrap_or(0)
     }
 }
 

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -1173,12 +1173,38 @@ impl XYLine {
         if !self.has_samples() {
             return;
         }
+        let x_class = value_shard_class(self.x_values.len());
+        let y_class = value_shard_class(self.y_values.len());
+        if self
+            .x_shard_alloc
+            .as_ref()
+            .is_some_and(|alloc| alloc.capacity_shards() < x_class)
+        {
+            for buffer in &self.x_values {
+                buffer.release_gpu();
+            }
+            if let Some(alloc) = self.x_shard_alloc.take() {
+                pool.release_value(alloc);
+            }
+        }
+        if self
+            .y_shard_alloc
+            .as_ref()
+            .is_some_and(|alloc| alloc.capacity_shards() < y_class)
+        {
+            for buffer in &self.y_values {
+                buffer.release_gpu();
+            }
+            if let Some(alloc) = self.y_shard_alloc.take() {
+                pool.release_value(alloc);
+            }
+        }
         let x_shard_alloc = self
             .x_shard_alloc
-            .get_or_insert_with(|| pool.take_value(render_device, render_queue));
+            .get_or_insert_with(|| pool.take_value(x_class, render_device, render_queue));
         let y_shard_alloc = self
             .y_shard_alloc
-            .get_or_insert_with(|| pool.take_value(render_device, render_queue));
+            .get_or_insert_with(|| pool.take_value(y_class, render_device, render_queue));
         for buf in &mut self.x_values {
             buf.queue_load(render_queue, x_shard_alloc);
         }
@@ -1189,6 +1215,24 @@ impl XYLine {
 
     pub fn gpu_resident(&self) -> bool {
         self.x_shard_alloc.is_some() || self.y_shard_alloc.is_some()
+    }
+
+    pub fn required_value_shards(&self) -> usize {
+        self.x_values.len().max(self.y_values.len()).max(1)
+    }
+
+    pub fn value_buffers_needing_allocation(&self) -> usize {
+        let x_class = value_shard_class(self.x_values.len());
+        let y_class = value_shard_class(self.y_values.len());
+        usize::from(
+            self.x_shard_alloc
+                .as_ref()
+                .is_none_or(|alloc| alloc.capacity_shards() < x_class),
+        ) + usize::from(
+            self.y_shard_alloc
+                .as_ref()
+                .is_none_or(|alloc| alloc.capacity_shards() < y_class),
+        )
     }
 
     pub fn unload_gpu(&mut self, pool: &mut PlotGpuBufferPool) {
@@ -1202,10 +1246,10 @@ impl XYLine {
             buf.release_gpu();
         }
         if let Some(alloc) = self.x_shard_alloc.take() {
-            pool.release_value(alloc.into_buffer());
+            pool.release_value(alloc);
         }
         if let Some(alloc) = self.y_shard_alloc.take() {
-            pool.release_value(alloc.into_buffer());
+            pool.release_value(alloc);
         }
     }
 
@@ -1229,36 +1273,34 @@ impl XYLine {
         index_buffer: &Buffer,
         render_queue: &RenderQueue,
         pixel_width: usize,
-    ) -> u32 {
+    ) -> Option<u32> {
         // Decimate to respect the fixed index buffer size (same pattern as timeseries)
         let desired_index_len = INDEX_BUFFER_LEN.min(pixel_width.max(1) * 4);
         let total_points: usize = self.x_values.iter().map(|c| c.cpu().len()).sum();
         if total_points == 0 {
-            return 0;
+            return Some(0);
         }
         let step = total_points.div_ceil(desired_index_len.max(1)).max(1);
 
-        let mut view = render_queue
-            .write_buffer_with(
-                index_buffer,
-                0,
-                NonZeroU64::new((INDEX_BUFFER_LEN * 4) as u64).unwrap(),
-            )
-            .expect("no write buf");
+        let mut view = render_queue.write_buffer_with(
+            index_buffer,
+            0,
+            NonZeroU64::new((INDEX_BUFFER_LEN * 4) as u64).unwrap(),
+        )?;
         let mut view = view.slice(..);
         let mut written_u32s: u32 = 0;
         let mut global_index = 0usize;
         for buf in &mut self.x_values {
             let gpu = buf.gpu.lock();
             let Some(gpu) = gpu.as_ref() else {
-                return 0;
+                return Some(0);
             };
             let chunk = gpu.as_index_chunk::<f32>(buf.cpu().len());
             for (i, index) in chunk.into_index_iter().enumerate() {
                 let absolute = global_index + i;
                 if absolute.is_multiple_of(step) || absolute + 1 == total_points {
                     let Some(v) = try_append_u32(view, index) else {
-                        return written_u32s;
+                        return Some(written_u32s);
                     };
                     view = v;
                     written_u32s += 1;
@@ -1267,7 +1309,7 @@ impl XYLine {
             global_index += buf.cpu().len();
         }
 
-        written_u32s
+        Some(written_u32s)
     }
 
     pub fn plot_bounds(&self) -> PlotBounds {
@@ -1359,6 +1401,10 @@ impl<T, const N: usize> SharedBuffer<T, N> {
     fn release_gpu(&self) {
         let _ = self.gpu.lock().take();
         self.gpu_dirty.store(true, atomic::Ordering::SeqCst);
+    }
+
+    fn gpu_resident(&self) -> bool {
+        self.gpu.lock().is_some()
     }
 
     #[cfg(test)]
@@ -1833,14 +1879,74 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
         if !self.has_samples() {
             return;
         }
+        let mut visible_shards = 0;
+        let mut missing_data_shards = 0;
+        let mut missing_timestamp_shards = 0;
+        for (_, chunk) in self.tree.overlapping(ii(range.start.0, range.end.0)) {
+            visible_shards += 1;
+            missing_data_shards += usize::from(!chunk.data.gpu_resident());
+            missing_timestamp_shards += usize::from(!chunk.timestamps_float.gpu_resident());
+        }
+        let value_class = value_shard_class(visible_shards);
+        let needs_resize = self.data_buffer_shard_alloc.as_ref().is_some_and(|alloc| {
+            alloc.capacity_shards() < value_class || alloc.free_shards() < missing_data_shards
+        }) || self
+            .timestamp_buffer_shard_alloc
+            .as_ref()
+            .is_some_and(|alloc| {
+                alloc.capacity_shards() < value_class
+                    || alloc.free_shards() < missing_timestamp_shards
+            });
+        if needs_resize {
+            for (_, chunk) in self.tree.overlapping_mut(ii(i64::MIN, i64::MAX)) {
+                chunk.data.release_gpu();
+                chunk.timestamps_float.release_gpu();
+            }
+            if let Some(alloc) = self.data_buffer_shard_alloc.take() {
+                pool.release_value(alloc);
+            }
+            if let Some(alloc) = self.timestamp_buffer_shard_alloc.take() {
+                pool.release_value(alloc);
+            }
+        }
         let data_buffer_alloc = self
             .data_buffer_shard_alloc
-            .get_or_insert_with(|| pool.take_value(render_device, render_queue));
+            .get_or_insert_with(|| pool.take_value(value_class, render_device, render_queue));
         let timestamp_buffer_alloc = self
             .timestamp_buffer_shard_alloc
-            .get_or_insert_with(|| pool.take_value(render_device, render_queue));
+            .get_or_insert_with(|| pool.take_value(value_class, render_device, render_queue));
         for (_, chunk) in self.tree.overlapping_mut(ii(range.start.0, range.end.0)) {
             chunk.queue_load(render_queue, data_buffer_alloc, timestamp_buffer_alloc);
+        }
+    }
+
+    pub fn required_value_shards(&self, range: Range<Timestamp>) -> usize {
+        self.range_iter(range).count().max(1)
+    }
+
+    pub fn value_buffers_needing_allocation(&self, range: Range<Timestamp>) -> usize {
+        let mut visible_shards = 0;
+        let mut missing_data_shards = 0;
+        let mut missing_timestamp_shards = 0;
+        for (_, chunk) in self.tree.overlapping(ii(range.start.0, range.end.0)) {
+            visible_shards += 1;
+            missing_data_shards += usize::from(!chunk.data.gpu_resident());
+            missing_timestamp_shards += usize::from(!chunk.timestamps_float.gpu_resident());
+        }
+        let class = value_shard_class(visible_shards);
+        let data_needed = self.data_buffer_shard_alloc.as_ref().is_none_or(|alloc| {
+            alloc.capacity_shards() < class || alloc.free_shards() < missing_data_shards
+        });
+        let timestamps_needed = self
+            .timestamp_buffer_shard_alloc
+            .as_ref()
+            .is_none_or(|alloc| {
+                alloc.capacity_shards() < class || alloc.free_shards() < missing_timestamp_shards
+            });
+        if data_needed || timestamps_needed {
+            2
+        } else {
+            0
         }
     }
 
@@ -1901,7 +2007,7 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
         render_queue: &RenderQueue,
         line_visible_range: Range<Timestamp>,
         pixel_width: usize,
-    ) -> u32 {
+    ) -> Option<u32> {
         // No selected-span context: treat as a long window (pixel-faithful on clip).
         self.write_to_index_buffer_with_sampling_range(
             index_buffer,
@@ -1919,7 +2025,7 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
         line_visible_range: Range<Timestamp>,
         selected_span_micros: i64,
         pixel_width: usize,
-    ) -> u32 {
+    ) -> Option<u32> {
         let (chunk_count, index_count) = self.range_index_stats(line_visible_range.clone());
         let step = index_sampling_step_for_selection(
             selected_span_micros,
@@ -1982,14 +2088,12 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
         render_queue: &RenderQueue,
         line_visible_range: Range<Timestamp>,
         step: usize,
-    ) -> u32 {
-        let mut view = render_queue
-            .write_buffer_with(
-                index_buffer,
-                0,
-                NonZeroU64::new((INDEX_BUFFER_LEN * 4) as u64).unwrap(),
-            )
-            .expect("no write buf");
+    ) -> Option<u32> {
+        let mut view = render_queue.write_buffer_with(
+            index_buffer,
+            0,
+            NonZeroU64::new((INDEX_BUFFER_LEN * 4) as u64).unwrap(),
+        )?;
         let mut view = view.slice(..);
         let mut written_u32s: u32 = 0;
         'chunks: for chunk in self.draw_index_chunk_iter(line_visible_range) {
@@ -2032,7 +2136,7 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
             view = v;
             written_u32s += 1;
         }
-        written_u32s
+        Some(written_u32s)
     }
 
     /// Visit `(chunk, offset)` for every sample in the visible strip that
@@ -2174,10 +2278,10 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
             chunk.timestamps_float.release_gpu();
         }
         if let Some(alloc) = self.data_buffer_shard_alloc.take() {
-            pool.release_value(alloc.into_buffer());
+            pool.release_value(alloc);
         }
         if let Some(alloc) = self.timestamp_buffer_shard_alloc.take() {
-            pool.release_value(alloc.into_buffer());
+            pool.release_value(alloc);
         }
     }
 
@@ -3563,6 +3667,19 @@ mod tests {
     }
 
     #[test]
+    fn value_shard_classes_choose_smallest_fit() {
+        assert_eq!(value_shard_class(1), 4);
+        assert_eq!(value_shard_class(4), 4);
+        assert_eq!(value_shard_class(5), 16);
+        assert_eq!(value_shard_class(17), 64);
+        assert_eq!(value_shard_class(257), CHUNK_COUNT);
+        assert_eq!(
+            value_buffer_bytes(4),
+            (5 * CHUNK_LEN * size_of::<f32>()) as u64
+        );
+    }
+
+    #[test]
     fn plot_gpu_snapshot_accounts_for_resident_and_pooled_buffers() {
         let snapshot = PlotGpuPoolSnapshot {
             value_live: 2,
@@ -3570,11 +3687,15 @@ mod tests {
             value_quarantined: 2,
             value_allocations: 8,
             value_destroyed: 3,
+            value_live_bytes: 2 * PLOT_VALUE_BUFFER_BYTES,
+            value_pooled_bytes: 3 * PLOT_VALUE_BUFFER_BYTES,
             index_live: 3,
             index_ready: 2,
             index_quarantined: 1,
             index_allocations: 10,
             index_destroyed: 4,
+            value_shards_used: 12,
+            value_shards_capacity: 48,
             ..Default::default()
         };
         assert_eq!(
@@ -3599,6 +3720,7 @@ mod tests {
                 + snapshot.index_quarantined as u64
                 + snapshot.index_destroyed
         );
+        assert_eq!(snapshot.shard_occupancy_percent(), Some(25.0));
     }
 
     #[test]
@@ -3659,6 +3781,7 @@ impl BoundOrd for f32 {
 /// switch must not be rewritten until those bind groups are gone.
 pub(crate) const PLOT_GPU_QUARANTINE_FRAMES: u8 = 3;
 pub(crate) const PLOT_GPU_POOL_IDLE_EVICT_FRAMES: u16 = 300;
+pub(crate) const PLOT_GPU_NEW_VALUE_BUFFERS_PER_FRAME: usize = 16;
 const PLOT_GPU_RECOVERY_PAUSE: Duration = Duration::from_secs(2);
 
 #[derive(Resource, Default)]
@@ -3765,8 +3888,20 @@ pub(crate) fn defer_new_plot_gpu_allocs(
     values_blocked || index_blocked
 }
 
-pub const PLOT_VALUE_BUFFER_BYTES: u64 = ((CHUNK_COUNT + 1) * CHUNK_LEN * size_of::<f32>()) as u64;
+pub const PLOT_VALUE_SHARD_CLASSES: [usize; 5] = [4, 16, 64, 256, CHUNK_COUNT];
+pub const PLOT_VALUE_BUFFER_BYTES: u64 = value_buffer_bytes(CHUNK_COUNT);
 pub const PLOT_INDEX_BUFFER_BYTES: u64 = (INDEX_BUFFER_LEN * size_of::<u32>()) as u64;
+
+pub const fn value_buffer_bytes(data_shards: usize) -> u64 {
+    ((data_shards + 1) * CHUNK_LEN * size_of::<f32>()) as u64
+}
+
+pub fn value_shard_class(required: usize) -> usize {
+    PLOT_VALUE_SHARD_CLASSES
+        .into_iter()
+        .find(|class| *class >= required.max(1))
+        .unwrap_or(CHUNK_COUNT)
+}
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct PlotGpuPoolSnapshot {
@@ -3776,36 +3911,53 @@ pub struct PlotGpuPoolSnapshot {
     pub value_allocations: u64,
     pub value_reuses: u64,
     pub value_destroyed: u64,
+    pub value_live_bytes: u64,
+    pub value_pooled_bytes: u64,
     pub index_live: usize,
     pub index_ready: usize,
     pub index_quarantined: usize,
     pub index_allocations: u64,
     pub index_reuses: u64,
     pub index_destroyed: u64,
+    pub value_shards_used: usize,
+    pub value_shards_capacity: usize,
 }
 
 impl PlotGpuPoolSnapshot {
     pub fn resident_bytes(self) -> u64 {
-        (self.value_live as u64)
-            .saturating_mul(PLOT_VALUE_BUFFER_BYTES)
+        self.value_live_bytes
             .saturating_add((self.index_live as u64).saturating_mul(PLOT_INDEX_BUFFER_BYTES))
     }
 
     pub fn pooled_bytes(self) -> u64 {
-        ((self.value_ready + self.value_quarantined) as u64)
-            .saturating_mul(PLOT_VALUE_BUFFER_BYTES)
-            .saturating_add(
-                ((self.index_ready + self.index_quarantined) as u64)
-                    .saturating_mul(PLOT_INDEX_BUFFER_BYTES),
-            )
+        self.value_pooled_bytes.saturating_add(
+            ((self.index_ready + self.index_quarantined) as u64)
+                .saturating_mul(PLOT_INDEX_BUFFER_BYTES),
+        )
+    }
+
+    pub fn shard_occupancy_percent(self) -> Option<f64> {
+        (self.value_shards_capacity > 0)
+            .then_some(self.value_shards_used as f64 / self.value_shards_capacity as f64 * 100.0)
     }
 }
 
 /// Recycles plot value/index buffers across tab switches so hidden-graph
 /// unload does not immediately allocate a second full set (GPU OOM).
+struct PooledValueBuffer {
+    buffer: Buffer,
+    data_capacity: usize,
+}
+
+impl PooledValueBuffer {
+    fn bytes(&self) -> u64 {
+        value_buffer_bytes(self.data_capacity)
+    }
+}
+
 #[derive(Resource, Default)]
 pub struct PlotGpuBufferPool {
-    value: QuarantinePool<Buffer>,
+    value: QuarantinePool<PooledValueBuffer>,
     index: QuarantinePool<Buffer>,
     value_live: usize,
     value_allocations: u64,
@@ -3815,6 +3967,9 @@ pub struct PlotGpuBufferPool {
     index_reuses: u64,
     value_destroyed: u64,
     index_destroyed: u64,
+    value_live_bytes: u64,
+    value_shards_used: usize,
+    value_shards_capacity: usize,
 }
 
 impl PlotGpuBufferPool {
@@ -3823,10 +3978,12 @@ impl PlotGpuBufferPool {
         self.index_destroyed += self.index.tick() as u64;
     }
 
-    pub fn release_value(&mut self, buffer: Buffer) {
+    pub fn release_value(&mut self, alloc: BufferShardAlloc) {
         debug_assert!(self.value_live > 0);
         self.value_live = self.value_live.saturating_sub(1);
-        self.value.release(buffer);
+        let pooled = alloc.into_pooled_value();
+        self.value_live_bytes = self.value_live_bytes.saturating_sub(pooled.bytes());
+        self.value.release(pooled);
     }
 
     pub fn release_index(&mut self, buffer: Buffer) {
@@ -3843,13 +4000,27 @@ impl PlotGpuBufferPool {
             value_allocations: self.value_allocations,
             value_reuses: self.value_reuses,
             value_destroyed: self.value_destroyed,
+            value_live_bytes: self.value_live_bytes,
+            value_pooled_bytes: self
+                .value
+                .items
+                .iter()
+                .map(|(buffer, _, _)| buffer.bytes())
+                .sum(),
             index_live: self.index_live,
             index_ready: self.index.ready_count(),
             index_quarantined: self.index.quarantined_count(),
             index_allocations: self.index_allocations,
             index_reuses: self.index_reuses,
             index_destroyed: self.index_destroyed,
+            value_shards_used: self.value_shards_used,
+            value_shards_capacity: self.value_shards_capacity,
         }
+    }
+
+    pub fn set_live_shard_occupancy(&mut self, used: usize, capacity: usize) {
+        self.value_shards_used = used;
+        self.value_shards_capacity = capacity;
     }
 
     pub fn trim_ready(&mut self) -> PlotGpuPoolTrim {
@@ -3872,30 +4043,77 @@ impl PlotGpuBufferPool {
         trim
     }
 
-    pub fn defer_new_allocs(&self, value_resident: bool, has_index_cache: bool) -> bool {
+    pub fn defer_new_allocs(
+        &self,
+        value_resident: bool,
+        has_index_cache: bool,
+        min_value_shards: usize,
+    ) -> bool {
+        let class = value_shard_class(min_value_shards);
         defer_new_plot_gpu_allocs(
             value_resident,
             has_index_cache,
-            self.value.ready_count(),
-            self.value.quarantined_count(),
+            self.value_count(class, true),
+            self.value_count(class, false),
             self.index.ready_count(),
             self.index.quarantined_count(),
         )
     }
 
+    pub fn new_value_allocations_needed(
+        &self,
+        buffers_needed: usize,
+        min_value_shards: usize,
+    ) -> usize {
+        buffers_needed.saturating_sub(self.value_count(value_shard_class(min_value_shards), true))
+    }
+
     pub fn take_value(
         &mut self,
+        min_shards: usize,
         render_device: &RenderDevice,
         render_queue: &RenderQueue,
     ) -> BufferShardAlloc {
+        let class = value_shard_class(min_shards);
         self.value_live += 1;
-        if let Some(buffer) = self.value.try_acquire() {
+        if let Some(pooled) = self.take_ready_value(class) {
             self.value_reuses += 1;
-            BufferShardAlloc::from_pooled_value(buffer, CHUNK_COUNT, CHUNK_LEN, render_queue)
+            self.value_live_bytes += pooled.bytes();
+            BufferShardAlloc::from_pooled_value(
+                pooled.buffer,
+                pooled.data_capacity,
+                CHUNK_LEN,
+                render_queue,
+            )
         } else {
             self.value_allocations += 1;
-            BufferShardAlloc::with_nan_chunk(CHUNK_COUNT, CHUNK_LEN, render_device, render_queue)
+            self.value_live_bytes += value_buffer_bytes(class);
+            BufferShardAlloc::with_nan_chunk(class, CHUNK_LEN, render_device, render_queue)
         }
+    }
+
+    fn value_count(&self, min_shards: usize, ready: bool) -> usize {
+        self.value
+            .items
+            .iter()
+            .filter(|(buffer, quarantine_frames, _)| {
+                buffer.data_capacity >= min_shards && (*quarantine_frames == 0) == ready
+            })
+            .count()
+    }
+
+    fn take_ready_value(&mut self, min_shards: usize) -> Option<PooledValueBuffer> {
+        let index = self
+            .value
+            .items
+            .iter()
+            .enumerate()
+            .filter(|(_, (buffer, quarantine_frames, _))| {
+                *quarantine_frames == 0 && buffer.data_capacity >= min_shards
+            })
+            .min_by_key(|(_, (buffer, _, _))| buffer.data_capacity)
+            .map(|(index, _)| index)?;
+        Some(self.value.items.swap_remove(index).0)
     }
 
     pub fn take_index(&mut self, render_device: &RenderDevice) -> Option<Buffer> {
@@ -3927,6 +4145,7 @@ pub struct PlotGpuPoolTrim {
 pub struct BufferShardAlloc {
     buffer: Buffer,
     chunk_size: usize,
+    data_capacity: usize,
     free_map: RoaringBitmap,
 }
 
@@ -3938,6 +4157,7 @@ impl BufferShardAlloc {
         render_queue: &RenderQueue,
     ) -> Self {
         let mut this = Self::new::<f32>(chunks + 1, chunk_len, render_device);
+        this.data_capacity = chunks;
         let shard = this.alloc().expect("couldn't alloc nan");
         render_queue.write_buffer_shard(&shard, &f32::NAN.to_le_bytes());
         this
@@ -3958,14 +4178,18 @@ impl BufferShardAlloc {
             buffer,
             free_map,
             chunk_size,
+            data_capacity: chunks,
         };
         let shard = this.alloc().expect("couldn't alloc nan");
         render_queue.write_buffer_shard(&shard, &f32::NAN.to_le_bytes());
         this
     }
 
-    fn into_buffer(self) -> Buffer {
-        self.buffer
+    fn into_pooled_value(self) -> PooledValueBuffer {
+        PooledValueBuffer {
+            buffer: self.buffer,
+            data_capacity: self.data_capacity,
+        }
     }
 
     pub fn new<T: Sized>(chunks: usize, chunk_len: usize, render_device: &RenderDevice) -> Self {
@@ -3984,6 +4208,7 @@ impl BufferShardAlloc {
             buffer,
             free_map,
             chunk_size,
+            data_capacity: chunks,
         }
     }
 
@@ -4001,6 +4226,23 @@ impl BufferShardAlloc {
 
     pub fn buffer(&self) -> &Buffer {
         &self.buffer
+    }
+
+    pub fn binding_size(&self) -> NonZeroU64 {
+        NonZeroU64::new(value_buffer_bytes(self.data_capacity)).unwrap()
+    }
+
+    pub fn capacity_shards(&self) -> usize {
+        self.data_capacity
+    }
+
+    pub fn free_shards(&self) -> usize {
+        self.free_map.len() as usize
+    }
+
+    pub fn used_shards(&self) -> usize {
+        self.data_capacity
+            .saturating_sub(self.free_map.len() as usize)
     }
 
     pub fn dealloc(&mut self, shard: BufferShard) {

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -1925,24 +1925,7 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
         if !self.has_samples() {
             return;
         }
-        let mut visible_shards = 0;
-        let mut missing_data_shards = 0;
-        let mut missing_timestamp_shards = 0;
-        for (_, chunk) in self.tree.overlapping(ii(range.start.0, range.end.0)) {
-            visible_shards += 1;
-            missing_data_shards += usize::from(!chunk.data.gpu_resident());
-            missing_timestamp_shards += usize::from(!chunk.timestamps_float.gpu_resident());
-        }
-        let value_class = value_shard_class(visible_shards);
-        let needs_resize = self.data_buffer_shard_alloc.as_ref().is_some_and(|alloc| {
-            alloc.capacity_shards() < value_class || alloc.free_shards() < missing_data_shards
-        }) || self
-            .timestamp_buffer_shard_alloc
-            .as_ref()
-            .is_some_and(|alloc| {
-                alloc.capacity_shards() < value_class
-                    || alloc.free_shards() < missing_timestamp_shards
-            });
+        let (value_class, needs_resize) = self.value_buffer_plan(&range);
         if needs_resize {
             for (_, chunk) in self.tree.overlapping_mut(ii(i64::MIN, i64::MAX)) {
                 chunk.data.release_gpu();
@@ -1976,7 +1959,9 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
         self.range_iter(range).count().max(1)
     }
 
-    pub fn value_buffers_needing_allocation(&self, range: Range<Timestamp>) -> usize {
+    /// The shard class `range` needs, and whether the current buffers have to be
+    /// rebuilt to host it.
+    fn value_buffer_plan(&self, range: &Range<Timestamp>) -> (usize, bool) {
         let mut visible_shards = 0;
         let mut missing_data_shards = 0;
         let mut missing_timestamp_shards = 0;
@@ -1986,20 +1971,33 @@ impl<D: Clone + BoundOrd + Immutable + IntoBytes + Debug> LineTree<D> {
             missing_timestamp_shards += usize::from(!chunk.timestamps_float.gpu_resident());
         }
         let class = value_shard_class(visible_shards);
-        let data_needed = self.data_buffer_shard_alloc.as_ref().is_none_or(|alloc| {
-            alloc.capacity_shards() < class || alloc.free_shards() < missing_data_shards
-        });
-        let timestamps_needed = self
-            .timestamp_buffer_shard_alloc
+        let outgrown = |alloc: &BufferShardAlloc, missing: usize| {
+            alloc.capacity_shards() < class || alloc.free_shards() < missing
+        };
+        let needs_resize = self
+            .data_buffer_shard_alloc
             .as_ref()
-            .is_none_or(|alloc| {
-                alloc.capacity_shards() < class || alloc.free_shards() < missing_timestamp_shards
-            });
-        if data_needed || timestamps_needed {
-            2
-        } else {
-            0
-        }
+            .is_some_and(|alloc| outgrown(alloc, missing_data_shards))
+            || self
+                .timestamp_buffer_shard_alloc
+                .as_ref()
+                .is_some_and(|alloc| outgrown(alloc, missing_timestamp_shards));
+        (class, needs_resize)
+    }
+
+    pub fn value_buffers_needing_allocation(&self, range: Range<Timestamp>) -> usize {
+        let (class, needs_resize) = self.value_buffer_plan(&range);
+        let capacity =
+            |slot: &Option<BufferShardAlloc>| slot.as_ref().map(BufferShardAlloc::capacity_shards);
+        usize::from(takes_from_pool(
+            capacity(&self.data_buffer_shard_alloc),
+            class,
+            needs_resize,
+        )) + usize::from(takes_from_pool(
+            capacity(&self.timestamp_buffer_shard_alloc),
+            class,
+            needs_resize,
+        ))
     }
 
     pub fn draw_index_count(&self, range: Range<Timestamp>) -> (usize, usize) {
@@ -3673,6 +3671,30 @@ mod tests {
     }
 
     #[test]
+    fn shard_exhaustion_at_the_same_class_needs_no_pool_buffer() {
+        assert!(
+            takes_from_pool(None, 16, false),
+            "a line without a buffer must take one"
+        );
+        assert!(
+            !takes_from_pool(Some(16), 16, true),
+            "exhausted shards at the same class are reclaimed in place"
+        );
+        assert!(
+            takes_from_pool(Some(4), 16, true),
+            "outgrowing the class needs a bigger buffer from the pool"
+        );
+        assert!(
+            takes_from_pool(Some(64), 16, true),
+            "shrinking the class returns the oversized buffer to the pool"
+        );
+        assert!(
+            !takes_from_pool(Some(64), 16, false),
+            "an oversized buffer with free shards is left alone"
+        );
+    }
+
+    #[test]
     fn new_plot_gpu_upload_is_blocked_only_while_value_buffers_are_quarantined() {
         assert!(!plot_gpu_upload_blocked(0, 0, 2));
         assert!(plot_gpu_upload_blocked(0, 4, 2));
@@ -3969,6 +3991,16 @@ pub fn value_shard_class(required: usize) -> usize {
         .into_iter()
         .find(|class| *class >= required.max(1))
         .unwrap_or(CHUNK_COUNT)
+}
+
+/// Whether `queue_load_range` will draw this slot's buffer from the pool. An
+/// empty slot always does; a resized one only when its class changes, since
+/// `reclaim_or_release` resets an unchanged class in place.
+fn takes_from_pool(capacity_shards: Option<usize>, value_class: usize, needs_resize: bool) -> bool {
+    match capacity_shards {
+        None => true,
+        Some(capacity) => needs_resize && capacity != value_class,
+    }
 }
 
 /// Hand a value buffer whose shards were all just released back to its owner or

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -1161,7 +1161,7 @@ impl XYLine {
     }
 
     pub fn has_samples(&self) -> bool {
-        self.x_values.iter().any(|c| c.cpu().len() > 0)
+        self.x_values.iter().any(|c| !c.cpu().is_empty())
     }
 
     pub fn queue_load(
@@ -3524,6 +3524,23 @@ mod tests {
         assert!(!plot_gpu_upload_blocked(2, 4, 2));
         assert!(!plot_gpu_upload_blocked(2, 0, 2));
     }
+
+    #[test]
+    fn resident_line_defers_when_index_pool_is_quarantined() {
+        assert!(
+            defer_new_plot_gpu_allocs(true, false, 0, 0, 0, 4),
+            "shared/resident values still need a recycled index buffer"
+        );
+        assert!(
+            !defer_new_plot_gpu_allocs(true, true, 0, 0, 0, 4),
+            "cached index must keep drawing while the pool cools down"
+        );
+        assert!(
+            !defer_new_plot_gpu_allocs(false, false, 0, 0, 0, 0),
+            "empty pools are a first load, not a tab-switch leak"
+        );
+        assert!(defer_new_plot_gpu_allocs(false, false, 0, 4, 0, 0));
+    }
 }
 
 fn try_append_u32(view: wgpu::WriteOnly<'_, [u8]>, val: u32) -> Option<wgpu::WriteOnly<'_, [u8]>> {
@@ -3605,6 +3622,21 @@ pub(crate) fn plot_gpu_upload_blocked(ready: usize, quarantined: usize, need: us
     ready < need && quarantined > 0
 }
 
+pub(crate) fn defer_new_plot_gpu_allocs(
+    value_resident: bool,
+    has_index_cache: bool,
+    value_ready: usize,
+    value_quarantined: usize,
+    index_ready: usize,
+    index_quarantined: usize,
+) -> bool {
+    let values_blocked =
+        !value_resident && plot_gpu_upload_blocked(value_ready, value_quarantined, 2);
+    let index_blocked =
+        !has_index_cache && plot_gpu_upload_blocked(index_ready, index_quarantined, 1);
+    values_blocked || index_blocked
+}
+
 /// Recycles plot value/index buffers across tab switches so hidden-graph
 /// unload does not immediately allocate a second full set (GPU OOM).
 #[derive(Resource, Default)]
@@ -3627,13 +3659,15 @@ impl PlotGpuBufferPool {
         self.index.release(buffer);
     }
 
-    pub fn ready_value_count(&self) -> usize {
-        self.value.ready_count()
-    }
-
-    pub fn defer_new_value_upload(&self, already_resident: bool) -> bool {
-        !already_resident
-            && plot_gpu_upload_blocked(self.ready_value_count(), self.value.quarantined_count(), 2)
+    pub fn defer_new_allocs(&self, value_resident: bool, has_index_cache: bool) -> bool {
+        defer_new_plot_gpu_allocs(
+            value_resident,
+            has_index_cache,
+            self.value.ready_count(),
+            self.value.quarantined_count(),
+            self.index.ready_count(),
+            self.index.quarantined_count(),
+        )
     }
 
     pub fn take_value(
@@ -3648,17 +3682,19 @@ impl PlotGpuBufferPool {
         }
     }
 
-    pub fn take_index(&mut self, render_device: &RenderDevice) -> Buffer {
+    pub fn take_index(&mut self, render_device: &RenderDevice) -> Option<Buffer> {
         if let Some(buffer) = self.index.try_acquire() {
-            buffer
-        } else {
-            render_device.create_buffer(&BufferDescriptor {
-                label: Some("Line index Buffer"),
-                size: (INDEX_BUFFER_LEN * size_of::<u32>()) as u64,
-                usage: BufferUsages::STORAGE | BufferUsages::COPY_DST,
-                mapped_at_creation: false,
-            })
+            return Some(buffer);
         }
+        if self.index.quarantined_count() > 0 {
+            return None;
+        }
+        Some(render_device.create_buffer(&BufferDescriptor {
+            label: Some("Line index Buffer"),
+            size: (INDEX_BUFFER_LEN * size_of::<u32>()) as u64,
+            usage: BufferUsages::STORAGE | BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        }))
     }
 }
 

--- a/libs/elodin-editor/src/ui/plot/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot/gpu.rs
@@ -1013,6 +1013,11 @@ fn extract_lines(
                 let y_size = Some(y_alloc.binding_size());
                 let y_buffer = y_alloc.buffer().clone();
                 let value_buffer_ids = (x_buffer.id(), y_buffer.id());
+                // The bind group must be rebuilt when the value buffers move, but the
+                // index buffer does not reference them and is rewritten below. Carry it
+                // over instead of releasing it: quarantining it here would make
+                // `take_index` refuse a replacement for the whole quarantine window.
+                let mut salvaged_index = None;
                 if let Some(ref mut cache) = cache
                     && cache
                         .0
@@ -1020,7 +1025,7 @@ fn extract_lines(
                         .is_some_and(|gpu| gpu.value_buffer_ids != value_buffer_ids)
                     && let Some(stale) = cache.0.take()
                 {
-                    plot_gpu_pool.release_index(stale.index_buffer);
+                    salvaged_index = Some(stale.index_buffer);
                 }
                 // Reuse the cached buffers/bind group unless the value buffers were
                 // reallocated (new `BufferShardAlloc`).
@@ -1034,7 +1039,9 @@ fn extract_lines(
                         gpu_line.values_bind_group.clone(),
                     )
                 } else {
-                    let Some(index_buffer) = plot_gpu_pool.take_index(&render_device) else {
+                    let Some(index_buffer) =
+                        salvaged_index.or_else(|| plot_gpu_pool.take_index(&render_device))
+                    else {
                         continue;
                     };
                     let values_bind_group = render_device.create_bind_group(

--- a/libs/elodin-editor/src/ui/plot/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot/gpu.rs
@@ -53,7 +53,7 @@ use std::ops::Range;
 use crate::ui::ViewportRect;
 use crate::ui::plot::{CHUNK_COUNT, CHUNK_LEN, Line, XYLine};
 
-use super::BufferShardAlloc;
+use super::{BufferShardAlloc, PlotGpuBufferPool};
 use crate::ui::widgets::SystemStateExt;
 
 const LINE_SHADER_HANDLE: Handle<Shader> = uuid_handle!("e44f3b60-cb86-42a2-b7d8-d8dbf1f0299a");
@@ -78,6 +78,7 @@ impl Plugin for PlotGpuPlugin {
     fn build(&self, app: &mut bevy::prelude::App) {
         app.add_plugins(UniformComponentPlugin::<LineUniform>::default())
             .init_resource::<ExtractLinesState>()
+            .init_resource::<PlotGpuBufferPool>()
             .init_asset::<Line>()
             .init_asset::<XYLine>();
 
@@ -167,15 +168,37 @@ impl LineMut<'_> {
         range: Range<Timestamp>,
         render_queue: &RenderQueue,
         render_device: &RenderDevice,
+        pool: &mut PlotGpuBufferPool,
     ) {
         match self {
             LineMut::Timeseries(line) => {
                 line.data
-                    .queue_load_range(range, render_queue, render_device)
+                    .queue_load_range(range, render_queue, render_device, pool)
             }
             LineMut::XY(xy_line) => {
-                xy_line.queue_load(render_queue, render_device);
+                xy_line.queue_load(render_queue, render_device, pool);
             }
+        }
+    }
+
+    pub fn gpu_resident(&self) -> bool {
+        match self {
+            LineMut::Timeseries(line) => line.data.gpu_resident(),
+            LineMut::XY(xy_line) => xy_line.gpu_resident(),
+        }
+    }
+
+    pub fn has_samples(&self) -> bool {
+        match self {
+            LineMut::Timeseries(line) => line.data.has_samples(),
+            LineMut::XY(xy_line) => xy_line.has_samples(),
+        }
+    }
+
+    pub fn unload_gpu(&mut self, pool: &mut PlotGpuBufferPool) {
+        match self {
+            LineMut::Timeseries(line) => line.data.unload_gpu(pool),
+            LineMut::XY(xy_line) => xy_line.unload_gpu(pool),
         }
     }
 
@@ -572,6 +595,7 @@ type ExtractLinesParams = (
     ResMut<'static, Assets<Line>>,
     ResMut<'static, Assets<XYLine>>,
     Res<'static, crate::SelectedTimeRange>,
+    ResMut<'static, PlotGpuBufferPool>,
     Commands<'static, 'static>,
 );
 
@@ -630,6 +654,7 @@ pub(crate) fn unload_plot_gpu_not_on_screen(
     xy_assets: &mut Assets<XYLine>,
     visible_ts: &HashSet<AssetId<Line>>,
     visible_xy: &HashSet<AssetId<XYLine>>,
+    pool: &mut PlotGpuBufferPool,
 ) {
     let ts_unload: Vec<AssetId<Line>> = line_assets
         .iter()
@@ -643,7 +668,7 @@ pub(crate) fn unload_plot_gpu_not_on_screen(
         .collect();
     for id in ts_unload {
         if let Some(mut line) = line_assets.get_mut(id) {
-            line.data.unload_gpu();
+            line.data.unload_gpu(pool);
         }
     }
 
@@ -659,7 +684,7 @@ pub(crate) fn unload_plot_gpu_not_on_screen(
         .collect();
     for id in xy_unload {
         if let Some(mut xy_line) = xy_assets.get_mut(id) {
-            xy_line.unload_gpu();
+            xy_line.unload_gpu(pool);
         }
     }
 }
@@ -679,17 +704,23 @@ fn extract_lines(
                 mut line_assets,
                 mut xy_lines,
                 selected_range,
+                mut plot_gpu_pool,
                 mut main_commands,
             ) = cached_state.state.params_mut(world);
             let selected = selected_range.0.clone();
             let selected_span_micros = selected.end.0.saturating_sub(selected.start.0);
             let short_window = crate::is_short_accuracy_window(&selected);
 
+            plot_gpu_pool.tick();
+
             let mut on_screen_entries = Vec::new();
             for (entity, line_handle, child_of, _, _, _, _, _, mut cache) in lines.iter_mut() {
                 let on_screen = line_gpu_pane_on_screen(child_of, &viewport_rects);
-                if !on_screen && let Some(ref mut cache) = cache {
-                    cache.0 = None;
+                if !on_screen
+                    && let Some(ref mut cache) = cache
+                    && let Some(gpu) = cache.0.take()
+                {
+                    plot_gpu_pool.release_index(gpu.index_buffer);
                 }
                 on_screen_entries.push((entity, line_handle.clone(), on_screen));
             }
@@ -703,6 +734,7 @@ fn extract_lines(
                 &mut xy_lines,
                 &visible_ts,
                 &visible_xy,
+                &mut plot_gpu_pool,
             );
 
             for (
@@ -723,6 +755,20 @@ fn extract_lines(
                 let Some(mut line) = line_handle.get(&mut line_assets, &mut xy_lines) else {
                     continue;
                 };
+                if !line.has_samples() {
+                    if line.gpu_resident() {
+                        line.unload_gpu(&mut plot_gpu_pool);
+                    }
+                    if let Some(ref mut cache) = cache
+                        && let Some(gpu) = cache.0.take()
+                    {
+                        plot_gpu_pool.release_index(gpu.index_buffer);
+                    }
+                    continue;
+                }
+                if plot_gpu_pool.defer_new_value_upload(line.gpu_resident()) {
+                    continue;
+                }
                 // Camera / clip: continuous visible range for short windows (silky scrub);
                 // long windows keep 100 ms quantum to limit index rewrite churn.
                 let visible = line_visible_range.0.clone();
@@ -735,17 +781,18 @@ fn extract_lines(
                     )
                 };
                 // Short windows: step = 1 on clip (truth). Long windows: pixel stride on clip.
-                line.queue_load_range(clip_range.clone(), &render_queue, &render_device);
-                let x_buffer = line
-                    .x_buffer_shard_alloc()
-                    .expect("no x buf")
-                    .buffer()
-                    .clone();
-                let y_buffer = line
-                    .y_buffer_shard_alloc()
-                    .expect("no y buf")
-                    .buffer()
-                    .clone();
+                line.queue_load_range(
+                    clip_range.clone(),
+                    &render_queue,
+                    &render_device,
+                    &mut plot_gpu_pool,
+                );
+                let Some(x_buffer) = line.x_buffer_shard_alloc().map(|a| a.buffer().clone()) else {
+                    continue;
+                };
+                let Some(y_buffer) = line.y_buffer_shard_alloc().map(|a| a.buffer().clone()) else {
+                    continue;
+                };
                 let value_buffer_ids = (x_buffer.id(), y_buffer.id());
                 // Reuse the cached buffers/bind group unless the value buffers were
                 // reallocated (new `BufferShardAlloc`).
@@ -759,14 +806,7 @@ fn extract_lines(
                         gpu_line.values_bind_group.clone(),
                     )
                 } else {
-                    let index_buffer = render_device.create_buffer(
-                        &(BufferDescriptor {
-                            label: Some("Line index Buffer"),
-                            size: (INDEX_BUFFER_LEN * size_of::<u32>()) as u64,
-                            usage: BufferUsages::STORAGE | BufferUsages::COPY_DST,
-                            mapped_at_creation: false,
-                        }),
-                    );
+                    let index_buffer = plot_gpu_pool.take_index(&render_device);
                     let size = Some(VALUE_BUFFER_SIZE);
                     let values_bind_group = render_device.create_bind_group(
                         "line values",

--- a/libs/elodin-editor/src/ui/plot/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot/gpu.rs
@@ -7,8 +7,10 @@ use bevy::core_pipeline::core_2d::CORE_2D_DEPTH_FORMAT;
 use bevy::ecs::bundle::Bundle;
 use bevy::ecs::entity::Entity;
 use bevy::ecs::hierarchy::ChildOf;
+use bevy::ecs::lifecycle::HookContext;
 use bevy::ecs::schedule::{IntoScheduleConfigs, SystemSet};
-use bevy::ecs::system::{Commands, Query, Res, ResMut, SystemState};
+use bevy::ecs::system::{Command, Commands, Query, Res, ResMut, SystemState};
+use bevy::ecs::world::DeferredWorld;
 use bevy::log::warn_once;
 use bevy::math::{FloatOrd, Vec4};
 use bevy::prelude::Deref;
@@ -33,7 +35,7 @@ use bevy::{
         component::Component,
         system::lifetimeless::{Read, SRes},
     },
-    prelude::{Color, Resource},
+    prelude::{Color, Mut, Resource, World},
     render::{
         RenderApp,
         extract_component::UniformComponentPlugin,
@@ -59,7 +61,10 @@ use crate::ui::plot::{CHUNK_COUNT, Line, XYLine};
 use super::data::{
     PLOT_GPU_NEW_VALUE_BUFFERS_PER_FRAME, PLOT_VALUE_SHARD_CLASSES, value_buffer_bytes,
 };
-use super::{BufferShardAlloc, PlotGpuAllocationPause, PlotGpuBufferPool, PlotGpuPoolTrim};
+use super::{
+    BufferShardAlloc, CollectedGraphData, PlotGpuAllocationPause, PlotGpuBufferPool,
+    PlotGpuPoolTrim, PlotLineKey, PlotLineUsers,
+};
 use crate::ui::widgets::SystemStateExt;
 
 const LINE_SHADER_HANDLE: Handle<Shader> = uuid_handle!("e44f3b60-cb86-42a2-b7d8-d8dbf1f0299a");
@@ -87,6 +92,7 @@ impl Plugin for PlotGpuPlugin {
             .init_resource::<ExtractLinesState>()
             .init_resource::<PlotGpuAllocationPause>()
             .init_resource::<PlotGpuBufferPool>()
+            .init_resource::<PlotLineUsers>()
             .init_asset::<Line>()
             .init_asset::<XYLine>();
 
@@ -160,9 +166,84 @@ impl Plugin for PlotGpuPlugin {
 
 #[derive(Component, Debug, Clone, ExtractComponent)]
 #[require(SyncToRenderWorld)]
+#[component(on_add = on_line_handle_add, on_remove = on_line_handle_remove)]
 pub enum LineHandle {
     Timeseries(Handle<Line>),
     XY(Handle<XYLine>),
+}
+
+impl LineHandle {
+    fn plot_line_key(&self) -> PlotLineKey {
+        match self {
+            Self::Timeseries(handle) => PlotLineKey::Timeseries(handle.id()),
+            Self::XY(handle) => PlotLineKey::XY(handle.id()),
+        }
+    }
+}
+
+fn on_line_handle_add(mut world: DeferredWorld, ctx: HookContext) {
+    let Some(handle) = world.get::<LineHandle>(ctx.entity) else {
+        return;
+    };
+    let key = handle.plot_line_key();
+    if let Some(mut users) = world.get_resource_mut::<PlotLineUsers>() {
+        users.retain(key);
+    }
+}
+
+fn on_line_handle_remove(mut world: DeferredWorld, ctx: HookContext) {
+    if let Some(mut cache) = world.get_mut::<GpuLineCache>(ctx.entity)
+        && let Some(index_buffer) = cache.take_index_buffer()
+        && let Some(mut pool) = world.get_resource_mut::<PlotGpuBufferPool>()
+    {
+        pool.release_index(index_buffer);
+    }
+    let Some(handle) = world.get::<LineHandle>(ctx.entity) else {
+        return;
+    };
+    let key = handle.plot_line_key();
+    let remaining = world
+        .get_resource_mut::<PlotLineUsers>()
+        .map(|mut users| users.release(key))
+        .unwrap_or(0);
+    if remaining == 0 {
+        world.commands().queue(ReleaseUnusedPlotLine(key));
+    }
+}
+
+struct ReleaseUnusedPlotLine(PlotLineKey);
+
+impl Command for ReleaseUnusedPlotLine {
+    type Out = ();
+
+    fn apply(self, world: &mut World) {
+        release_unused_plot_line(world, self.0);
+    }
+}
+
+fn release_unused_plot_line(world: &mut World, key: PlotLineKey) {
+    if world.get_resource::<PlotGpuBufferPool>().is_none() {
+        world.init_resource::<PlotGpuBufferPool>();
+    }
+    world.resource_scope(|world, mut pool: Mut<PlotGpuBufferPool>| match key {
+        PlotLineKey::Timeseries(id) => {
+            if let Some(mut lines) = world.get_resource_mut::<Assets<Line>>()
+                && let Some(mut line) = lines.get_mut(id)
+            {
+                line.data.unload_gpu(&mut pool);
+            }
+            if let Some(mut collected) = world.get_resource_mut::<CollectedGraphData>() {
+                collected.remove_line_handle(id);
+            }
+        }
+        PlotLineKey::XY(id) => {
+            if let Some(mut xy_lines) = world.get_resource_mut::<Assets<XYLine>>()
+                && let Some(mut xy) = xy_lines.get_mut(id)
+            {
+                xy.unload_gpu(&mut pool);
+            }
+        }
+    });
 }
 
 pub enum LineMut<'a> {
@@ -539,6 +620,12 @@ pub struct GpuLine {
 /// dominates frame time on graph-heavy schematics.
 #[derive(Component, Default)]
 pub struct GpuLineCache(Option<GpuLine>);
+
+impl GpuLineCache {
+    fn take_index_buffer(&mut self) -> Option<Buffer> {
+        self.0.take().map(|gpu| gpu.index_buffer)
+    }
+}
 
 pub struct SetLineBindGroup;
 

--- a/libs/elodin-editor/src/ui/plot/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot/gpu.rs
@@ -53,7 +53,7 @@ use std::ops::Range;
 use crate::ui::ViewportRect;
 use crate::ui::plot::{CHUNK_COUNT, CHUNK_LEN, Line, XYLine};
 
-use super::{BufferShardAlloc, PlotGpuBufferPool};
+use super::{BufferShardAlloc, PlotGpuAllocationPause, PlotGpuBufferPool, PlotGpuPoolTrim};
 use crate::ui::widgets::SystemStateExt;
 
 const LINE_SHADER_HANDLE: Handle<Shader> = uuid_handle!("e44f3b60-cb86-42a2-b7d8-d8dbf1f0299a");
@@ -78,6 +78,7 @@ impl Plugin for PlotGpuPlugin {
     fn build(&self, app: &mut bevy::prelude::App) {
         app.add_plugins(UniformComponentPlugin::<LineUniform>::default())
             .init_resource::<ExtractLinesState>()
+            .init_resource::<PlotGpuAllocationPause>()
             .init_resource::<PlotGpuBufferPool>()
             .init_asset::<Line>()
             .init_asset::<XYLine>();
@@ -689,6 +690,42 @@ pub(crate) fn unload_plot_gpu_not_on_screen(
     }
 }
 
+pub(crate) fn evict_all_plot_gpu(
+    main_world: &mut bevy::prelude::World,
+    render_world: &mut bevy::prelude::World,
+) -> PlotGpuPoolTrim {
+    let trim =
+        main_world.resource_scope(|world, mut pool: bevy::prelude::Mut<PlotGpuBufferPool>| {
+            if let Some(mut lines) = world.get_resource_mut::<Assets<Line>>() {
+                for (_, line) in lines.iter_mut() {
+                    line.data.unload_gpu(&mut pool);
+                }
+            }
+            if let Some(mut xy_lines) = world.get_resource_mut::<Assets<XYLine>>() {
+                for (_, line) in xy_lines.iter_mut() {
+                    line.unload_gpu(&mut pool);
+                }
+            }
+            let mut caches = world.query::<&mut GpuLineCache>();
+            for mut cache in caches.iter_mut(world) {
+                if let Some(gpu) = cache.0.take() {
+                    pool.release_index(gpu.index_buffer);
+                }
+            }
+            pool.drain()
+        });
+    if let Some(mut pause) = main_world.get_resource_mut::<PlotGpuAllocationPause>() {
+        pause.pause_for_recovery();
+    }
+
+    let mut gpu_lines = render_world.query_filtered::<Entity, bevy::prelude::With<GpuLine>>();
+    let entities: Vec<_> = gpu_lines.iter(render_world).collect();
+    for entity in entities {
+        render_world.despawn(entity);
+    }
+    trim
+}
+
 fn extract_lines(
     mut main_world: ResMut<MainWorld>,
     mut commands: Commands,
@@ -698,6 +735,12 @@ fn extract_lines(
 ) {
     main_world.resource_scope(
         |world, mut cached_state: bevy::prelude::Mut<ExtractLinesState>| {
+            if world
+                .get_resource_mut::<PlotGpuAllocationPause>()
+                .is_some_and(|mut pause| pause.is_active())
+            {
+                return;
+            }
             let (
                 mut lines,
                 viewport_rects,

--- a/libs/elodin-editor/src/ui/plot/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot/gpu.rs
@@ -983,7 +983,7 @@ fn extract_lines(
                 let value_buffers_needed =
                     line.value_buffers_needing_allocation(clip_range.clone());
                 if plot_gpu_pool.defer_new_allocs(
-                    value_buffers_needed == 0,
+                    value_buffers_needed,
                     has_index_cache,
                     required_value_shards,
                 ) {

--- a/libs/elodin-editor/src/ui/plot/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot/gpu.rs
@@ -766,7 +766,8 @@ fn extract_lines(
                     }
                     continue;
                 }
-                if plot_gpu_pool.defer_new_value_upload(line.gpu_resident()) {
+                let has_index_cache = cache.as_ref().is_some_and(|c| c.0.is_some());
+                if plot_gpu_pool.defer_new_allocs(line.gpu_resident(), has_index_cache) {
                     continue;
                 }
                 // Camera / clip: continuous visible range for short windows (silky scrub);
@@ -806,7 +807,9 @@ fn extract_lines(
                         gpu_line.values_bind_group.clone(),
                     )
                 } else {
-                    let index_buffer = plot_gpu_pool.take_index(&render_device);
+                    let Some(index_buffer) = plot_gpu_pool.take_index(&render_device) else {
+                        continue;
+                    };
                     let size = Some(VALUE_BUFFER_SIZE);
                     let values_bind_group = render_device.create_bind_group(
                         "line values",

--- a/libs/elodin-editor/src/ui/plot/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot/gpu.rs
@@ -9,7 +9,7 @@ use bevy::ecs::entity::Entity;
 use bevy::ecs::hierarchy::ChildOf;
 use bevy::ecs::lifecycle::HookContext;
 use bevy::ecs::schedule::{IntoScheduleConfigs, SystemSet};
-use bevy::ecs::system::{Command, Commands, Query, Res, ResMut, SystemState};
+use bevy::ecs::system::{Commands, Query, Res, ResMut, SystemState};
 use bevy::ecs::world::DeferredWorld;
 use bevy::log::warn_once;
 use bevy::math::{FloatOrd, Vec4};
@@ -28,7 +28,7 @@ use bevy::render::{ExtractSchedule, MainWorld, Render, RenderStartup, RenderSyst
 use bevy::shader::Shader;
 use bevy::sprite_render::{Mesh2dPipeline, SetMesh2dViewBindGroup, init_mesh_2d_pipeline};
 use bevy::{
-    app::Plugin,
+    app::{Last, Plugin},
     asset::load_internal_asset,
     core_pipeline::core_2d::Transparent2d,
     ecs::{
@@ -93,8 +93,10 @@ impl Plugin for PlotGpuPlugin {
             .init_resource::<PlotGpuAllocationPause>()
             .init_resource::<PlotGpuBufferPool>()
             .init_resource::<PlotLineUsers>()
+            .init_resource::<PendingUnusedPlotLines>()
             .init_asset::<Line>()
-            .init_asset::<XYLine>();
+            .init_asset::<XYLine>()
+            .add_systems(Last, apply_pending_unused_plot_lines);
 
         load_internal_asset!(app, LINE_SHADER_HANDLE, "./line.wgsl", Shader::from_wgsl);
         load_internal_asset!(app, POINT_SHADER_HANDLE, "./points.wgsl", Shader::from_wgsl);
@@ -189,6 +191,9 @@ fn on_line_handle_add(mut world: DeferredWorld, ctx: HookContext) {
     if let Some(mut users) = world.get_resource_mut::<PlotLineUsers>() {
         users.retain(key);
     }
+    if let Some(mut pending) = world.get_resource_mut::<PendingUnusedPlotLines>() {
+        pending.cancel(key);
+    }
 }
 
 fn on_line_handle_remove(mut world: DeferredWorld, ctx: HookContext) {
@@ -206,22 +211,50 @@ fn on_line_handle_remove(mut world: DeferredWorld, ctx: HookContext) {
         .get_resource_mut::<PlotLineUsers>()
         .map(|mut users| users.release(key))
         .unwrap_or(0);
-    if remaining == 0 {
-        world.commands().queue(ReleaseUnusedPlotLine(key));
+    if remaining == 0
+        && let Some(mut pending) = world.get_resource_mut::<PendingUnusedPlotLines>()
+    {
+        pending.insert(key);
     }
 }
 
-struct ReleaseUnusedPlotLine(PlotLineKey);
+#[derive(Resource, Default)]
+pub(crate) struct PendingUnusedPlotLines {
+    keys: HashSet<PlotLineKey>,
+}
 
-impl Command for ReleaseUnusedPlotLine {
-    type Out = ();
+impl PendingUnusedPlotLines {
+    fn insert(&mut self, key: PlotLineKey) {
+        self.keys.insert(key);
+    }
 
-    fn apply(self, world: &mut World) {
-        release_unused_plot_line(world, self.0);
+    fn cancel(&mut self, key: PlotLineKey) {
+        self.keys.remove(&key);
+    }
+
+    fn drain(&mut self) -> Vec<PlotLineKey> {
+        self.keys.drain().collect()
+    }
+}
+
+/// After the current command flush, so a same-batch retain can cancel first.
+pub(crate) fn apply_pending_unused_plot_lines(world: &mut World) {
+    let keys = world
+        .get_resource_mut::<PendingUnusedPlotLines>()
+        .map(|mut pending| pending.drain())
+        .unwrap_or_default();
+    for key in keys {
+        release_unused_plot_line(world, key);
     }
 }
 
 fn release_unused_plot_line(world: &mut World, key: PlotLineKey) {
+    if world
+        .get_resource::<PlotLineUsers>()
+        .is_some_and(|users| users.is_used(key))
+    {
+        return;
+    }
     if world.get_resource::<PlotGpuBufferPool>().is_none() {
         world.init_resource::<PlotGpuBufferPool>();
     }
@@ -1179,5 +1212,112 @@ fn queue_line(
                 indexed: true,
             });
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        LineHandle, PendingUnusedPlotLines, apply_pending_unused_plot_lines,
+        release_unused_plot_line,
+    };
+    use crate::ui::plot::{
+        CollectedGraphData, Line, PlotDataComponent, PlotGpuBufferPool, PlotLineKey, PlotLineUsers,
+    };
+    use bevy::asset::Assets;
+    use bevy::ecs::system::SystemState;
+    use bevy::prelude::{Commands, World};
+    use impeller2::types::ComponentId;
+
+    fn plot_world() -> World {
+        let mut world = World::new();
+        world.init_resource::<PlotLineUsers>();
+        world.init_resource::<PendingUnusedPlotLines>();
+        world.init_resource::<CollectedGraphData>();
+        world.init_resource::<PlotGpuBufferPool>();
+        world.insert_resource(Assets::<Line>::default());
+        world
+    }
+
+    fn insert_collected_line(world: &mut World, handle: bevy::asset::Handle<Line>) -> ComponentId {
+        let component_id = ComponentId::new("rocket.mach");
+        let mut collected = world.resource_mut::<CollectedGraphData>();
+        let mut component = PlotDataComponent::new("rocket.mach", vec!["x".into()]);
+        component.lines.insert(0, handle);
+        collected.components.insert(component_id, component);
+        component_id
+    }
+
+    #[test]
+    fn release_is_noop_while_line_still_has_users() {
+        let mut world = plot_world();
+        let handle = world.resource_mut::<Assets<Line>>().add(Line::default());
+        let component_id = insert_collected_line(&mut world, handle.clone());
+        world.spawn(LineHandle::Timeseries(handle.clone()));
+        let key = PlotLineKey::Timeseries(handle.id());
+
+        release_unused_plot_line(&mut world, key);
+
+        assert!(
+            world
+                .resource::<CollectedGraphData>()
+                .get_line(&component_id, 0)
+                .is_some(),
+            "in-use line must not be removed from collected data"
+        );
+        assert_eq!(world.resource::<PlotLineUsers>().count(key), 1);
+    }
+
+    #[test]
+    fn deferred_release_skips_line_reacquired_before_apply() {
+        let mut world = plot_world();
+        let handle = world.resource_mut::<Assets<Line>>().add(Line::default());
+        let component_id = insert_collected_line(&mut world, handle.clone());
+        let entity = world.spawn(LineHandle::Timeseries(handle.clone())).id();
+        let key = PlotLineKey::Timeseries(handle.id());
+        assert_eq!(world.resource::<PlotLineUsers>().count(key), 1);
+
+        // Same command batch: last user drops, then a new handle retains the key.
+        // A hook-queued Command would flush after despawn and unload the live line.
+        let mut system_state: SystemState<Commands> = SystemState::new(&mut world);
+        {
+            let mut commands = system_state.get_mut(&mut world).expect("commands");
+            commands.entity(entity).despawn();
+            commands.spawn(LineHandle::Timeseries(handle));
+        }
+        system_state.apply(&mut world);
+        world.flush();
+        apply_pending_unused_plot_lines(&mut world);
+
+        assert!(
+            world
+                .resource::<CollectedGraphData>()
+                .get_line(&component_id, 0)
+                .is_some(),
+            "reacquired line must stay collected after deferred release"
+        );
+        assert_eq!(world.resource::<PlotLineUsers>().count(key), 1);
+        assert_eq!(world.query::<&LineHandle>().iter(&world).count(), 1);
+    }
+
+    #[test]
+    fn deferred_release_drops_line_that_stays_unused() {
+        let mut world = plot_world();
+        let handle = world.resource_mut::<Assets<Line>>().add(Line::default());
+        let component_id = insert_collected_line(&mut world, handle.clone());
+        let entity = world.spawn(LineHandle::Timeseries(handle.clone())).id();
+        let key = PlotLineKey::Timeseries(handle.id());
+
+        world.despawn(entity);
+        apply_pending_unused_plot_lines(&mut world);
+
+        assert!(
+            world
+                .resource::<CollectedGraphData>()
+                .get_line(&component_id, 0)
+                .is_none(),
+            "unused line must still be dropped"
+        );
+        assert_eq!(world.resource::<PlotLineUsers>().count(key), 0);
     }
 }

--- a/libs/elodin-editor/src/ui/plot/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot/gpu.rs
@@ -9,6 +9,7 @@ use bevy::ecs::entity::Entity;
 use bevy::ecs::hierarchy::ChildOf;
 use bevy::ecs::schedule::{IntoScheduleConfigs, SystemSet};
 use bevy::ecs::system::{Commands, Query, Res, ResMut, SystemState};
+use bevy::log::warn_once;
 use bevy::math::{FloatOrd, Vec4};
 use bevy::prelude::Deref;
 use bevy::render::extract_component::{ComponentUniforms, DynamicUniformIndex};
@@ -50,9 +51,14 @@ use std::collections::HashSet;
 use std::num::NonZeroU64;
 use std::ops::Range;
 
+#[cfg(not(target_family = "wasm"))]
+use crate::plugins::hw_stats::HardwareStats;
 use crate::ui::ViewportRect;
-use crate::ui::plot::{CHUNK_COUNT, CHUNK_LEN, Line, XYLine};
+use crate::ui::plot::{CHUNK_COUNT, Line, XYLine};
 
+use super::data::{
+    PLOT_GPU_NEW_VALUE_BUFFERS_PER_FRAME, PLOT_VALUE_SHARD_CLASSES, value_buffer_bytes,
+};
 use super::{BufferShardAlloc, PlotGpuAllocationPause, PlotGpuBufferPool, PlotGpuPoolTrim};
 use crate::ui::widgets::SystemStateExt;
 
@@ -60,8 +66,9 @@ const LINE_SHADER_HANDLE: Handle<Shader> = uuid_handle!("e44f3b60-cb86-42a2-b7d8
 const POINT_SHADER_HANDLE: Handle<Shader> = uuid_handle!("4f1aa57d-aacd-4d17-859f-0dad0ee3890f");
 const BAR_SHADER_HANDLE: Handle<Shader> = uuid_handle!("091989F7-D5B1-4C6C-B9C1-EDD5EE51F1B1");
 
-pub const VALUE_BUFFER_SIZE: NonZeroU64 =
-    NonZeroU64::new((CHUNK_COUNT * CHUNK_LEN * size_of::<f32>()) as u64).unwrap();
+pub const VALUE_BUFFER_SIZE: NonZeroU64 = NonZeroU64::new(value_buffer_bytes(CHUNK_COUNT)).unwrap();
+pub const MIN_VALUE_BUFFER_SIZE: NonZeroU64 =
+    NonZeroU64::new(value_buffer_bytes(PLOT_VALUE_SHARD_CLASSES[0])).unwrap();
 /// Sized for ≤30 s @ ~4 kHz truth strips (plus per-chunk sentinel overhead).
 pub const INDEX_BUFFER_LEN: usize = 1024 * 128;
 pub const INDEX_BUFFER_SIZE: NonZeroU64 =
@@ -130,8 +137,8 @@ impl Plugin for PlotGpuPlugin {
         let layout_entries = BindGroupLayoutEntries::sequential(
             ShaderStages::VERTEX,
             (
-                storage_buffer_read_only_sized(false, Some(VALUE_BUFFER_SIZE)),
-                storage_buffer_read_only_sized(false, Some(VALUE_BUFFER_SIZE)),
+                storage_buffer_read_only_sized(false, Some(MIN_VALUE_BUFFER_SIZE)),
+                storage_buffer_read_only_sized(false, Some(MIN_VALUE_BUFFER_SIZE)),
                 storage_buffer_read_only_sized(false, Some(INDEX_BUFFER_SIZE)),
             ),
         );
@@ -189,6 +196,20 @@ impl LineMut<'_> {
         }
     }
 
+    pub fn value_buffers_needing_allocation(&self, range: Range<Timestamp>) -> usize {
+        match self {
+            LineMut::Timeseries(line) => line.data.value_buffers_needing_allocation(range),
+            LineMut::XY(line) => line.value_buffers_needing_allocation(),
+        }
+    }
+
+    pub fn required_value_shards(&self, range: Range<Timestamp>) -> usize {
+        match self {
+            LineMut::Timeseries(line) => line.data.required_value_shards(range),
+            LineMut::XY(line) => line.required_value_shards(),
+        }
+    }
+
     pub fn has_samples(&self) -> bool {
         match self {
             LineMut::Timeseries(line) => line.data.has_samples(),
@@ -209,7 +230,7 @@ impl LineMut<'_> {
         render_queue: &RenderQueue,
         line_visible_range: Range<Timestamp>,
         pixel_width: usize,
-    ) -> u32 {
+    ) -> Option<u32> {
         self.write_to_index_buffer_sampled(
             index_buffer,
             render_queue,
@@ -226,7 +247,7 @@ impl LineMut<'_> {
         line_visible_range: Range<Timestamp>,
         selected_span_micros: i64,
         pixel_width: usize,
-    ) -> u32 {
+    ) -> Option<u32> {
         match self {
             LineMut::Timeseries(line) => line.data.write_to_index_buffer_with_sampling_range(
                 index_buffer,
@@ -712,6 +733,7 @@ pub(crate) fn evict_all_plot_gpu(
                     pool.release_index(gpu.index_buffer);
                 }
             }
+            pool.set_live_shard_occupancy(0, 0);
             pool.drain()
         });
     if let Some(mut pause) = main_world.get_resource_mut::<PlotGpuAllocationPause>() {
@@ -741,6 +763,22 @@ fn extract_lines(
             {
                 return;
             }
+            #[cfg(not(target_family = "wasm"))]
+            let gpu_pressure_high = world
+                .get_resource::<HardwareStats>()
+                .and_then(|stats| stats.device_memory)
+                .is_some_and(|memory| {
+                    memory.total_bytes > 0
+                        && memory.used_bytes.saturating_mul(100)
+                            >= memory.total_bytes.saturating_mul(92)
+                });
+            #[cfg(target_family = "wasm")]
+            let gpu_pressure_high = false;
+            let mut new_value_budget = if gpu_pressure_high {
+                0
+            } else {
+                PLOT_GPU_NEW_VALUE_BUFFERS_PER_FRAME
+            };
             let (
                 mut lines,
                 viewport_rects,
@@ -810,9 +848,6 @@ fn extract_lines(
                     continue;
                 }
                 let has_index_cache = cache.as_ref().is_some_and(|c| c.0.is_some());
-                if plot_gpu_pool.defer_new_allocs(line.gpu_resident(), has_index_cache) {
-                    continue;
-                }
                 // Camera / clip: continuous visible range for short windows (silky scrub);
                 // long windows keep 100 ms quantum to limit index rewrite churn.
                 let visible = line_visible_range.0.clone();
@@ -824,6 +859,22 @@ fn extract_lines(
                         crate::TRAILING_RANGE_QUANTUM_MICROS,
                     )
                 };
+                let required_value_shards = line.required_value_shards(clip_range.clone());
+                let value_buffers_needed =
+                    line.value_buffers_needing_allocation(clip_range.clone());
+                if plot_gpu_pool.defer_new_allocs(
+                    value_buffers_needed == 0,
+                    has_index_cache,
+                    required_value_shards,
+                ) {
+                    continue;
+                }
+                let new_values = plot_gpu_pool
+                    .new_value_allocations_needed(value_buffers_needed, required_value_shards);
+                if new_values > new_value_budget {
+                    continue;
+                }
+                new_value_budget -= new_values;
                 // Short windows: step = 1 on clip (truth). Long windows: pixel stride on clip.
                 line.queue_load_range(
                     clip_range.clone(),
@@ -831,13 +882,26 @@ fn extract_lines(
                     &render_device,
                     &mut plot_gpu_pool,
                 );
-                let Some(x_buffer) = line.x_buffer_shard_alloc().map(|a| a.buffer().clone()) else {
+                let Some(x_alloc) = line.x_buffer_shard_alloc() else {
                     continue;
                 };
-                let Some(y_buffer) = line.y_buffer_shard_alloc().map(|a| a.buffer().clone()) else {
+                let x_size = Some(x_alloc.binding_size());
+                let x_buffer = x_alloc.buffer().clone();
+                let Some(y_alloc) = line.y_buffer_shard_alloc() else {
                     continue;
                 };
+                let y_size = Some(y_alloc.binding_size());
+                let y_buffer = y_alloc.buffer().clone();
                 let value_buffer_ids = (x_buffer.id(), y_buffer.id());
+                if let Some(ref mut cache) = cache
+                    && cache
+                        .0
+                        .as_ref()
+                        .is_some_and(|gpu| gpu.value_buffer_ids != value_buffer_ids)
+                    && let Some(stale) = cache.0.take()
+                {
+                    plot_gpu_pool.release_index(stale.index_buffer);
+                }
                 // Reuse the cached buffers/bind group unless the value buffers were
                 // reallocated (new `BufferShardAlloc`).
                 let cached = cache
@@ -853,7 +917,6 @@ fn extract_lines(
                     let Some(index_buffer) = plot_gpu_pool.take_index(&render_device) else {
                         continue;
                     };
-                    let size = Some(VALUE_BUFFER_SIZE);
                     let values_bind_group = render_device.create_bind_group(
                         "line values",
                         &values_layout.layout,
@@ -863,7 +926,7 @@ fn extract_lines(
                                 resource: BindingResource::Buffer(BufferBinding {
                                     buffer: &x_buffer,
                                     offset: 0,
-                                    size,
+                                    size: x_size,
                                 }),
                             },
                             BindGroupEntry {
@@ -871,7 +934,7 @@ fn extract_lines(
                                 resource: BindingResource::Buffer(BufferBinding {
                                     buffer: &y_buffer,
                                     offset: 0,
-                                    size,
+                                    size: y_size,
                                 }),
                             },
                             BindGroupEntry {
@@ -906,7 +969,7 @@ fn extract_lines(
                         range_key.3,
                         content_gen,
                     )) {
-                    cached.map(|g| g.count).unwrap_or(0)
+                    Some(cached.map(|g| g.count).unwrap_or(0))
                 } else {
                     line.write_to_index_buffer_sampled(
                         &index_buffer,
@@ -915,6 +978,13 @@ fn extract_lines(
                         selected_span_micros,
                         width.0,
                     )
+                };
+                let Some(count) = count else {
+                    if cached.is_none() {
+                        plot_gpu_pool.release_index(index_buffer);
+                    }
+                    warn_once!("Plot index upload failed; waiting for renderer recovery");
+                    continue;
                 };
                 let gpu_line = GpuLine {
                     values_bind_group,
@@ -948,6 +1018,30 @@ fn extract_lines(
                     TemporaryRenderEntity,
                 ));
             }
+            let mut shards_used = 0;
+            let mut shards_capacity = 0;
+            for (_, line) in line_assets.iter() {
+                for alloc in [
+                    line.data.data_buffer_shard_alloc(),
+                    line.data.timestamp_buffer_shard_alloc(),
+                ]
+                .into_iter()
+                .flatten()
+                {
+                    shards_used += alloc.used_shards();
+                    shards_capacity += alloc.capacity_shards();
+                }
+            }
+            for (_, line) in xy_lines.iter() {
+                for alloc in [line.x_shard_alloc.as_ref(), line.y_shard_alloc.as_ref()]
+                    .into_iter()
+                    .flatten()
+                {
+                    shards_used += alloc.used_shards();
+                    shards_capacity += alloc.capacity_shards();
+                }
+            }
+            plot_gpu_pool.set_live_shard_occupancy(shards_used, shards_capacity);
             cached_state.state.apply(world);
         },
     );

--- a/libs/elodin-editor/src/ui/plot/mod.rs
+++ b/libs/elodin-editor/src/ui/plot/mod.rs
@@ -7,9 +7,9 @@ pub use hamann_chen_line::{
 
 pub use data::{
     BufferShardAlloc, CHUNK_COUNT, CHUNK_LEN, CollectedGraphData, CurveCompressSettings, Line,
-    OVERVIEW_MAX_POINTS, PlotDataComponent, PlotGpuBufferPool, PlotSyncState, XYLine,
-    maybe_compress_all_graph_lines, queue_timestamp_read, setup_pkt_handler,
-    update_series_fetch_priority,
+    OVERVIEW_MAX_POINTS, PlotDataComponent, PlotGpuAllocationPause, PlotGpuBufferPool,
+    PlotGpuPoolTrim, PlotSyncState, XYLine, maybe_compress_all_graph_lines, queue_timestamp_read,
+    setup_pkt_handler, update_series_fetch_priority,
 };
 
 pub mod gpu;

--- a/libs/elodin-editor/src/ui/plot/mod.rs
+++ b/libs/elodin-editor/src/ui/plot/mod.rs
@@ -8,8 +8,9 @@ pub use hamann_chen_line::{
 pub use data::{
     BufferShardAlloc, CHUNK_COUNT, CHUNK_LEN, CollectedGraphData, CurveCompressSettings, Line,
     OVERVIEW_MAX_POINTS, PlotDataComponent, PlotGpuAllocationPause, PlotGpuBufferPool,
-    PlotGpuPoolTrim, PlotSyncState, XYLine, maybe_compress_all_graph_lines, queue_timestamp_read,
-    setup_pkt_handler, update_series_fetch_priority,
+    PlotGpuPoolTrim, PlotLineKey, PlotLineUsers, PlotSyncState, XYLine,
+    maybe_compress_all_graph_lines, queue_timestamp_read, setup_pkt_handler,
+    update_series_fetch_priority,
 };
 
 pub mod gpu;
@@ -39,6 +40,7 @@ pub struct PlotPlugin;
 impl Plugin for PlotPlugin {
     fn build(&self, app: &mut bevy::prelude::App) {
         app.init_resource::<CollectedGraphData>()
+            .init_resource::<PlotLineUsers>()
             .init_resource::<CurveCompressSettings>()
             .init_resource::<LockTracker>()
             .init_resource::<XSyncClock>()

--- a/libs/elodin-editor/src/ui/plot/mod.rs
+++ b/libs/elodin-editor/src/ui/plot/mod.rs
@@ -7,8 +7,9 @@ pub use hamann_chen_line::{
 
 pub use data::{
     BufferShardAlloc, CHUNK_COUNT, CHUNK_LEN, CollectedGraphData, CurveCompressSettings, Line,
-    OVERVIEW_MAX_POINTS, PlotDataComponent, PlotSyncState, XYLine, maybe_compress_all_graph_lines,
-    queue_timestamp_read, setup_pkt_handler, update_series_fetch_priority,
+    OVERVIEW_MAX_POINTS, PlotDataComponent, PlotGpuBufferPool, PlotSyncState, XYLine,
+    maybe_compress_all_graph_lines, queue_timestamp_read, setup_pkt_handler,
+    update_series_fetch_priority,
 };
 
 pub mod gpu;

--- a/libs/elodin-editor/src/ui/plot/state.rs
+++ b/libs/elodin-editor/src/ui/plot/state.rs
@@ -16,6 +16,8 @@ use super::gpu::LineVisibleRange;
 use crate::MainCamera;
 use crate::plugins::render_layer_alloc::{RenderLayerAllocator, RenderLayerLease};
 use crate::ui::{ViewportRect, colors};
+use bevy::ecs::lifecycle::HookContext;
+use bevy::ecs::world::DeferredWorld;
 
 pub type GraphStateComponent = Vec<(bool, egui::Color32)>;
 pub type GraphStateEntity = BTreeMap<ComponentId, GraphStateComponent>;
@@ -34,6 +36,7 @@ pub struct GraphBundle {
 }
 
 #[derive(Clone, Debug, Component)]
+#[component(on_remove = on_graph_state_remove)]
 pub struct GraphState {
     pub components: BTreeMap<ComponentPath, GraphStateComponent>,
     pub enabled_lines: BTreeMap<(ComponentPath, usize), (Entity, Color32)>,
@@ -58,6 +61,24 @@ pub struct GraphState {
     // peer-ready metadata (not used until widget.rs switches to peers)
     pub x_rev: u64,
     pub x_dirty: bool,
+}
+
+fn on_graph_state_remove(mut world: DeferredWorld, ctx: HookContext) {
+    let lines: Vec<Entity> = world
+        .get::<GraphState>(ctx.entity)
+        .map(|state| {
+            state
+                .enabled_lines
+                .values()
+                .map(|(entity, _)| *entity)
+                .collect()
+        })
+        .unwrap_or_default();
+    for entity in lines {
+        if world.get_entity(entity).is_ok() {
+            world.commands().entity(entity).despawn();
+        }
+    }
 }
 
 impl GraphBundle {

--- a/libs/elodin-editor/src/ui/status_bar.rs
+++ b/libs/elodin-editor/src/ui/status_bar.rs
@@ -175,10 +175,11 @@ impl RootWidgetSystem for StatusBar<'_, '_> {
                             .color(pressure_color(gpu_pressure)),
                     ))
                     .on_hover_text(format!(
-                        "App GPU allocations\nBuffers: {:.2} GiB\nTextures: {:.2} GiB\nAllocations: {}\n\nPlot buffers\nResident: {:.2} GiB ({} value, {} index)\nPooled: {:.2} GiB\nReady: {} value, {} index\nQuarantined: {} value, {} index\nCumulative: {} value alloc / {} reuse, {} index alloc / {} reuse",
+                        "App GPU allocations\nBuffers: {:.2} GiB ({} objects)\nTextures: {:.2} GiB ({} objects)\n\nPlot buffers\nResident: {:.2} GiB ({} value, {} index)\nPooled: {:.2} GiB\nReady: {} value, {} index\nQuarantined: {} value, {} index\nCumulative: {} value alloc / {} reuse / {} destroyed, {} index alloc / {} reuse / {} destroyed",
                         bytes_to_gib(hardware_stats.app_buffer_bytes),
+                        format_object_count(hardware_stats.app_buffer_count),
                         bytes_to_gib(hardware_stats.app_texture_bytes),
-                        hardware_stats.app_memory_allocations,
+                        format_object_count(hardware_stats.app_texture_count),
                         bytes_to_gib(pool.resident_bytes()),
                         pool.value_live,
                         pool.index_live,
@@ -189,8 +190,10 @@ impl RootWidgetSystem for StatusBar<'_, '_> {
                         pool.index_quarantined,
                         pool.value_allocations,
                         pool.value_reuses,
+                        pool.value_destroyed,
                         pool.index_allocations,
                         pool.index_reuses,
+                        pool.index_destroyed,
                     ));
 
                     super::skybox_status::draw_skybox_status_bar(ui, skybox_ui, skybox_cache);
@@ -334,6 +337,12 @@ fn bytes_to_gib(bytes: u64) -> f64 {
 fn format_percent(value: Option<f64>) -> String {
     value
         .map(|percent| format!("{percent:.0}%"))
+        .unwrap_or_else(|| "N/A".to_string())
+}
+
+fn format_object_count(value: Option<u64>) -> String {
+    value
+        .map(|count| count.to_string())
         .unwrap_or_else(|| "N/A".to_string())
 }
 

--- a/libs/elodin-editor/src/ui/status_bar.rs
+++ b/libs/elodin-editor/src/ui/status_bar.rs
@@ -1,5 +1,7 @@
 use bevy::{
-    diagnostic::{DiagnosticsStore, FrameTimeDiagnosticsPlugin},
+    diagnostic::{
+        DiagnosticsStore, FrameTimeDiagnosticsPlugin, SystemInformationDiagnosticsPlugin,
+    },
     ecs::{
         query::With,
         system::{Query, Res, SystemParam, SystemState},
@@ -14,9 +16,15 @@ use impeller2_wkt::SimulationTimeStep;
 use std::time::{Duration, Instant};
 
 use crate::ui::{
-    colors::get_scheme,
     input_owner::{PointerOwnerPriority, UiBlocker},
     register_window_input_blocker,
+};
+use crate::{
+    plugins::hw_stats::HardwareStats,
+    ui::{
+        colors::{PUMPKIN_DEFAULT, get_scheme},
+        plot::PlotGpuBufferPool,
+    },
 };
 
 use super::RootWidgetSystem;
@@ -30,6 +38,8 @@ pub struct StatusBar<'w, 's> {
     primary_window: Query<'w, 's, Entity, With<PrimaryWindow>>,
     skybox_ui: Res<'w, SkyboxGenerationUi>,
     skybox_cache: Res<'w, SkyboxCacheHealth>,
+    hardware_stats: Res<'w, HardwareStats>,
+    plot_gpu_pool: Res<'w, PlotGpuBufferPool>,
 }
 
 impl RootWidgetSystem for StatusBar<'_, '_> {
@@ -51,6 +61,8 @@ impl RootWidgetSystem for StatusBar<'_, '_> {
         let diagnostics = state_mut.diagnostics;
         let skybox_ui = &state_mut.skybox_ui;
         let skybox_cache = &state_mut.skybox_cache;
+        let hardware_stats = &state_mut.hardware_stats;
+        let plot_gpu_pool = &state_mut.plot_gpu_pool;
 
         let panel = super::utils::show_panel(
             egui::Panel::bottom("status_bar").frame(egui::Frame {
@@ -98,10 +110,87 @@ impl RootWidgetSystem for StatusBar<'_, '_> {
                     let ram_str = process_resident_memory_gb()
                         .map(|gb| format!("{gb:.1}"))
                         .unwrap_or_else(|| "N/A".to_string());
+                    let system_memory_percent = diagnostics
+                        .get(&SystemInformationDiagnosticsPlugin::SYSTEM_MEM_USAGE)
+                        .and_then(|diagnostic| diagnostic.smoothed());
                     ui.add(egui::Label::new(
                         egui::RichText::new(format!("RAM Usage: {ram_str} GB"))
                             .text_style(egui::TextStyle::Small)
+                            .color(pressure_color(system_memory_percent)),
+                    ))
+                    .on_hover_text(format!(
+                        "Editor resident memory: {ram_str} GiB\nSystem memory used: {}",
+                        format_percent(system_memory_percent)
+                    ));
+
+                    let process_cpu = diagnostics
+                        .get(&SystemInformationDiagnosticsPlugin::PROCESS_CPU_USAGE)
+                        .and_then(|diagnostic| diagnostic.smoothed());
+                    let system_cpu = diagnostics
+                        .get(&SystemInformationDiagnosticsPlugin::SYSTEM_CPU_USAGE)
+                        .and_then(|diagnostic| diagnostic.smoothed());
+                    ui.add(egui::Label::new(
+                        egui::RichText::new(format!("CPU {}", format_percent(process_cpu)))
+                            .text_style(egui::TextStyle::Small)
                             .color(get_scheme().text_secondary),
+                    ))
+                    .on_hover_text(format!(
+                        "Editor CPU: {}\nSystem CPU: {}",
+                        format_percent(process_cpu),
+                        format_percent(system_cpu)
+                    ));
+
+                    let pool = plot_gpu_pool.snapshot();
+                    let plot_gib = bytes_to_gib(pool.resident_bytes());
+                    let (gpu_label, gpu_pressure) =
+                        if let Some(memory) = hardware_stats.device_memory {
+                            let pressure = if memory.total_bytes > 0 {
+                                Some(memory.used_bytes as f64 / memory.total_bytes as f64 * 100.0)
+                            } else {
+                                None
+                            };
+                            (
+                                format!(
+                                    "GPU {:.1}/{:.1} GB · {} · PLOT {plot_gib:.1} GB",
+                                    bytes_to_gib(memory.used_bytes),
+                                    bytes_to_gib(memory.total_bytes),
+                                    format_percent(
+                                        hardware_stats.gpu_utilization_percent.map(f64::from)
+                                    )
+                                ),
+                                pressure,
+                            )
+                        } else {
+                            (
+                                format!(
+                                    "GPU app {:.1} GB · PLOT {plot_gib:.1} GB",
+                                    bytes_to_gib(hardware_stats.app_gpu_bytes()),
+                                ),
+                                None,
+                            )
+                        };
+                    ui.add(egui::Label::new(
+                        egui::RichText::new(gpu_label)
+                            .text_style(egui::TextStyle::Small)
+                            .color(pressure_color(gpu_pressure)),
+                    ))
+                    .on_hover_text(format!(
+                        "App GPU allocations\nBuffers: {:.2} GiB\nTextures: {:.2} GiB\nAllocations: {}\n\nPlot buffers\nResident: {:.2} GiB ({} value, {} index)\nPooled: {:.2} GiB\nReady: {} value, {} index\nQuarantined: {} value, {} index\nCumulative: {} value alloc / {} reuse, {} index alloc / {} reuse",
+                        bytes_to_gib(hardware_stats.app_buffer_bytes),
+                        bytes_to_gib(hardware_stats.app_texture_bytes),
+                        hardware_stats.app_memory_allocations,
+                        bytes_to_gib(pool.resident_bytes()),
+                        pool.value_live,
+                        pool.index_live,
+                        bytes_to_gib(pool.pooled_bytes()),
+                        pool.value_ready,
+                        pool.index_ready,
+                        pool.value_quarantined,
+                        pool.index_quarantined,
+                        pool.value_allocations,
+                        pool.value_reuses,
+                        pool.index_allocations,
+                        pool.index_reuses,
                     ));
 
                     super::skybox_status::draw_skybox_status_bar(ui, skybox_ui, skybox_cache);
@@ -236,6 +325,24 @@ fn process_resident_memory_bytes() -> Option<u64> {
 #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
 fn process_resident_memory_bytes() -> Option<u64> {
     None
+}
+
+fn bytes_to_gib(bytes: u64) -> f64 {
+    bytes as f64 / (1024.0 * 1024.0 * 1024.0)
+}
+
+fn format_percent(value: Option<f64>) -> String {
+    value
+        .map(|percent| format!("{percent:.0}%"))
+        .unwrap_or_else(|| "N/A".to_string())
+}
+
+fn pressure_color(percent: Option<f64>) -> egui::Color32 {
+    match percent {
+        Some(percent) if percent >= 90.0 => get_scheme().error,
+        Some(percent) if percent >= 80.0 => PUMPKIN_DEFAULT,
+        _ => get_scheme().text_secondary,
+    }
 }
 
 fn editor_status_label_ui(ui: &mut egui::Ui, status: ConnectionStatus) -> egui::Response {

--- a/libs/elodin-editor/src/ui/status_bar.rs
+++ b/libs/elodin-editor/src/ui/status_bar.rs
@@ -141,7 +141,12 @@ impl RootWidgetSystem for StatusBar<'_, '_> {
                     ));
 
                     let pool = plot_gpu_pool.snapshot();
-                    let plot_gib = bytes_to_gib(pool.resident_bytes());
+                    let plot_label = match pool.shard_occupancy_percent() {
+                        Some(percent) => {
+                            format!("{} · {percent:.0}% shards", format_plot_bytes(pool.resident_bytes()))
+                        }
+                        None => format_plot_bytes(pool.resident_bytes()),
+                    };
                     let (gpu_label, gpu_pressure) =
                         if let Some(memory) = hardware_stats.device_memory {
                             let pressure = if memory.total_bytes > 0 {
@@ -151,7 +156,7 @@ impl RootWidgetSystem for StatusBar<'_, '_> {
                             };
                             (
                                 format!(
-                                    "GPU {:.1}/{:.1} GB · {} · PLOT {plot_gib:.1} GB",
+                                    "GPU {:.1}/{:.1} GB · {} · {plot_label}",
                                     bytes_to_gib(memory.used_bytes),
                                     bytes_to_gib(memory.total_bytes),
                                     format_percent(
@@ -163,7 +168,7 @@ impl RootWidgetSystem for StatusBar<'_, '_> {
                         } else {
                             (
                                 format!(
-                                    "GPU app {:.1} GB · PLOT {plot_gib:.1} GB",
+                                    "GPU app {:.1} GB · {plot_label}",
                                     bytes_to_gib(hardware_stats.app_gpu_bytes()),
                                 ),
                                 None,
@@ -175,7 +180,7 @@ impl RootWidgetSystem for StatusBar<'_, '_> {
                             .color(pressure_color(gpu_pressure)),
                     ))
                     .on_hover_text(format!(
-                        "App GPU allocations\nBuffers: {:.2} GiB ({} objects)\nTextures: {:.2} GiB ({} objects)\n\nPlot buffers\nResident: {:.2} GiB ({} value, {} index)\nPooled: {:.2} GiB\nReady: {} value, {} index\nQuarantined: {} value, {} index\nCumulative: {} value alloc / {} reuse / {} destroyed, {} index alloc / {} reuse / {} destroyed",
+                        "App GPU allocations\nBuffers: {:.2} GiB ({} objects)\nTextures: {:.2} GiB ({} objects)\n\nPlot buffers\nResident: {:.2} GiB ({} value, {} index)\nPooled: {:.2} GiB\nShard occupancy: {} / {} ({})\nReady: {} value, {} index\nQuarantined: {} value, {} index\nCumulative: {} value alloc / {} reuse / {} destroyed, {} index alloc / {} reuse / {} destroyed",
                         bytes_to_gib(hardware_stats.app_buffer_bytes),
                         format_object_count(hardware_stats.app_buffer_count),
                         bytes_to_gib(hardware_stats.app_texture_bytes),
@@ -184,6 +189,9 @@ impl RootWidgetSystem for StatusBar<'_, '_> {
                         pool.value_live,
                         pool.index_live,
                         bytes_to_gib(pool.pooled_bytes()),
+                        pool.value_shards_used,
+                        pool.value_shards_capacity,
+                        format_percent(pool.shard_occupancy_percent()),
                         pool.value_ready,
                         pool.index_ready,
                         pool.value_quarantined,
@@ -332,6 +340,14 @@ fn process_resident_memory_bytes() -> Option<u64> {
 
 fn bytes_to_gib(bytes: u64) -> f64 {
     bytes as f64 / (1024.0 * 1024.0 * 1024.0)
+}
+
+fn format_plot_bytes(bytes: u64) -> String {
+    if bytes < 1024 * 1024 * 1024 {
+        format!("PLOT {:.0} MB", bytes as f64 / (1024.0 * 1024.0))
+    } else {
+        format!("PLOT {:.1} GB", bytes_to_gib(bytes))
+    }
 }
 
 fn format_percent(value: Option<f64>) -> String {

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -3960,6 +3960,7 @@ mod close_tests {
     use crate::ui::plot::{
         CollectedGraphData, GraphBundle, GraphState, Line, LineHandle, PlotDataComponent,
         PlotGpuBufferPool, PlotLineKey, PlotLineUsers,
+        gpu::{PendingUnusedPlotLines, apply_pending_unused_plot_lines},
     };
     use bevy::asset::Assets;
     use bevy::ecs::hierarchy::ChildOf;
@@ -3973,6 +3974,7 @@ mod close_tests {
     fn plot_world() -> World {
         let mut world = World::new();
         world.init_resource::<PlotLineUsers>();
+        world.init_resource::<PendingUnusedPlotLines>();
         world.init_resource::<CollectedGraphData>();
         world.init_resource::<PlotGpuBufferPool>();
         world.insert_resource(Assets::<Line>::default());
@@ -4026,6 +4028,7 @@ mod close_tests {
         tile_state.tree.remove_recursively(tile_id);
         system_state.apply(world);
         world.flush();
+        apply_pending_unused_plot_lines(world);
     }
 
     #[test]

--- a/libs/elodin-editor/src/ui/tiles.rs
+++ b/libs/elodin-editor/src/ui/tiles.rs
@@ -960,86 +960,40 @@ impl TileState {
         !self.has_content()
     }
 
-    pub fn clear(&mut self, commands: &mut Commands) {
-        for (tile_id, tile) in self.tree.tiles.iter() {
+    /// Despawn every pane entity under `tile_id`, including nested containers.
+    /// Named schematic tabs are containers; closing them must release graphs,
+    /// cameras, and other pane entities, not only the egui tile.
+    pub(crate) fn despawn_tile(&mut self, tile_id: TileId, commands: &mut Commands) {
+        fn visit(
+            tree: &egui_tiles::Tree<Pane>,
+            graphs: &mut HashMap<TileId, Entity>,
+            tile_id: TileId,
+            commands: &mut Commands,
+        ) {
+            let Some(tile) = tree.tiles.get(tile_id) else {
+                return;
+            };
             match tile {
-                Tile::Pane(Pane::Viewport(viewport)) => {
-                    if let Some(camera) = viewport.camera
-                        && let Ok(mut e) = commands.get_entity(camera)
-                    {
-                        e.despawn();
-                    }
-                    if let Some(nav_gizmo_camera) = viewport.nav_gizmo_camera
-                        && let Ok(mut e) = commands.get_entity(nav_gizmo_camera)
-                    {
-                        e.despawn();
+                Tile::Pane(pane) => {
+                    pane.despawn_entities(commands);
+                    if let Some(graph_id) = graphs.remove(&tile_id) {
+                        try_despawn(commands, graph_id);
                     }
                 }
-                Tile::Pane(Pane::Graph(graph)) => {
-                    if let Ok(mut e) = commands.get_entity(graph.id) {
-                        e.despawn();
-                    }
-                    if let Some(graph_id) = self.graphs.get(tile_id) {
-                        if let Ok(mut e) = commands.get_entity(*graph_id) {
-                            e.despawn();
-                        }
-                        self.graphs.remove(tile_id);
+                Tile::Container(container) => {
+                    for child in container.children().copied().collect::<Vec<_>>() {
+                        visit(tree, graphs, child, commands);
                     }
                 }
-
-                Tile::Pane(Pane::VideoStream(pane) | Pane::SensorView(pane)) => {
-                    if let Ok(mut e) = commands.get_entity(pane.entity) {
-                        e.despawn();
-                    }
-                }
-                Tile::Pane(Pane::LogStream(pane)) => {
-                    if let Ok(mut e) = commands.get_entity(pane.entity) {
-                        e.despawn();
-                    }
-                }
-                Tile::Pane(Pane::ActionTile(pane)) => {
-                    if let Ok(mut e) = commands.get_entity(pane.entity) {
-                        e.despawn();
-                    }
-                }
-                Tile::Pane(Pane::QueryTable(pane)) => {
-                    if let Ok(mut e) = commands.get_entity(pane.entity) {
-                        e.despawn();
-                    }
-                }
-                Tile::Pane(Pane::QueryPlot(pane)) => {
-                    if let Ok(mut e) = commands.get_entity(pane.entity) {
-                        e.despawn();
-                    }
-                }
-                Tile::Pane(Pane::SchematicTree(pane)) => {
-                    if let Ok(mut e) = commands.get_entity(pane.entity) {
-                        e.despawn();
-                    }
-                }
-                Tile::Pane(Pane::Monitor(monitor)) => {
-                    if let Ok(mut e) = commands.get_entity(monitor.entity) {
-                        e.despawn();
-                    }
-                }
-                Tile::Pane(
-                    Pane::GeoPositionGauge(gauge)
-                    | Pane::OrientationGauge(gauge)
-                    | Pane::HorizonGauge(gauge),
-                ) => {
-                    if let Ok(mut e) = commands.get_entity(gauge.entity) {
-                        e.despawn();
-                    }
-                }
-                _ => {}
             }
         }
+        visit(&self.tree, &mut self.graphs, tile_id, commands);
+    }
 
-        if let Some(root_id) = self.tree.root()
-            && let Some(Tile::Container(root)) = self.tree.tiles.get_mut(root_id)
-        {
-            root.retain(|_| false);
-        };
+    pub fn clear(&mut self, commands: &mut Commands) {
+        if let Some(root_id) = self.tree.root() {
+            self.despawn_tile(root_id, commands);
+        }
         self.graphs.clear();
         self.container_titles.clear();
         self.reset_tree();
@@ -1108,6 +1062,12 @@ pub enum Pane {
     DataOverview(DataOverviewPane),
 }
 
+fn try_despawn(commands: &mut Commands, entity: Entity) {
+    if let Ok(mut e) = commands.get_entity(entity) {
+        e.despawn();
+    }
+}
+
 impl Pane {
     fn collect_render_targets(&self, out: &mut PaneRenderTargets) {
         match self {
@@ -1132,6 +1092,31 @@ impl Pane {
             | Pane::LogStream(_)
             | Pane::SchematicTree(_)
             | Pane::DataOverview(_) => {}
+        }
+    }
+
+    fn despawn_entities(&self, commands: &mut Commands) {
+        match self {
+            Pane::Viewport(viewport) => {
+                if let Some(camera) = viewport.camera {
+                    try_despawn(commands, camera);
+                }
+                if let Some(nav_gizmo_camera) = viewport.nav_gizmo_camera {
+                    try_despawn(commands, nav_gizmo_camera);
+                }
+            }
+            Pane::Graph(graph) => try_despawn(commands, graph.id),
+            Pane::Monitor(pane) => try_despawn(commands, pane.entity),
+            Pane::GeoPositionGauge(pane)
+            | Pane::OrientationGauge(pane)
+            | Pane::HorizonGauge(pane) => try_despawn(commands, pane.entity),
+            Pane::QueryTable(pane) => try_despawn(commands, pane.entity),
+            Pane::QueryPlot(pane) => try_despawn(commands, pane.entity),
+            Pane::ActionTile(pane) => try_despawn(commands, pane.entity),
+            Pane::VideoStream(pane) | Pane::SensorView(pane) => try_despawn(commands, pane.entity),
+            Pane::LogStream(pane) => try_despawn(commands, pane.entity),
+            Pane::SchematicTree(pane) => try_despawn(commands, pane.entity),
+            Pane::DataOverview(_) => {}
         }
     }
 
@@ -3218,62 +3203,9 @@ impl WidgetSystem for TileLayout<'_, '_> {
                         if read_only {
                             continue;
                         }
-                        let Some(tile) = tile_state.tree.tiles.get(tile_id) else {
+                        if tile_state.tree.tiles.get(tile_id).is_none() {
                             continue;
-                        };
-
-                        if let egui_tiles::Tile::Pane(Pane::Viewport(viewport)) = tile {
-                            if let Some(camera) = viewport.camera {
-                                state_mut.commands.entity(camera).despawn();
-                            }
-                            if let Some(nav_gizmo_camera) = viewport.nav_gizmo_camera {
-                                state_mut.commands.entity(nav_gizmo_camera).despawn();
-                            }
-                        };
-
-                        if let egui_tiles::Tile::Pane(Pane::Graph(graph)) = tile {
-                            state_mut.commands.entity(graph.id).despawn();
-                        };
-
-                        if let egui_tiles::Tile::Pane(Pane::ActionTile(action)) = tile {
-                            state_mut.commands.entity(action.entity).despawn();
-                        };
-
-                        if let egui_tiles::Tile::Pane(Pane::Monitor(pane)) = tile {
-                            state_mut.commands.entity(pane.entity).despawn();
-                        };
-
-                        if let egui_tiles::Tile::Pane(
-                            Pane::GeoPositionGauge(pane)
-                            | Pane::OrientationGauge(pane)
-                            | Pane::HorizonGauge(pane),
-                        ) = tile
-                        {
-                            state_mut.commands.entity(pane.entity).despawn();
-                        };
-
-                        if let egui_tiles::Tile::Pane(
-                            Pane::VideoStream(pane) | Pane::SensorView(pane),
-                        ) = tile
-                        {
-                            state_mut.commands.entity(pane.entity).despawn();
-                        };
-
-                        if let egui_tiles::Tile::Pane(Pane::LogStream(pane)) = tile {
-                            state_mut.commands.entity(pane.entity).despawn();
-                        };
-
-                        if let egui_tiles::Tile::Pane(Pane::QueryPlot(pane)) = tile {
-                            state_mut.commands.entity(pane.entity).despawn();
-                        };
-
-                        if let egui_tiles::Tile::Pane(Pane::QueryTable(pane)) = tile {
-                            state_mut.commands.entity(pane.entity).despawn();
-                        };
-
-                        if let egui_tiles::Tile::Pane(Pane::SchematicTree(pane)) = tile {
-                            state_mut.commands.entity(pane.entity).despawn();
-                        };
+                        }
 
                         // Find a sibling to select if the deleted tile was active
                         let sibling_to_select =
@@ -3294,6 +3226,7 @@ impl WidgetSystem for TileLayout<'_, '_> {
                                 }
                             });
 
+                        tile_state.despawn_tile(tile_id, &mut state_mut.commands);
                         tile_state.tree.remove_recursively(tile_id);
 
                         // Select the sibling if we found one
@@ -3302,11 +3235,6 @@ impl WidgetSystem for TileLayout<'_, '_> {
                                 tile_state.tree.tiles.get_mut(parent_id)
                         {
                             tabs.set_active(sibling_id);
-                        }
-
-                        if let Some(graph_id) = tile_state.graphs.get(&tile_id) {
-                            state_mut.commands.entity(*graph_id).despawn();
-                            tile_state.graphs.remove(&tile_id);
                         }
 
                         if tile_state.has_content() {
@@ -4022,5 +3950,162 @@ mod grid_lod_tests {
             (cell - 10_000_000.0).abs() / 10_000_000.0 < 1.0e-6,
             "80,000 km ECEF view should stay ~10,000 km cells, got {cell}"
         );
+    }
+}
+
+#[cfg(test)]
+mod close_tests {
+    use super::{Container, GraphPane, Pane, Tile, TileId, TileState};
+    use crate::plugins::render_layer_alloc::RenderLayerAllocator;
+    use crate::ui::plot::{
+        CollectedGraphData, GraphBundle, GraphState, Line, LineHandle, PlotDataComponent,
+        PlotGpuBufferPool, PlotLineKey, PlotLineUsers,
+    };
+    use bevy::asset::Assets;
+    use bevy::ecs::hierarchy::ChildOf;
+    use bevy::ecs::system::SystemState;
+    use bevy::prelude::{Commands, Entity, World};
+    use bevy_egui::egui::Color32;
+    use impeller2::types::ComponentId;
+    use impeller2_bevy::ComponentPath;
+    use std::collections::BTreeMap;
+
+    fn plot_world() -> World {
+        let mut world = World::new();
+        world.init_resource::<PlotLineUsers>();
+        world.init_resource::<CollectedGraphData>();
+        world.init_resource::<PlotGpuBufferPool>();
+        world.insert_resource(Assets::<Line>::default());
+        world
+    }
+
+    fn spawn_graph_with_line(
+        world: &mut World,
+        handle: bevy::asset::Handle<Line>,
+        path: &str,
+    ) -> (Entity, Entity) {
+        let mut alloc = RenderLayerAllocator::default();
+        let bundle = GraphBundle::try_new(&mut alloc, BTreeMap::new(), path.to_string())
+            .expect("a free render layer");
+        let graph_id = world.spawn(bundle).id();
+        let line_id = world
+            .spawn((LineHandle::Timeseries(handle), ChildOf(graph_id)))
+            .id();
+        world
+            .get_mut::<GraphState>(graph_id)
+            .expect("graph state")
+            .enabled_lines
+            .insert((ComponentPath::from_name(path), 0), (line_id, Color32::RED));
+        (graph_id, line_id)
+    }
+
+    fn named_tab_with_graph(tile_state: &mut TileState, graph_id: Entity) -> TileId {
+        let pane_id = tile_state
+            .tree
+            .tiles
+            .insert_new(Tile::Pane(Pane::Graph(GraphPane::new(
+                graph_id,
+                "graph".into(),
+            ))));
+        let named_id = tile_state
+            .tree
+            .tiles
+            .insert_new(Tile::Container(Container::new_tabs(vec![pane_id])));
+        let root = tile_state.tree.root().expect("root tabs");
+        if let Some(Tile::Container(Container::Tabs(tabs))) = tile_state.tree.tiles.get_mut(root) {
+            tabs.add_child(named_id);
+        }
+        tile_state.graphs.insert(pane_id, graph_id);
+        named_id
+    }
+
+    fn close_tile(world: &mut World, tile_state: &mut TileState, tile_id: TileId) {
+        let mut system_state: SystemState<Commands> = SystemState::new(world);
+        let mut commands = system_state.get_mut(world).expect("commands");
+        tile_state.despawn_tile(tile_id, &mut commands);
+        tile_state.tree.remove_recursively(tile_id);
+        system_state.apply(world);
+        world.flush();
+    }
+
+    #[test]
+    fn closing_container_tab_despawns_graphs_and_unused_line_assets() {
+        let mut world = plot_world();
+        let handle = world.resource_mut::<Assets<Line>>().add(Line::default());
+        let component_id = ComponentId::new("rocket.mach");
+        {
+            let mut collected = world.resource_mut::<CollectedGraphData>();
+            let mut component = PlotDataComponent::new("rocket.mach", vec!["x".into()]);
+            component.lines.insert(0, handle.clone());
+            collected.components.insert(component_id, component);
+        }
+        let (graph_id, line_id) = spawn_graph_with_line(&mut world, handle.clone(), "rocket.mach");
+        let key = PlotLineKey::Timeseries(handle.id());
+        assert_eq!(world.resource::<PlotLineUsers>().count(key), 1);
+
+        let mut tile_state = TileState::default();
+        let tab_id = named_tab_with_graph(&mut tile_state, graph_id);
+        close_tile(&mut world, &mut tile_state, tab_id);
+
+        assert!(
+            world.get_entity(graph_id).is_err(),
+            "graph pane entity must be despawned"
+        );
+        assert!(
+            world.get_entity(line_id).is_err(),
+            "line entity must be despawned with the graph"
+        );
+        assert!(
+            world.query::<&GraphState>().iter(&world).next().is_none(),
+            "no GraphState remains"
+        );
+        assert!(
+            world.query::<&LineHandle>().iter(&world).next().is_none(),
+            "no LineHandle remains"
+        );
+        assert!(
+            world
+                .resource::<CollectedGraphData>()
+                .get_line(&component_id, 0)
+                .is_none(),
+            "unused CollectedGraphData line handle must be dropped"
+        );
+        assert_eq!(world.resource::<PlotLineUsers>().count(key), 0);
+        assert!(tile_state.graphs.is_empty());
+    }
+
+    #[test]
+    fn closing_one_tab_keeps_shared_line_used_by_another_graph() {
+        let mut world = plot_world();
+        let handle = world.resource_mut::<Assets<Line>>().add(Line::default());
+        let component_id = ComponentId::new("rocket.mach");
+        {
+            let mut collected = world.resource_mut::<CollectedGraphData>();
+            let mut component = PlotDataComponent::new("rocket.mach", vec!["x".into()]);
+            component.lines.insert(0, handle.clone());
+            collected.components.insert(component_id, component);
+        }
+        let (graph_a, line_a) = spawn_graph_with_line(&mut world, handle.clone(), "rocket.mach");
+        let (graph_b, line_b) = spawn_graph_with_line(&mut world, handle.clone(), "rocket.mach");
+        let key = PlotLineKey::Timeseries(handle.id());
+        assert_eq!(world.resource::<PlotLineUsers>().count(key), 2);
+
+        let mut tile_state = TileState::default();
+        let tab_a = named_tab_with_graph(&mut tile_state, graph_a);
+        let _tab_b = named_tab_with_graph(&mut tile_state, graph_b);
+        close_tile(&mut world, &mut tile_state, tab_a);
+
+        assert!(world.get_entity(graph_a).is_err());
+        assert!(world.get_entity(line_a).is_err());
+        assert!(world.get_entity(graph_b).is_ok());
+        assert!(world.get_entity(line_b).is_ok());
+        assert!(
+            world
+                .resource::<CollectedGraphData>()
+                .get_line(&component_id, 0)
+                .is_some(),
+            "shared line asset must stay while another graph uses it"
+        );
+        assert_eq!(world.resource::<PlotLineUsers>().count(key), 1);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes GPU memory management, custom render-error recovery, and the plot render hot path; regressions could affect stability, rendering after OOM, or graph/tab teardown.
> 
> **Overview**
> Addresses **GPU out-of-memory** when switching graph tabs or running heavy schematics by recycling plot value/index buffers instead of allocating a fresh set on every show/hide cycle. A new **`PlotGpuBufferPool`** quarantines released buffers for a few frames, caps new allocations per frame, trims under NVML-reported pressure (~90%), and coordinates with **`PlotLineUsers`** so shared line assets stay loaded until the last graph drops them.
> 
> **OOM / device-lost handling** is centralized in **`HardwareStatsPlugin`**: wgpu allocator reports are written under `/tmp`, plot GPU caches are evicted, and the renderer is recreated once per cooldown window; **`editor_wgpu_settings`** enables wgpu counters and memory-usage hints.
> 
> **Observability**: the status bar shows CPU, system RAM, GPU VRAM/utilization (NVML on NVIDIA), and plot buffer/shard stats with pressure coloring; the command palette adds **Dump GPU Allocations** under Diagnostics.
> 
> **Lifecycle fixes**: closing nested tile tabs now **`despawn_tile`** recursively (graphs and line entities), **`GraphState`** despawns enabled line children on remove, and index buffer uploads return **`Option`** instead of panicking when the staging write fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4ae06d32c62be50c941b41dc835230c685d42d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->