### PR TITLE
feat(examples): default Betaflight SITL to 8 kHz

### DIFF
--- a/examples/betaflight-sitl/README.md
+++ b/examples/betaflight-sitl/README.md
@@ -12,7 +12,7 @@ The simulation provides:
 - **6-DOF Physics**: Rigid body dynamics with motor thrust, drag, and gravity
 - **Betaflight Integration**: Real Betaflight flight controller running as SITL
 - **UDP Communication**: Bidirectional sensor/motor data exchange
-- **4kHz Lockstep Loop**: Real-time physics and Betaflight PID updates by default
+- **8kHz Lockstep Loop**: Real-time physics and Betaflight PID updates by default
 - **Multi-Rate Sensors**: Requested sensor rates are capped by the simulation rate
 
 ```
@@ -101,7 +101,7 @@ and verifies the persisted settings. To do the same setup manually:
    ```
    
    This configures ARM on AUX1 and processes every lockstep update. The actual
-   lockstep rate is set by `simulation_rate` (4kHz by default).
+   lockstep rate is set by `simulation_rate` (8kHz by default).
 
 4. **Exit screen**: Press `Ctrl+A` then `K` then `Y`
 
@@ -291,11 +291,11 @@ DroneConfig(
     arm_length=0.12,             # meters
     motor_max_thrust=15.0,       # Newtons per motor
     motor_time_constant=0.02,    # seconds
-    simulation_rate=4000.0,      # 4kHz physics/PID lockstep
+    simulation_rate=8000.0,      # 8kHz physics/PID lockstep
     sensor_noise=True,           # Enable realistic sensor noise
     # Requested sensor rates (capped by the simulation rate)
-    gyro_rate=8000.0,            # Effective rate is 4kHz by default
-    accel_rate=4800.0,           # Effective rate is 4kHz by default
+    gyro_rate=8000.0,            # Effective rate is 8kHz by default
+    accel_rate=4800.0,           # Effective rate is 4kHz after tick rounding
     baro_rate=480.0,             # 480Hz (BMP581)
     mag_rate=200.0,              # 200Hz (BMM350)
 )
