### PR TITLE
Fix: aarch64 cortex flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,59 +199,39 @@ jobs:
 
           # Wrappers needed because cc-rs treats CC_*/CXX_* as paths, not shell
           # commands, so we cannot inline `-target <triple>` in the env var.
-          # The wrappers strip the `--target=<rust-triple>` that cc-rs appends
-          # to every invocation: Zig rejects it with "UnknownOperatingSystem"
-          # because it expects its own triple format (e.g. `aarch64-linux-musl`
-          # without the `unknown` vendor component). We then pass the correct
-          # Zig-flavoured `-target` ourselves.
-          # printf (no heredoc) ensures the shebang sits at byte 0 of the file
-          # — kernels require `#!` as the first two bytes for it to be honored.
+          # printf (no heredoc) keeps `#!` at byte 0 of each trampoline.
           wrap_dir="/opt/zig-cc-${env_target}"
           sudo mkdir -p "$wrap_dir"
-          # Use `printf '%s\n'` line-by-line so each wrapper-script line is
-          # a distinct printf arg — keeps the YAML block scalar valid even
-          # though the generated script itself has no leading indentation.
-          # The wrapper strips:
-          #   1. --target=<rust-triple>  — Zig rejects this format
-          #      ("UnknownOperatingSystem"); we pass the Zig-flavoured
-          #      -target ourselves.
-          #   2. rustc self-contained CRT objects (rcrt1.o, crti.o,
-          #      crtbeginS.o, crtendS.o, crtn.o passed positionally) — Zig
-          #      adds its own CRT for -target *-linux-musl, so without this
-          #      filter we get duplicate _start / _start_c symbols at link
-          #      time. Filtering here (rather than via -C link-self-contained
-          #      =no in cargo config) is robust against `dist build` setting
-          #      its own RUSTFLAGS env var which would shadow our config.
-          printf '%s\n' \
-            '#!/bin/bash' \
-            'args=()' \
-            'for a in "$@"; do' \
-            '  case "$a" in' \
-            '    --target=*) ;;' \
-            '    */self-contained/*crt*.o) ;;' \
-            '    *) args+=("$a") ;;' \
-            '  esac' \
-            'done' \
-            "exec \"${zig_bin}\" cc -target ${zig_target} \"\${args[@]}\"" \
-            | sudo tee "${wrap_dir}/cc" >/dev/null
-          printf '%s\n' \
-            '#!/bin/bash' \
-            'args=()' \
-            'for a in "$@"; do' \
-            '  case "$a" in' \
-            '    --target=*) ;;' \
-            '    */self-contained/*crt*.o) ;;' \
-            '    *) args+=("$a") ;;' \
-            '  esac' \
-            'done' \
-            "exec \"${zig_bin}\" c++ -target ${zig_target} \"\${args[@]}\"" \
-            | sudo tee "${wrap_dir}/c++" >/dev/null
+          # Trampolines (not the logic) live here: cc-rs needs CC_*/CXX_* as
+          # paths. Logic is scripts/zig-musl-wrapper.sh.
+          #
+          # rustc 1.98+ gcc-flavor injects -Wl,--fix-cortex-a53-843419 on
+          # aarch64-linux. zig cc 0.16 rejects it even with -fuse-ld=lld;
+          # the wrapper unwraps -Wl, and execs zig ld.lld, failing if rustc
+          # asked for the flag and LLD would not run with it.
+          wrapper_src="$(pwd)/scripts/zig-musl-wrapper.sh"
+          if [ ! -f "$wrapper_src" ]; then
+            echo "::error::missing $wrapper_src"
+            exit 1
+          fi
+          write_zig_trampoline() {
+            local dest="$1" cmd="$2"
+            printf '%s\n' \
+              '#!/bin/bash' \
+              "export ELODIN_ZIG_BIN=\"${zig_bin}\"" \
+              "export ELODIN_ZIG_TARGET=\"${zig_target}\"" \
+              "export ELODIN_ZIG_CMD=\"${cmd}\"" \
+              "exec /bin/bash \"${wrapper_src}\" \"\$@\"" \
+              | sudo tee "$dest" >/dev/null
+          }
+          write_zig_trampoline "${wrap_dir}/cc" cc
+          write_zig_trampoline "${wrap_dir}/c++" c++
           printf '%s\n' \
             '#!/bin/sh' \
             "exec \"${zig_bin}\" ar \"\$@\"" \
             | sudo tee "${wrap_dir}/ar" >/dev/null
           sudo chmod +x "${wrap_dir}/cc" "${wrap_dir}/c++" "${wrap_dir}/ar"
