### PR TITLE
Real bdx fixes

### DIFF
--- a/libs/bevy_world_mesh/src/terrain/shaders/tiling_prepass/refine_tiles.wgsl
+++ b/libs/bevy_world_mesh/src/terrain/shaders/tiling_prepass/refine_tiles.wgsl
@@ -42,6 +42,10 @@ fn try_reserve_children() -> i32 {
             return current;
         }
     }
+
+    // Naga does not infer that the loop can only exit via one of the returns
+    // above, so an explicit fallback is required to satisfy the i32 return.
+    return -1;
 }
 
 fn subdivide(tile: TileCoordinate) -> bool {

--- a/libs/elodin-editor/src/lib.rs
+++ b/libs/elodin-editor/src/lib.rs
@@ -69,8 +69,14 @@ pub struct Coordinate(pub Option<GeoFrame>);
 
 pub(crate) fn editor_wgpu_settings() -> WgpuSettings {
     WgpuSettings {
+        // wgpu's Vulkan preflight cannot determine which device-local heap a
+        // resource will use, so it rejects the allocation when *any* such
+        // heap would cross this threshold. NVIDIA exposes its small BAR heap
+        // as device-local in addition to VRAM; large VRAM-only textures (for
+        // example, terrain atlases) can therefore get a false OOM while VRAM
+        // is almost empty. Let the native allocator report real OOMs instead.
         instance_memory_budget_thresholds: wgpu::MemoryBudgetThresholds {
-            for_resource_creation: Some(99),
+            for_resource_creation: None,
             for_device_loss: None,
         },
         memory_hints: wgpu::MemoryHints::MemoryUsage,


### PR DESCRIPTION
2 fixes:

1. the shader fix is because naga compilation was failing for me after @zxq82lm's recent fixes

2. the OOM fix is because my nvidia GPUs have a small BAR heap which was triggering the proactive OOM check, which ironically caused OOM every time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted fixes: unreachable-style shader fallback and relaxed wgpu budget pre-check; slightly less early OOM protection on other GPUs.
> 
> **Overview**
> Fixes two runtime/build issues: terrain tiling prepass shader compilation and spurious GPU OOM on some NVIDIA cards.
> 
> In **`refine_tiles.wgsl`**, **`try_reserve_children`** now ends with an explicit **`return -1`** after its atomic reservation loop. Naga does not prove the loop always exits through the inner returns, so the **`i32`** return type was failing validation; the fallback matches the existing failure path when the tile buffer is full.
> 
> In **`editor_wgpu_settings`**, **`instance_memory_budget_thresholds.for_resource_creation`** is set to **`None`** instead of **`Some(99)`**. Vulkan preflight can treat NVIDIA’s small BAR heap as device-local and reject large allocations (e.g. terrain atlases) while VRAM is still free; disabling the proactive threshold lets the driver report real OOM instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d8902f4fee846033f5dc02df057fdcf6bf243d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->