@@ -368,7 +368,7 @@ sequenceDiagram
 make variable:
 
 ```bash
-make TARGET=SITL OPTIONS="ENABLE_SIMULATOR_GYROPID_SYNC=1 VIRTUAL_GYRO_SAMPLE_RATE_HZ=4000 RUN_LOOP_DELAY_US=5"
+make TARGET=SITL OPTIONS="ENABLE_SIMULATOR_GYROPID_SYNC=1 VIRTUAL_GYRO_SAMPLE_RATE_HZ=8000 RUN_LOOP_DELAY_US=0"
 ```
 
 (2026.6.1 renamed the option to an `ENABLE_*` boolean macro; `OPTIONS` entries
@@ -391,12 +391,12 @@ iteration, one motor response out:
   task, which slows the loop further — the rate never recovers.
 - **core.c**: the now-redundant per-task PID mutex gate is dropped; the whole
   realtime group is gated at the boundary.
-- **platform.h**: `RUN_LOOP_DELAY_US` becomes overridable; the build sets it to
-  `5` µs. The stock 50 µs real-time sleep in the main loop adds directly to
-  packet→motor latency on every tick, while `0` (busy-wait) pegs a core at ~100%
-  CPU. A 5 µs sleep recovers most of that CPU (down to ~20%) for only a few
-  percent of real-time at 8 kHz — and nothing at ≤4 kHz. Set `RUN_LOOP_DELAY_US=0`
-  for the absolute best lockstep latency.
+- **platform.h**: `RUN_LOOP_DELAY_US` becomes overridable. The 8 kHz default
+  build sets it to `0`, making the main loop busy-wait for the lowest possible
+  packet→motor latency. This consumes approximately one CPU core. Set a nonzero
+  value to trade lockstep performance for lower CPU usage; host scheduler wakeup
+  latency is paid on every iteration and may prevent the loop from sustaining
+  8 kHz.
 
 Asynchronous SITL (lockstep disabled) is unchanged.
 
@@ -572,11 +572,13 @@ lsof -i :5761
 
 ### Performance
 
-**Simulation too slow**: The default `simulation_rate = 4000.0` gives the
-Python/UDP lockstep bridge a 1ms budget per tick and is intended to run in real
-time on typical hosts. Higher rates remain available but may run slower than
-real time because every tick includes DB access and a synchronous Betaflight
-UDP round trip. The default 15-second run produces 60,000 simulation ticks.
+**Simulation too slow**: The default `simulation_rate = 8000.0` gives the
+Python/UDP lockstep bridge a 125µs budget per tick and requires Betaflight's
+busy-waiting `RUN_LOOP_DELAY_US=0` build to hold real time. This consumes
+approximately one CPU core on the Betaflight side. Lower rates or a nonzero
+run-loop delay reduce CPU usage, but a sleeping Betaflight loop may not sustain
+8kHz because every tick includes DB access and a synchronous UDP round trip.
+The default 15-second run produces 120,000 simulation ticks.
 
 ## Development
 
@@ -612,21 +614,21 @@ high-rate physics/PID loop.
 ### Configured and Effective Rates
 
 Configured sensor rates represent hardware targets. A sensor cannot update more
-than once per physics tick, so its effective rate is capped by the 4kHz default
+than once per physics tick, so its effective rate is capped by the 8kHz default
 simulation rate and rounded to a whole number of ticks.
 
 | Sensor | Hardware | Configured rate | Effective default rate | Datasheet |
 |--------|----------|-----------------|------------------------|-----------|
-| Gyroscope | BMI270 (3x with timing offset) | 8 kHz | 4 kHz | [bst-bmi270-ds000.pdf](https://www.mouser.com/datasheet/3/1046/1/bst-bmi270-ds000.pdf) |
+| Gyroscope | BMI270 (3x with timing offset) | 8 kHz | 8 kHz | [bst-bmi270-ds000.pdf](https://www.mouser.com/datasheet/3/1046/1/bst-bmi270-ds000.pdf) |
 | Accelerometer | BMI270 (3x with timing offset) | 4.8 kHz | 4 kHz | [bst-bmi270-ds000.pdf](https://www.mouser.com/datasheet/3/1046/1/bst-bmi270-ds000.pdf) |
-| Barometer | BMP581 | 480 Hz | 500 Hz | [bst_bmp581_ds004.pdf](https://www.mouser.com/datasheet/3/1046/1/bst_bmp581_ds004.pdf) |
+| Barometer | BMP581 | 480 Hz | ~471 Hz | [bst_bmp581_ds004.pdf](https://www.mouser.com/datasheet/3/1046/1/bst_bmp581_ds004.pdf) |
 | Magnetometer | BMM350 | 200 Hz | 200 Hz | [bst-bmm350-ds001.pdf](https://www.mouser.com/datasheet/3/1046/1/bst-bmm350-ds001.pdf) |
 
 ### Why Multi-Rate?
 
 Real sensors don't all sample at the same frequency. The physics/PID lockstep
-runs at 4kHz by default. Gyroscope and accelerometer targets above that rate are
-therefore capped at 4kHz, while slower sensors update less frequently:
+runs at 8kHz by default. The gyroscope updates every physics tick, while slower
+sensors update less frequently:
 
 - **Gyroscope (8 kHz)**: Drives the PID loop. The BMI270 supports up to 6.4 kHz per
   sensor; with 3 IMUs running with timing offsets, effective rate exceeds 8 kHz.
@@ -653,8 +655,8 @@ sensor_out = jax.lax.cond(
 )
 ```
 
-For example, with the default 4kHz PID rate and a 200Hz magnetometer,
-`tick_interval = 20` (the magnetometer updates every twentieth physics tick).
+For example, with the default 8kHz PID rate and a 200Hz magnetometer,
+`tick_interval = 40` (the magnetometer updates every fortieth physics tick).
 
 ### Customizing for Different Hardware
 

--- a/examples/betaflight-sitl/build.sh
+++ b/examples/betaflight-sitl/build.sh
@@ -22,14 +22,14 @@ BETAFLIGHT_DIR="$SCRIPT_DIR/betaflight"
 # LPF setup and PID dt. The actual loop rate is set at runtime by the FDM
 # packet rate from the Python side (config.py simulation_rate) via lockstep.
 # The two MUST match, so keep SITL_RATE_HZ in sync with simulation_rate.
-SITL_RATE_HZ="${SITL_RATE_HZ:-4000}"
+SITL_RATE_HZ="${SITL_RATE_HZ:-8000}"
 #
 # RUN_LOOP_DELAY_US (new in 2026.6.1) inserts a real-time nanosleep into
-# Betaflight's main loop to cap its spin rate. In lockstep mode that sleep adds
-# directly to packet->motor latency on every tick. Default 5us: drops the SITL
-# from a pegged core (~100% CPU) to ~20% while costing only a few percent of
-# real-time at 8kHz (and nothing at <=4kHz). Set to 0 for busy-wait best latency.
-RUN_LOOP_DELAY_US="${RUN_LOOP_DELAY_US:-5}"
+# Betaflight's main loop to cap its spin rate. In lockstep mode host scheduler
+# wakeup latency is paid directly on every packet->motor round trip, so the 8kHz
+# default busy-waits for minimum latency. Set this above 0 to trade loop rate for
+# lower CPU usage; 0 consumes approximately one CPU core.
+RUN_LOOP_DELAY_US="${RUN_LOOP_DELAY_US:-0}"
 BETAFLIGHT_OPTIONS="ENABLE_SIMULATOR_GYROPID_SYNC=1 VIRTUAL_GYRO_SAMPLE_RATE_HZ=$SITL_RATE_HZ RUN_LOOP_DELAY_US=$RUN_LOOP_DELAY_US"
 
 # Check if betaflight submodule is cloned (directory may exist as empty gitlink before update)

--- a/examples/betaflight-sitl/config.py
+++ b/examples/betaflight-sitl/config.py
@@ -139,11 +139,10 @@ class DroneConfig:
 
     # --- Simulation Settings ---
 
-    # Physics/PID lockstep rate in Hz. 4kHz is the default and holds real-time;
-    # higher rates (e.g. 8kHz) run slightly slower than real time because each
-    # tick includes a UDP round trip.
-    simulation_rate: float = 4000.0  # 250µs
-    # simulation_rate: float = 8000.0  # 125µs
+    # Physics/PID lockstep rate in Hz. The default 8kHz loop uses a busy-waiting
+    # Betaflight SITL build to avoid host scheduler wakeup latency.
+    simulation_rate: float = 8000.0  # 125µs
+    # simulation_rate: float = 4000.0  # 250µs
     # simulation_rate: float = 2000.0  # 500µs
     # simulation_rate: float = 1500.0  # 667µs
     # simulation_rate: float = 1000.0  # 1000µs

--- a/examples/betaflight-sitl/sensors.py
+++ b/examples/betaflight-sitl/sensors.py
@@ -5,16 +5,16 @@ This module simulates the IMU (Inertial Measurement Unit) and other sensors
 that provide data to Betaflight's flight controller algorithms.
 
 Sensor Models (configured targets; effective rates are capped by the physics rate):
-- Gyroscope: Measures angular velocity in body frame (8 kHz target, 1 kHz default)
-- Accelerometer: Measures linear acceleration in body frame (4.8 kHz target, 1 kHz default)
-- Barometer: Measures altitude via pressure (480 Hz target, 500 Hz default)
-- Magnetometer: Measures heading reference (200 Hz target and default)
+- Gyroscope: Measures angular velocity in body frame (8 kHz target and default)
+- Accelerometer: Measures linear acceleration in body frame (4.8 kHz target, 4 kHz effective)
+- Barometer: Measures altitude via pressure (480 Hz target, ~471 Hz effective)
+- Magnetometer: Measures heading reference (200 Hz target and effective)
 
 Multi-Rate Simulation:
 Sensors request rates based on the Elodin Aleph flight controller hardware
 (BMI270 IMU, BMP581 barometer, BMM350 magnetometer). The physics/PID lockstep
-runs at 1kHz by default, so faster sensor targets are capped at 1kHz and slower
-sensors use tick decimation.
+runs at 8kHz by default. Slower sensors use whole-tick decimation, so their
+actual rates are the closest rates representable at 8kHz.
 
 Noise Model (from proven drone example):
 - Gaussian measurement noise on each sample
@@ -427,7 +427,7 @@ def create_baro_system(config: DroneConfig):
         """
         Compute barometer reading with multi-rate decimation.
 
-        Updates at baro_tick_interval (every 2 ticks at the default 1kHz rate).
+        Updates at baro_tick_interval (every 17 ticks at the default 8kHz rate).
         Returns previous reading when not updating.
         """
         new_reading = _compute_baro_reading(tick, pos)
@@ -482,7 +482,7 @@ def create_mag_system(config: DroneConfig):
         """
         Compute magnetometer reading with multi-rate decimation.
 
-        Updates at mag_tick_interval (every 5 ticks at the default 1kHz rate).
+        Updates at mag_tick_interval (every 40 ticks at the default 8kHz rate).
         Returns previous reading when not updating.
         """
         new_reading = _compute_mag_reading(tick, pos)
@@ -534,9 +534,9 @@ def create_sensor_system(config: DroneConfig) -> el.System:
     Create the complete sensor system with multi-rate simulation.
 
     Combines sensors at their configured target rates, capped by the physics rate:
-    - Gyroscope: 8 kHz target (1 kHz at the default physics rate)
-    - Accelerometer: 4.8 kHz target (1 kHz at the default physics rate)
-    - Barometer: 480 Hz target (500 Hz after whole-tick rounding at 1 kHz)
+    - Gyroscope: 8 kHz target and effective default rate
+    - Accelerometer: 4.8 kHz target (4 kHz after whole-tick rounding at 8 kHz)
+    - Barometer: 480 Hz target (~471 Hz after whole-tick rounding at 8 kHz)
     - Magnetometer: 200 Hz target and effective rate
 
     Args:

--- a/examples/betaflight-sitl/sim.py
+++ b/examples/betaflight-sitl/sim.py
@@ -418,8 +418,8 @@ if __name__ == "__main__":
     system = create_physics_system(config)
     exec = world.build(system)
 
-    # Run 200 ticks (200ms at 1kHz)
-    exec.run(200)
+    # Run for the configured 200ms duration at the configured simulation rate
+    exec.run(config.total_sim_ticks)
 
     # Get history data
     df = exec.history(["drone.world_pos", "drone.world_vel", "drone.sim_time"])


### PR DESCRIPTION
Tradeoffs:

betaflight pegs a CPU core busy waiting. This saves up to ~50us per tick due to avoiding thread wakeup and packets arriving at bad times.

Most of the PR is documentation. I tried to mark all the relevant code changes with comments below.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default SITL timing and Betaflight build flags (rate + busy-wait), which affects real-time performance and CPU use; physics logic is unchanged aside from the test harness tick count.
> 
> **Overview**
> The Betaflight SITL example now defaults to an **8 kHz** physics/PID lockstep loop instead of 4 kHz. **`config.py`** sets `simulation_rate=8000.0`, and **`build.sh`** aligns `SITL_RATE_HZ` and `VIRTUAL_GYRO_SAMPLE_RATE_HZ` so Betaflight’s compile-time gyro/PID assumptions match the Python side.
> 
> The default Betaflight build switches **`RUN_LOOP_DELAY_US` from 5 to 0**, busy-waiting the SITL main loop for lower packet→motor latency at the cost of roughly one pegged CPU core; docs note that nonzero delay trades CPU for rate stability.
> 
> **`sensors.py`** and the README refresh effective multi-rate sensor behavior at 8 kHz (gyro every tick, accel ~4 kHz, baro ~471 Hz, mag every 40 ticks). **`sim.py`**’s standalone physics test runs `config.total_sim_ticks` instead of a hardcoded 200 ticks so duration follows `simulation_time` and rate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 379ad99dcd8d555b2d387bb5d86e34a9b34bf720. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->