### PR TITLE
fix(editor): bind terrain views to viewports and sensor cameras.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 - **(fix)** Bind world-mesh terrain views to schematic viewports and sensor cameras, not 2D graph cameras.
 - **(fix)** Size planar terrain atlases to the dataset working set instead of 1024 GPU layers.
+- **(fix)** Size terrain view geometry buffers from the clipmap instead of 1e6 tiles.
 - **(fix)** Draw 2D plot windows longer than 30 s at full resolution instead of a few points per pixel.
 - **(fix)** Slide trailing 2D plot windows over existing samples instead of rebuilding every 100 ms.
 - **(fix)** Rebuild 2D plot lines when backfill fills holes inside an already-covered window.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 - **(fix)** Bind world-mesh terrain views to schematic viewports and sensor cameras, not 2D graph cameras.
 - **(fix)** Size planar terrain atlases to the dataset working set instead of 1024 GPU layers.
+- **(fix)** Keep planar preprocess atlases large enough for the full tile set, retry rejected clipmap requests, and ignore stale loads after LRU eviction.
 - **(fix)** Size terrain view geometry buffers from the clipmap instead of 1e6 tiles.
 - **(fix)** Draw 2D plot windows longer than 30 s at full resolution instead of a few points per pixel.
 - **(fix)** Slide trailing 2D plot windows over existing samples instead of rebuilding every 100 ms.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - **(fix)** Bind world-mesh terrain views to schematic viewports and sensor cameras, not 2D graph cameras.
 - **(fix)** Size planar terrain atlases to the dataset working set instead of 1024 GPU layers.
 - **(fix)** Keep planar preprocess atlases large enough for the full tile set, retry rejected clipmap requests, and ignore stale loads after LRU eviction.
-- **(fix)** Size terrain view geometry buffers from the clipmap instead of 1e6 tiles.
+- **(fix)** Size terrain view geometry buffers for refine fan-out instead of 1e6 tiles.
 - **(fix)** Draw 2D plot windows longer than 30 s at full resolution instead of a few points per pixel.
 - **(fix)** Slide trailing 2D plot windows over existing samples instead of rebuilding every 100 ms.
 - **(fix)** Rebuild 2D plot lines when backfill fills holes inside an already-covered window.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## unreleased
+- **(fix)** Bind world-mesh terrain views to schematic viewports and sensor cameras, not 2D graph cameras.
 - **(fix)** Draw 2D plot windows longer than 30 s at full resolution instead of a few points per pixel.
 - **(fix)** Slide trailing 2D plot windows over existing samples instead of rebuilding every 100 ms.
 - **(fix)** Rebuild 2D plot lines when backfill fills holes inside an already-covered window.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 - **(fix)** Bind world-mesh terrain views to schematic viewports and sensor cameras, not 2D graph cameras.
+- **(fix)** Size planar terrain atlases to the dataset working set instead of 1024 GPU layers.
 - **(fix)** Draw 2D plot windows longer than 30 s at full resolution instead of a few points per pixel.
 - **(fix)** Slide trailing 2D plot windows over existing samples instead of rebuilding every 100 ms.
 - **(fix)** Rebuild 2D plot lines when backfill fills holes inside an already-covered window.

--- a/libs/bevy_world_mesh/src/bin/preprocess.rs
+++ b/libs/bevy_world_mesh/src/bin/preprocess.rs
@@ -14,7 +14,7 @@ use bevy::{
     winit::WinitPlugin,
 };
 use bevy_world_mesh::prelude::*;
-use bevy_world_mesh::scenes::planar::{planar_path, terrain_config, LOD_COUNT};
+use bevy_world_mesh::scenes::planar::{planar_path, preprocess_terrain_config, LOD_COUNT};
 use bevy_world_mesh::terrain::util::{asset_path, assets_root};
 use std::time::Duration;
 