-          echo "--- generated cc wrapper ---"
+          echo "--- generated cc trampoline ---"
           cat "${wrap_dir}/cc"
 
           {
@@ -266,14 +246,21 @@ jobs:
           # var is silently ignored by cargo, but a [target.<triple>] section
           # in config.toml has unambiguous higher precedence.
           #
-          # link-self-contained=no disables rustc's bundled CRT
-          # (crt1.o, crti.o, libc.a, ...) — Zig provides those itself when
-          # invoked with -target *-linux-musl. Same approach as cargo-zigbuild.
+          # Keep rustc's gcc linker-flavor (linker named cc) so it still
+          # emits -Wl,--fix-cortex-a53-843419. On aarch64 the wrapper
+          # forwards that to zig ld.lld and rustc must supply musl CRT
+          # (do not set link-self-contained=no). On x86_64 there is no
+          # errata flag; zig cc remains the linker and provides CRT.
           mkdir -p .cargo
-          printf '\n[target.%s]\nlinker = "%s/cc"\nrustflags = ["-C", "link-self-contained=no"]\n' \
-            "$target" "$wrap_dir" >> .cargo/config.toml
+          if [ "$target" = "aarch64-unknown-linux-musl" ]; then
+            printf '\n[target.%s]\nlinker = "%s/cc"\n' \
+              "$target" "$wrap_dir" >> .cargo/config.toml
+          else
+            printf '\n[target.%s]\nlinker = "%s/cc"\nrustflags = ["-C", "link-self-contained=no"]\n' \
+              "$target" "$wrap_dir" >> .cargo/config.toml
+          fi
           echo "--- appended to .cargo/config.toml ---"
-          tail -5 .cargo/config.toml
+          tail -8 .cargo/config.toml
       - name: Build artifacts
         run: |
           # Actually do builds and make zips and whatnot

--- a/scripts/test-musl-build.sh
+++ b/scripts/test-musl-build.sh
@@ -111,39 +111,29 @@ build_one_target() {
   local wrap_dir="${session_dir}/zig-cc-${env_target}"
   mkdir -p "$wrap_dir"
 
-  # Wrapper strips:
-  #   --target=*                       (Zig rejects Rust triple format)
-  #   */self-contained/*crt*.o         (rustc CRT objects, Zig adds its own)
-  printf '%s\n' \
-    '#!/bin/bash' \
-    'args=()' \
-    'for a in "$@"; do' \
-    '  case "$a" in' \
-    '    --target=*) ;;' \
-    '    */self-contained/*crt*.o) ;;' \
-    '    *) args+=("$a") ;;' \
-    '  esac' \
-    'done' \
-    "exec \"${zig_bin}\" cc -target ${zig_target} \"\${args[@]}\"" \
-    > "${wrap_dir}/cc"
-  printf '%s\n' \
-    '#!/bin/bash' \
-    'args=()' \
-    'for a in "$@"; do' \
-    '  case "$a" in' \
-    '    --target=*) ;;' \
-    '    */self-contained/*crt*.o) ;;' \
-    '    *) args+=("$a") ;;' \
-    '  esac' \
-    'done' \
-    "exec \"${zig_bin}\" c++ -target ${zig_target} \"\${args[@]}\"" \
-    > "${wrap_dir}/c++"
+  local wrapper_src="${repo_root}/scripts/zig-musl-wrapper.sh"
+  if [ ! -f "$wrapper_src" ]; then
+    echo "error: missing $wrapper_src" >&2
+    return 2
+  fi
+  write_zig_trampoline() {
+    local dest="$1" cmd="$2"
+    printf '%s\n' \
+      '#!/bin/bash' \
+      "export ELODIN_ZIG_BIN=\"${zig_bin}\"" \
+      "export ELODIN_ZIG_TARGET=\"${zig_target}\"" \
+      "export ELODIN_ZIG_CMD=\"${cmd}\"" \
+      "exec /bin/bash \"${wrapper_src}\" \"\$@\"" \
+      >"$dest"
+  }
+  write_zig_trampoline "${wrap_dir}/cc" cc
+  write_zig_trampoline "${wrap_dir}/c++" c++
   printf '%s\n' \
     '#!/bin/sh' \
     "exec \"${zig_bin}\" ar \"\$@\"" \
-    > "${wrap_dir}/ar"
+    >"${wrap_dir}/ar"
   chmod +x "${wrap_dir}/cc" "${wrap_dir}/c++" "${wrap_dir}/ar"
-  echo "--- generated cc wrapper ---"
+  echo "--- generated cc trampoline ---"
   cat "${wrap_dir}/cc"
 
   # Restore original .cargo/config.toml then append fresh target section
@@ -154,8 +144,14 @@ build_one_target() {
   fi
   mkdir -p .cargo
   touch "$cargo_config"
-  printf '\n[target.%s]\nlinker = "%s/cc"\nrustflags = ["-C", "link-self-contained=no"]\n' \
-    "$target" "$wrap_dir" >> "$cargo_config"
+  # aarch64: rustc CRT for zig ld.lld. x86_64: zig cc provides CRT.
+  if [ "$target" = "aarch64-unknown-linux-musl" ]; then
+    printf '\n[target.%s]\nlinker = "%s/cc"\n' \
+      "$target" "$wrap_dir" >> "$cargo_config"
+  else
+    printf '\n[target.%s]\nlinker = "%s/cc"\nrustflags = ["-C", "link-self-contained=no"]\n' \
+      "$target" "$wrap_dir" >> "$cargo_config"
+  fi
 
   export "CC_${env_target}=${wrap_dir}/cc"
   export "CXX_${env_target}=${wrap_dir}/c++"

--- a/scripts/zig-musl-wrapper.sh
+++ b/scripts/zig-musl-wrapper.sh
@@ -11,6 +11,9 @@
 # zig cc 0.16 rejects that flag even with -fuse-ld=lld / -Wl,; LLVM LLD
 # implements it. Fail closed if rustc asked for the errata rewrite and LLD
 # would not run with the flag.
+#
+# zig ld.lld does not know Zig's C++ runtime. rustc passes -lstdc++ (openh264).
+# Rewrite that to Zig's cached libc++.a / libc++abi.a for this target.
 set -eo pipefail
 
 die() {
@@ -21,6 +24,53 @@ die() {
 zig_bin="${ELODIN_ZIG_BIN:?ELODIN_ZIG_BIN is not set}"
 zig_target="${ELODIN_ZIG_TARGET:?ELODIN_ZIG_TARGET is not set}"
 zig_cmd="${ELODIN_ZIG_CMD:?ELODIN_ZIG_CMD is not set}"
+
+# Print libc++abi.a then libc++.a (Zig's link order) for $zig_target.
+# Materializes them via a cached dummy zig c++ link if needed.
+resolve_zig_libcxx() {
+  local cache_root="${XDG_CACHE_HOME:-${HOME}/.cache}/elodin-zig-libcxx"
+  mkdir -p "$cache_root"
+  local zig_ver
+  zig_ver=$("$zig_bin" version)
+  local stamp="$cache_root/${zig_ver}-${zig_target}.txt"
+  if [ -f "$stamp" ]; then
+    local abi cxx
+    abi=$(sed -n '1p' "$stamp")
+    cxx=$(sed -n '2p' "$stamp")
+    if [ -f "$abi" ] && [ -f "$cxx" ]; then
+      printf '%s\n%s\n' "$abi" "$cxx"
+      return
+    fi
+  fi
+
+  local probe
+  probe=$(mktemp -d)
+  printf 'int main(void){return 0;}\n' >"$probe/p.cpp"
+  local verbose
+  if ! verbose=$(ZIG_VERBOSE_LINK=1 "$zig_bin" c++ -target "$zig_target" -static \
+    "$probe/p.cpp" -o "$probe/p" 2>&1); then
+    rm -rf "$probe"
+    printf '%s\n' "$verbose" >&2
+    die "failed to materialize zig libc++ for $zig_target"
+  fi
+  rm -rf "$probe"
+
+  local abi cxx
+  abi=$(printf '%s\n' "$verbose" | tr ' ' '\n' | grep '/libc++abi.a$' | tail -1 || true)
+  cxx=$(printf '%s\n' "$verbose" | tr ' ' '\n' | grep '/libc++.a$' | tail -1 || true)
+  if [ ! -f "$abi" ] || [ ! -f "$cxx" ]; then
+    die "could not find zig libc++ archives for $zig_target"
+  fi
+  printf '%s\n%s\n' "$abi" "$cxx" >"$stamp"
+  printf '%s\n%s\n' "$abi" "$cxx"
+}
+
+append_zig_libcxx() {
+  local abi cxx
+  abi=$(printf '%s\n' "$1" | sed -n '1p')
+  cxx=$(printf '%s\n' "$1" | sed -n '2p')
+  lld_args+=("$abi" "$cxx")
+}
 
 rust_wants_cortex=0
 is_compile=0
@@ -59,6 +109,7 @@ if [ "$rust_wants_cortex" -eq 1 ]; then
   lld_args=()
   skip_next=
   lld_has_cortex=0
+  libcxx_paths=
   for a in "$@"; do
     if [ -n "$skip_next" ]; then
       skip_next=
@@ -68,15 +119,31 @@ if [ "$rust_wants_cortex" -eq 1 ]; then
       --target=*|-nodefaultlibs|-nostartfiles|-no-pie|-pie|-pthread|-flavor)
         [ "$a" = "-flavor" ] && skip_next=1
         ;;
+      -lstdc++|-lc++)
+        if [ -z "$libcxx_paths" ]; then
+          libcxx_paths=$(resolve_zig_libcxx)
+        fi
+        append_zig_libcxx "$libcxx_paths"
+        ;;
       -Wl,*)
         spec="${a#-Wl,}"
         IFS=',' read -ra parts <<< "$spec"
         for p in "${parts[@]}"; do
           [ -z "$p" ] && continue
-          lld_args+=("$p")
-          if [ "$p" = "--fix-cortex-a53-843419" ]; then
-            lld_has_cortex=1
-          fi
+          case "$p" in
+            -lstdc++|-lc++)
+              if [ -z "$libcxx_paths" ]; then
+                libcxx_paths=$(resolve_zig_libcxx)
+              fi
+              append_zig_libcxx "$libcxx_paths"
+              ;;
+            *)
+              lld_args+=("$p")
+              if [ "$p" = "--fix-cortex-a53-843419" ]; then
+                lld_has_cortex=1
+              fi
+              ;;
+          esac
         done
         ;;
       --fix-cortex-a53-843419)

