### PR TITLE
Chore/update hanabi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1987,7 +1987,7 @@ dependencies = [
 [[package]]
 name = "bevy_hanabi"
 version = "0.20.0-dev"
-source = "git+https://github.com/elodin-sys/bevy_hanabi?rev=91176ce93c2b6226f320c3f2ae11b10170dd6317#91176ce93c2b6226f320c3f2ae11b10170dd6317"
+source = "git+https://github.com/elodin-sys/bevy_hanabi?rev=485c0a6ca18065a8a5b6de30190a9fe94a337176#485c0a6ca18065a8a5b6de30190a9fe94a337176"
 dependencies = [
  "anyhow",
  "bevy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,7 +187,7 @@ version = "0.2.5"
 map_3d = { git = "https://github.com/shanecelis/map_3d.git", branch = "feat/sphere" }
 # Local-space FaceCamera/AlongVelocity: full inverse affine for camera
 # position in effect space (elodin-sys fork; upstream candidate).
-bevy_hanabi = { git = "https://github.com/elodin-sys/bevy_hanabi", rev = "91176ce93c2b6226f320c3f2ae11b10170dd6317" }
+bevy_hanabi = { git = "https://github.com/elodin-sys/bevy_hanabi", rev = "485c0a6ca18065a8a5b6de30190a9fe94a337176" }
 
 # bevy_editor_cam's bevy-0.19 branch depends on bevy_framepace from this
 # personal git branch; redirect it to the official v0.22.0 tag so the whole

--- a/assets/effects/apollo-lander/descent_glow.effect
+++ b/assets/effects/apollo-lander/descent_glow.effect
@@ -57,7 +57,7 @@
     },
     {
       "bevy_hanabi::modifier::output::ParticleTextureModifier": (
-        texture_slot: "#16",
+        texture_slot: 0,
         sample_mapping: ModulateOpacityFromR,
       ),
     },
@@ -148,6 +148,7 @@
       layout: [
         (
           name: "mask",
+          dimension: r#2d,
         ),
       ],
     ),

--- a/assets/effects/apollo-lander/descent_plume.effect
+++ b/assets/effects/apollo-lander/descent_plume.effect
@@ -57,7 +57,7 @@
     },
     {
       "bevy_hanabi::modifier::output::ParticleTextureModifier": (
-        texture_slot: "#16",
+        texture_slot: 0,
         sample_mapping: ModulateOpacityFromR,
       ),
     },
@@ -152,6 +152,7 @@
       layout: [
         (
           name: "mask",
+          dimension: r#2d,
         ),
       ],
     ),

--- a/assets/effects/apollo-lander/ground_dust.effect
+++ b/assets/effects/apollo-lander/ground_dust.effect
@@ -77,7 +77,7 @@
     },
     {
       "bevy_hanabi::modifier::output::ParticleTextureModifier": (
-        texture_slot: "#37",
+        texture_slot: 0,
         sample_mapping: ModulateOpacityFromR,
       ),
     },
@@ -228,6 +228,7 @@
       layout: [
         (
           name: "mask",
+          dimension: r#2d,
         ),
       ],
     ),

--- a/assets/effects/apollo-lander/rcs_puff.effect
+++ b/assets/effects/apollo-lander/rcs_puff.effect
@@ -51,7 +51,7 @@
     },
     {
       "bevy_hanabi::modifier::output::ParticleTextureModifier": (
-        texture_slot: "#12",
+        texture_slot: 0,
         sample_mapping: ModulateOpacityFromR,
       ),
     },
@@ -128,6 +128,7 @@
       layout: [
         (
           name: "mask",
+          dimension: r#2d,
         ),
       ],
     ),

--- a/assets/effects/falcon9/exhaust_smoke.effect
+++ b/assets/effects/falcon9/exhaust_smoke.effect
@@ -74,7 +74,7 @@
     },
     {
       "bevy_hanabi::modifier::output::ParticleTextureModifier": (
-        texture_slot: "#38",
+        texture_slot: 0,
         sample_mapping: Modulate,
       ),
     },
@@ -253,6 +253,7 @@
       layout: [
         (
           name: "smoke",
+          dimension: r#2d,
         ),
       ],
     ),

--- a/assets/effects/falcon9/merlin_core.effect
+++ b/assets/effects/falcon9/merlin_core.effect
@@ -63,7 +63,7 @@
     },
     {
       "bevy_hanabi::modifier::output::ParticleTextureModifier": (
-        texture_slot: "#29",
+        texture_slot: 0,
         sample_mapping: ModulateOpacityFromR,
       ),
     },
@@ -202,6 +202,7 @@
       layout: [
         (
           name: "mask",
+          dimension: r#2d,
         ),
       ],
     ),

--- a/assets/effects/falcon9/merlin_flame.effect
+++ b/assets/effects/falcon9/merlin_flame.effect
@@ -63,7 +63,7 @@
     },
     {
       "bevy_hanabi::modifier::output::ParticleTextureModifier": (
-        texture_slot: "#32",
+        texture_slot: 0,
         sample_mapping: ModulateOpacityFromR,
       ),
     },
@@ -214,6 +214,7 @@
       layout: [
         (
           name: "mask",
+          dimension: r#2d,
         ),
       ],
     ),

--- a/assets/effects/falcon9/pad_smoke.effect
+++ b/assets/effects/falcon9/pad_smoke.effect
@@ -82,7 +82,7 @@
     },
     {
       "bevy_hanabi::modifier::output::ParticleTextureModifier": (
-        texture_slot: "#38",
+        texture_slot: 0,
         sample_mapping: Modulate,
       ),
     },
@@ -242,6 +242,7 @@
       layout: [
         (
           name: "smoke",
+          dimension: r#2d,
         ),
       ],
     ),

--- a/assets/effects/falcon9/rcs_dart.effect
+++ b/assets/effects/falcon9/rcs_dart.effect
@@ -51,7 +51,7 @@
     },
     {
       "bevy_hanabi::modifier::output::ParticleTextureModifier": (
-        texture_slot: "#12",
+        texture_slot: 0,
         sample_mapping: ModulateOpacityFromR,
       ),
     },
@@ -128,6 +128,7 @@
       layout: [
         (
           name: "mask",
+          dimension: r#2d,
         ),
       ],
     ),

--- a/assets/spacex_drone_barge.glb
+++ b/assets/spacex_drone_barge.glb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1abdbc992d7966c0aca50ec6999cb86502eb34c068e2799bc6479364c0fb98b5
-size 3627764
+oid sha256:4421afca84cc5d1de5664c027c81ad0abfeb601d3b3724b7ab1ac99c58dcb372
+size 3627744

--- a/examples/cube-sat/visual_check.py
+++ b/examples/cube-sat/visual_check.py
@@ -116,7 +116,7 @@ w.run(
     system=park,
     simulation_rate=SIM_HZ,
     generate_real_time=True,
-    max_ticks=int((T_S + 5.0) * SIM_HZ),
+    max_ticks=int((T_S + float(os.environ.get("ELODIN_VIZCHECK_PAD", "5.0"))) * SIM_HZ),
     optimize=True,
     interactive=False,
     start_timestamp=START_TIMESTAMP_US,

--- a/examples/falcon9/README.md
+++ b/examples/falcon9/README.md
@@ -359,7 +359,7 @@ Defaults in `main.py` fly that vehicle. Nominal run vs targets:
 | Event: touchdown | ±3 s | **~+1 s** |
 | Speed RMSE (display space) | ≤ 15 m/s | ~48 m/s (display-lag ascent still dominates residual) |
 | Altitude RMSE (display space) | ≤ 150 m | ~1,410 m |
-| Touchdown vertical / lateral / impact | ≤ 2 / ≤ 1.5 / ≤ 2 m/s | **~1.5 / ~1.2 / ~1.9 m/s** (`soft_landing: true`) |
+| Touchdown vertical / lateral / impact | ≤ 2 / ≤ 1.5 / ≤ 2 m/s | **0.57 / 0.22 / 0.61 m/s** (`soft_landing: true`) |
 | Touchdown tilt / \|ω\| | ≤ 2° / ≤ 1°/s | **~0.6° / ~0.4°/s** |
 | Touchdown position error | ≤ 5 m (bullseye) | **~4.9 m** |
 | Descent max \|ω_yz\| / AoA (aero, &lt;30 km) | &lt; 10°/s / &lt; 12° | **~4.2°/s / ~12°** |

--- a/examples/falcon9/WHITEPAPER.md
+++ b/examples/falcon9/WHITEPAPER.md
@@ -1008,9 +1008,11 @@ quantization, sample-and-hold at the IMU rate).
 - **GPS** emits ECEF position/velocity directly (its native frame — another
   ECEF convenience), at 25 Hz with meter-class position noise, plus an
   outage window during the high-plasma entry burn (flagged, dispersable).
