### PR TITLE
Fix: Plot line flicker.

### DIFF
--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -778,7 +778,6 @@ pub fn sync_plot_lines_from_series_store(
     if !(range_changed || enabled_changed || (gen_changed && due)) {
         return;
     }
-
     sync_state.last_range = Some(range_key);
     sync_state.last_generation = series_store.generation();
     sync_state.last_enabled = fetch_ids.clone();
@@ -1432,11 +1431,30 @@ pub struct XYLine {
     pub y_shard_alloc: Option<BufferShardAlloc>,
     pub x_values: Vec<SharedBuffer<f32, CHUNK_LEN>>,
     pub y_values: Vec<SharedBuffer<f32, CHUNK_LEN>>,
+    /// Set by [`XYLine::replace_points`]; consumed by [`XYLine::queue_load`].
+    content_replaced: bool,
 }
 
 impl XYLine {
     pub fn point_count(&self) -> usize {
         self.x_values.iter().map(|c| c.cpu().len()).sum()
+    }
+
+    /// Swap in a whole new point set, keeping the shard allocations so a
+    /// re-queried line does not have to take pool buffers on every refresh.
+    ///
+    /// Dropping the old chunks does not deallocate their shards, so the
+    /// allocations are reclaimed by the next `queue_load`, which holds the
+    /// render queue that a reset needs.
+    pub fn replace_points(&mut self, label: String, points: impl IntoIterator<Item = (f32, f32)>) {
+        self.label = label;
+        self.x_values.clear();
+        self.y_values.clear();
+        self.content_replaced = true;
+        for (x, y) in points {
+            self.push_x_value(x);
+            self.push_y_value(y);
+        }
     }
 
     pub fn has_samples(&self) -> bool {
@@ -1454,6 +1472,14 @@ impl XYLine {
         }
         let x_class = value_shard_class(self.x_values.len());
         let y_class = value_shard_class(self.y_values.len());
+        if std::mem::take(&mut self.content_replaced) {
+            // The replaced chunks dropped their shards without deallocating
+            // them, so hand the whole allocation back rather than leaking a
+            // shard per refresh. An unchanged class is reset in place, which
+            // keeps this off the pool entirely.
+            reclaim_or_release(&mut self.x_shard_alloc, x_class, pool, render_queue);
+            reclaim_or_release(&mut self.y_shard_alloc, y_class, pool, render_queue);
+        }
         if self
             .x_shard_alloc
             .as_ref()
@@ -4113,6 +4139,31 @@ mod tests {
         tree.unload_gpu(&mut PlotGpuBufferPool::default());
         assert!(!tree.all_gpu_dirty());
         assert!(!tree.gpu_resident());
+    }
+
+    #[test]
+    fn replace_points_swaps_content_instead_of_appending() {
+        let mut xy = XYLine::default();
+        xy.replace_points("first".into(), [(0.0, 1.0), (1.0, 2.0)]);
+        assert_eq!(xy.point_count(), 2);
+
+        xy.replace_points("second".into(), [(5.0, 6.0)]);
+
+        assert_eq!(xy.label, "second");
+        assert_eq!(xy.point_count(), 1);
+        let xs: Vec<f32> = xy.x_values.iter().flat_map(|c| c.cpu()).copied().collect();
+        let ys: Vec<f32> = xy.y_values.iter().flat_map(|c| c.cpu()).copied().collect();
+        assert_eq!(xs, vec![5.0]);
+        assert_eq!(ys, vec![6.0]);
+    }
+
+    #[test]
+    fn replace_points_marks_allocations_for_reclaim() {
+        let mut xy = XYLine::default();
+        xy.replace_points("first".into(), [(0.0, 1.0)]);
+        // `queue_load` needs a render queue, so the reclaim itself can only be
+        // exercised on a device; assert the request survives until then.
+        assert!(xy.content_replaced);
     }
 
     #[test]

--- a/libs/elodin-editor/src/ui/plot/data.rs
+++ b/libs/elodin-editor/src/ui/plot/data.rs
@@ -1527,17 +1527,15 @@ impl XYLine {
     }
 
     pub fn value_buffers_needing_allocation(&self) -> usize {
-        let x_class = value_shard_class(self.x_values.len());
-        let y_class = value_shard_class(self.y_values.len());
-        usize::from(
-            self.x_shard_alloc
-                .as_ref()
-                .is_none_or(|alloc| alloc.capacity_shards() < x_class),
-        ) + usize::from(
-            self.y_shard_alloc
-                .as_ref()
-                .is_none_or(|alloc| alloc.capacity_shards() < y_class),
-        )
+        let needed = |slot: &Option<BufferShardAlloc>, class: usize| {
+            usize::from(xy_takes_from_pool(
+                slot.as_ref().map(BufferShardAlloc::capacity_shards),
+                class,
+                self.content_replaced,
+            ))
+        };
+        needed(&self.x_shard_alloc, value_shard_class(self.x_values.len()))
+            + needed(&self.y_shard_alloc, value_shard_class(self.y_values.len()))
     }
 
     pub fn unload_gpu(&mut self, pool: &mut PlotGpuBufferPool) {
@@ -4329,6 +4327,30 @@ mod tests {
     }
 
     #[test]
+    fn a_shrinking_xy_refresh_is_counted_as_an_allocation() {
+        assert!(
+            xy_takes_from_pool(Some(64), 16, true),
+            "a refresh that drops a class hands its buffer back, so the gate must see it"
+        );
+        assert!(
+            !xy_takes_from_pool(Some(16), 16, true),
+            "a refresh that keeps its class is reclaimed in place"
+        );
+        assert!(
+            xy_takes_from_pool(Some(4), 16, true),
+            "a refresh that outgrows its class needs a bigger buffer"
+        );
+        assert!(
+            !xy_takes_from_pool(Some(64), 16, false),
+            "an untouched oversized buffer is left alone"
+        );
+        assert!(
+            xy_takes_from_pool(None, 16, false),
+            "a line without a buffer must take one"
+        );
+    }
+
+    #[test]
     fn new_plot_gpu_upload_is_blocked_only_while_value_buffers_are_quarantined() {
         assert!(!plot_gpu_upload_blocked(0, 0, 2));
         assert!(plot_gpu_upload_blocked(0, 4, 2));
@@ -4635,6 +4657,19 @@ fn takes_from_pool(capacity_shards: Option<usize>, value_class: usize, needs_res
         None => true,
         Some(capacity) => needs_resize && capacity != value_class,
     }
+}
+
+/// Same question for [`XYLine::queue_load`], which rebuilds on two triggers:
+/// replaced content, which hands back every class but its own, and an outgrown
+/// buffer. A shrinking refresh therefore allocates just like a growing one.
+fn xy_takes_from_pool(
+    capacity_shards: Option<usize>,
+    value_class: usize,
+    content_replaced: bool,
+) -> bool {
+    let needs_resize =
+        content_replaced || capacity_shards.is_some_and(|capacity| capacity < value_class);
+    takes_from_pool(capacity_shards, value_class, needs_resize)
 }
 
 /// Hand a value buffer whose shards were all just released back to its owner or

--- a/libs/elodin-editor/src/ui/plot/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot/gpu.rs
@@ -738,6 +738,29 @@ impl bevy::prelude::FromWorld for ExtractLinesState {
     }
 }
 
+/// Whether last frame's draw may stand in for a line whose upload was deferred.
+///
+/// Only when the cache still names the value buffers the line owns. An
+/// allocation the line has given up may already have been handed to another
+/// line and overwritten, and replaying that bind group would draw the wrong
+/// data — a far worse failure than a gap.
+pub(crate) fn plot_draw_replay_allowed<T: PartialEq>(cached: Option<T>, owned: Option<T>) -> bool {
+    owned.is_some() && cached == owned
+}
+
+/// Last frame's draw for this line, if replaying it is safe.
+fn replayable_gpu_line<'a>(
+    cache: Option<&'a GpuLineCache>,
+    line: &LineMut<'_>,
+) -> Option<&'a GpuLine> {
+    let owned = line
+        .x_buffer_shard_alloc()
+        .zip(line.y_buffer_shard_alloc())
+        .map(|(x, y)| (x.buffer().id(), y.buffer().id()));
+    let gpu = cache?.0.as_ref()?;
+    plot_draw_replay_allowed(Some(gpu.value_buffer_ids), owned).then_some(gpu)
+}
+
 fn line_gpu_pane_on_screen(
     child_of: Option<&ChildOf>,
     viewport_rects: &Query<&ViewportRect>,
@@ -964,16 +987,32 @@ fn extract_lines(
                 let required_value_shards = line.required_value_shards(clip_range.clone());
                 let value_buffers_needed =
                     line.value_buffers_needing_allocation(clip_range.clone());
+                let new_values = plot_gpu_pool
+                    .new_value_allocations_needed(value_buffers_needed, required_value_shards);
                 if plot_gpu_pool.defer_new_allocs(
                     value_buffers_needed,
                     has_index_cache,
                     required_value_shards,
-                ) {
-                    continue;
-                }
-                let new_values = plot_gpu_pool
-                    .new_value_allocations_needed(value_buffers_needed, required_value_shards);
-                if new_values > new_value_budget {
+                ) || new_values > new_value_budget
+                {
+                    // Replay last frame's geometry rather than leaving the line
+                    // out of this frame: the draw is rebuilt from scratch every
+                    // frame, so a gap here is a visible flicker while a few
+                    // stale frames are not.
+                    if let Some(gpu_line) = replayable_gpu_line(cache.as_deref(), &line) {
+                        commands.spawn((
+                            MainEntity::from(entity),
+                            LineBundle {
+                                line: line_handle.clone(),
+                                config: config.clone(),
+                                uniform: *uniform,
+                                line_visible_range: line_visible_range.clone(),
+                                graph_type: *graph_type,
+                            },
+                            gpu_line.clone(),
+                            TemporaryRenderEntity,
+                        ));
+                    }
                     continue;
                 }
                 new_value_budget -= new_values;
@@ -1207,7 +1246,7 @@ fn queue_line(
 mod tests {
     use super::{
         LineHandle, PendingUnusedPlotLines, apply_pending_unused_plot_lines,
-        release_unused_plot_line,
+        plot_draw_replay_allowed, release_unused_plot_line,
     };
     use crate::ui::plot::{
         CollectedGraphData, Line, PlotDataComponent, PlotGpuBufferPool, PlotLineKey, PlotLineUsers,
@@ -1308,6 +1347,24 @@ mod tests {
             "unused line must still be dropped"
         );
         assert_eq!(world.resource::<PlotLineUsers>().count(key), 0);
+    }
+
+    #[test]
+    fn draw_replay_needs_the_line_to_still_own_the_cached_buffers() {
+        assert!(plot_draw_replay_allowed(Some((1, 2)), Some((1, 2))));
+        assert!(
+            !plot_draw_replay_allowed(Some((1, 2)), Some((3, 4))),
+            "buffers moved: the cached bind group may now hold another line's data"
+        );
+        assert!(
+            !plot_draw_replay_allowed(Some((1, 2)), None),
+            "line owns no buffers, so nothing keeps the cached ones out of the pool"
+        );
+        assert!(
+            !plot_draw_replay_allowed(None, Some((1, 2))),
+            "nothing drawn yet"
+        );
+        assert!(!plot_draw_replay_allowed::<(u32, u32)>(None, None));
     }
 
     /// Bevy runs `on_discard`/`on_insert` — not `on_add`/`on_remove` — when a

--- a/libs/elodin-editor/src/ui/plot/gpu.rs
+++ b/libs/elodin-editor/src/ui/plot/gpu.rs
@@ -1211,6 +1211,7 @@ mod tests {
     };
     use crate::ui::plot::{
         CollectedGraphData, Line, PlotDataComponent, PlotGpuBufferPool, PlotLineKey, PlotLineUsers,
+        XYLine,
     };
     use bevy::asset::Assets;
     use bevy::ecs::system::SystemState;
@@ -1307,5 +1308,42 @@ mod tests {
             "unused line must still be dropped"
         );
         assert_eq!(world.resource::<PlotLineUsers>().count(key), 0);
+    }
+
+    /// Bevy runs `on_discard`/`on_insert` — not `on_add`/`on_remove` — when a
+    /// component is overwritten, so `LineHandle`'s hooks skip a replacement and
+    /// neither retain the new asset nor release the old one. No caller replaces
+    /// a handle with a different asset today; this records the latent trap.
+    #[test]
+    #[ignore = "LineHandle still uses on_add/on_remove; see #822 follow-up"]
+    fn replacing_line_handle_runs_retain_and_release_hooks() {
+        let mut world = plot_world();
+        world.insert_resource(Assets::<XYLine>::default());
+        let old = world
+            .resource_mut::<Assets<XYLine>>()
+            .add(XYLine::default());
+        let new = world
+            .resource_mut::<Assets<XYLine>>()
+            .add(XYLine::default());
+        let old_key = PlotLineKey::XY(old.id());
+        let new_key = PlotLineKey::XY(new.id());
+
+        let entity = world.spawn(LineHandle::XY(old.clone())).id();
+        assert_eq!(world.resource::<PlotLineUsers>().count(old_key), 1);
+
+        world.entity_mut(entity).insert(LineHandle::XY(new.clone()));
+        world.flush();
+        apply_pending_unused_plot_lines(&mut world);
+
+        assert_eq!(
+            world.resource::<PlotLineUsers>().count(new_key),
+            1,
+            "replacement handle must be retained"
+        );
+        assert_eq!(
+            world.resource::<PlotLineUsers>().count(old_key),
+            0,
+            "replaced handle must be released"
+        );
     }
 }

--- a/libs/elodin-editor/src/ui/query_plot.rs
+++ b/libs/elodin-editor/src/ui/query_plot.rs
@@ -108,10 +108,14 @@ impl QueryPlotData {
         xy_lines: &mut Assets<XYLine>,
     ) -> Vec<Entity> {
         let default_color = self.data.color.into_color32();
+        // Refill last refresh's lines so their GPU allocations survive; fresh
+        // assets would force new pool buffers on every interval.
+        let reusable: Vec<_> = self.series.iter().map(|s| s.handle.clone()).collect();
         let Some(plot) = process_sql_record_batch(
             &batch,
             self.data.plot_mode,
             xy_lines,
+            &reusable,
             &self.series_colors,
             default_color,
         ) else {
@@ -541,5 +545,33 @@ mod tests {
         assert_eq!(plot.series.len(), 1);
         assert_eq!(plot.series[0].entity, Some(kept));
         assert_eq!(leftover, vec![extra_a, extra_b]);
+    }
+
+    #[test]
+    fn refresh_keeps_series_asset_and_entity() {
+        let mut xy_lines = Assets::<XYLine>::default();
+        let mut plot = QueryPlotData::default();
+        plot.data.plot_mode = PlotMode::XY;
+
+        assert!(
+            plot.process_record_batch(batch_xy(1), &mut xy_lines)
+                .is_empty()
+        );
+        let handle = plot.series[0].handle.clone();
+        let entity = Entity::from_bits(1);
+        plot.series[0].entity = Some(entity);
+
+        assert!(
+            plot.process_record_batch(batch_xy(1), &mut xy_lines)
+                .is_empty()
+        );
+
+        assert_eq!(
+            plot.series[0].handle.id(),
+            handle.id(),
+            "refresh must refill the same asset so its GPU allocations survive"
+        );
+        assert_eq!(plot.series[0].entity, Some(entity));
+        assert_eq!(xy_lines.len(), 1);
     }
 }

--- a/libs/elodin-editor/src/ui/sql_eql.rs
+++ b/libs/elodin-editor/src/ui/sql_eql.rs
@@ -137,10 +137,15 @@ fn column_label(batch: &RecordBatch, col: usize) -> String {
 }
 
 /// Build one XY line per Y column. Column 0 is X (time); columns 1..N are series.
+///
+/// `reusable` holds the handles this plot produced last time, positionally by
+/// series. Refilling them keeps their GPU allocations alive across a refresh,
+/// so an auto-refreshing plot does not take new pool buffers every interval.
 pub fn process_sql_record_batch(
     batch: &RecordBatch,
     plot_mode: PlotMode,
     xy_lines: &mut Assets<XYLine>,
+    reusable: &[Handle<XYLine>],
     series_colors: &[Color32],
     default_color: Color32,
 ) -> Option<SqlBatchPlot> {
@@ -184,17 +189,22 @@ pub fn process_sql_record_batch(
 
         let skip = skip_initial_points(&points, is_xy_mode);
         let label = column_label(batch, col_idx);
-        let mut xy_line = XYLine {
-            label: label.clone(),
-            x_shard_alloc: None,
-            y_shard_alloc: None,
-            x_values: vec![],
-            y_values: vec![],
+        let points = points
+            .into_iter()
+            .skip(skip)
+            .map(|(x, y)| ((x - x_offset) as f32, (y - y_offset) as f32));
+
+        let reused = reusable.get(col_idx - 1).cloned();
+        let handle = if let Some(handle) = reused
+            && let Some(mut line) = xy_lines.get_mut(handle.id())
+        {
+            line.replace_points(label.clone(), points);
+            handle
+        } else {
+            let mut line = XYLine::default();
+            line.replace_points(label.clone(), points);
+            xy_lines.add(line)
         };
-        for (x_value, y_value) in points.into_iter().skip(skip) {
-            xy_line.push_x_value((x_value - x_offset) as f32);
-            xy_line.push_y_value((y_value - y_offset) as f32);
-        }
 
         let color = series_colors.get(col_idx - 1).copied().unwrap_or_else(|| {
             if col_idx == 1 {
@@ -206,7 +216,7 @@ pub fn process_sql_record_batch(
 
         series.push(SqlPlotSeries {
             label,
-            handle: xy_lines.add(xy_line),
+            handle,
             color,
         });
     }
@@ -413,6 +423,7 @@ mod tests {
             &batch,
             PlotMode::TimeSeries,
             &mut xy_lines,
+            &[],
             &colors,
             Color32::WHITE,
         )
@@ -425,5 +436,55 @@ mod tests {
         assert_eq!(plot.series[1].color, colors[1]);
         assert_eq!(plot.series[2].color, colors[2]);
         assert!(plot.x_offset.is_finite());
+    }
+
+    fn plot_batch(xy_lines: &mut Assets<XYLine>, reusable: &[Handle<XYLine>]) -> SqlBatchPlot {
+        process_sql_record_batch(
+            &batch_time_xyz(),
+            PlotMode::TimeSeries,
+            xy_lines,
+            reusable,
+            &[],
+            Color32::WHITE,
+        )
+        .expect("plot")
+    }
+
+    #[test]
+    fn refresh_refills_previous_series_assets() {
+        let mut xy_lines = Assets::<XYLine>::default();
+        let first = plot_batch(&mut xy_lines, &[]);
+        let handles: Vec<_> = first.series.iter().map(|s| s.handle.clone()).collect();
+        let ids: Vec<_> = handles.iter().map(|h| h.id()).collect();
+
+        let second = plot_batch(&mut xy_lines, &handles);
+
+        assert_eq!(
+            second
+                .series
+                .iter()
+                .map(|s| s.handle.id())
+                .collect::<Vec<_>>(),
+            ids,
+            "a refresh must refill the same assets, not allocate new ones"
+        );
+        assert_eq!(xy_lines.len(), 3, "refresh must not accumulate assets");
+        assert_eq!(
+            xy_lines.get(ids[0]).expect("line").point_count(),
+            3,
+            "refilled line must hold one copy of the batch"
+        );
+    }
+
+    #[test]
+    fn refresh_adds_assets_only_for_series_without_a_predecessor() {
+        let mut xy_lines = Assets::<XYLine>::default();
+        let first = plot_batch(&mut xy_lines, &[]);
+        let kept = first.series[0].handle.clone();
+
+        let second = plot_batch(&mut xy_lines, std::slice::from_ref(&kept));
+
+        assert_eq!(second.series[0].handle.id(), kept.id());
+        assert_ne!(second.series[1].handle.id(), first.series[1].handle.id());
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches GPU buffer lifecycle and render replay with correctness guards; wrong replay would show stale or cross-line geometry, though buffer-ID checks mitigate that.
> 
> **Overview**
> Addresses visible plot flicker when SQL/query plots auto-refresh and when the GPU buffer pool defers new allocations.
> 
> **Stable XY assets across refresh:** Query plots now pass prior series handles into SQL batch processing so each series **refills the same `XYLine` asset** via new `replace_points` (swap data, keep shard slots). `queue_load` reclaims or resets GPU allocations through `content_replaced` and `xy_takes_from_pool`, so refreshes do not allocate a new pool buffer every interval.
> 
> **Deferred upload fallback:** When value-buffer uploads are deferred or over the per-frame budget, the extract path can **replay last frame’s cached draw** instead of omitting the line, but only if `plot_draw_replay_allowed` confirms the line still owns the same value buffer IDs (avoids drawing another line’s data).
> 
> Tests cover replace/refill behavior, replay safety, and allocation gating; an ignored test documents a latent `LineHandle` hook issue (#822).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9729009ac5f5e4ae938da457619003885da89800. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->