--- a/scripts/zig-musl-wrapper.sh
+++ b/scripts/zig-musl-wrapper.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Zig musl compiler/linker wrapper for elodin-db dist builds.
+#
+# Required env:
+#   ELODIN_ZIG_BIN     path to zig
+#   ELODIN_ZIG_TARGET  zig triple, e.g. aarch64-linux-musl
+#   ELODIN_ZIG_CMD     cc or c++
+#
+# Compile (-c): zig cc/c++. Link: zig cc, unless rustc emitted
+# --fix-cortex-a53-843419, in which case we unwrap -Wl, and exec zig ld.lld.
+# zig cc 0.16 rejects that flag even with -fuse-ld=lld / -Wl,; LLVM LLD
+# implements it. Fail closed if rustc asked for the errata rewrite and LLD
+# would not run with the flag.
+set -eo pipefail
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+zig_bin="${ELODIN_ZIG_BIN:?ELODIN_ZIG_BIN is not set}"
+zig_target="${ELODIN_ZIG_TARGET:?ELODIN_ZIG_TARGET is not set}"
+zig_cmd="${ELODIN_ZIG_CMD:?ELODIN_ZIG_CMD is not set}"
+
+rust_wants_cortex=0
+is_compile=0
+for a in "$@"; do
+  case "$a" in
+    -c) is_compile=1 ;;
+    --fix-cortex-a53-843419) rust_wants_cortex=1 ;;
+    -Wl,*)
+      case ",${a#-Wl,}," in
+        *,--fix-cortex-a53-843419,*) rust_wants_cortex=1 ;;
+      esac
+      ;;
+  esac
+done
+
+filter_zig_cc_args() {
+  args=()
+  for a in "$@"; do
+    case "$a" in
+      --target=*) ;;
+      */self-contained/*crt*.o) ;;
+      *) args+=("$a") ;;
+    esac
+  done
+}
+
+if [ "$is_compile" -eq 1 ]; then
+  if [ "$rust_wants_cortex" -eq 1 ]; then
+    die "rustc emitted --fix-cortex-a53-843419 on a compile (-c) invocation; zig ld.lld would not run"
+  fi
+  filter_zig_cc_args "$@"
+  exec "$zig_bin" "$zig_cmd" -target "$zig_target" "${args[@]}"
+fi
+
+if [ "$rust_wants_cortex" -eq 1 ]; then
+  lld_args=()
+  skip_next=
+  lld_has_cortex=0
+  for a in "$@"; do
+    if [ -n "$skip_next" ]; then
+      skip_next=
+      continue
+    fi
+    case "$a" in
+      --target=*|-nodefaultlibs|-nostartfiles|-no-pie|-pie|-pthread|-flavor)
+        [ "$a" = "-flavor" ] && skip_next=1
+        ;;
+      -Wl,*)
+        spec="${a#-Wl,}"
+        IFS=',' read -ra parts <<< "$spec"
+        for p in "${parts[@]}"; do
+          [ -z "$p" ] && continue
+          lld_args+=("$p")
+          if [ "$p" = "--fix-cortex-a53-843419" ]; then
+            lld_has_cortex=1
+          fi
+        done
+        ;;
+      --fix-cortex-a53-843419)
+        lld_args+=("$a")
+        lld_has_cortex=1
+        ;;
+      *)
+        lld_args+=("$a")
+        ;;
+    esac
+  done
+  if [ "$lld_has_cortex" -ne 1 ]; then
+    die "rustc emitted --fix-cortex-a53-843419 but it is missing from the zig ld.lld argument list"
+  fi
+  exec "$zig_bin" ld.lld "${lld_args[@]}"
+fi
+
+filter_zig_cc_args "$@"
+exec "$zig_bin" "$zig_cmd" -target "$zig_target" "${args[@]}"


### PR DESCRIPTION
# Problem

The new version of rustc that we use emits a new flag `--fix-cortex-a53-843419` that the zig cross compile does not know or accept.

# Solution

When rustc emits this flag, which will only be on aarch64 builds, then we use the `lld` linker which respects this argument. We also use zig's C++ library. The x86 build should be unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release musl linking for aarch64 only, but the new wrapper/LLD path is intricate and affects how C++ and CRT objects are supplied at link time.
> 
> **Overview**
> **Fixes aarch64 `*-linux-musl` release builds** when rustc 1.98+ passes `-Wl,--fix-cortex-a53-843419`, which Zig 0.16’s `zig cc` rejects.
> 
> Musl cross-compile logic moves into **`scripts/zig-musl-wrapper.sh`**. CI and `scripts/test-musl-build.sh` now install thin **`cc`/`c++` trampolines** that set `ELODIN_ZIG_*` and exec that script instead of inlining wrapper bash in YAML.
> 
> On **link** when the cortex flag is present, the wrapper **unwraps `-Wl,` args** and runs **`zig ld.lld`** (which accepts the errata flag). It **rewrites `-lstdc++`** to Zig’s cached **`libc++abi.a` / `libc++.a`** for deps like openh264. Compile (`-c`) still goes through **`zig cc`/`c++`** with the same filtering of Rust triples and self-contained CRT objects.
> 
> **`.cargo/config.toml` wiring is target-specific**: **`aarch64-unknown-linux-musl`** gets a linker path only (no `link-self-contained=no`, so rustc’s musl CRT stays in play for the LLD path). **`x86_64-unknown-linux-musl`** keeps **`link-self-contained=no`** and the prior zig-cc-as-linker behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d1249e92c97fb391aa499d36ac420a85d4df5f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->