@@ -48,7 +48,7 @@ fn main() {
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    let config = terrain_config();
+    let config = preprocess_terrain_config();
     let mut tile_atlas = TileAtlas::new(&config);
     let path = planar_path();
 

--- a/libs/bevy_world_mesh/src/scenes/planar.rs
+++ b/libs/bevy_world_mesh/src/scenes/planar.rs
@@ -67,6 +67,15 @@ impl Plugin for PlanarScenePlugin {
 /// uses, so the `preprocess` binary builds an atlas with matching scale +
 /// height bounds.
 pub fn terrain_config() -> TerrainConfig {
+    terrain_config_with_atlas(crate::terrain::terrain::planar_atlas_size)
+}
+
+/// Preprocess atlas: one layer per on-disk tile, not the runtime working set.
+pub fn preprocess_terrain_config() -> TerrainConfig {
+    terrain_config_with_atlas(crate::terrain::terrain::planar_preprocess_atlas_size)
+}
+
+fn terrain_config_with_atlas(atlas_size: fn(u32) -> u32) -> TerrainConfig {
     let manifest = RegionManifest::load_or_default();
     let terrain_size = manifest.terrain_size_m();
     let height = manifest.height_m();
@@ -84,7 +93,7 @@ pub fn terrain_config() -> TerrainConfig {
             height,
         ),
         path,
-        atlas_size: crate::terrain::terrain::planar_atlas_size(dataset_tiles),
+        atlas_size: atlas_size(dataset_tiles),
         ..default()
     }
     .add_attachment(AttachmentConfig {

--- a/libs/bevy_world_mesh/src/scenes/planar.rs
+++ b/libs/bevy_world_mesh/src/scenes/planar.rs
@@ -25,8 +25,8 @@ pub const TEXTURE_SIZE: u32 = 512;
 /// Atlas LOD depth for the planar path. LOD_COUNT=5 gives deepest LOD at
 /// 2^4 * TEXTURE_SIZE = 8192 px per terrain dim; for a 20-30 km region that
 /// resolves to ~2-4 m/px display, backed by Sentinel-2 z=14 source via
-/// OUTPUT_SIZE=4096. Default `atlas_size=1024` comfortably fits
-/// (4^5 - 1) / 3 = 341 total tiles.
+/// OUTPUT_SIZE=4096. The on-disk set is (4^5 - 1) / 3 = 341 tiles; the GPU
+/// atlas is sized by [`crate::terrain::terrain::planar_atlas_size`].
 pub const LOD_COUNT: u32 = 5;
 
 /// End-to-end scene plugin for planar terrain. Reads the active region's
@@ -71,6 +71,8 @@ pub fn terrain_config() -> TerrainConfig {
     let terrain_size = manifest.terrain_size_m();
     let height = manifest.height_m();
 
+    let path = planar_path();
+    let dataset_tiles = TileAtlas::load_tile_config(&path).len() as u32;
     TerrainConfig {
         lod_count: LOD_COUNT,
         // y=0 sits at min_height_m on the ground. Anchor the centre of the
@@ -81,7 +83,8 @@ pub fn terrain_config() -> TerrainConfig {
             0.0,
             height,
         ),
-        path: planar_path(),
+        path,
+        atlas_size: crate::terrain::terrain::planar_atlas_size(dataset_tiles),
         ..default()
     }
     .add_attachment(AttachmentConfig {

--- a/libs/bevy_world_mesh/src/terrain/render/terrain_view_bind_group.rs
+++ b/libs/bevy_world_mesh/src/terrain/render/terrain_view_bind_group.rs
@@ -128,7 +128,6 @@ pub struct TerrainViewData {
 
 impl TerrainViewData {
     fn new(device: &RenderDevice, tile_tree: &TileTree, gpu_tile_tree: &GpuTileTree) -> Self {
-        // Todo: figure out a better way of limiting the tile buffer size
         let tile_buffer_size =
             TileCoordinate::min_size().get() * tile_tree.geometry_tile_count as BufferAddress;
 

--- a/libs/bevy_world_mesh/src/terrain/shaders/tiling_prepass/prepare_prepass.wgsl
+++ b/libs/bevy_world_mesh/src/terrain/shaders/tiling_prepass/prepare_prepass.wgsl
@@ -25,10 +25,13 @@ fn prepare_root() {
 @compute @workgroup_size(1, 1, 1)
 fn prepare_next() {
     if (parameters.counter == 1) {
-        parameters.tile_count = u32(atomicExchange(&parameters.child_index, i32(view_config.tile_count - 1u)));
+        let raw = atomicExchange(&parameters.child_index, i32(view_config.tile_count - 1u));
+        parameters.tile_count = min(u32(max(raw, 0)), view_config.tile_count);
     }
     else {
-        parameters.tile_count = view_config.tile_count - 1u - u32(atomicExchange(&parameters.child_index, 0));
+        let raw = atomicExchange(&parameters.child_index, 0);
+        let used = i32(view_config.tile_count) - 1 - raw;
+        parameters.tile_count = min(u32(max(used, 0)), view_config.tile_count);
     }
 
     parameters.counter = -parameters.counter;
@@ -37,7 +40,7 @@ fn prepare_next() {
 
 @compute @workgroup_size(1, 1, 1)
 fn prepare_render() {
-    let tile_count = u32(atomicLoad(&parameters.final_index));
+    let tile_count = min(u32(max(atomicLoad(&parameters.final_index), 0)), view_config.tile_count);
     let vertex_count = view_config.vertices_per_tile * tile_count;
 
     indirect_buffer.workgroup_count = vec3<u32>(vertex_count, 1u, 0u);

--- a/libs/bevy_world_mesh/src/terrain/shaders/tiling_prepass/refine_tiles.wgsl
+++ b/libs/bevy_world_mesh/src/terrain/shaders/tiling_prepass/refine_tiles.wgsl
@@ -2,8 +2,8 @@
 #import bevy_terrain::bindings::{config, culling_view, view_config, final_tiles, temporary_tiles, parameters, terrain_model_approximation}
 #import bevy_terrain::functions::{approximate_view_distance, compute_relative_position, position_local_to_world, normal_local_to_world, tile_count, compute_subdivision_coordinate}
 
-fn child_index() -> i32 {
-    return atomicAdd(&parameters.child_index, parameters.counter);
+fn in_tile_buffer(index: i32) -> bool {
+    return index >= 0 && index < i32(view_config.tile_count);
 }
 
 fn parent_index(id: u32) -> i32 {
@@ -21,24 +21,45 @@ fn should_be_divided(tile: TileCoordinate) -> bool {
     return view_distance < view_config.subdivision_distance / tile_count(tile.lod);
 }
 
-fn subdivide(tile: TileCoordinate) {
+fn emit_final(tile: TileCoordinate) {
+    let index = final_index();
+    if (in_tile_buffer(index)) {
+        final_tiles[index] = tile;
+    }
+}
+
+fn subdivide(tile: TileCoordinate) -> bool {
+    let first = atomicAdd(&parameters.child_index, 4 * parameters.counter);
     for (var i: u32 = 0u; i < 4u; i = i + 1u) {
+        if (!in_tile_buffer(first + i32(i) * parameters.counter)) {
+            return false;
+        }
+    }
+
+    for (var i: u32 = 0u; i < 4u; i = i + 1u) {
+        let index = first + i32(i) * parameters.counter;
         let child_xy  = vec2<u32>((tile.xy.x << 1u) + (i & 1u), (tile.xy.y << 1u) + (i >> 1u & 1u));
         let child_lod = tile.lod + 1u;
-
-        temporary_tiles[child_index()] = TileCoordinate(tile.side, child_lod, child_xy);
+        temporary_tiles[index] = TileCoordinate(tile.side, child_lod, child_xy);
     }
+
+    return true;
 }
 
 @compute @workgroup_size(64, 1, 1)
 fn refine_tiles(@builtin(global_invocation_id) invocation_id: vec3<u32>) {
     if (invocation_id.x >= parameters.tile_count) { return; }
 
-    let tile = temporary_tiles[parent_index(invocation_id.x)];
+    let parent = parent_index(invocation_id.x);
+    if (!in_tile_buffer(parent)) { return; }
+
+    let tile = temporary_tiles[parent];
 
     if (should_be_divided(tile)) {
-        subdivide(tile);
+        if (!subdivide(tile)) {
+            emit_final(tile);
+        }
     } else {
-        final_tiles[final_index()] = tile;
+        emit_final(tile);
     }
 }

--- a/libs/bevy_world_mesh/src/terrain/shaders/tiling_prepass/refine_tiles.wgsl
+++ b/libs/bevy_world_mesh/src/terrain/shaders/tiling_prepass/refine_tiles.wgsl
@@ -28,12 +28,26 @@ fn emit_final(tile: TileCoordinate) {
     }
 }
 
-fn subdivide(tile: TileCoordinate) -> bool {
-    let first = atomicAdd(&parameters.child_index, 4 * parameters.counter);
-    for (var i: u32 = 0u; i < 4u; i = i + 1u) {
-        if (!in_tile_buffer(first + i32(i) * parameters.counter)) {
-            return false;
+fn try_reserve_children() -> i32 {
+    loop {
+        let current = atomicLoad(&parameters.child_index);
+        let last = current + 3 * parameters.counter;
+        if (!in_tile_buffer(current) || !in_tile_buffer(last)) {
+            return -1;
         }
+
+        let next = current + 4 * parameters.counter;
+        let gate = atomicCompareExchangeWeak(&parameters.child_index, current, next);
+        if (gate.exchanged) {
+            return current;
+        }
+    }
+}
+
+fn subdivide(tile: TileCoordinate) -> bool {
+    let first = try_reserve_children();
+    if (first < 0) {
+        return false;
     }
 
     for (var i: u32 = 0u; i < 4u; i = i + 1u) {

--- a/libs/bevy_world_mesh/src/terrain/terrain.rs
+++ b/libs/bevy_world_mesh/src/terrain/terrain.rs
@@ -59,6 +59,8 @@ impl TerrainConfig {
 pub const PLANAR_ATLAS_MIN: u32 = 64;
 /// Working-set cap. LOD5 planar datasets are 341 tiles; 1024 layers is ~2 GiB.
 pub const PLANAR_ATLAS_MAX: u32 = 256;
+/// Preprocess must hold every on-disk tile. First-run `config.tc` is empty.
+pub const PLANAR_PREPROCESS_ATLAS_MIN: u32 = 1024;
 
 /// GPU atlas layers for a planar region: at least [`PLANAR_ATLAS_MIN`], at
 /// most [`PLANAR_ATLAS_MAX`], and never larger than the on-disk tile count
@@ -68,6 +70,12 @@ pub fn planar_atlas_size(dataset_tiles: u32) -> u32 {
         return PLANAR_ATLAS_MIN;
     }
     dataset_tiles.clamp(PLANAR_ATLAS_MIN, PLANAR_ATLAS_MAX)
+}
+
+/// Atlas layers for the preprocess binary. Must fit the full dataset, not
+/// the runtime working set.
+pub fn planar_preprocess_atlas_size(dataset_tiles: u32) -> u32 {
+    dataset_tiles.max(PLANAR_PREPROCESS_ATLAS_MIN)
 }
 
 #[cfg(test)]
@@ -85,6 +93,16 @@ mod tests {
         assert_eq!(planar_atlas_size(80), 80);
         assert_eq!(planar_atlas_size(341), PLANAR_ATLAS_MAX);
         assert_eq!(planar_atlas_size(1024), PLANAR_ATLAS_MAX);
+    }
+
+    #[test]
+    fn planar_preprocess_atlas_holds_the_full_dataset() {
+        assert_eq!(planar_preprocess_atlas_size(0), PLANAR_PREPROCESS_ATLAS_MIN);
+        assert_eq!(
+            planar_preprocess_atlas_size(341),
+            PLANAR_PREPROCESS_ATLAS_MIN
+        );
+        assert_eq!(planar_preprocess_atlas_size(2048), 2048);
     }
 }
 

--- a/libs/bevy_world_mesh/src/terrain/terrain.rs
+++ b/libs/bevy_world_mesh/src/terrain/terrain.rs
@@ -55,6 +55,39 @@ impl TerrainConfig {
     }
 }
 
+/// Smallest planar clipmap that stayed in-index on RC-jet (32 was too small).
+pub const PLANAR_ATLAS_MIN: u32 = 64;
+/// Working-set cap. LOD5 planar datasets are 341 tiles; 1024 layers is ~2 GiB.
+pub const PLANAR_ATLAS_MAX: u32 = 256;
+
+/// GPU atlas layers for a planar region: at least [`PLANAR_ATLAS_MIN`], at
+/// most [`PLANAR_ATLAS_MAX`], and never larger than the on-disk tile count
+/// when that count already exceeds the minimum.
+pub fn planar_atlas_size(dataset_tiles: u32) -> u32 {
+    if dataset_tiles == 0 {
+        return PLANAR_ATLAS_MIN;
+    }
+    dataset_tiles.clamp(PLANAR_ATLAS_MIN, PLANAR_ATLAS_MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn planar_atlas_size_uses_min_when_dataset_is_unknown() {
+        assert_eq!(planar_atlas_size(0), PLANAR_ATLAS_MIN);
+    }
+
+    #[test]
+    fn planar_atlas_size_clamps_to_working_set() {
+        assert_eq!(planar_atlas_size(32), PLANAR_ATLAS_MIN);
+        assert_eq!(planar_atlas_size(80), 80);
+        assert_eq!(planar_atlas_size(341), PLANAR_ATLAS_MAX);
+        assert_eq!(planar_atlas_size(1024), PLANAR_ATLAS_MAX);
+    }
+}
+
 /// The components of a terrain.
 ///
 /// Does not include loader(s) and a material.

--- a/libs/bevy_world_mesh/src/terrain/terrain_data/tile_atlas.rs
+++ b/libs/bevy_world_mesh/src/terrain/terrain_data/tile_atlas.rs
@@ -290,6 +290,7 @@ pub(crate) struct TileAtlasState {
     to_load: VecDeque<AtlasTileAttachment>,
     load_slots: u32,
     to_save: VecDeque<AtlasTileAttachment>,
+    pending_requests: Vec<TileCoordinate>,
     pub(crate) save_slots: u32,
     pub(crate) max_save_slots: u32,
 
@@ -316,6 +317,7 @@ impl TileAtlasState {
             attachment_count,
             to_save: default(),
             to_load: default(),
+            pending_requests: default(),
             save_slots: 64,
             max_save_slots: 64,
             load_slots: 64,
@@ -348,15 +350,20 @@ impl TileAtlasState {
     fn loaded_tile_attachment(&mut self, tile: AtlasTileAttachment) {
         self.load_slots += 1;
 
-        let tile_state = self.tile_states.get_mut(&tile.coordinate).unwrap();
-
-        tile_state.state = match tile_state.state {
-            LoadingState::Loading(1) => LoadingState::Loaded,
-            LoadingState::Loading(n) => LoadingState::Loading(n - 1),
-            LoadingState::Loaded => {
-                panic!("Loaded more attachments, than registered with the tile atlas.")
-            }
+        let Some(tile_state) = self.tile_states.get_mut(&tile.coordinate) else {
+            return;
         };
+        if tile_state.atlas_index != tile.atlas_index {
+            return;
+        }
+
+        if let LoadingState::Loading(n) = tile_state.state {
+            tile_state.state = if n == 1 {
+                LoadingState::Loaded
+            } else {
+                LoadingState::Loading(n - 1)
+            };
+        }
     }
 
     fn saved_tile_attachment(&mut self, _tile: AtlasTileAttachment) {
@@ -372,11 +379,11 @@ impl TileAtlasState {
             return AtlasTile::new(TileCoordinate::INVALID, INVALID_ATLAS_INDEX);
         }
 
-        let atlas_index = if self.existing_tiles.contains(&tile_coordinate) {
-            self.tile_states.get(&tile_coordinate).unwrap().atlas_index
-        } else {
-            INVALID_ATLAS_INDEX
-        };
+        let atlas_index = self
+            .tile_states
+            .get(&tile_coordinate)
+            .map(|tile| tile.atlas_index)
+            .unwrap_or(INVALID_ATLAS_INDEX);
 
         AtlasTile::new(tile_coordinate, atlas_index)
     }
@@ -390,16 +397,16 @@ impl TileAtlasState {
             return AtlasTile::new(TileCoordinate::INVALID, INVALID_ATLAS_INDEX);
         }
 
-        self.existing_tiles.insert(tile_coordinate);
-
         let atlas_index = if let Some(tile) = self.tile_states.get(&tile_coordinate) {
+            self.existing_tiles.insert(tile_coordinate);
             tile.atlas_index
         } else {
             let Some(unused) = self.allocate_tile() else {
                 return AtlasTile::new(tile_coordinate, INVALID_ATLAS_INDEX);
             };
-            self.tile_states.remove(&unused.coordinate);
+            self.evict_atlas_index(unused.atlas_index, unused.coordinate);
 
+            self.existing_tiles.insert(tile_coordinate);
             self.tile_states.insert(
                 tile_coordinate,
                 TileState {
@@ -413,6 +420,26 @@ impl TileAtlasState {
         };
 
         AtlasTile::new(tile_coordinate, atlas_index)
+    }
+
+    fn evict_atlas_index(&mut self, atlas_index: u32, coordinate: TileCoordinate) {
+        self.tile_states.remove(&coordinate);
+        self.to_load.retain(|tile| tile.atlas_index != atlas_index);
+        self.pending_requests
+            .retain(|pending| *pending != coordinate);
+    }
+
+    fn enqueue_pending_request(&mut self, tile_coordinate: TileCoordinate) {
+        if !self.pending_requests.contains(&tile_coordinate) {
+            self.pending_requests.push(tile_coordinate);
+        }
+    }
+
+    fn retry_pending_requests(&mut self) {
+        let pending = mem::take(&mut self.pending_requests);
+        for tile_coordinate in pending {
+            self.request_tile(tile_coordinate);
+        }
     }
 
     fn request_tile(&mut self, tile_coordinate: TileCoordinate) {
@@ -435,11 +462,16 @@ impl TileAtlasState {
             // Todo: implement better loading strategy
             let Some(unused) = self.allocate_tile() else {
                 self.tile_states = tile_states;
+                self.enqueue_pending_request(tile_coordinate);
                 return;
             };
             // `tile_states` was taken; drop the LRU occupant here, not on
             // the empty `self.tile_states`.
             tile_states.remove(&unused.coordinate);
+            self.to_load
+                .retain(|tile| tile.atlas_index != unused.atlas_index);
+            self.pending_requests
+                .retain(|pending| *pending != unused.coordinate);
             let atlas_index = unused.atlas_index;
 
             tile_states.insert(
@@ -600,7 +632,13 @@ impl TileAtlas {
 
             for tile_coordinate in tile_tree.released_tiles.drain(..) {
                 tile_atlas.state.release_tile(tile_coordinate);
+                tile_atlas
+                    .state
+                    .pending_requests
+                    .retain(|pending| *pending != tile_coordinate);
             }
+
+            tile_atlas.state.retry_pending_requests();
 
             for tile_coordinate in tile_tree.requested_tiles.drain(..) {
                 tile_atlas.state.request_tile(tile_coordinate);
@@ -658,5 +696,44 @@ mod tests {
         state.request_tile(coord(1));
         assert!(state.tile_states.contains_key(&coord(0)));
         assert!(!state.tile_states.contains_key(&coord(1)));
+        assert_eq!(state.pending_requests, vec![coord(1)]);
+    }
+
+    #[test]
+    fn request_retries_after_a_slot_is_released() {
+        let mut state = TileAtlasState::new(1, 1, HashSet::default());
+        state.existing_tiles.extend([coord(0), coord(1)]);
+        state.request_tile(coord(0));
+        state.request_tile(coord(1));
+        state.release_tile(coord(0));
+        state.retry_pending_requests();
+        assert!(state.tile_states.contains_key(&coord(1)));
+        assert!(state.pending_requests.is_empty());
+    }
+
+    #[test]
+    fn get_or_allocate_does_not_mark_existing_when_full() {
+        let mut state = TileAtlasState::new(0, 1, HashSet::default());
+        let tile = state.get_or_allocate_tile(coord(0));
+        assert_eq!(tile.atlas_index, INVALID_ATLAS_INDEX);
+        assert!(!state.existing_tiles.contains(&coord(0)));
+        assert_eq!(state.get_tile(coord(0)).atlas_index, INVALID_ATLAS_INDEX);
+    }
+
+    #[test]
+    fn loaded_attachment_ignores_evicted_tile() {
+        let mut state = TileAtlasState::new(1, 1, HashSet::default());
+        state.existing_tiles.extend([coord(0), coord(1)]);
+        state.request_tile(coord(0));
+        let atlas_index = state.tile_states[&coord(0)].atlas_index;
+        state.release_tile(coord(0));
+        state.request_tile(coord(1));
+        state.loaded_tile_attachment(AtlasTileAttachment {
+            coordinate: coord(0),
+            atlas_index,
+            attachment_index: 0,
+        });
+        assert!(state.tile_states.contains_key(&coord(1)));
+        assert!(!state.tile_states.contains_key(&coord(0)));
     }
 }

--- a/libs/bevy_world_mesh/src/terrain/terrain_data/tile_atlas.rs
+++ b/libs/bevy_world_mesh/src/terrain/terrain_data/tile_atlas.rs
@@ -290,7 +290,7 @@ pub(crate) struct TileAtlasState {
     to_load: VecDeque<AtlasTileAttachment>,
     load_slots: u32,
     to_save: VecDeque<AtlasTileAttachment>,
-    pending_requests: Vec<TileCoordinate>,
+    pending_requests: HashMap<TileCoordinate, u32>,
     pub(crate) save_slots: u32,
     pub(crate) max_save_slots: u32,
 
@@ -425,21 +425,70 @@ impl TileAtlasState {
     fn evict_atlas_index(&mut self, atlas_index: u32, coordinate: TileCoordinate) {
         self.tile_states.remove(&coordinate);
         self.to_load.retain(|tile| tile.atlas_index != atlas_index);
-        self.pending_requests
-            .retain(|pending| *pending != coordinate);
+        self.pending_requests.remove(&coordinate);
     }
 
     fn enqueue_pending_request(&mut self, tile_coordinate: TileCoordinate) {
-        if !self.pending_requests.contains(&tile_coordinate) {
-            self.pending_requests.push(tile_coordinate);
+        *self.pending_requests.entry(tile_coordinate).or_insert(0) += 1;
+    }
+
+    fn cancel_pending_request(&mut self, tile_coordinate: TileCoordinate) {
+        let Some(count) = self.pending_requests.get_mut(&tile_coordinate) else {
+            return;
+        };
+        *count = count.saturating_sub(1);
+        if *count == 0 {
+            self.pending_requests.remove(&tile_coordinate);
         }
     }
 
     fn retry_pending_requests(&mut self) {
         let pending = mem::take(&mut self.pending_requests);
-        for tile_coordinate in pending {
-            self.request_tile(tile_coordinate);
+        for (tile_coordinate, count) in pending {
+            if !self.fulfill_requests(tile_coordinate, count) {
+                self.pending_requests.insert(tile_coordinate, count);
+            }
         }
+    }
+
+    fn fulfill_requests(&mut self, tile_coordinate: TileCoordinate, count: u32) -> bool {
+        if count == 0 || !self.existing_tiles.contains(&tile_coordinate) {
+            return true;
+        }
+
+        if let Some(tile) = self.tile_states.get_mut(&tile_coordinate) {
+            if tile.requests == 0 {
+                self.unused_tiles
+                    .retain(|unused_tile| tile.atlas_index != unused_tile.atlas_index);
+            }
+            tile.requests += count;
+            return true;
+        }
+
+        let Some(unused) = self.allocate_tile() else {
+            return false;
+        };
+        self.evict_atlas_index(unused.atlas_index, unused.coordinate);
+
+        let atlas_index = unused.atlas_index;
+        self.tile_states.insert(
+            tile_coordinate,
+            TileState {
+                requests: count,
+                state: LoadingState::Loading(self.attachment_count),
+                atlas_index,
+            },
+        );
+
+        for attachment_index in 0..self.attachment_count {
+            self.to_load.push_back(AtlasTileAttachment {
+                coordinate: tile_coordinate,
+                atlas_index,
+                attachment_index,
+            });
+        }
+
+        true
     }
 
     fn request_tile(&mut self, tile_coordinate: TileCoordinate) {
@@ -470,8 +519,7 @@ impl TileAtlasState {
             tile_states.remove(&unused.coordinate);
             self.to_load
                 .retain(|tile| tile.atlas_index != unused.atlas_index);
-            self.pending_requests
-                .retain(|pending| *pending != unused.coordinate);
+            self.pending_requests.remove(&unused.coordinate);
             let atlas_index = unused.atlas_index;
 
             tile_states.insert(
@@ -501,6 +549,7 @@ impl TileAtlasState {
         }
 
         let Some(tile) = self.tile_states.get_mut(&tile_coordinate) else {
+            self.cancel_pending_request(tile_coordinate);
             return;
         };
         tile.requests -= 1;
@@ -632,13 +681,17 @@ impl TileAtlas {
 
             for tile_coordinate in tile_tree.released_tiles.drain(..) {
                 tile_atlas.state.release_tile(tile_coordinate);
-                tile_atlas
-                    .state
-                    .pending_requests
-                    .retain(|pending| *pending != tile_coordinate);
             }
+        }
 
+        for mut tile_atlas in tile_atlases.iter_mut() {
             tile_atlas.state.retry_pending_requests();
+        }
+
+        for (&(terrain, _view), tile_tree) in tile_trees.iter_mut() {
+            let Ok(mut tile_atlas) = tile_atlases.get_mut(terrain) else {
+                continue;
+            };
 
             for tile_coordinate in tile_tree.requested_tiles.drain(..) {
                 tile_atlas.state.request_tile(tile_coordinate);
@@ -696,7 +749,36 @@ mod tests {
         state.request_tile(coord(1));
         assert!(state.tile_states.contains_key(&coord(0)));
         assert!(!state.tile_states.contains_key(&coord(1)));
-        assert_eq!(state.pending_requests, vec![coord(1)]);
+        assert_eq!(state.pending_requests.get(&coord(1)), Some(&1));
+    }
+
+    #[test]
+    fn pending_keeps_other_views_after_one_release() {
+        let mut state = TileAtlasState::new(1, 1, HashSet::default());
+        state.existing_tiles.extend([coord(0), coord(1)]);
+        state.request_tile(coord(0));
+        state.request_tile(coord(1));
+        state.request_tile(coord(1));
+        assert_eq!(state.pending_requests.get(&coord(1)), Some(&2));
+        state.release_tile(coord(1));
+        assert_eq!(state.pending_requests.get(&coord(1)), Some(&1));
+        state.release_tile(coord(0));
+        state.retry_pending_requests();
+        assert_eq!(state.tile_states[&coord(1)].requests, 1);
+        assert!(state.pending_requests.is_empty());
+    }
+
+    #[test]
+    fn pending_retry_preserves_all_view_requests() {
+        let mut state = TileAtlasState::new(1, 1, HashSet::default());
+        state.existing_tiles.extend([coord(0), coord(1)]);
+        state.request_tile(coord(0));
+        state.request_tile(coord(1));
+        state.request_tile(coord(1));
+        state.release_tile(coord(0));
+        state.retry_pending_requests();
+        assert_eq!(state.tile_states[&coord(1)].requests, 2);
+        assert!(state.pending_requests.is_empty());
     }
 
     #[test]

--- a/libs/bevy_world_mesh/src/terrain/terrain_data/tile_atlas.rs
+++ b/libs/bevy_world_mesh/src/terrain/terrain_data/tile_atlas.rs
@@ -197,9 +197,13 @@ impl AtlasAttachment {
         self.loading_tiles.retain_mut(|tile| {
             future::block_on(future::poll_once(tile)).is_none_or(|tile| {
                 if let Ok(tile) = tile {
-                    atlas_state.loaded_tile_attachment(tile.tile);
-                    self.uploading_tiles.push(tile.clone());
-                    self.data[tile.tile.atlas_index as usize] = tile.data;
+                    if atlas_state.occupies_slot(tile.tile) {
+                        atlas_state.loaded_tile_attachment(tile.tile);
+                        self.uploading_tiles.push(tile.clone());
+                        self.data[tile.tile.atlas_index as usize] = tile.data;
+                    } else {
+                        atlas_state.load_slots += 1;
+                    }
                 } else {
                     atlas_state.load_slots += 1;
                 }
@@ -211,7 +215,9 @@ impl AtlasAttachment {
         self.downloading_tiles.retain_mut(|tile| {
             future::block_on(future::poll_once(tile)).is_none_or(|tile| {
                 atlas_state.downloaded_tile_attachment(tile.tile);
-                self.data[tile.tile.atlas_index as usize] = tile.data;
+                if atlas_state.occupies_slot(tile.tile) {
+                    self.data[tile.tile.atlas_index as usize] = tile.data;
+                }
                 false
             })
         });
@@ -345,6 +351,12 @@ impl TileAtlasState {
                 break;
             }
         }
+    }
+
+    fn occupies_slot(&self, tile: AtlasTileAttachment) -> bool {
+        self.tile_states
+            .get(&tile.coordinate)
+            .is_some_and(|state| state.atlas_index == tile.atlas_index)
     }
 
     fn loaded_tile_attachment(&mut self, tile: AtlasTileAttachment) {
@@ -491,7 +503,21 @@ impl TileAtlasState {
         true
     }
 
-    fn request_tile(&mut self, tile_coordinate: TileCoordinate) {
+    pub(crate) fn request_count(&self, tile_coordinate: TileCoordinate) -> u32 {
+        self.tile_states
+            .get(&tile_coordinate)
+            .map(|tile| tile.requests)
+            .unwrap_or(0)
+    }
+
+    pub(crate) fn pending_count(&self, tile_coordinate: TileCoordinate) -> u32 {
+        self.pending_requests
+            .get(&tile_coordinate)
+            .copied()
+            .unwrap_or(0)
+    }
+
+    pub(crate) fn request_tile(&mut self, tile_coordinate: TileCoordinate) {
         if !self.existing_tiles.contains(&tile_coordinate) {
             return;
         }
@@ -543,7 +569,7 @@ impl TileAtlasState {
         self.tile_states = tile_states;
     }
 
-    fn release_tile(&mut self, tile_coordinate: TileCoordinate) {
+    pub(crate) fn release_tile(&mut self, tile_coordinate: TileCoordinate) {
         if !self.existing_tiles.contains(&tile_coordinate) {
             return;
         }
@@ -817,5 +843,26 @@ mod tests {
         });
         assert!(state.tile_states.contains_key(&coord(1)));
         assert!(!state.tile_states.contains_key(&coord(0)));
+    }
+
+    #[test]
+    fn occupies_slot_is_false_after_reuse() {
+        let mut state = TileAtlasState::new(1, 1, HashSet::default());
+        state.existing_tiles.extend([coord(0), coord(1)]);
+        state.request_tile(coord(0));
+        let stale = AtlasTileAttachment {
+            coordinate: coord(0),
+            atlas_index: state.tile_states[&coord(0)].atlas_index,
+            attachment_index: 0,
+        };
+        assert!(state.occupies_slot(stale));
+        state.release_tile(coord(0));
+        state.request_tile(coord(1));
+        assert!(!state.occupies_slot(stale));
+        assert!(state.occupies_slot(AtlasTileAttachment {
+            coordinate: coord(1),
+            atlas_index: stale.atlas_index,
+            attachment_index: 0,
+        }));
     }
 }

--- a/libs/bevy_world_mesh/src/terrain/terrain_data/tile_atlas.rs
+++ b/libs/bevy_world_mesh/src/terrain/terrain_data/tile_atlas.rs
@@ -381,12 +381,8 @@ impl TileAtlasState {
         AtlasTile::new(tile_coordinate, atlas_index)
     }
 
-    fn allocate_tile(&mut self) -> u32 {
-        let unused_tile = self.unused_tiles.pop_front().expect("Atlas out of indices");
-
-        self.tile_states.remove(&unused_tile.coordinate);
-
-        unused_tile.atlas_index
+    fn allocate_tile(&mut self) -> Option<AtlasTile> {
+        self.unused_tiles.pop_front()
     }
 
     fn get_or_allocate_tile(&mut self, tile_coordinate: TileCoordinate) -> AtlasTile {
@@ -399,18 +395,21 @@ impl TileAtlasState {
         let atlas_index = if let Some(tile) = self.tile_states.get(&tile_coordinate) {
             tile.atlas_index
         } else {
-            let atlas_index = self.allocate_tile();
+            let Some(unused) = self.allocate_tile() else {
+                return AtlasTile::new(tile_coordinate, INVALID_ATLAS_INDEX);
+            };
+            self.tile_states.remove(&unused.coordinate);
 
             self.tile_states.insert(
                 tile_coordinate,
                 TileState {
                     requests: 1,
                     state: LoadingState::Loaded,
-                    atlas_index,
+                    atlas_index: unused.atlas_index,
                 },
             );
 
-            atlas_index
+            unused.atlas_index
         };
 
         AtlasTile::new(tile_coordinate, atlas_index)
@@ -434,7 +433,14 @@ impl TileAtlasState {
             tile.requests += 1;
         } else {
             // Todo: implement better loading strategy
-            let atlas_index = self.allocate_tile();
+            let Some(unused) = self.allocate_tile() else {
+                self.tile_states = tile_states;
+                return;
+            };
+            // `tile_states` was taken; drop the LRU occupant here, not on
+            // the empty `self.tile_states`.
+            tile_states.remove(&unused.coordinate);
+            let atlas_index = unused.atlas_index;
 
             tile_states.insert(
                 tile_coordinate,
@@ -462,10 +468,9 @@ impl TileAtlasState {
             return;
         }
 
-        let tile = self
-            .tile_states
-            .get_mut(&tile_coordinate)
-            .expect("Tried releasing a tile, which is not present.");
+        let Some(tile) = self.tile_states.get_mut(&tile_coordinate) else {
+            return;
+        };
         tile.requests -= 1;
 
         if tile.requests == 0 {
@@ -623,5 +628,35 @@ impl TileAtlas {
             println!("Tile config not found.");
             HashSet::default()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn coord(x: u32) -> TileCoordinate {
+        TileCoordinate::new(0, 0, x, 0)
+    }
+
+    #[test]
+    fn request_reuses_a_released_slot() {
+        let mut state = TileAtlasState::new(1, 1, HashSet::default());
+        state.existing_tiles.extend([coord(0), coord(1)]);
+        state.request_tile(coord(0));
+        state.release_tile(coord(0));
+        state.request_tile(coord(1));
+        assert!(state.tile_states.contains_key(&coord(1)));
+        assert!(!state.tile_states.contains_key(&coord(0)));
+    }
+
+    #[test]
+    fn request_skips_when_every_slot_is_in_use() {
+        let mut state = TileAtlasState::new(1, 1, HashSet::default());
+        state.existing_tiles.extend([coord(0), coord(1)]);
+        state.request_tile(coord(0));
+        state.request_tile(coord(1));
+        assert!(state.tile_states.contains_key(&coord(0)));
+        assert!(!state.tile_states.contains_key(&coord(1)));
     }
 }

--- a/libs/bevy_world_mesh/src/terrain/terrain_data/tile_tree.rs
+++ b/libs/bevy_world_mesh/src/terrain/terrain_data/tile_tree.rs
@@ -186,6 +186,20 @@ impl TileTree {
         }
     }
 
+    /// Drop this tree's atlas holds. Despawned views never emit `Released`.
+    pub fn disconnect(&mut self, tile_atlas: &mut TileAtlas) {
+        self.requested_tiles.clear();
+        for tile in self.tiles.iter_mut() {
+            if tile.state == RequestState::Requested {
+                tile.state = RequestState::Released;
+                self.released_tiles.push(tile.coordinate);
+            }
+        }
+        for coordinate in self.released_tiles.drain(..) {
+            tile_atlas.state.release_tile(coordinate);
+        }
+    }
+
     fn compute_tree_xy(coordinate: Coordinate, tile_count: f64) -> DVec2 {
         // scale and clamp the coordinate to the tile tree bounds
         (coordinate.uv * tile_count).min(DVec2::splat(tile_count - 0.000001))
@@ -446,5 +460,47 @@ impl TileTree {
             tile_tree.approximate_height =
                 sample_height(tile_tree, tile_atlas, tile_tree.view_world_position);
         }
+    }
+
+    #[cfg(test)]
+    fn mark_requested_for_test(&mut self, slot: usize, coordinate: TileCoordinate) {
+        self.tiles[[0, 0, 0, slot]] = TileState {
+            coordinate,
+            state: RequestState::Requested,
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::terrain::math::TerrainModel;
+    use crate::terrain::terrain::TerrainConfig;
+    use bevy::math::DVec3;
+
+    fn coord(x: u32) -> TileCoordinate {
+        TileCoordinate::new(0, 0, x, 0)
+    }
+
+    #[test]
+    fn disconnect_releases_atlas_and_pending_holds() {
+        let mut atlas = TileAtlas::new(&TerrainConfig {
+            atlas_size: 1,
+            lod_count: 1,
+            model: TerrainModel::planar(DVec3::ZERO, 1.0, 0.0, 1.0),
+            ..Default::default()
+        });
+        atlas.state.existing_tiles.extend([coord(0), coord(1)]);
+        atlas.state.request_tile(coord(0));
+        atlas.state.request_tile(coord(1));
+        assert_eq!(atlas.state.pending_count(coord(1)), 1);
+
+        let mut tree = TileTree::new(&atlas, &TerrainViewConfig::default());
+        tree.mark_requested_for_test(0, coord(0));
+        tree.mark_requested_for_test(1, coord(1));
+        tree.disconnect(&mut atlas);
+
+        assert_eq!(atlas.state.request_count(coord(0)), 0);
+        assert_eq!(atlas.state.pending_count(coord(1)), 0);
     }
 }

--- a/libs/bevy_world_mesh/src/terrain/terrain_data/tile_tree.rs
+++ b/libs/bevy_world_mesh/src/terrain/terrain_data/tile_tree.rs
@@ -1,7 +1,7 @@
 use crate::terrain::{
     math::{Coordinate, TerrainModel, TileCoordinate},
     terrain_data::{sample_height, tile_atlas::TileAtlas, INVALID_ATLAS_INDEX, INVALID_LOD},
-    terrain_view::{TerrainViewComponents, TerrainViewConfig},
+    terrain_view::{geometry_tile_capacity, TerrainViewComponents, TerrainViewConfig},
     util::inverse_mix,
 };
 use bevy::{
@@ -149,7 +149,11 @@ impl TileTree {
         Self {
             lod_count: tile_atlas.lod_count,
             tree_size: view_config.tree_size,
-            geometry_tile_count: view_config.geometry_tile_count,
+            geometry_tile_count: geometry_tile_capacity(
+                view_config.tree_size,
+                tile_atlas.lod_count,
+                tile_atlas.model.side_count(),
+            ),
             refinement_count: view_config.refinement_count,
             grid_size: view_config.grid_size,
             morph_distance: view_config.morph_distance * scale,

--- a/libs/bevy_world_mesh/src/terrain/terrain_view.rs
+++ b/libs/bevy_world_mesh/src/terrain/terrain_view.rs
@@ -48,7 +48,7 @@ impl Default for TerrainViewConfig {
     fn default() -> Self {
         Self {
             tree_size: 8,
-            geometry_tile_count: 1000000,
+            geometry_tile_count: geometry_tile_capacity(8, 5, 6),
             refinement_count: 30,
             grid_size: 16,
             subdivision_tolerance: 0.1,
@@ -60,5 +60,42 @@ impl Default for TerrainViewConfig {
             precision_threshold_distance: 0.001,
             origin_lod: 10,
         }
+    }
+}
+
+/// STORAGE slots for the refine/draw tile lists (two buffers of
+/// `count * 16` bytes per view). `1_000_000` was ~15.26 MiB each; a
+/// clipmap of `tree_size² × lods × sides` with leaf headroom covers the
+/// refine fan-out.
+pub fn geometry_tile_capacity(tree_size: u32, lod_count: u32, side_count: u32) -> u32 {
+    const LEAF_HEADROOM: u32 = 16;
+    const MIN: u32 = 4096;
+    const MAX: u32 = 65_536;
+    tree_size
+        .saturating_mul(tree_size)
+        .saturating_mul(lod_count.max(1))
+        .saturating_mul(side_count.max(1))
+        .saturating_mul(LEAF_HEADROOM)
+        .clamp(MIN, MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn geometry_tile_capacity_fits_a_planar_clipmap() {
+        assert_eq!(geometry_tile_capacity(8, 5, 1), 8 * 8 * 5 * 16);
+    }
+
+    #[test]
+    fn geometry_tile_capacity_fits_a_globe_clipmap() {
+        assert_eq!(geometry_tile_capacity(8, 5, 6), 8 * 8 * 5 * 6 * 16);
+    }
+
+    #[test]
+    fn geometry_tile_capacity_clamps() {
+        assert_eq!(geometry_tile_capacity(1, 1, 1), 4096);
+        assert_eq!(geometry_tile_capacity(32, 16, 6), 65_536);
     }
 }

--- a/libs/bevy_world_mesh/src/terrain/terrain_view.rs
+++ b/libs/bevy_world_mesh/src/terrain/terrain_view.rs
@@ -84,6 +84,17 @@ pub fn geometry_tile_capacity(tree_size: u32, lod_count: u32, side_count: u32) -
     clipmap.max(refine).clamp(MIN, MAX)
 }
 
+/// Matches `try_reserve_children` in `refine_tiles.wgsl`: four ping-pong
+/// slots, or none. A failed reserve must not move `child_index`.
+pub fn try_reserve_refine_children(child_index: i32, counter: i32, tile_count: i32) -> Option<i32> {
+    let last = child_index.checked_add(counter.checked_mul(3)?)?;
+    if (0..tile_count).contains(&child_index) && (0..tile_count).contains(&last) {
+        Some(child_index)
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -102,5 +113,13 @@ mod tests {
     fn geometry_tile_capacity_clamps() {
         assert_eq!(geometry_tile_capacity(1, 1, 1), 65_536);
         assert_eq!(geometry_tile_capacity(32, 16, 6), 262_144);
+    }
+
+    #[test]
+    fn refine_reserve_rejects_a_partial_generation() {
+        assert_eq!(try_reserve_refine_children(0, 1, 8), Some(0));
+        assert_eq!(try_reserve_refine_children(5, 1, 8), None);
+        assert_eq!(try_reserve_refine_children(7, -1, 8), Some(7));
+        assert_eq!(try_reserve_refine_children(2, -1, 8), None);
     }
 }

--- a/libs/bevy_world_mesh/src/terrain/terrain_view.rs
+++ b/libs/bevy_world_mesh/src/terrain/terrain_view.rs
@@ -64,19 +64,24 @@ impl Default for TerrainViewConfig {
 }
 
 /// STORAGE slots for the refine/draw tile lists (two buffers of
-/// `count * 16` bytes per view). `1_000_000` was ~15.26 MiB each; a
-/// clipmap of `tree_size² × lods × sides` with leaf headroom covers the
-/// refine fan-out.
+/// `count * 16` bytes per view). `1_000_000` was ~15.26 MiB each.
+///
+/// The data clipmap is `tree_size² × lods × sides`. GPU `refine_tiles`
+/// can 4× that working set each step, so the buffer also holds one
+/// generation of `4^REFINE_STEPS` children per side.
 pub fn geometry_tile_capacity(tree_size: u32, lod_count: u32, side_count: u32) -> u32 {
     const LEAF_HEADROOM: u32 = 16;
+    const REFINE_STEPS: u32 = 8;
     const MIN: u32 = 4096;
-    const MAX: u32 = 65_536;
-    tree_size
+    const MAX: u32 = 262_144;
+    let sides = side_count.max(1);
+    let clipmap = tree_size
         .saturating_mul(tree_size)
         .saturating_mul(lod_count.max(1))
-        .saturating_mul(side_count.max(1))
-        .saturating_mul(LEAF_HEADROOM)
-        .clamp(MIN, MAX)
+        .saturating_mul(sides)
+        .saturating_mul(LEAF_HEADROOM);
+    let refine = sides.saturating_mul(1 << (2 * REFINE_STEPS));
+    clipmap.max(refine).clamp(MIN, MAX)
 }
 
 #[cfg(test)]
@@ -84,18 +89,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn geometry_tile_capacity_fits_a_planar_clipmap() {
-        assert_eq!(geometry_tile_capacity(8, 5, 1), 8 * 8 * 5 * 16);
+    fn geometry_tile_capacity_fits_planar_refine() {
+        assert_eq!(geometry_tile_capacity(8, 5, 1), 65_536);
     }
 
     #[test]
-    fn geometry_tile_capacity_fits_a_globe_clipmap() {
-        assert_eq!(geometry_tile_capacity(8, 5, 6), 8 * 8 * 5 * 6 * 16);
+    fn geometry_tile_capacity_fits_globe_refine() {
+        assert_eq!(geometry_tile_capacity(8, 5, 6), 262_144);
     }
 
     #[test]
     fn geometry_tile_capacity_clamps() {
-        assert_eq!(geometry_tile_capacity(1, 1, 1), 4096);
-        assert_eq!(geometry_tile_capacity(32, 16, 6), 65_536);
+        assert_eq!(geometry_tile_capacity(1, 1, 1), 65_536);
+        assert_eq!(geometry_tile_capacity(32, 16, 6), 262_144);
     }
 }

--- a/libs/elodin-editor/src/plugins/world_mesh/mod.rs
+++ b/libs/elodin-editor/src/plugins/world_mesh/mod.rs
@@ -17,9 +17,11 @@ use bevy_world_mesh::terrain::{
     terrain_view::{TerrainViewComponents, TerrainViewConfig},
 };
 
-use crate::{MainCamera, sensor_camera::SensorCamera};
+use crate::{MainCamera, sensor_camera::SensorCamera, ui::tiles::ViewportConfig};
 
-type WorldMeshViewFilter = Or<(With<MainCamera>, With<SensorCamera>)>;
+/// 3D viewports and sensor feeds — not 2D graph cameras, which also carry
+/// [`MainCamera`] and would each allocate a full terrain view (~30 MiB).
+type WorldMeshViewFilter = Or<((With<MainCamera>, With<ViewportConfig>), With<SensorCamera>)>;
 type WorldMeshTerrainQuery<'w, 's> =
     Query<'w, 's, (Entity, &'static ChildOf), (With<WorldMeshTerrain>, With<TileAtlas>)>;
 #[cfg(feature = "big_space")]
@@ -499,8 +501,8 @@ fn spawn_globe_fallback(
 }
 
 /// The terrain renderer needs one [`TileTree`] per `(terrain, camera)` pair.
-/// Editor viewports are spawned dynamically from KDL, so wire the pairs after
-/// both the terrain entity and viewport cameras exist.
+/// Only schematic viewports and sensor cameras participate — graph
+/// `MainCamera`s are excluded by [`WorldMeshViewFilter`].
 fn sync_terrain_view_components(
     terrains: Query<(Entity, &TileAtlas), With<WorldMeshTerrain>>,
     cameras: Query<Entity, WorldMeshViewFilter>,
@@ -651,7 +653,11 @@ mod tests {
         let camera_pos = anchor_transform.translation + Vec3::new(3.0, 4.0, 5.0);
         let camera = app
             .world_mut()
-            .spawn((Transform::from_translation(camera_pos), MainCamera))
+            .spawn((
+                Transform::from_translation(camera_pos),
+                MainCamera,
+                test_viewport_config(),
+            ))
             .id();
         #[cfg(feature = "big_space")]
         app.world_mut()
@@ -681,6 +687,51 @@ mod tests {
         // The pulled-back position must be near the model origin, not out at
         // the anchor's world offset.
         assert!(local.length() < 10.0, "not terrain-relative: {local:?}");
+    }
+
+    #[test]
+    fn sync_skips_graph_cameras_that_only_have_main_camera() {
+        let (mut app, _, renderer) = spawn_model_terrain(
+            TerrainModel::planar(DVec3::ZERO, 250.0, 0.0, 100.0),
+            world_mesh(Some(GeoFrame::ENU), None),
+        );
+        app.init_resource::<TerrainViewComponents<TileTree>>();
+        let graph_cam = app.world_mut().spawn(MainCamera).id();
+
+        app.world_mut()
+            .run_system_once(sync_terrain_view_components)
+            .unwrap();
+
+        let trees = app.world().resource::<TerrainViewComponents<TileTree>>();
+        assert!(
+            trees.get(&(renderer, graph_cam)).is_none(),
+            "2D graph cameras must not allocate a terrain view"
+        );
+    }
+
+    #[test]
+    fn sync_creates_views_for_viewports_and_sensor_cameras() {
+        let (mut app, _, renderer) = spawn_model_terrain(
+            TerrainModel::planar(DVec3::ZERO, 250.0, 0.0, 100.0),
+            world_mesh(Some(GeoFrame::ENU), None),
+        );
+        app.init_resource::<TerrainViewComponents<TileTree>>();
+        let viewport = app
+            .world_mut()
+            .spawn((MainCamera, test_viewport_config()))
+            .id();
+        let sensor = app.world_mut().spawn(SensorCamera { config_index: 0 }).id();
+        let graph_cam = app.world_mut().spawn(MainCamera).id();
+
+        app.world_mut()
+            .run_system_once(sync_terrain_view_components)
+            .unwrap();
+
+        let trees = app.world().resource::<TerrainViewComponents<TileTree>>();
+        assert!(trees.get(&(renderer, viewport)).is_some());
+        assert!(trees.get(&(renderer, sensor)).is_some());
+        assert!(trees.get(&(renderer, graph_cam)).is_none());
+        assert_eq!(trees.len(), 2);
     }
 
     #[test]
@@ -848,6 +899,24 @@ mod tests {
         app.world_mut()
             .run_system_once(bevy_geo_frames::apply_geo_rotation)
             .unwrap();
+    }
+
+    fn test_viewport_config() -> ViewportConfig {
+        ViewportConfig {
+            aspect: None,
+            configured_near: None,
+            configured_far: None,
+            show_arrows: false,
+            create_frustum: false,
+            show_frustums: false,
+            show_coverage_in_viewport: false,
+            show_projection_2d: false,
+            frustums_color: default(),
+            projection_color: default(),
+            frustums_thickness: 0.006,
+            cinematic: false,
+            bloom: None,
+        }
     }
 
     fn world_mesh(frame: Option<GeoFrame>, translate: Option<(f64, f64, f64)>) -> WorldMesh {

--- a/libs/elodin-editor/src/plugins/world_mesh/mod.rs
+++ b/libs/elodin-editor/src/plugins/world_mesh/mod.rs
@@ -246,6 +246,12 @@ fn planar_terrain_config(region: &str, lod_count: Option<u32>) -> WorldMeshConfi
         "fetch_real_terrain and preprocess",
     );
 
+    let dataset_tiles = bevy_world_mesh::terrain::formats::TC::load_file(
+        bevy_world_mesh::terrain::util::asset_path(format!("{terrain_path}/config.tc")),
+    )
+    .map(|tc| tc.tiles.len() as u32)
+    .unwrap_or(0);
+
     let config = TerrainConfig {
         lod_count: planar_lod_count(lod_count),
         model: TerrainModel::planar(
@@ -255,6 +261,7 @@ fn planar_terrain_config(region: &str, lod_count: Option<u32>) -> WorldMeshConfi
             height,
         ),
         path: terrain_path,
+        atlas_size: bevy_world_mesh::terrain::terrain::planar_atlas_size(dataset_tiles),
         ..default()
     }
     .add_attachment(AttachmentConfig {

--- a/libs/elodin-editor/src/plugins/world_mesh/mod.rs
+++ b/libs/elodin-editor/src/plugins/world_mesh/mod.rs
@@ -2,6 +2,7 @@ use bevy::{
     ecs::query::Or,
     math::{DQuat, DVec3},
     pbr::wireframe::{Wireframe, WireframeColor},
+    platform::collections::HashSet,
     prelude::*,
 };
 use bevy_geo_frames::{GeoContext, GeoPosition, GeoRotation, OrDefault};
@@ -511,19 +512,32 @@ fn spawn_globe_fallback(
 /// Only schematic viewports and sensor cameras participate — graph
 /// `MainCamera`s are excluded by [`WorldMeshViewFilter`].
 fn sync_terrain_view_components(
-    terrains: Query<(Entity, &TileAtlas), With<WorldMeshTerrain>>,
+    mut terrains: Query<(Entity, &mut TileAtlas), With<WorldMeshTerrain>>,
     cameras: Query<Entity, WorldMeshViewFilter>,
     mut tile_trees: ResMut<TerrainViewComponents<TileTree>>,
 ) {
-    tile_trees
-        .retain(|(terrain, view), _| terrains.get(*terrain).is_ok() && cameras.get(*view).is_ok());
+    let live_terrains: HashSet<Entity> = terrains.iter().map(|(terrain, _)| terrain).collect();
+    let live_views: HashSet<Entity> = cameras.iter().collect();
+    let dropped: Vec<(Entity, Entity)> = tile_trees
+        .keys()
+        .copied()
+        .filter(|(terrain, view)| !live_terrains.contains(terrain) || !live_views.contains(view))
+        .collect();
+
+    for key in dropped {
+        if let Some(mut tree) = tile_trees.remove(&key) {
+            if let Ok((_, mut tile_atlas)) = terrains.get_mut(key.0) {
+                tree.disconnect(&mut tile_atlas);
+            }
+        }
+    }
 
     let view_config = TerrainViewConfig::default();
-    for (terrain, tile_atlas) in &terrains {
+    for (terrain, tile_atlas) in &mut terrains {
         for view in &cameras {
             tile_trees
                 .entry((terrain, view))
-                .or_insert_with(|| TileTree::new(tile_atlas, &view_config));
+                .or_insert_with(|| TileTree::new(&tile_atlas, &view_config));
         }
     }
 }
@@ -739,6 +753,41 @@ mod tests {
         assert!(trees.get(&(renderer, sensor)).is_some());
         assert!(trees.get(&(renderer, graph_cam)).is_none());
         assert_eq!(trees.len(), 2);
+    }
+
+    #[test]
+    fn sync_drops_trees_for_despawned_viewports() {
+        let (mut app, _, renderer) = spawn_model_terrain(
+            TerrainModel::planar(DVec3::ZERO, 250.0, 0.0, 100.0),
+            world_mesh(Some(GeoFrame::ENU), None),
+        );
+        app.init_resource::<TerrainViewComponents<TileTree>>();
+        let viewport = app
+            .world_mut()
+            .spawn((MainCamera, test_viewport_config()))
+            .id();
+
+        app.world_mut()
+            .run_system_once(sync_terrain_view_components)
+            .unwrap();
+        assert!(
+            app.world()
+                .resource::<TerrainViewComponents<TileTree>>()
+                .get(&(renderer, viewport))
+                .is_some()
+        );
+
+        app.world_mut().entity_mut(viewport).despawn();
+        app.world_mut()
+            .run_system_once(sync_terrain_view_components)
+            .unwrap();
+        assert!(
+            app.world()
+                .resource::<TerrainViewComponents<TileTree>>()
+                .get(&(renderer, viewport))
+                .is_none(),
+            "despawned viewports must drop their terrain tree"
+        );
     }
 
     #[test]

--- a/libs/elodin-editor/src/plugins/world_mesh/mod.rs
+++ b/libs/elodin-editor/src/plugins/world_mesh/mod.rs
@@ -525,10 +525,10 @@ fn sync_terrain_view_components(
         .collect();
 
     for key in dropped {
-        if let Some(mut tree) = tile_trees.remove(&key) {
-            if let Ok((_, mut tile_atlas)) = terrains.get_mut(key.0) {
-                tree.disconnect(&mut tile_atlas);
-            }
+        if let Some(mut tree) = tile_trees.remove(&key)
+            && let Ok((_, mut tile_atlas)) = terrains.get_mut(key.0)
+        {
+            tree.disconnect(&mut tile_atlas);
         }
     }
 


### PR DESCRIPTION
This branch based on feat/real-bdx, includes the three first points from this comment https://github.com/elodin-sys/elodin/pull/820#issuecomment-5430720614 by Anders:
- 1. 
```
Fix terrain camera filtering in libs/elodin-editor/src/plugins/world_mesh/mod.rs. WorldMeshViewFilter matches every MainCamera, including graph render cameras. RCJET created 21 terrain views
instead of four, allocating 42 × 15.26 MiB buffers (~641 MiB). Requiring MainCamera + ViewportConfig reduced this to eight buffers (~122 MiB).
```
- 2.
```
Right-size the planar terrain atlas. planar_terrain_config inherits atlas_size=1024, consuming ~2 GiB per process (~4 GiB for editor + render server). Mojave contains only 341 total tiles and
needs a much smaller active working set. Make capacity configurable/dynamic, cap it to dataset size, and handle capacity pressure without Atlas out of indices. A 64-layer diagnostic worked for
RCJET; 32 was too small.
```
- 3.
```
Replace geometry_tile_count=1_000_000 in terrain_view.rs with a measured/dynamic capacity. It creates two ~15 MiB buffers per terrain view.       
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches GPU buffer sizing, compute refine logic, and atlas LRU/eviction; incorrect bounds could cause terrain gaps or OOM, but behavior is covered by new unit tests.
> 
> **Overview**
> Reduces world-mesh **GPU and per-view memory** by fixing who gets a terrain view, how big atlases and refine buffers are, and how the tile clipmap behaves under pressure.
> 
> In the **editor**, terrain `TileTree`s are created only for schematic viewports (`MainCamera` + `ViewportConfig`) and **sensor cameras**, not for 2D graph cameras that also carry `MainCamera`. Despawned views call **`TileTree::disconnect`** so atlas holds and pending requests are released instead of leaking.
> 
> **Planar atlases** are split: runtime uses `planar_atlas_size` (clamped ~64–256 from dataset tile count) while **preprocess** keeps `planar_preprocess_atlas_size` (≥1024 for the full on-disk set). When the runtime atlas is full, tile **requests queue and retry** after LRU eviction; **async loads** apply only if the slot still matches (`occupies_slot`).
> 
> **Per-view geometry buffers** drop the fixed `1_000_000` tile cap in favor of **`geometry_tile_capacity`** (clipmap + refine fan-out, clamped). Matching **WGSL** changes bound refine/subdivide indices, atomically reserve four child slots, and fall back to drawing a parent tile when subdivision cannot reserve space.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0748a4abdaee02d1b15e79a277f62a25bd54b722. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->