### PR TITLE
fix: Cancel release-dry-run when canceled.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -606,7 +606,7 @@ jobs:
   # Single status check for main-push / workflow_dispatch dry runs.
   # Publish jobs (host, announce, pypi-publish) stay skipped.
   release-dry-run:
-    if: ${{ always() && needs.plan.outputs.dry-run == 'true' }}
+    if: ${{ always() && !cancelled() && needs.plan.outputs.dry-run == 'true' }}
     needs:
       - plan
       - build-local-artifacts


### PR DESCRIPTION
# Problem

Merge CI can be canceled when other merges come in. release-dry-run would be marked as failed in that case.

# Solution

Skip release-dry-run when the CI is canceled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single GitHub Actions conditional change with no runtime or security impact.
> 
> **Overview**
> When merge CI is superseded and **cancelled** (release workflow uses `cancel-in-progress` on non-tag refs), the **`release-dry-run`** job no longer runs.
> 
> Its `if` condition now includes **`!cancelled()`** alongside `always()` and the dry-run flag. Previously, `always()` still scheduled the job after upstream build jobs were cancelled; the aggregate step treats any non-`success` result (including **cancelled**) as failure, so the dry-run status check showed red even though nothing actually broke.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b4d94b3ead01486f2b56f8689a27cc95dbdee8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->