-- **Radar altimeter** measures the boresight ray to terrain, not CG
-  altitude: `range = (h − h_terrain)/cosθ_tilt` within FOV and a max-range
-  gate of a few hundred meters (Ainstein-class device
+- **Radar altimeter** measures the boresight ray from the engine-plane
+  antenna to terrain, not CoM altitude:
+  `range = (h_ant − h_terrain)/cosθ_tilt`, with `h_terrain` the 5 m LZ-1
+  deck inside a 5 km gate (else ellipsoid 0). Valid within FOV and a
+  max-range gate of a few hundred meters (Ainstein-class device
   [product family docs](https://ainstein.ai/us-d1-all-weather-radar-altimeter/)),
   at 40 Hz with latency and dropout. It matters only in the last
   seconds — which is honest: that is also true on the real vehicle.

--- a/examples/falcon9/constants.py
+++ b/examples/falcon9/constants.py
@@ -38,10 +38,8 @@ PAD_ALT_M = 3.0
 LZ1_LAT_DEG = 28.48580  # Landing Zone 1
 LZ1_LON_DEG = -80.54440
 LZ1_ALT_M = 5.0
-# Visual drop so the keel sits in the cinematic floor under LZ-1.
-BARGE_TRANSLATE_Y_M = -48.0
-# GLB origin vs deck; negative plants the bells / legs.
-BOOSTER_DECK_UP_M = -2.0
+# falcon9.glb origin is 0.13 m above the Merlin bells (Y-up); KDL scale 0.9944.
+GLB_ORIGIN_STATION_M = 0.129
 
 # --- Stage 1 geometry and mass (WHITEPAPER 9.4) -------------------------------
 STAGE1_LENGTH_M = 47.0  # EST: tank stack + interstage

--- a/examples/falcon9/constants.py
+++ b/examples/falcon9/constants.py
@@ -38,6 +38,10 @@ PAD_ALT_M = 3.0
 LZ1_LAT_DEG = 28.48580  # Landing Zone 1
 LZ1_LON_DEG = -80.54440
 LZ1_ALT_M = 5.0
+# Visual drop so the keel sits in the cinematic floor under LZ-1.
+BARGE_TRANSLATE_Y_M = -48.0
+# GLB origin vs deck; negative plants the bells / legs.
+BOOSTER_DECK_UP_M = -2.0
 
 # --- Stage 1 geometry and mass (WHITEPAPER 9.4) -------------------------------
 STAGE1_LENGTH_M = 47.0  # EST: tank stack + interstage

--- a/examples/falcon9/controller/src/main.rs
+++ b/examples/falcon9/controller/src/main.rs
@@ -36,7 +36,6 @@ const THROTTLE_MIN: f64 = 0.57;
 const T_VAC_PER_ENGINE: f64 = 829_000.0; // matches plant constants
 const A_E_M2: f64 = 0.681;
 const LZ1_ALT_M: f64 = 5.0;
-const RADAR_STATION_M: f64 = 16.5; // CoM above the engine-plane antenna at landing mass
 const LZ1_LAT_RAD: f64 = 28.48580_f64.to_radians();
 const LZ1_LON_RAD: f64 = -80.54440_f64.to_radians();
 /// ZEM/ZEV terminal guidance (Guo/Hawkins/Wie) — LandingBurn.
@@ -200,6 +199,14 @@ impl Command {
     }
 }
 
+/// CoM station from the engine-plane antenna (plant `stack_mass_props`, m_upper=0).
+fn cg_station_m(lox_kg: f64, rp1_kg: f64) -> f64 {
+    let area = std::f64::consts::PI * 1.83 * 1.83;
+    let cg_lox = 17.5 + 0.5 * lox_kg / (1220.0 * area);
+    let cg_rp1 = 3.0 + 0.5 * rp1_kg / (830.0 * area);
+    (25_600.0 * 18.8 + lox_kg * cg_lox + rp1_kg * cg_rp1) / (25_600.0 + lox_kg + rp1_kg)
+}
+
 /// IMU + GPS navigator with the rotating-frame mechanization (WHITEPAPER 12).
 struct Navigator {
     pos: V3,
@@ -212,6 +219,8 @@ struct Navigator {
     wind_est: V3,
     /// Radar-smoothed antenna height above terrain (m); <0 when invalid.
     radar_agl_m: f64,
+    /// CoM above the engine-plane antenna (m), from current propellant.
+    station_m: f64,
 }
 
 impl Navigator {
@@ -225,6 +234,7 @@ impl Navigator {
             initialized: false,
             wind_est: [0.0; 3],
             radar_agl_m: -1.0,
+            station_m: 18.8,
         }
     }
 
@@ -249,9 +259,11 @@ impl Navigator {
         self.initialized = true;
         self.wind_est = [0.0; 3];
         self.radar_agl_m = -1.0;
+        self.station_m = cg_station_m(s.lox_kg, s.rp1_kg);
     }
 
     fn step(&mut self, s: &SensorPacket) {
+        self.station_m = cg_station_m(s.lox_kg, s.rp1_kg);
         if !self.initialized {
             if s.gps_count > 0.0 {
                 self.init(s);
@@ -291,7 +303,7 @@ impl Navigator {
             } else {
                 self.radar_agl_m = 0.7 * self.radar_agl_m + 0.3 * h_agl;
             }
-            let dh = (self.radar_agl_m + RADAR_STATION_M + self.site_alt()) - geo_alt;
+            let dh = (self.radar_agl_m + self.station_m + self.site_alt()) - geo_alt;
             if dh.abs() < 50.0 {
                 self.pos = add(self.pos, scale(up, 0.35 * dh));
             }
@@ -302,7 +314,7 @@ impl Navigator {
 
     fn altitude(&self) -> f64 {
         if self.radar_agl_m >= 0.0 {
-            self.radar_agl_m + RADAR_STATION_M + self.site_alt()
+            self.radar_agl_m + self.station_m + self.site_alt()
         } else {
             ecef_to_geodetic(self.pos).2
         }
@@ -312,7 +324,7 @@ impl Navigator {
         if self.radar_agl_m >= 0.0 {
             self.radar_agl_m
         } else {
-            ecef_to_geodetic(self.pos).2 - RADAR_STATION_M - self.site_alt()
+            ecef_to_geodetic(self.pos).2 - self.station_m - self.site_alt()
         }
     }
 

--- a/examples/falcon9/controller/src/main.rs
+++ b/examples/falcon9/controller/src/main.rs
@@ -35,6 +35,10 @@ const V_PURGE: usize = 7;
 const THROTTLE_MIN: f64 = 0.57;
 const T_VAC_PER_ENGINE: f64 = 829_000.0; // matches plant constants
 const A_E_M2: f64 = 0.681;
+const LZ1_ALT_M: f64 = 5.0;
+const RADAR_STATION_M: f64 = 16.5; // CoM above the engine-plane antenna at landing mass
+const LZ1_LAT_RAD: f64 = 28.48580_f64.to_radians();
+const LZ1_LON_RAD: f64 = -80.54440_f64.to_radians();
 /// ZEM/ZEV terminal guidance (Guo/Hawkins/Wie) — LandingBurn.
 const ZEM_WAYPOINT_ALT_M: f64 = 150.0;
 const ZEM_WAYPOINT_VDOWN_MPS: f64 = 25.0;
@@ -206,8 +210,8 @@ struct Navigator {
     initialized: bool,
     /// Steady wind estimate (ECEF m/s) from GPS–IMU innovation.
     wind_est: V3,
-    /// Radar-smoothed altitude (m); <0 when invalid.
-    radar_alt_m: f64,
+    /// Radar-smoothed antenna height above terrain (m); <0 when invalid.
+    radar_agl_m: f64,
 }
 
 impl Navigator {
@@ -220,7 +224,16 @@ impl Navigator {
             last_t: 0.0,
             initialized: false,
             wind_est: [0.0; 3],
-            radar_alt_m: -1.0,
+            radar_agl_m: -1.0,
+        }
+    }
+
+    fn site_alt(&self) -> f64 {
+        let lz1 = geodetic_to_ecef(LZ1_LAT_RAD, LZ1_LON_RAD, LZ1_ALT_M);
+        if norm(sub(self.pos, lz1)) < 5_000.0 {
+            LZ1_ALT_M
+        } else {
+            0.0
         }
     }
 
@@ -235,7 +248,7 @@ impl Navigator {
         self.last_t = s.t;
         self.initialized = true;
         self.wind_est = [0.0; 3];
-        self.radar_alt_m = -1.0;
+        self.radar_agl_m = -1.0;
     }
 
     fn step(&mut self, s: &SensorPacket) {
@@ -266,30 +279,40 @@ impl Navigator {
             self.vel = add(self.vel, scale(sub(s.gps_vel, self.vel), 0.50));
             self.last_gps_count = s.gps_count;
         }
-        // Radar altimeter below 500 m for h / t_go (when valid).
+        // Radar altimeter below 500 m: slant → antenna AGL, then reconstruct CoM.
         if s.radar_range >= 0.0 && s.radar_range < 500.0 {
-            let geo_alt = ecef_to_geodetic(self.pos).2;
-            if self.radar_alt_m < 0.0 {
-                self.radar_alt_m = s.radar_range;
-            } else {
-                self.radar_alt_m = 0.7 * self.radar_alt_m + 0.3 * s.radar_range;
-            }
-            let (lat, lon, _) = ecef_to_geodetic(self.pos);
+            let (lat, lon, geo_alt) = ecef_to_geodetic(self.pos);
             let up = scale(ned_basis(lat, lon)[2], -1.0);
-            let dh = self.radar_alt_m - geo_alt;
+            let body_x = quat_rotate(self.att, [1.0, 0.0, 0.0]);
+            let cos_tilt = dot(body_x, up).max(0.6);
+            let h_agl = s.radar_range * cos_tilt;
+            if self.radar_agl_m < 0.0 {
+                self.radar_agl_m = h_agl;
+            } else {
+                self.radar_agl_m = 0.7 * self.radar_agl_m + 0.3 * h_agl;
+            }
+            let dh = (self.radar_agl_m + RADAR_STATION_M + self.site_alt()) - geo_alt;
             if dh.abs() < 50.0 {
                 self.pos = add(self.pos, scale(up, 0.35 * dh));
             }
         } else {
-            self.radar_alt_m = -1.0;
+            self.radar_agl_m = -1.0;
         }
     }
 
     fn altitude(&self) -> f64 {
-        if self.radar_alt_m >= 0.0 {
-            self.radar_alt_m
+        if self.radar_agl_m >= 0.0 {
+            self.radar_agl_m + RADAR_STATION_M + self.site_alt()
         } else {
             ecef_to_geodetic(self.pos).2
+        }
+    }
+
+    fn height_agl(&self) -> f64 {
+        if self.radar_agl_m >= 0.0 {
+            self.radar_agl_m
+        } else {
+            ecef_to_geodetic(self.pos).2 - RADAR_STATION_M - self.site_alt()
         }
     }
 
@@ -324,7 +347,7 @@ struct Fsw {
 
 impl Fsw {
     fn new() -> Self {
-        let lz1 = geodetic_to_ecef(28.48580_f64.to_radians(), -80.54440_f64.to_radians(), 5.0);
+        let lz1 = geodetic_to_ecef(LZ1_LAT_RAD, LZ1_LON_RAD, LZ1_ALT_M);
         Fsw {
             nav: Navigator::new(),
             phase: Phase::PadPress,
@@ -399,6 +422,7 @@ impl Fsw {
         let p = &s.params;
         let t = s.t;
         let alt = self.nav.altitude();
+        let h_agl = self.nav.height_agl();
         let speed = self.nav.speed();
 
         // Common frames.
@@ -620,7 +644,7 @@ impl Fsw {
                 // charging ~2.5 s of spool-up distance against the altitude.
                 let vdown = -dot(self.nav.vel, up_here);
                 let a_land = 0.70 * self.landing_accel_net(s, 3.0);
-                let h_eff = (alt - 2.5 * vdown.max(0.0) - 20.0).max(1.0);
+                let h_eff = (h_agl - 2.5 * vdown.max(0.0)).max(1.0);
                 let v_profile = (2.0 * a_land * h_eff).sqrt();
                 if t - self.phase_t0 > 5.0
                     && ((t - self.phase_t0) as u64).is_multiple_of(10)
@@ -650,14 +674,15 @@ impl Fsw {
                 // the center engine once a single-engine profile can finish.
                 let mass = 25_600.0 + s.lox_kg + s.rp1_kg;
                 let vdown = -dot(self.nav.vel, up_here);
-                let h = (alt - 2.0).max(0.5);
+                let h = h_agl.max(0.5);
                 let t_single_min = THROTTLE_MIN * T_VAC_PER_ENGINE - 101_325.0 * A_E_M2;
                 let a_floor = (t_single_min / mass - 9.81).max(0.5);
                 let a_single = self.landing_accel_net(s, 1.0);
                 let a_mid = 0.5 * (a_floor + a_single);
+                let a_land_1 = 0.70 * a_mid;
                 if self.landing_escalated
                     && !self.landing_deescalated
-                    && vdown <= (2.0 * a_mid * h).sqrt() + 1.0
+                    && vdown <= (2.0 * a_land_1 * h).sqrt() + 1.0
                 {
                     self.landing_deescalated = true;
                 }
@@ -665,15 +690,26 @@ impl Fsw {
                 let (n, a_land) = if three {
                     (3.0, 0.70 * self.landing_accel_net(s, 3.0))
                 } else {
-                    (1.0, a_mid)
+                    (1.0, a_land_1)
                 };
                 // Continuous hoverslam vertical (WHITEAPER 11.5): T_min/W > 1
                 // so we never coast mid-burn — the rate loop keeps vdown on the
                 // suicide curve. ZEM/ZEV only shapes the thrust *direction*.
                 let v_des = (2.0 * a_land * h).sqrt() + ZEM_V_TD_MPS;
-                // Slightly higher rate gain in the last 200 m to keep impact ≤ 2 m/s.
-                let kv = if alt < 200.0 { 4.0 } else { 3.2 };
-                let a_up = (9.81 + kv * (vdown - v_des)).max(0.0);
+                let kv = if h_agl < 15.0 {
+                    6.5
+                } else if h_agl < 50.0 {
+                    5.0
+                } else if h_agl < 200.0 {
+                    4.0
+                } else {
+                    3.2
+                };
+                // Feedforward a_land: on-speed must still decelerate, not hover.
+                let mut a_up = (9.81 + a_land + kv * (vdown - v_des)).max(0.0);
+                if h_agl < 8.0 && vdown > 2.5 {
+                    a_up += 2.0; // last-metres flare for spool lag
+                }
 
                 let (t_go, t_raw) = Self::t_go_hoverslam(h, vdown.max(1.0));
                 let miss_h = {
@@ -683,9 +719,9 @@ impl Fsw {
                 // Commit-to-vertical once near the pad *and* the divert is
                 // mostly closed — don't freeze lateral with a large miss left.
                 if !self.landing_vertical_commit {
-                    let time_gate = t_raw > 0.0 && t_raw < ZEM_COMMIT_TGO_S && alt < 200.0;
-                    let alt_gate = alt < ZEM_COMMIT_ALT_M;
-                    if (alt_gate || time_gate) && (miss_h < 25.0 || alt < 25.0) {
+                    let time_gate = t_raw > 0.0 && t_raw < ZEM_COMMIT_TGO_S && h_agl < 200.0;
+                    let alt_gate = h_agl < ZEM_COMMIT_ALT_M;
+                    if (alt_gate || time_gate) && (miss_h < 25.0 || h_agl < 25.0) {
                         self.landing_vertical_commit = true;
                     }
                 }
@@ -711,12 +747,16 @@ impl Fsw {
                 cmd.fins = self.fin_attitude_pd(body_x, s, true);
 
                 let cos_tilt = dot(body_x, up_here).max(0.6);
-                let u = ((mass * a_up / cos_tilt / n + 101_325.0 * A_E_M2) / T_VAC_PER_ENGINE)
+                let mut u = ((mass * a_up / cos_tilt / n + 101_325.0 * A_E_M2)
+                    / T_VAC_PER_ENGINE)
                     .clamp(THROTTLE_MIN, 1.0);
+                if h_agl < 2.5 && vdown > 2.2 {
+                    u = u.max(0.76); // don't ease off in the last 2.5 m
+                }
                 let mut engines = [0.0; N_ENGINES];
                 // If min-throttle has lofted us (T_min/W > 1), cut until we
                 // are descending again — otherwise we climb away from the pad.
-                let lofting = alt < 100.0 && vdown < -0.5;
+                let lofting = h_agl > 1.0 && h_agl < 100.0 && vdown < -0.5;
                 if !lofting {
                     engines[0] = u;
                     if three {
@@ -725,7 +765,8 @@ impl Fsw {
                     }
                 }
                 cmd.engines = engines;
-                if s.landed > 0.5 || (alt < 2.0 && speed < 1.5) {
+                if s.landed > 0.5 || (h_agl < 0.25 && vdown > 0.0 && vdown < 1.0 && speed < 1.5)
+                {
                     self.cutoff_with_purge(&mut cmd, t);
                     self.set_phase(Phase::Touchdown, t);
                 }
@@ -925,7 +966,7 @@ impl Fsw {
         let aim = sub(self.lz1_pos, scale(wind_h, t_go.min(25.0)));
         let r = sub(self.nav.pos, aim);
         let v = self.nav.vel;
-        let alt = self.nav.altitude();
+        let alt = self.nav.height_agl();
         let g_vec = scale(up, -9.81);
         let (r_tgt, v_tgt) = if alt > ZEM_WAYPOINT_ALT_M {
             (scale(up, ZEM_WAYPOINT_ALT_M), scale(up, -ZEM_WAYPOINT_VDOWN_MPS))

--- a/examples/falcon9/falcon9.kdl
+++ b/examples/falcon9/falcon9.kdl
@@ -71,7 +71,7 @@ vsplit {
 }
 
 // Rotate the 70 m Y-up GLB onto the simulation's body +X axis.
-object_3d orientation=absolute booster.world_pos {
+object_3d orientation=absolute booster.visual_pos {
     glb path="falcon9.glb" rotate="(0, 0, -90)" scale=0.9944
     icon builtin="rocket_launch" size=32 {
         color 70 130 240
@@ -102,8 +102,8 @@ object_3d orientation=absolute pad.world_pos {
 
 // Landing dust and ASDS visual at LZ-1.
 object_3d orientation=absolute lz1.world_pos {
-    // Y-up deck; Rx(-90) cancels y_up_to_schematic. translate matches BARGE_TRANSLATE_Y_M.
-    glb path="spacex_drone_barge.glb" rotate="(-90, 0, 0)" translate="(0, -48, 0)"
+    // Rx(-90) cancels the editor's Y-up lift for a +Y-up parent; barge floats above the coarse globe until the surface fix.
+    glb path="spacex_drone_barge.glb" rotate="(-90, 0, 0)"
     thruster name="lz1_smoke" effect="effects/falcon9/pad_smoke.effect" body_frame=#true position="(0, 2, 0)" direction="(0, -1, 0)" intensity="booster.landing_smoke_viz[0]" cutoff=0.01
 }
 

--- a/examples/falcon9/falcon9.kdl
+++ b/examples/falcon9/falcon9.kdl
@@ -15,7 +15,8 @@ environment {
 // Cinematic chase viewport with telemetry panels.
 vsplit {
     hsplit share=0.75 {
-        viewport name="Chase" share=0.72 near=1.0 pos="booster.world_pos.translate_world(46.740, -100.549, -144.705)" look_at="booster.world_pos.translate_world(1.433, -8.661, 4.788)" up="(0.1433, -0.8661, 0.4788)" cinematic=#true show_grid=#false active=#true
+        // Same series as the GLB (visual_pos); body +X ~20 m is near CoM so framing matches the old world_pos chase.
+        viewport name="Chase" share=0.72 near=1.0 pos="booster.visual_pos.translate(20, 0, 0).translate_world(46.740, -100.549, -144.705)" look_at="booster.visual_pos.translate(20, 0, 0).translate_world(1.433, -8.661, 4.788)" up="(0.1433, -0.8661, 0.4788)" cinematic=#true show_grid=#false active=#true
         vsplit share=0.28 {
             hsplit {
                 graph "booster.ground_speed[0], booster_truth.ground_speed[0]" name="Speed vs recorded (m/s)" {

--- a/examples/falcon9/falcon9.kdl
+++ b/examples/falcon9/falcon9.kdl
@@ -102,8 +102,8 @@ object_3d orientation=absolute pad.world_pos {
 
 // Landing dust and ASDS visual at LZ-1.
 object_3d orientation=absolute lz1.world_pos {
-    // Y-up, deck-centered ASDS mesh.
-    glb path="spacex_drone_barge.glb"
+    // Y-up deck; Rx(-90) cancels y_up_to_schematic. translate matches BARGE_TRANSLATE_Y_M.
+    glb path="spacex_drone_barge.glb" rotate="(-90, 0, 0)" translate="(0, -48, 0)"
     thruster name="lz1_smoke" effect="effects/falcon9/pad_smoke.effect" body_frame=#true position="(0, 2, 0)" direction="(0, -1, 0)" intensity="booster.landing_smoke_viz[0]" cutoff=0.01
 }
 

--- a/examples/falcon9/main.py
+++ b/examples/falcon9/main.py
@@ -368,6 +368,7 @@ def post_step(tick: int, ctx: el.StepContext) -> None:
             "pos_err_m": float(np.hypot(miss_ned[0], miss_ned[1])),
             "miss_north_m": float(miss_ned[0]),
             "miss_east_m": float(miss_ned[1]),
+            "alt_m": float(reads["booster.altitude_geodetic"][0]),
         }
 
     # Let the run continue ~2 s past contact so the shutdown purge is visible.
@@ -416,6 +417,10 @@ def post_step(tick: int, ctx: el.StepContext) -> None:
             "descent_max_aoa_deg": float(max(descent[1], 0.0)),
             "landing_ignition_tilt_deg": float(max(descent[2], 0.0)),
             "vlat_at_100m_mps": float(max(descent[3], 0.0)),
+            "touchdown_alt_m": (touchdown_state or {}).get(
+                "alt_m", float(reads["booster.altitude_geodetic"][0])
+            ),
+            "rest_alt_m": float(reads["booster.altitude_geodetic"][0]),
         }
         # Phase entry times as scalar metrics (phase id -> seconds).
         for pid, ev in phase_events.items():

--- a/examples/falcon9/sim.py
+++ b/examples/falcon9/sim.py
@@ -36,8 +36,7 @@ from constants import (
     LEG_STIFFNESS_NPM,
     LEG_STROKE_M,
     LOX_LOAD_KG,
-    BARGE_TRANSLATE_Y_M,
-    BOOSTER_DECK_UP_M,
+    GLB_ORIGIN_STATION_M,
     LZ1_ALT_M,
     LZ1_LAT_DEG,
     LZ1_LON_DEG,
@@ -166,6 +165,14 @@ InletPressureRp1 = ty.Annotated[
 CgStation = ty.Annotated[
     jax.Array,
     el.Component("cg_station", el.ComponentType(el.PrimitiveType.F64, (1,))),
+]
+VisualPos = ty.Annotated[
+    el.SpatialTransform,
+    el.Component(
+        "visual_pos",
+        el.ComponentType.SpatialPosF64,
+        metadata={"element_names": "q0,q1,q2,q3,x,y,z"},
+    ),
 ]
 AxialSpecificForce = ty.Annotated[
     jax.Array,
@@ -775,7 +782,7 @@ def leg_contact_wrench(
         offset_world = q @ offset_body
         pad_r = r + offset_world
         _, _, pad_alt = ecef_to_geodetic(pad_r)
-        depth = jnp.clip(-pad_alt, 0.0, LEG_STROKE_M)
+        depth = jnp.clip(LZ1_ALT_M - pad_alt, 0.0, LEG_STROKE_M)
         v_pad = v + jnp.cross(q @ omega_body, offset_world)
         v_n = jnp.dot(v_pad, up)
         # Compression-only damper (no stick-to-ground suction).
@@ -831,7 +838,7 @@ def ground_contact(
         return ecef_to_geodetic(pad_r)[2]
 
     pad_alts = jax.vmap(pad_alt)(pads)
-    n_contact = jnp.sum(pad_alts <= 0.0)
+    n_contact = jnp.sum(pad_alts <= LZ1_ALT_M)
     near_lz = jnp.linalg.norm(r - lz1_ecef()) < 5_000.0
     legs_live = (lifted[0] > 0.5) & near_lz & (alt < 200.0)
     any_contact = jnp.logical_and(legs_live, n_contact >= 1.0)
@@ -850,7 +857,7 @@ def ground_contact(
     # Tip-over: CoM ground projection outside support radius, or extreme tilt.
     pad_world = jax.vmap(lambda o: r + q @ o)(pads)
     pad_cent = jnp.sum(
-        jnp.where(pad_alts[:, None] <= 0.0, pad_world, jnp.zeros_like(pad_world)), axis=0
+        jnp.where(pad_alts[:, None] <= LZ1_ALT_M, pad_world, jnp.zeros_like(pad_world)), axis=0
     ) / jnp.maximum(n_contact, 1.0)
     com_ground = r - alt * up
     cent_ground = pad_cent - jnp.dot(pad_cent, up) * up
@@ -872,7 +879,9 @@ def ground_contact(
         & (jnp.abs(cross_m) <= DECK_HALF_CROSS_M)
         & any_contact
     )
-    peak_load = jnp.maximum(deck[4], LEG_STIFFNESS_NPM * jnp.max(jnp.maximum(-pad_alts, 0.0)))
+    peak_load = jnp.maximum(
+        deck[4], LEG_STIFFNESS_NPM * jnp.max(jnp.maximum(LZ1_ALT_M - pad_alts, 0.0))
+    )
     deck_at_contact = jnp.array(
         [
             along_m,
@@ -928,9 +937,7 @@ def ground_contact(
     q_up = el.Quaternion.from_axis_angle(axis, angle)
 
     do_pin = landed_now & ~tipped
-    # WorldPos is the GLB origin; sit it BOOSTER_DECK_UP_M above the translated deck.
-    deck_alt = LZ1_ALT_M + BARGE_TRANSLATE_Y_M + BOOSTER_DECK_UP_M
-    pinned_pos = jnp.where(do_pin, r - (alt - deck_alt) * up, r)
+    pinned_pos = jnp.where(do_pin, r - (alt - (LZ1_ALT_M + cg[0])) * up, r)
     pinned_lin = jnp.where(do_pin, jnp.zeros(3), v)
     pinned_ang = jnp.where(do_pin, jnp.zeros(3), vel.angular())
     q_out = el.Quaternion.from_array(jnp.where(do_pin, q_up.vector(), q.vector()))
@@ -941,6 +948,14 @@ def ground_contact(
         latched,
         deck_next,
     )
+
+
+@el.map
+def booster_visual_pose(pos: el.WorldPos, cg: CgStation) -> VisualPos:
+    r = pos.linear()
+    q = pos.angular()
+    offset = q @ jnp.array([GLB_ORIGIN_STATION_M - cg[0], 0.0, 0.0])
+    return el.SpatialTransform(angular=q, linear=r + offset)
 
 
 @el.map
@@ -988,21 +1003,23 @@ def descent_metrics_latch(
 @el.system
 def pad_clamp(
     tick: el.Query[el.SimulationTick],
-    q: el.Query[el.WorldPos, el.WorldVel, Lifted, LiftoffTime, ThrustTotal, el.Inertia],
+    q: el.Query[el.WorldPos, el.WorldVel, Lifted, LiftoffTime, ThrustTotal, el.Inertia, CgStation],
 ) -> el.Query[el.WorldPos, el.WorldVel, Lifted, LiftoffTime]:
     """Hold-down clamps: pin the stack to the pad until thrust exceeds
     weight, then release for good (the real T-0 release condition), latching
     the release time for liftoff-referenced truth comparison."""
     t_s = tick[0] * SIM_TIME_STEP
     pad = pad_ecef()
+    up = jnp.asarray(PAD_UP)
 
-    def update(pos, vel, lifted, t_liftoff, thrust, inertia):
+    def update(pos, vel, lifted, t_liftoff, thrust, inertia, cg):
         r = pos.linear()
         weight = inertia.mass() * 9.79
         was_lifted = lifted[0] > 0.5
         release = jnp.logical_or(was_lifted, thrust[0] > weight)
         first = jnp.logical_and(~was_lifted, release)
-        held_pos = el.SpatialTransform(angular=pos.angular(), linear=jnp.where(release, r, pad))
+        pin = pad + up * cg[0]
+        held_pos = el.SpatialTransform(angular=pos.angular(), linear=jnp.where(release, r, pin))
         held_vel = el.SpatialMotion(
             angular=jnp.where(release, vel.angular(), jnp.zeros(3)),
             linear=jnp.where(release, vel.linear(), jnp.zeros(3)),
@@ -1488,10 +1505,12 @@ def build_powered(
     world = el.World()
     if init_attitude is None:
         init_attitude = el.Quaternion.identity()
-    mass0, _cg0, inertia0 = propulsion.stack_mass_props(lox_kg, rp1_kg, upper_kg)
+    mass0, cg0, inertia0 = propulsion.stack_mass_props(lox_kg, rp1_kg, upper_kg)
     # The hold-down clamp only applies to pad starts; test articles spawned
     # aloft are born released.
     on_pad = float(jnp.linalg.norm(jnp.asarray(init_pos_ecef) - pad_ecef())) < 100.0
+    vis_off = init_attitude @ jnp.array([GLB_ORIGIN_STATION_M - float(cg0), 0.0, 0.0])
+    vis_lin = jnp.asarray(init_pos_ecef, dtype=jnp.float64) + vis_off
     world.spawn(
         [
             el.Body(
@@ -1501,6 +1520,7 @@ def build_powered(
                 world_vel=el.SpatialMotion(linear=jnp.asarray(init_vel_ecef, dtype=jnp.float64)),
                 inertia=el.SpatialInertia(float(mass0), inertia0),
             ),
+            el.C(VisualPos, el.SpatialTransform(angular=init_attitude, linear=vis_lin)),
             el.C(AltitudeGeodetic, jnp.array([0.0])),
             el.C(GroundSpeed, jnp.array([0.0])),
             el.C(ScoreState, jnp.zeros(3)),
@@ -1528,6 +1548,7 @@ def build_powered(
         | el.six_dof(sys=effectors, integrator=integrator)
         | pad_clamp
         | ground_contact
+        | booster_visual_pose
         | descent_metrics_latch
     )
     system = (extra_systems | plant) if extra_systems is not None else plant
@@ -1553,8 +1574,9 @@ def build_mission(
 ) -> tuple[el.World, el.System]:
     """The full mission world: booster upright on the pad, truth ghost
     replaying `ref`, display scoring accumulating in-sim."""
+    _, cg0, _ = propulsion.stack_mass_props(lox_kg, rp1_kg, upper_kg)
     world, system = build_powered(
-        pad_ecef(),
+        pad_ecef() + jnp.asarray(PAD_UP) * cg0,
         jnp.zeros(3),
         init_attitude=upright_attitude(),
         lox_kg=lox_kg,

--- a/examples/falcon9/sim.py
+++ b/examples/falcon9/sim.py
@@ -36,6 +36,8 @@ from constants import (
     LEG_STIFFNESS_NPM,
     LEG_STROKE_M,
     LOX_LOAD_KG,
+    BARGE_TRANSLATE_Y_M,
+    BOOSTER_DECK_UP_M,
     LZ1_ALT_M,
     LZ1_LAT_DEG,
     LZ1_LON_DEG,
@@ -926,7 +928,9 @@ def ground_contact(
     q_up = el.Quaternion.from_axis_angle(axis, angle)
 
     do_pin = landed_now & ~tipped
-    pinned_pos = jnp.where(do_pin, r - alt * up, r)
+    # WorldPos is the GLB origin; sit it BOOSTER_DECK_UP_M above the translated deck.
+    deck_alt = LZ1_ALT_M + BARGE_TRANSLATE_Y_M + BOOSTER_DECK_UP_M
+    pinned_pos = jnp.where(do_pin, r - (alt - deck_alt) * up, r)
     pinned_lin = jnp.where(do_pin, jnp.zeros(3), v)
     pinned_ang = jnp.where(do_pin, jnp.zeros(3), vel.angular())
     q_out = el.Quaternion.from_array(jnp.where(do_pin, q_up.vector(), q.vector()))

--- a/examples/falcon9/sim.py
+++ b/examples/falcon9/sim.py
@@ -843,7 +843,7 @@ def ground_contact(
     legs_live = (lifted[0] > 0.5) & near_lz & (alt < 200.0)
     any_contact = jnp.logical_and(legs_live, n_contact >= 1.0)
     was_landed = landed[0] > 0.5
-    first_contact = jnp.logical_and(~was_landed, any_contact)
+    first_contact = (~was_landed) & any_contact & (metrics[3] <= 0.0)
 
     v_up = jnp.dot(v, up)
     v_lat = jnp.linalg.norm(v - v_up * up)
@@ -1093,23 +1093,27 @@ def gps_model(
 def radar_altimeter_model(
     timer: sn.RadarTimer,
     pos: el.WorldPos,
+    cg: CgStation,
     rng_prev: sn.RadarRange,
     count: sn.RadarCount,
 ) -> tuple[sn.RadarTimer, sn.RadarRange, sn.RadarCount]:
-    """Boresight (-X body) range to terrain at 40 Hz within FOV/max-range
-    gates; -1 when invalid (WHITEPAPER 12.2)."""
+    """Boresight range from the engine-plane antenna to terrain (deck at LZ-1)."""
     t = timer[0] + SIM_TIME_STEP
     fired = t >= sn.RADAR_DT_S
     t = jnp.where(fired, t - sn.RADAR_DT_S, t)
-    lat, lon, alt = ecef_to_geodetic(pos.linear())
+    r = pos.linear()
+    lat, lon, alt = ecef_to_geodetic(r)
     sin_lat, cos_lat = jnp.sin(lat), jnp.cos(lat)
     sin_lon, cos_lon = jnp.sin(lon), jnp.cos(lon)
     up = jnp.array([cos_lat * cos_lon, cos_lat * sin_lon, sin_lat])
     bore_world = pos.angular() @ jnp.array([-1.0, 0.0, 0.0])
     cos_tilt = jnp.dot(bore_world, -up)
-    slant = alt / jnp.maximum(cos_tilt, 1e-3)
+    h_ant = alt - cg[0] * jnp.maximum(cos_tilt, 1e-3)
+    near_lz = jnp.linalg.norm(r - lz1_ecef()) < 5_000.0
+    h_terr = jnp.where(near_lz, LZ1_ALT_M, 0.0)
+    slant = jnp.maximum(h_ant - h_terr, 0.0) / jnp.maximum(cos_tilt, 1e-3)
     n = count[0] + jnp.where(fired, 1.0, 0.0)
-    valid = (cos_tilt > sn.RADAR_FOV_COS) & (slant <= sn.RADAR_MAX_RANGE_M) & (alt > 0.0)
+    valid = (cos_tilt > sn.RADAR_FOV_COS) & (slant <= sn.RADAR_MAX_RANGE_M)
     meas = jnp.where(valid, slant + sn._noise(n, 5, (), sn.RADAR_SIGMA_M), -1.0)
     return (
         jnp.array([t]),

--- a/examples/falcon9/test_sensors.py
+++ b/examples/falcon9/test_sensors.py
@@ -6,7 +6,16 @@ import math
 import jax.numpy as jnp
 import numpy as np
 import sensors as sn
-from constants import GLB_ORIGIN_STATION_M, LOX_LOAD_KG, N_ENGINES, OMEGA_EARTH_RADPS, PAD_ALT_M, RP1_LOAD_KG
+from constants import (
+    GLB_ORIGIN_STATION_M,
+    LOX_LOAD_KG,
+    LZ1_LAT_DEG,
+    LZ1_LON_DEG,
+    N_ENGINES,
+    OMEGA_EARTH_RADPS,
+    PAD_ALT_M,
+    RP1_LOAD_KG,
+)
 from reference import build_reference, sanity_check
 from sim import (
     N_VALVES,
@@ -19,6 +28,7 @@ from sim import (
     ValveCmd,
     build_mission,
     build_powered,
+    lz1_ecef,
     pad_ecef,
     upright_attitude,
 )
@@ -135,11 +145,21 @@ def test_gps_cadence_hold_and_display_quantization():
     assert abs(dalt / sn.DISPLAY_ALT_STEP - round(dalt / sn.DISPLAY_ALT_STEP)) < 1e-9
 
 
+def _attitude_along_up(up):
+    x = jnp.array([1.0, 0.0, 0.0])
+    axis = jnp.cross(x, up)
+    axis = axis / jnp.linalg.norm(axis)
+    angle = jnp.arccos(jnp.clip(jnp.dot(x, up), -1.0, 1.0))
+    return el.Quaternion.from_axis_angle(axis, angle)
+
+
 def test_radar_geometry_gates():
-    # 100 m up, nose up: boresight (-X body) looks straight down -> range ~ alt.
+    # 100 m up, nose up: boresight from the engine plane to ellipsoid 0.
     import frames
+    import propulsion
 
     up = frames.ellipsoid_up(math.radians(28.60839), math.radians(-80.60433))
+    cg = float(propulsion.stack_mass_props(LOX_LOAD_KG, RP1_LOAD_KG, 0.0)[1])
     world, system = build_powered(
         pad_ecef() + up * 100.0,
         jnp.zeros(3),
@@ -150,7 +170,7 @@ def test_radar_geometry_gates():
     rng_meas = float(get("radar_range")[0])
     alt = float(get("altitude_geodetic")[0])
     assert rng_meas > 0.0
-    assert abs(rng_meas - alt) < 2.0
+    assert abs(rng_meas - (alt - cg)) < 2.0
     # 45-degree tilt about the pad's local NORTH axis exceeds the 35-degree
     # FOV: invalid (-1). (Tilting about a world axis would not tilt from
     # vertical by the same angle.)
@@ -173,6 +193,51 @@ def test_radar_geometry_gates():
     )
     get = _run(world, system, 100)
     assert float(get("radar_range")[0]) < 0.0
+
+
+def test_radar_reads_deck_clearance_near_lz1():
+    import frames
+    import propulsion
+
+    up = frames.ellipsoid_up(math.radians(LZ1_LAT_DEG), math.radians(LZ1_LON_DEG))
+    att = _attitude_along_up(up)
+    cg = float(propulsion.stack_mass_props(LOX_LOAD_KG, RP1_LOAD_KG, 0.0)[1])
+    world, system = build_powered(
+        lz1_ecef() + up * (cg + 30.0),
+        jnp.zeros(3),
+        init_attitude=att,
+        extra_systems=_script(_no_valves, _engines_off),
+    )
+    get = _run(world, system, 100)
+    assert abs(float(get("radar_range")[0]) - 30.0) < 0.5
+    world, system = build_powered(
+        lz1_ecef() + up * cg,
+        jnp.zeros(3),
+        init_attitude=att,
+        extra_systems=_script(_no_valves, _engines_off),
+    )
+    get = _run(world, system, 100)
+    rng = float(get("radar_range")[0])
+    assert rng >= 0.0
+    assert rng < 0.5
+
+
+def test_touchdown_metrics_latch_first_impact():
+    import frames
+    import propulsion
+
+    up = frames.ellipsoid_up(math.radians(LZ1_LAT_DEG), math.radians(LZ1_LON_DEG))
+    att = _attitude_along_up(up)
+    cg = float(propulsion.stack_mass_props(LOX_LOAD_KG, RP1_LOAD_KG, 0.0)[1])
+    world, system = build_powered(
+        lz1_ecef() + up * (cg + 1.0),
+        -up * 3.0,
+        init_attitude=att,
+        extra_systems=_script(_no_valves, _engines_off),
+    )
+    get = _run(world, system, 2000)
+    v_up = float(get("touchdown_metrics")[0])
+    assert 2.5 < v_up < 8.0
 
 
 def test_mission_scoring_gates_on_liftoff():

--- a/examples/falcon9/test_sensors.py
+++ b/examples/falcon9/test_sensors.py
@@ -6,7 +6,7 @@ import math
 import jax.numpy as jnp
 import numpy as np
 import sensors as sn
-from constants import N_ENGINES, OMEGA_EARTH_RADPS
+from constants import GLB_ORIGIN_STATION_M, LOX_LOAD_KG, N_ENGINES, OMEGA_EARTH_RADPS, PAD_ALT_M, RP1_LOAD_KG
 from reference import build_reference, sanity_check
 from sim import (
     N_VALVES,
@@ -205,3 +205,23 @@ def test_mission_scoring_gates_on_liftoff():
     # (altitude_geodetic exists on both entities; index the ghost's row.)
     ghost_alt = float(get("altitude_geodetic", "booster_truth")[0])
     assert abs(ghost_alt - ref.altitude(0.5)) < 200.0
+
+
+def test_visual_pose_tracks_engine_plane():
+    import frames
+    import propulsion
+
+    up = frames.ellipsoid_up(math.radians(28.60839), math.radians(-80.60433))
+    cg = float(propulsion.stack_mass_props(LOX_LOAD_KG, RP1_LOAD_KG, 0.0)[1])
+    world, system = build_powered(
+        pad_ecef() + up * cg,
+        jnp.zeros(3),
+        init_attitude=upright_attitude(),
+        extra_systems=_script(_no_valves, _engines_off),
+    )
+    get = _run(world, system, 1)
+    vis = get("visual_pos")
+    _, _, vis_alt = frames.ecef_to_geodetic(vis[4:7])
+    assert abs(float(vis_alt) - (PAD_ALT_M + GLB_ORIGIN_STATION_M)) < 0.05
+    alt = float(get("altitude_geodetic")[0])
+    assert abs(alt - (PAD_ALT_M + cg)) < 0.05

--- a/examples/falcon9/visual_check.kdl
+++ b/examples/falcon9/visual_check.kdl
@@ -12,7 +12,8 @@ environment {
 tabs {
     viewport name="Chase" near=1.0 pos="booster.world_pos.translate_world(46.740, -100.549, -144.705)" look_at="booster.world_pos.translate_world(1.433, -8.661, 4.788)" up="(0.1433, -0.8661, 0.4788)" cinematic=#true show_grid=#false active=#true
     // Body frame on lz1: +Y is local up.
-    viewport name="Landing" near=1.0 pos="lz1.world_pos.translate(109.3, 39.0, 124.9)" look_at="lz1.world_pos" up="(0.1444, -0.8670, 0.4769)" cinematic=#true ev100=12.5 show_grid=#false active=#true
+    viewport name="Landing" near=1.0 pos="lz1.world_pos.translate(80.0, -30.0, 90.0)" look_at="lz1.world_pos.translate(0, -48, 0)" up="(0.1444, -0.8670, 0.4769)" cinematic=#true ev100=12.5 show_grid=#false active=#true
+    viewport name="Waterline" near=0.5 pos="lz1.world_pos.translate(40.0, -45.0, 0.0)" look_at="lz1.world_pos.translate(0, -48, 0)" up="(0.1444, -0.8670, 0.4769)" cinematic=#true ev100=14.0 show_grid=#false
     // Same SoCal LEO night LOS as cube-sat/main.py, pulled back so the 70 m stack fits.
     viewport name="NightSky" near=1.0 pos="booster.world_pos.translate_world(-459.2083, 178.2587, 73.6618)" look_at="booster.world_pos.translate_world(1.6581, -1.1184, 0.0)" up="(-0.46332, -0.68690, 0.55992)" cinematic=#true show_grid=#false active=#true
 }
@@ -40,8 +41,8 @@ object_3d orientation=absolute pad.world_pos {
 }
 
 object_3d orientation=absolute lz1.world_pos {
-    // Y-up deck-centered barge (~52×96 m); see falcon9.kdl.
-    glb path="spacex_drone_barge.glb"
+    // Y-up deck; Rx(-90) cancels y_up_to_schematic. translate matches BARGE_TRANSLATE_Y_M.
+    glb path="spacex_drone_barge.glb" rotate="(-90, 0, 0)" translate="(0, -48, 0)"
     thruster name="lz1_smoke" effect="effects/falcon9/pad_smoke.effect" body_frame=#true position="(0, 2, 0)" direction="(0, -1, 0)" intensity="booster.landing_smoke_viz[0]" cutoff=0.01
 }
 

--- a/examples/falcon9/visual_check.kdl
+++ b/examples/falcon9/visual_check.kdl
@@ -12,12 +12,13 @@ environment {
 tabs {
     viewport name="Chase" near=1.0 pos="booster.world_pos.translate_world(46.740, -100.549, -144.705)" look_at="booster.world_pos.translate_world(1.433, -8.661, 4.788)" up="(0.1433, -0.8661, 0.4788)" cinematic=#true show_grid=#false active=#true
     // Body frame on lz1: +Y is local up.
-    viewport name="Landing" near=1.0 pos="lz1.world_pos.translate(80.0, -30.0, 90.0)" look_at="lz1.world_pos.translate(0, -48, 0)" up="(0.1444, -0.8670, 0.4769)" cinematic=#true ev100=12.5 show_grid=#false active=#true
-    viewport name="Waterline" near=0.5 pos="lz1.world_pos.translate(40.0, -45.0, 0.0)" look_at="lz1.world_pos.translate(0, -48, 0)" up="(0.1444, -0.8670, 0.4769)" cinematic=#true ev100=14.0 show_grid=#false
+    viewport name="Landing" near=1.0 pos="lz1.world_pos.translate(109.3, 39.0, 124.9)" look_at="lz1.world_pos" up="(0.1444, -0.8670, 0.4769)" cinematic=#true ev100=12.5 show_grid=#false active=#true
+    viewport name="Waterline" near=0.5 pos="lz1.world_pos.translate(40.0, -1.0, 0.0)" look_at="lz1.world_pos.translate(0, 0, 0)" up="(0.1444, -0.8670, 0.4769)" cinematic=#true ev100=14.0 show_grid=#false
     // Same SoCal LEO night LOS as cube-sat/main.py, pulled back so the 70 m stack fits.
     viewport name="NightSky" near=1.0 pos="booster.world_pos.translate_world(-459.2083, 178.2587, 73.6618)" look_at="booster.world_pos.translate_world(1.6581, -1.1184, 0.0)" up="(-0.46332, -0.68690, 0.55992)" cinematic=#true show_grid=#false active=#true
 }
 
+// WorldPos is the visual pose here (engine plane); live sim binds falcon9.glb to visual_pos.
 object_3d orientation=absolute booster.world_pos {
     glb path="falcon9.glb" rotate="(0, 0, -90)" scale=0.9944
     thruster name="merlin" effect="effects/falcon9/merlin_core.effect" body_frame=#true position="(-1.2, 0, 0)" intensity="booster.plume_viz" {
@@ -41,8 +42,8 @@ object_3d orientation=absolute pad.world_pos {
 }
 
 object_3d orientation=absolute lz1.world_pos {
-    // Y-up deck; Rx(-90) cancels y_up_to_schematic. translate matches BARGE_TRANSLATE_Y_M.
-    glb path="spacex_drone_barge.glb" rotate="(-90, 0, 0)" translate="(0, -48, 0)"
+    // Rx(-90) cancels the editor's Y-up lift for a +Y-up parent; barge floats above the coarse globe until the surface fix.
+    glb path="spacex_drone_barge.glb" rotate="(-90, 0, 0)"
     thruster name="lz1_smoke" effect="effects/falcon9/pad_smoke.effect" body_frame=#true position="(0, 2, 0)" direction="(0, -1, 0)" intensity="booster.landing_smoke_viz[0]" cutoff=0.01
 }
 

--- a/examples/falcon9/visual_check.py
+++ b/examples/falcon9/visual_check.py
@@ -16,6 +16,8 @@ import jax
 import jax.numpy as jnp
 
 from constants import (
+    BARGE_TRANSLATE_Y_M,
+    BOOSTER_DECK_UP_M,
     LZ1_ALT_M,
     LZ1_LAT_DEG,
     LZ1_LON_DEG,
@@ -48,6 +50,10 @@ SCENARIOS = {
     "plume-close": {"t0": 22.0, "t_s": 8.0, "delay": 10.0},
     "rcs-flip": {"t0": 36.0, "t_s": 4.0, "delay": 8.0},
     "barge": {"t0": 0.0, "t_s": 8.0, "delay": 10.0},
+    # Same landed pose, low side camera for the hull / water gap.
+    "barge-waterline": {"t0": 0.0, "t_s": 8.0, "delay": 10.0},
+    # Same pose, main.py chase camera.
+    "barge-chase": {"t0": 0.0, "t_s": 8.0, "delay": 10.0},
     # Coast near apogee with the Earth limb behind the booster.
     "apogee": {"t0": 225.0, "t_s": 8.0, "delay": 10.0},
     # Night phases at the same SoCal LEO slot as cube-sat/main.py.
@@ -87,6 +93,10 @@ RcsLevels = ty.Annotated[
 BoosterMarker = ty.Annotated[
     jax.Array, el.Component("vizcheck_booster", el.ComponentType(el.PrimitiveType.F64, (1,)))
 ]
+
+
+# Same deck as falcon9.kdl translate + the sim's landed pin.
+LAND_UP_M = BOOSTER_DECK_UP_M + BARGE_TRANSLATE_Y_M
 
 
 def pad_ecef() -> jnp.ndarray:
@@ -185,7 +195,7 @@ def make_advance():
 
         return advance_night_sky
 
-    if SCENARIO == "barge":
+    if SCENARIO in ("barge", "barge-waterline", "barge-chase"):
 
         @el.system
         def advance_barge(
@@ -201,17 +211,15 @@ def make_advance():
             RcsLevels,
         ]:
             _ = tick[0]
-            # ~35 m above deck; keep landing smoke low so the barge stays visible.
-            r = lz1 + jnp.asarray(LZ1_UP) * 35.0
+            r = lz1 + jnp.asarray(LZ1_UP) * LAND_UP_M
             pose = el.SpatialTransform(angular=landing_att, linear=r)
-            thrust = 0.12
             vals = (
                 pose,
-                jnp.array([thrust]),
-                _plume_from_thrust(thrust, yaw_gimbal_rad=0.05),
-                jnp.array([0.05]),
                 jnp.array([0.0]),
-                jnp.array([0.08]),
+                jnp.zeros(3),
+                jnp.array([0.0]),
+                jnp.array([0.0]),
+                jnp.array([0.0]),
                 jnp.zeros(8),
             )
             return boosters.map(out_tys, lambda _m: vals)
@@ -269,12 +277,12 @@ pad_att = surface_attitude(PAD_LAT_DEG, PAD_LON_DEG)
 lz1_att = surface_attitude(LZ1_LAT_DEG, LZ1_LON_DEG)
 lz1_up = jnp.asarray(LZ1_UP)
 
-init_att = landing_att if SCENARIO == "barge" else ascent_att
+init_att = landing_att if SCENARIO.startswith("barge") else ascent_att
 if SCENARIO.startswith("night-sky"):
     init_r = cs_leo_ecef()
     init_att = attitude_along(init_r / jnp.linalg.norm(init_r))
-elif SCENARIO == "barge":
-    init_r = lz1 + lz1_up * 35.0
+elif SCENARIO.startswith("barge"):
+    init_r = lz1 + lz1_up * LAND_UP_M
 else:
     init_alt = float(jnp.interp(T0, ref_t, ref_alt))
     init_dr = float(jnp.interp(T0, ref_t, ref_dr))
@@ -300,6 +308,10 @@ kdl_path = Path(__file__).with_name("visual_check.kdl")
 # One viewport per scenario so the cinematic camera is unique.
 if SCENARIO == "barge":
     keep = "Landing"
+elif SCENARIO == "barge-waterline":
+    keep = "Waterline"
+elif SCENARIO == "barge-chase":
+    keep = "Chase"
 elif SCENARIO.startswith("night-sky"):
     keep = "NightSky"
 else:
@@ -317,7 +329,7 @@ world.run(
     make_advance(),
     simulation_rate=SIM_HZ,
     generate_real_time=True,
-    max_ticks=int((_cfg["t_s"] + 5.0) * SIM_HZ),
+    max_ticks=int((_cfg["t_s"] + float(os.environ.get("ELODIN_VIZCHECK_PAD", "5.0"))) * SIM_HZ),
     optimize=True,
     interactive=False,
     start_timestamp=(_cs_timestamp_us(*_cfg["utc"]) if "utc" in _cfg else START_TIMESTAMP_US),

--- a/examples/falcon9/visual_check.py
+++ b/examples/falcon9/visual_check.py
@@ -16,8 +16,7 @@ import jax
 import jax.numpy as jnp
 
 from constants import (
-    BARGE_TRANSLATE_Y_M,
-    BOOSTER_DECK_UP_M,
+    GLB_ORIGIN_STATION_M,
     LZ1_ALT_M,
     LZ1_LAT_DEG,
     LZ1_LON_DEG,
@@ -95,8 +94,8 @@ BoosterMarker = ty.Annotated[
 ]
 
 
-# Same deck as falcon9.kdl translate + the sim's landed pin.
-LAND_UP_M = BOOSTER_DECK_UP_M + BARGE_TRANSLATE_Y_M
+# Origin sits GLB_ORIGIN_STATION_M above the deck so the bells / tips touch.
+LAND_UP_M = GLB_ORIGIN_STATION_M
 
 
 def pad_ecef() -> jnp.ndarray:

--- a/libs/db/examples/grpc_full_api_demo.py
+++ b/libs/db/examples/grpc_full_api_demo.py
@@ -26,6 +26,12 @@ from elodin.db.v1 import (
 from grpc_health.v1 import health_pb2, health_pb2_grpc
 from grpc_reflection.v1alpha import reflection_pb2, reflection_pb2_grpc
 
+LIVE_BUDGET_S = 90.0
+
+
+def live_timeout(deadline):
+    return max(1.0, deadline - time.monotonic())
+
 
 def requests_from(items):
     while True:
@@ -486,7 +492,7 @@ def exercise_recorded_playback(channel, call_metadata, camera_messages):
     return second_frame_ns - first_frame_ns
 
 
-def collect_live_component(stub, call_metadata, component, immediate):
+def collect_live_component(stub, call_metadata, component, immediate, timeout):
     responses = stub.StreamComponents(
         iter(
             [
@@ -499,7 +505,7 @@ def collect_live_component(stub, call_metadata, component, immediate):
             ]
         ),
         metadata=call_metadata,
-        timeout=8,
+        timeout=timeout,
     )
     timestamps = []
     for response in responses:
@@ -514,8 +520,7 @@ def collect_live_component(stub, call_metadata, component, immediate):
     raise RuntimeError(f"live {component} stream ended before three updates")
 
 
-def collect_live_camera(stub, call_metadata):
-    deadline = time.monotonic() + 6
+def collect_live_camera(stub, call_metadata, deadline):
     while time.monotonic() < deadline:
         responses = stub.StreamMessages(
             iter(
@@ -529,7 +534,7 @@ def collect_live_camera(stub, call_metadata):
                 ]
             ),
             metadata=call_metadata,
-            timeout=8,
+            timeout=live_timeout(deadline),
         )
         try:
             timestamps = []
@@ -548,7 +553,7 @@ def collect_live_camera(stub, call_metadata):
 
 def exercise_live(channel, call_metadata):
     query = query_pb2_grpc.QueryServiceStub(channel)
-    deadline = time.monotonic() + 6
+    deadline = time.monotonic() + LIVE_BUDGET_S
     while time.monotonic() < deadline:
         schema = query.DumpSchema(query_pb2.DumpSchemaRequest(), metadata=call_metadata)
         names = {component.name for component in schema.components}
@@ -559,10 +564,18 @@ def exercise_live(channel, call_metadata):
         raise RuntimeError("live RC-jet schema did not become available")
 
     stream = stream_pb2_grpc.StreamServiceStub(channel)
-    batched = collect_live_component(stream, call_metadata, "bdx.world_pos", False)
-    immediate = collect_live_component(stream, call_metadata, "bdx.mach", True)
-    frames = collect_live_camera(stream, call_metadata)
-    events = stream.WatchDb(stream_pb2.WatchDbRequest(), metadata=call_metadata, timeout=8)
+    batched = collect_live_component(
+        stream, call_metadata, "bdx.world_pos", False, live_timeout(deadline)
+    )
+    immediate = collect_live_component(
+        stream, call_metadata, "bdx.mach", True, live_timeout(deadline)
+    )
+    frames = collect_live_camera(stream, call_metadata, deadline)
+    events = stream.WatchDb(
+        stream_pb2.WatchDbRequest(),
+        metadata=call_metadata,
+        timeout=live_timeout(deadline),
+    )
     last_updated = []
     for event in events:
         if event.WhichOneof("event") != "last_updated_ns":

--- a/libs/elodin-editor/src/plugins/cinematic_earth/effects.rs
+++ b/libs/elodin-editor/src/plugins/cinematic_earth/effects.rs
@@ -192,9 +192,8 @@ fn star_field(
     color.add_key(0.0, hdr);
     color.add_key(1.0, hdr);
 
-    let mask_slot = writer.lit(0u32).expr();
     let mut module = writer.finish();
-    module.add_texture_slot("mask");
+    module.add_texture_slot("mask", SlotDimension::D2);
 
     let effect = EffectAsset::new(
         capacity,
@@ -219,7 +218,7 @@ fn star_field(
         .update(update_size)
         .render(OrientModifier::new(OrientMode::FaceCameraPosition))
         .render(ParticleTextureModifier {
-            texture_slot: mask_slot,
+            texture_slot: 0,
             sample_mapping: ImageSampleMapping::ModulateOpacityFromR,
         })
         .render(ColorOverLifetimeModifier {
@@ -299,10 +298,9 @@ pub fn city_lights(earth: &EarthConfig) -> EffectAsset {
     color.add_key(0.0, hdr);
     color.add_key(1.0, hdr);
 
-    let veil_slot = writer.lit(0u32).expr();
     let mut module = writer.finish();
-    module.add_texture_slot("veil");
-    module.add_texture_slot("night");
+    module.add_texture_slot("veil", SlotDimension::D2);
+    module.add_texture_slot("night", SlotDimension::D2);
 
     EffectAsset::new(
         capacity,
@@ -323,7 +321,7 @@ pub fn city_lights(earth: &EarthConfig) -> EffectAsset {
     // Screen-aligned so lights stay round at the limb.
     .render(OrientModifier::new(OrientMode::ParallelCameraDepthPlane))
     .render(ParticleTextureModifier {
-        texture_slot: veil_slot,
+        texture_slot: 0,
         sample_mapping: ImageSampleMapping::ModulateOpacityFromR,
     })
     .render(SphereMapColorModifier {
@@ -374,9 +372,8 @@ fn airglow_shell(
     color.add_key(0.0, hdr);
     color.add_key(1.0, hdr);
 
-    let veil_slot = writer.lit(0u32).expr();
     let mut module = writer.finish();
-    module.add_texture_slot("veil");
+    module.add_texture_slot("veil", SlotDimension::D2);
 
     EffectAsset::new(
         capacity,
@@ -396,7 +393,7 @@ fn airglow_shell(
     .update(update_size)
     .render(OrientModifier::new(OrientMode::FaceCameraPosition))
     .render(ParticleTextureModifier {
-        texture_slot: veil_slot,
+        texture_slot: 0,
         sample_mapping: ImageSampleMapping::ModulateOpacityFromR,
     })
     .render(ColorOverLifetimeModifier {

--- a/libs/elodin-editor/src/plugins/cinematic_earth/mod.rs
+++ b/libs/elodin-editor/src/plugins/cinematic_earth/mod.rs
@@ -21,6 +21,7 @@ use bevy_geo_frames::{GeoContext, GeoFrame, GeoPosition, GeoRotation};
 use bevy_hanabi::{EffectAsset, EffectMaterial, EffectProperties, ParticleEffect};
 
 use crate::plugins::render_layer_alloc::CINEMATIC_EARTH_RENDER_LAYER;
+use crate::plugins::thruster_particles::images_ready;
 use crate::plugins::scene_environment::{
     CinematicViewport, SceneEnvironment, SchematicAtmosphere, SchematicSun, SpaceVisibility,
 };
@@ -148,6 +149,12 @@ struct SkyEmitter;
 
 #[derive(Component)]
 struct CinematicParticleEmitter;
+
+#[derive(Component)]
+struct PendingEffectMaterial {
+    effect: Handle<EffectAsset>,
+    images: Vec<Handle<Image>>,
+}
 
 /// Globe-attached emitter (city lights / airglow).
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -284,7 +291,13 @@ impl Plugin for CinematicEarthPlugin {
             // The chain flushes emitter swaps before Hanabi runs in PostUpdate.
             .add_systems(
                 Update,
-                (sync_cinematic_earth, sync_earth_look, tag_globe_meshes).chain(),
+                (
+                    sync_cinematic_earth,
+                    bind_ready_emitters,
+                    sync_earth_look,
+                    tag_globe_meshes,
+                )
+                    .chain(),
             );
         app.add_systems(
             PostUpdate,
@@ -428,14 +441,34 @@ fn sky_emitter_bundle(
     (
         Name::new(name),
         CinematicParticleEmitter,
-        ParticleEffect::new(effect),
-        EffectMaterial { images },
+        PendingEffectMaterial { effect, images },
         EffectProperties::default(),
         Transform::default(),
         Visibility::default(),
         NoFrustumCulling,
         RenderLayers::layer(CINEMATIC_EARTH_RENDER_LAYER),
     )
+}
+
+fn bind_ready_emitters(
+    mut commands: Commands,
+    pending: Query<(Entity, &PendingEffectMaterial)>,
+    asset_server: Res<AssetServer>,
+) {
+    for (entity, pending) in &pending {
+        if !images_ready(&pending.images, &asset_server) {
+            continue;
+        }
+        commands
+            .entity(entity)
+            .insert((
+                ParticleEffect::new(pending.effect.clone()),
+                EffectMaterial {
+                    images: pending.images.clone(),
+                },
+            ))
+            .remove::<PendingEffectMaterial>();
+    }
 }
 
 /// Spawns/despawns the whole rig when `environment { earth }` toggles.

--- a/libs/elodin-editor/src/plugins/cinematic_earth/mod.rs
+++ b/libs/elodin-editor/src/plugins/cinematic_earth/mod.rs
@@ -21,10 +21,10 @@ use bevy_geo_frames::{GeoContext, GeoFrame, GeoPosition, GeoRotation};
 use bevy_hanabi::{EffectAsset, EffectMaterial, EffectProperties, ParticleEffect};
 
 use crate::plugins::render_layer_alloc::CINEMATIC_EARTH_RENDER_LAYER;
-use crate::plugins::thruster_particles::images_ready;
 use crate::plugins::scene_environment::{
     CinematicViewport, SceneEnvironment, SchematicAtmosphere, SchematicSun, SpaceVisibility,
 };
+use crate::plugins::thruster_particles::images_ready;
 
 use earth_night_material::{EarthNightExt, EarthNightMaterial, EarthNightParams};
 

--- a/libs/elodin-editor/src/plugins/cinematic_earth/modifiers.rs
+++ b/libs/elodin-editor/src/plugins/cinematic_earth/modifiers.rs
@@ -45,6 +45,7 @@ impl Modifier for SphereMapColorModifier {
         Err(ExprError::InvalidModifierContext(
             context.modifier_context(),
             ModifierContext::Render,
+            "",
         ))
     }
 }

--- a/libs/elodin-editor/src/plugins/thruster_particles/mod.rs
+++ b/libs/elodin-editor/src/plugins/thruster_particles/mod.rs
@@ -27,7 +27,7 @@
 
 use std::collections::HashMap;
 
-use bevy::asset::RenderAssetUsages;
+use bevy::asset::{LoadState, RenderAssetUsages};
 use bevy::camera::visibility::{NoFrustumCulling, RenderLayers};
 use bevy::math::{DQuat, DVec3, Quat, Vec4};
 use bevy::prelude::*;
@@ -37,7 +37,7 @@ use bevy_geo_frames::{GeoContext, GeoFrame, GeoPosition, GeoRotation};
 use bevy_hanabi::{
     AlphaMode, Attribute, CpuValue, EffectAsset, EffectMaterial, EffectProperties,
     EffectSimulation, EffectSimulationTime, EffectSpawner, Gradient, HanabiPlugin, Module,
-    ParticleEffect, SimulationSpace, SpawnerSettings,
+    ParticleEffect, SimulationSpace, SlotDimension, SpawnerSettings,
     modifier::{
         ShapeDimension,
         attr::SetAttributeModifier,
@@ -120,6 +120,20 @@ impl FileEffectAssets {
         self.handles.insert(path, handle.clone());
         handle
     }
+}
+
+/// Server-loaded images must be `Loaded` before `EffectMaterial` is inserted.
+/// `Assets::add` handles have no load state (`None`) and are ready immediately.
+pub(crate) fn images_ready(images: &[Handle<Image>], server: &AssetServer) -> bool {
+    images
+        .iter()
+        .all(|h| server.get_load_state(h.id()).is_none_or(|s| s.is_loaded()))
+}
+
+fn images_failed(images: &[Handle<Image>], server: &AssetServer) -> bool {
+    images
+        .iter()
+        .any(|h| matches!(server.get_load_state(h.id()), Some(LoadState::Failed(_))))
 }
 
 /// Retained sprite handles (`smoke` / fallback). Seek despawns jets; this map
@@ -426,8 +440,7 @@ fn build_dps_exhaust() -> EffectAsset {
     size_over_life.add_key(0.75, Vec3::new(1.18, 0.52, 0.52));
     size_over_life.add_key(1.0, Vec3::new(0.42, 0.2, 0.2));
 
-    let mask_slot = module.lit(0u32);
-    module.add_texture_slot("mask");
+    module.add_texture_slot("mask", SlotDimension::D2);
 
     EffectAsset::new(16384, SpawnerSettings::rate(220.0.into()), module)
         .with_name("dps_exhaust")
@@ -441,7 +454,7 @@ fn build_dps_exhaust() -> EffectAsset {
         .render(OrientModifier::new(OrientMode::AlongVelocity))
         // Soft round mask so the quads are not visible flat squares up close.
         .render(ParticleTextureModifier {
-            texture_slot: mask_slot,
+            texture_slot: 0,
             sample_mapping: ImageSampleMapping::ModulateOpacityFromR,
         })
         .render(SizeOverLifetimeModifier {
@@ -499,8 +512,7 @@ fn build_rcs_jet() -> EffectAsset {
     size_over_life.add_key(0.75, Vec3::splat(0.17));
     size_over_life.add_key(1.0, Vec3::splat(0.07));
 
-    let mask_slot = module.lit(0u32);
-    module.add_texture_slot("mask");
+    module.add_texture_slot("mask", SlotDimension::D2);
 
     EffectAsset::new(16384, SpawnerSettings::rate(1100.0.into()), module)
         .with_name("rcs_jet")
@@ -515,7 +527,7 @@ fn build_rcs_jet() -> EffectAsset {
         .render(OrientModifier::new(OrientMode::FaceCameraPosition))
         // Soft round mask so the quads are not visible flat squares up close.
         .render(ParticleTextureModifier {
-            texture_slot: mask_slot,
+            texture_slot: 0,
             sample_mapping: ImageSampleMapping::ModulateOpacityFromR,
         })
         .render(SizeOverLifetimeModifier {
@@ -871,6 +883,17 @@ fn bind_file_effect_assets(
                 )
             })
             .collect();
+        if images_failed(&images, &asset_server) {
+            warn!(
+                "hanabi effect textures failed to load; skipping bind for {}",
+                handle.path().map(|p| p.to_string()).unwrap_or_default()
+            );
+            jet.pending_effect = None;
+            continue;
+        }
+        if !images_ready(&images, &asset_server) {
+            continue;
+        }
         jet.has_intensity_property = asset
             .properties()
             .iter()

--- a/scripts/ci/db_grpc_cpp_smoke.sh
+++ b/scripts/ci/db_grpc_cpp_smoke.sh
@@ -32,8 +32,37 @@ if [[ ! -x "${server_bin}" ]]; then
   exit 1
 fi
 
-db_port=$((30000 + $$ % 10000))
-grpc_port=$((db_port + 2))
+port_listening() {
+  python3 - "$1" <<'PY'
+import socket
+import sys
+
+with socket.socket() as sock:
+    sock.settimeout(0.1)
+    sys.exit(sock.connect_ex(("127.0.0.1", int(sys.argv[1]))) != 0)
+PY
+}
+
+pick_ports() {
+  local base attempts
+  base=$((20000 + $$ % 10000))
+  (( base > 29997 )) && base=20000
+  for attempts in $(seq 1 64); do
+    if ! port_listening "${base}" && ! port_listening "$((base + 1))" && ! port_listening "$((base + 2))"; then
+      db_port="${base}"
+      grpc_port="$((base + 2))"
+      return 0
+    fi
+    base=$((base + 3))
+    if (( base > 29997 )); then
+      base=20000
+    fi
+  done
+  printf 'no free elodin-db port triple in 20000-29999\n' >&2
+  exit 1
+}
+
+pick_ports
 db_dir="${work}/db"
 (
   trap - INT
@@ -43,15 +72,7 @@ server_pid=$!
 
 ready=0
 for _ in $(seq 1 100); do
-  if python3 - "${grpc_port}" <<'PY'
-import socket
-import sys
-
-with socket.socket() as sock:
-    sock.settimeout(0.1)
-    sys.exit(sock.connect_ex(("127.0.0.1", int(sys.argv[1]))) != 0)
-PY
-  then
+  if port_listening "${grpc_port}"; then
     ready=1
     break
   fi

--- a/scripts/ci/db_grpc_full_api_demo.sh
+++ b/scripts/ci/db_grpc_full_api_demo.sh
@@ -34,8 +34,38 @@ trap cleanup EXIT
 
 cd "${root}"
 python3 -c 'import elodin, grpc, grpc_tools, pyarrow'
-db_port=$((30000 + $$ % 10000))
-grpc_port=$((db_port + 2))
+
+port_listening() {
+  python3 - "$1" <<'PY'
+import socket
+import sys
+
+with socket.socket() as sock:
+    sock.settimeout(0.1)
+    sys.exit(sock.connect_ex(("127.0.0.1", int(sys.argv[1]))) != 0)
+PY
+}
+
+pick_ports() {
+  local base attempts
+  base=$((20000 + $$ % 10000))
+  (( base > 29997 )) && base=20000
+  for attempts in $(seq 1 64); do
+    if ! port_listening "${base}" && ! port_listening "$((base + 1))" && ! port_listening "$((base + 2))"; then
+      db_port="${base}"
+      grpc_port="$((base + 2))"
+      return 0
+    fi
+    base=$((base + 3))
+    if (( base > 29997 )); then
+      base=20000
+    fi
+  done
+  printf 'no free elodin-db port triple in 20000-29999\n' >&2
+  exit 1
+}
+
+pick_ports
 
 generated="${work}/python"
 mkdir -p "${generated}"
@@ -55,51 +85,66 @@ touch "${generated}/elodin/db/v1/__init__.py"
 
 wait_for_port() {
   local port="$1"
-  for _ in $(seq 1 100); do
-    if python3 - "${port}" <<'PY'
-import socket
-import sys
-
-with socket.socket() as sock:
-    sock.settimeout(0.1)
-    sys.exit(sock.connect_ex(("127.0.0.1", int(sys.argv[1]))) != 0)
-PY
-    then
+  local pid="${2:-}"
+  local deadline=$((SECONDS + 120))
+  while (( SECONDS < deadline )); do
+    if port_listening "${port}"; then
       return 0
+    fi
+    if [[ -n "${pid}" ]] && ! kill -0 "${pid}" 2>/dev/null; then
+      return 1
     fi
     sleep 0.1
   done
   return 1
 }
 
-if [[ -n "${ELODIN_GRPC_DEMO_DB:-}" ]]; then
-  cp -a "${ELODIN_GRPC_DEMO_DB}" "${work}/db"
-else
+start_sim() {
+  local ticks="$1"
   sim_log="${work}/rc-jet.log"
   touch "${sim_log}"
-  controller_bin="${ELODIN_RC_JET_CONTROLLER_BIN:-}"
-  if [[ -z "${controller_bin}" ]] && command -v cargo >/dev/null; then
-    cargo build --release -p rc-jet-controller
-    controller_bin="${root}/target/release/rc-jet-controller"
-  fi
   setsid env \
     ELODIN_DB_PATH="${work}/db" \
-    ELODIN_MAX_TICKS="${ELODIN_GRPC_DEMO_TICKS:-3000}" \
+    ELODIN_MAX_TICKS="${ticks}" \
     ELODIN_NON_INTERACTIVE=1 \
     ELODIN_RC_JET_CONTROLLER_HOST="127.0.0.1:${db_port}" \
     ELODIN_RC_JET_CONTROLLER_BIN="${controller_bin}" \
     elodin run examples/rc-jet/main.py --addr "127.0.0.1:${db_port}" \
     >"${sim_log}" 2>&1 &
   sim_pid=$!
-  if ! wait_for_port "${grpc_port}"; then
-    rg -n '^' "${sim_log}" >&2 || true
-    printf 'embedded RC-jet gRPC server did not become ready\n' >&2
-    exit 1
+}
+
+stop_sim() {
+  if [[ -z "${sim_pid}" ]]; then
+    return
   fi
-  PYTHONPATH="${generated}" python3 libs/db/examples/grpc_full_api_demo.py \
-    --live --target "127.0.0.1:${grpc_port}"
-  complete=0
-  for _ in $(seq 1 720); do
+  if kill -0 "${sim_pid}" 2>/dev/null; then
+    kill -INT -- "-${sim_pid}" 2>/dev/null || true
+    local deadline=$((SECONDS + 20))
+    while (( SECONDS < deadline )) && kill -0 "${sim_pid}" 2>/dev/null; do
+      sleep 0.1
+    done
+    if kill -0 "${sim_pid}" 2>/dev/null; then
+      kill -KILL -- "-${sim_pid}" 2>/dev/null || true
+    fi
+  fi
+  wait "${sim_pid}" 2>/dev/null || true
+  sim_pid=""
+}
+
+wait_for_sim_ready() {
+  if wait_for_port "${grpc_port}" "${sim_pid}"; then
+    return 0
+  fi
+  rg -n '^' "${sim_log}" >&2 || true
+  printf 'embedded RC-jet gRPC server did not become ready\n' >&2
+  exit 1
+}
+
+wait_for_sim_summary() {
+  local complete=0
+  local deadline=$((SECONDS + 120))
+  while (( SECONDS < deadline )); do
     if rg -q 'elodin simulation summary' "${sim_log}"; then
       complete=1
       break
@@ -114,6 +159,14 @@ else
     printf 'RC-jet simulation did not complete\n' >&2
     exit 1
   fi
+}
+
+assert_sim_log() {
+  if ! rg -q 'elodin simulation summary' "${sim_log}"; then
+    rg -n '^' "${sim_log}" >&2 || true
+    printf 'RC-jet simulation did not complete\n' >&2
+    exit 1
+  fi
   if ! rg -q 'controller.*Connected to' "${sim_log}"; then
     rg -n '^' "${sim_log}" >&2 || true
     printf 'RC controller did not connect\n' >&2
@@ -124,17 +177,38 @@ else
     printf 'headless renderer did not initialize the sensor camera\n' >&2
     exit 1
   fi
-  sleep 1
-  kill -TERM -- "-${sim_pid}" 2>/dev/null || true
-  for _ in $(seq 1 40); do
-    kill -0 "${sim_pid}" 2>/dev/null || break
-    sleep 0.1
-  done
-  if kill -0 "${sim_pid}" 2>/dev/null; then
-    kill -KILL -- "-${sim_pid}" 2>/dev/null || true
+}
+
+run_recorded_demo() {
+  PYTHONPATH="${generated}" python3 libs/db/examples/grpc_full_api_demo.py \
+    --target "127.0.0.1:${grpc_port}"
+}
+
+run_sim_fixed() {
+  local ticks="$1"
+  rm -rf "${work}/db"
+  : > "${sim_log}"
+  start_sim "${ticks}"
+  wait_for_sim_ready
+  wait_for_sim_summary
+  stop_sim
+  assert_sim_log
+}
+
+if [[ -n "${ELODIN_GRPC_DEMO_DB:-}" ]]; then
+  cp -a "${ELODIN_GRPC_DEMO_DB}" "${work}/db"
+else
+  controller_bin="${ELODIN_RC_JET_CONTROLLER_BIN:-}"
+  if [[ -z "${controller_bin}" ]] && command -v cargo >/dev/null; then
+    cargo build --release -p rc-jet-controller
+    controller_bin="${root}/target/release/rc-jet-controller"
   fi
-  wait "${sim_pid}" 2>/dev/null || true
-  sim_pid=""
+  start_sim "${ELODIN_GRPC_DEMO_TICKS:-36000}"
+  wait_for_sim_ready
+  PYTHONPATH="${generated}" python3 libs/db/examples/grpc_full_api_demo.py \
+    --live --target "127.0.0.1:${grpc_port}"
+  stop_sim
+  assert_sim_log
 fi
 
 if [[ -n "${ELODIN_DB_BIN:-}" ]]; then
@@ -165,7 +239,7 @@ start_server() {
       "${auth[@]}"
   ) >"${work}/server.log" 2>&1 &
   server_pid=$!
-  wait_for_port "${grpc_port}" && return
+  wait_for_port "${grpc_port}" "${server_pid}" && return
   rg -n '^' "${work}/server.log" >&2 || true
   printf 'elodin-db did not become ready\n' >&2
   exit 1
@@ -184,8 +258,17 @@ stop_server() {
 }
 
 start_server
-PYTHONPATH="${generated}" python3 libs/db/examples/grpc_full_api_demo.py \
-  --target "127.0.0.1:${grpc_port}"
+if ! run_recorded_demo; then
+  stop_server
+  if [[ -n "${ELODIN_GRPC_DEMO_DB:-}" ]]; then
+    printf 'recorded gRPC demo failed against the provided DB\n' >&2
+    exit 1
+  fi
+  printf 'recorded DB incomplete after SIGINT; falling back to a 45s run\n' >&2
+  run_sim_fixed 13500
+  start_server
+  run_recorded_demo
+fi
 stop_server
 
 start_server "demo-token"


### PR DESCRIPTION
Updates to our latest bevy_hanabi fork changes, and fixes examples to use the updated API. Also found and fixed an breakage in the falcon 9 example from some previous coordinate frame changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches particle rendering bind timing and Falcon 9 plant/FSW landing geometry; wrong frame or texture readiness could regress visuals or touchdown scoring, but changes are scoped to examples and editor plugins with added tests.
> 
> **Overview**
> Bumps the **`bevy_hanabi`** git pin and migrates Hanabi usage across the editor and shipped **`.effect`** assets: texture slots are **2D** with numeric **`texture_slot: 0`**, and thruster/cinematic emitters wait for **`images_ready`** before inserting **`ParticleEffect`** + **`EffectMaterial`** (same deferred bind pattern as cinematic Earth).
> 
> **Falcon 9** separates dynamics from visuals: a new **`booster.visual_pos`** offsets the GLB from CoM using **`GLB_ORIGIN_STATION_M`**, KDL/schematics chase **`visual_pos`**, and pad clamp / mission spawn account for CG. Landing fixes treat **LZ-1 at 5 m** as the deck (leg contact, pinning, radar terrain), model radar from the **engine-plane antenna** with FSW **AGL**-based hoverslam and tighter terminal gains; docs/tests/README metrics reflect softer touchdowns.
> 
> CI/grpc demo scripts get **dynamic port selection**, longer live-stream budgets, and a **recorded-demo fallback** if the RC-jet DB is incomplete after SIGINT.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5beba909e84b06794e294f6eddd838d11a0633e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->