### PR TITLE
Fix: unbreak the Windows release build.

### DIFF
--- a/.github/workflows/windows-check.yml
+++ b/.github/workflows/windows-check.yml
@@ -1,0 +1,54 @@
+# The release pipeline is the only place Windows gets compiled, and it only runs
+# on a tag, so portability breaks surface after a release is already announced.
+# This job type-checks the one package dist builds for Windows (`--package=elodin`,
+# see dist-workspace.toml) on every pull request instead.
+
+name: Windows Check
+
+on:
+  pull_request:
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.toml"
+      - "Cargo.lock"
+      - ".cargo/**"
+      - "rust-toolchain.toml"
+      - ".github/workflows/windows-check.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.toml"
+      - "Cargo.lock"
+      - ".cargo/**"
+      - "rust-toolchain.toml"
+      - ".github/workflows/windows-check.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: cargo check (x86_64-pc-windows-msvc)
+    runs-on: windows-latest
+    steps:
+      - name: Enable windows longpaths
+        run: git config --global core.longpaths true
+      - uses: actions/checkout@v4
+        with:
+          # `embedded_lfs_asset!` const-asserts that embedded assets are not LFS
+          # pointer stubs, and const assertions are evaluated by `cargo check`.
+          lfs: true
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      # Mirrors [dist.dependencies.chocolatey] in dist-workspace.toml.
+      - name: Install dependencies
+        run: |
+          choco install cmake --yes
+          choco install protoc --yes
+      - name: cargo check
+        run: cargo check --locked --package elodin

--- a/.github/workflows/windows-check.yml
+++ b/.github/workflows/windows-check.yml
@@ -45,6 +45,11 @@ jobs:
           # pointer stubs, and const assertions are evaluated by `cargo check`.
           lfs: true
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          # The action defaults to `-D warnings`, which would make this job
+          # stricter than the release build. It also sets RUSTFLAGS, which
+          # overrides `[build] rustflags` in .cargo/config.toml.
+          rustflags: ""
       # Mirrors [dist.dependencies.chocolatey] in dist-workspace.toml.
       - name: Install dependencies
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - **(feat)** Add an artificial horizon gauge. (#753)
 - **(feat)** Add headless video capture. (#754, #757)
 - **(feat)** Add --kdl to allow local KDL and asset development. (#763)
+- **(feat:examples)** Model the RC-jet on measured BDX aero data, with WGS84 ECEF trim, a Mojave RC field scene, and an LWIR sensor camera. (#820)
 - **(feat:examples)** Update Betaflight SITL to 2026.6.1 with 8 kHz real-time lockstep. (#815, #818)
 - **(feat:aleph)** Add initrd-based one-shot Aleph UEFI and OS flashing over USB-C. (#748)
 - **(feat:db)** Add Elodin DB gRPC. (#772)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,6 @@
 # Changelog
 
 ## unreleased
-- **(fix)** Bind world-mesh terrain views to schematic viewports and sensor cameras, not 2D graph cameras.
-- **(fix)** Size planar terrain atlases to the dataset working set instead of 1024 GPU layers.
-- **(fix)** Keep planar preprocess atlases large enough for the full tile set, retry rejected clipmap requests, and ignore stale loads after LRU eviction.
-- **(fix)** Size terrain view geometry buffers for refine fan-out instead of 1e6 tiles.
-- **(fix)** Draw 2D plot windows longer than 30 s at full resolution instead of a few points per pixel.
-- **(fix)** Slide trailing 2D plot windows over existing samples instead of rebuilding every 100 ms.
-- **(fix)** Rebuild 2D plot lines when backfill fills holes inside an already-covered window.
-- **(fix)** Clear 2D plot lines when seeking or sliding into a covered gap instead of leaving a phantom trace.
 
 ## v0.19
 

--- a/apps/elodin/src/cli/editor.rs
+++ b/apps/elodin/src/cli/editor.rs
@@ -231,6 +231,7 @@ impl Cli {
         }))
     }
 
+    #[cfg_attr(target_os = "windows", allow(unused_mut))]
     pub fn editor(self, mut args: Args, rt: Runtime) -> miette::Result<()> {
         #[cfg(not(target_os = "windows"))]
         use_plan_addr(&mut args)?;

--- a/libs/db/src/append_log.rs
+++ b/libs/db/src/append_log.rs
@@ -7,7 +7,6 @@ use std::{
     io::{Seek, SeekFrom, Write as _},
     marker::PhantomData,
     mem::size_of,
-    os::fd::AsRawFd,
     path::{Path, PathBuf},
     slice::{self, SliceIndex},
     sync::{
@@ -62,7 +61,7 @@ impl<E: IntoBytes + Immutable> AppendLog<E> {
             .open(path)?;
         file.seek(SeekFrom::Start(FILE_SIZE))?;
         file.write_all(&[0])?;
-        let map = Arc::new(memmap2::MmapRaw::map_raw(file.as_raw_fd())?);
+        let map = Arc::new(memmap2::MmapRaw::map_raw(&file)?);
         let map = Self {
             map,
             header_extra: PhantomData,
@@ -83,7 +82,7 @@ impl<E: IntoBytes + Immutable> AppendLog<E> {
     pub fn open(path: impl AsRef<Path>) -> Result<Self, Error> {
         let path = path.as_ref();
         let file = OpenOptions::new().write(true).read(true).open(path)?;
-        let map = Arc::new(memmap2::MmapRaw::map_raw(file.as_raw_fd())?);
+        let map = Arc::new(memmap2::MmapRaw::map_raw(&file)?);
         let map = Self {
             map,
             header_extra: PhantomData,


### PR DESCRIPTION
apps/elodin gained an unconditional elodin-db dependency in #807, which pulled AppendLog into the Windows dependency graph for the first time. It imported std::os::fd::AsRawFd, which does not exist on Windows, so v0.19.0 failed on the one target that had never been compiled.

Pass &File to MmapRaw::map_raw instead: memmap2 implements MmapAsRawDesc for
&T: AsRawFd on unix and &T: AsRawHandle on windows, so this is a no-op on unix.

The release pipeline is the only place Windows is compiled and it only runs on a tag, so add a pull-request job that checks the package dist builds for Windows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cross-platform mmap API change is the standard memmap2 pattern; Unix behavior is unchanged, and CI now catches Windows regressions earlier.
> 
> **Overview**
> Restores **Windows compilation** after `AppendLog` entered the `elodin` dependency graph via the DB editor path. **`append_log`** no longer uses Unix-only `AsRawFd`; it passes **`&File`** into `MmapRaw::map_raw`, which `memmap2` maps via the right handle API on each OS.
> 
> On **`editor`**, adds a Windows-only **`allow(unused_mut)`** because plan-address parsing is skipped there, so `mut args` would otherwise warn under stricter CI.
> 
> Adds a **Windows Check** GitHub Actions workflow that runs **`cargo check --locked --package elodin`** on `windows-latest` for Rust/Cargo changes (LFS checkout, cmake/protoc via Chocolatey, rustflags aligned with release). **CHANGELOG** unreleased notes were cleared and one example entry was moved under v0.19.0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e0c59c23e6f00fc8f0aaec1a90185801eafce7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->