### PR TITLE
fix(elodin): propagate headless simulation failures

### DIFF
--- a/apps/elodin/src/cli/editor.rs
+++ b/apps/elodin/src/cli/editor.rs
@@ -159,6 +159,7 @@ impl Cli {
         args: &Args,
         rt: Runtime,
         cancel_token: CancelToken,
+        execution: elodin_editor::run::RecipeExecution,
     ) -> miette::Result<JoinHandle<miette::Result<()>>> {
         let sim = args.sim.clone();
         let sim_addr = args.addr;
@@ -186,12 +187,14 @@ impl Cli {
                 match &sim {
                     Simulator::File(path) => {
                         let mut res = None;
-                        let mut recipe_fut = Box::pin(elodin_editor::run::run_recipe_at(
-                            cache_dir,
-                            path.clone(),
-                            cancel_token.clone(),
-                            sim_addr,
-                        ));
+                        let mut recipe_fut =
+                            Box::pin(elodin_editor::run::run_recipe_at_with_execution(
+                                cache_dir,
+                                path.clone(),
+                                cancel_token.clone(),
+                                sim_addr,
+                                execution,
+                            ));
                         tokio::select! {
                             r = &mut recipe_fut => res = Some(r),
                             _ = cancel_on_ctrl_c => {
@@ -222,6 +225,7 @@ impl Cli {
         _args: &Args,
         rt: Runtime,
         cancel_token: CancelToken,
+        _execution: elodin_editor::run::RecipeExecution,
     ) -> miette::Result<JoinHandle<miette::Result<()>>> {
         Ok(std::thread::spawn(move || {
             rt.block_on(async move {
@@ -245,7 +249,12 @@ impl Cli {
             )?),
             _ => None,
         };
-        let thread = self.run_sim(&args, rt, cancel_token.clone())?;
+        let thread = self.run_sim(
+            &args,
+            rt,
+            cancel_token.clone(),
+            elodin_editor::run::RecipeExecution::Watch,
+        )?;
         let mut app = self.editor_app()?;
         match args.sim {
             Simulator::None => {
@@ -298,7 +307,12 @@ impl Cli {
             )?),
             _ => None,
         };
-        let thread = self.run_sim(&args, rt, cancel_token.clone())?;
+        let thread = self.run_sim(
+            &args,
+            rt,
+            cancel_token.clone(),
+            elodin_editor::run::RecipeExecution::Once,
+        )?;
         let result = thread
             .join()
             .map_err(|_| miette!("simulation thread panicked"))

--- a/libs/elodin-editor/src/run.rs
+++ b/libs/elodin-editor/src/run.rs
@@ -6,9 +6,37 @@ use miette::{Context, IntoDiagnostic, miette};
 use std::{
     net::{Ipv6Addr, SocketAddr},
     path::{Path, PathBuf},
+    sync::Arc,
 };
 #[cfg(not(target_os = "windows"))]
 use stellarator::util::CancelToken;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RecipeExecution {
+    Once,
+    Watch,
+}
+
+#[cfg(not(target_os = "windows"))]
+async fn execute_recipe(
+    recipe: s10::Recipe,
+    execution: RecipeExecution,
+    cancel_token: CancelToken,
+    cgroup: Option<Arc<s10::CgroupScope>>,
+) -> Result<(), s10::Error> {
+    match execution {
+        RecipeExecution::Once => {
+            recipe
+                .run("sim".to_string(), false, cancel_token, cgroup)
+                .await
+        }
+        RecipeExecution::Watch => {
+            recipe
+                .watch("sim".to_string(), false, cancel_token, cgroup)
+                .await
+        }
+    }
+}
 
 #[cfg(not(target_os = "windows"))]
 pub async fn run_recipe(
@@ -31,6 +59,17 @@ pub async fn run_recipe_at(
     path: PathBuf,
     cancel_token: CancelToken,
     addr: SocketAddr,
+) -> miette::Result<()> {
+    run_recipe_at_with_execution(cache_dir, path, cancel_token, addr, RecipeExecution::Watch).await
+}
+
+#[cfg(not(target_os = "windows"))]
+pub async fn run_recipe_at_with_execution(
+    cache_dir: PathBuf,
+    path: PathBuf,
+    cancel_token: CancelToken,
+    addr: SocketAddr,
+    execution: RecipeExecution,
 ) -> miette::Result<()> {
     let mut path = if path.is_dir() {
         let toml = path.join("s10.toml");
@@ -106,14 +145,7 @@ pub async fn run_recipe_at(
         None
     };
 
-    let result = recipe
-        .watch(
-            "sim".to_string(),
-            false,
-            cancel_token.clone(),
-            cgroup.clone(),
-        )
-        .await;
+    let result = execute_recipe(recipe, execution, cancel_token.clone(), cgroup.clone()).await;
     cancel_token.cancel();
     if let Some(scope) = cgroup {
         let _ = scope.kill();
@@ -156,8 +188,25 @@ mod tests {
     use std::path::Path;
 
     use s10::{GroupRecipe, ProcessArgs, ProcessRecipe, Recipe, RestartPolicy};
+    use stellarator::util::CancelToken;
 
-    use super::pin_render_server_recipe;
+    use super::{RecipeExecution, execute_recipe, pin_render_server_recipe};
+
+    #[tokio::test]
+    async fn one_shot_recipe_propagates_process_failure() {
+        let mut process_args = empty_process_args();
+        process_args.args = vec!["-c".to_string(), "exit 7".to_string()];
+        process_args.fail_on_error = true;
+        let recipe = Recipe::Process(ProcessRecipe {
+            cmd: "sh".to_string(),
+            process_args,
+            no_watch: true,
+        });
+
+        let result = execute_recipe(recipe, RecipeExecution::Once, CancelToken::new(), None).await;
+
+        assert!(result.is_err());
+    }
 
     #[test]
     fn pins_render_server_recipe_to_current_binary() {


### PR DESCRIPTION
## Summary

This is a pre-req PR for the betaflight example changes.

Separates simulation recipe execution by mode:

- `elodin run` executes once and propagates simulation failures.
- `elodin editor` retains watch-and-reload behavior.

Previously, a failed headless simulation logged the error and waited indefinitely for a source change, preventing CI from receiving a nonzero exit status.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is scoped to headless `run` vs interactive editor; editor watch path is unchanged by default.
> 
> **Overview**
> Introduces **`RecipeExecution`** (`Once` vs `Watch`) so s10 recipes can run as a single shot or with file watching. **`run_recipe_at_with_execution`** routes through **`execute_recipe`**, calling **`recipe.run`** for once and **`recipe.watch`** for watch; **`run_recipe_at`** keeps default **Watch** behavior.
> 
> The CLI threads this through **`run_sim`**: **`elodin editor`** passes **Watch**; **`run_headless`** passes **Once**, so failed headless sims return errors instead of hanging for a reload. A unit test asserts **Once** propagates process failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd3aa4b9ea3e84ff068271f3d0b2f5d3a861aa84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->