### PR TITLE
chore: Add `nix run .#elodin` = `nix run .`.

### DIFF
--- a/aleph/pkgs/elodin-db.nix
+++ b/aleph/pkgs/elodin-db.nix
@@ -36,6 +36,11 @@
     GIT_HASH = gitRev;
 
     doCheck = false;
+
+    meta = {
+      description = "Elodin time-series database";
+      mainProgram = "elodin-db";
+    };
   };
 in
   bin

--- a/flake.nix
+++ b/flake.nix
@@ -91,6 +91,25 @@
         packages = with pkgs.elodin; {
           inherit elodin-cli elodin-db elodin-db-protos elodinsink rtsp-streamer;
           elodin-py = elodin-py.py;
+          elodin = elodin-cli;
+          default = elodin-cli;
+        };
+
+        apps = let
+          elodinApp = {
+            type = "app";
+            program = "${pkgs.elodin.elodin-cli}/bin/elodin";
+            meta.description = "Elodin CLI and editor";
+          };
+          elodinDbApp = {
+            type = "app";
+            program = "${pkgs.elodin.elodin-db}/bin/elodin-db";
+            meta.description = "Elodin time-series database";
+          };
+        in {
+          elodin = elodinApp;
+          elodin-db = elodinDbApp;
+          default = elodinApp;
         };
 
         devShells =

--- a/nix/pkgs/elodin-cli.nix
+++ b/nix/pkgs/elodin-cli.nix
@@ -67,6 +67,11 @@
     # uncomment for debug mode (slower)
     # CARGO_PROFILE = "dev";
     # CARGO_PROFILE_RELEASE_DEBUG = true;
+
+    meta = {
+      description = "Elodin CLI and editor";
+      mainProgram = "elodin";
+    };
   };
 in
   bin


### PR DESCRIPTION
This is a simple thing. It essentially adds an alias and default for the nix run command to run the elodin binary. These commands all do the same thing.

```sh
nix run .#elodin-cli ...; # This is what works today (before this PR).
nix run .#elodin ...; # What this PR adds.
nix run . ...; # A default nix run, runs the elodin binary.
```

One nicety about `nix run` is, that unlike the `nix develop .#run` shell, it doesn't require building elodin-db and everything else. And now that `elodin` can accept a $DB argument directly, one can view a database with a one-line command:

```sh
nix run .#elodin editor $DB
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Nix flake packaging and metadata only; no application runtime or security logic changes.
> 
> **Overview**
> Makes **`nix run .`** and **`nix run .#elodin`** run the Elodin CLI the same way as **`nix run .#elodin-cli`**, without pulling in the full dev shell build graph.
> 
> The flake now exposes **`packages.elodin`** and **`packages.default`** as aliases of `elodin-cli`, and adds an **`apps`** output with **`elodin`** (default) and **`elodin-db`** so `nix run` can launch the CLI or database binary directly.
> 
> **`meta`** (`description`, `mainProgram`) is added on the **`elodin-cli`** and **`elodin-db`** Nix derivations for clearer package metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b08be94236dec8e7cf6d3c6d88b6d0237a0bb8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->