### PR TITLE
Fix/headless s10 lifecycle followup

### DIFF
--- a/.buildkite/pipeline.py
+++ b/.buildkite/pipeline.py
@@ -160,6 +160,11 @@ test_steps = [
             ),
         ],
     ),
+    nix_step(
+        emoji=":gear:",
+        label="headless s10 lifecycle",
+        command="cargo build --release -p elodin && scripts/ci/test-headless-s10-exit.sh",
+    ),
     group(
         name=":racehorse: performance",
         steps=[

--- a/libs/elodin-editor/src/run.rs
+++ b/libs/elodin-editor/src/run.rs
@@ -6,37 +6,11 @@ use miette::{Context, IntoDiagnostic, miette};
 use std::{
     net::{Ipv6Addr, SocketAddr},
     path::{Path, PathBuf},
-    sync::Arc,
 };
 #[cfg(not(target_os = "windows"))]
 use stellarator::util::CancelToken;
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum RecipeExecution {
-    Once,
-    Watch,
-}
-
-#[cfg(not(target_os = "windows"))]
-async fn execute_recipe(
-    recipe: s10::Recipe,
-    execution: RecipeExecution,
-    cancel_token: CancelToken,
-    cgroup: Option<Arc<s10::CgroupScope>>,
-) -> Result<(), s10::Error> {
-    match execution {
-        RecipeExecution::Once => {
-            recipe
-                .run("sim".to_string(), false, cancel_token, cgroup)
-                .await
-        }
-        RecipeExecution::Watch => {
-            recipe
-                .watch("sim".to_string(), false, cancel_token, cgroup)
-                .await
-        }
-    }
-}
+pub use s10::cli::RecipeExecution;
 
 #[cfg(not(target_os = "windows"))]
 pub async fn run_recipe(
@@ -145,7 +119,15 @@ pub async fn run_recipe_at_with_execution(
         None
     };
 
-    let result = execute_recipe(recipe, execution, cancel_token.clone(), cgroup.clone()).await;
+    let result = s10::cli::execute_recipe_with_token_in_cgroup(
+        "sim".to_string(),
+        recipe,
+        execution,
+        false,
+        cancel_token.clone(),
+        cgroup.clone(),
+    )
+    .await;
     cancel_token.cancel();
     if let Some(scope) = cgroup {
         let _ = scope.kill();
@@ -188,25 +170,8 @@ mod tests {
     use std::path::Path;
 
     use s10::{GroupRecipe, ProcessArgs, ProcessRecipe, Recipe, RestartPolicy};
-    use stellarator::util::CancelToken;
 
-    use super::{RecipeExecution, execute_recipe, pin_render_server_recipe};
-
-    #[tokio::test]
-    async fn one_shot_recipe_propagates_process_failure() {
-        let mut process_args = empty_process_args();
-        process_args.args = vec!["-c".to_string(), "exit 7".to_string()];
-        process_args.fail_on_error = true;
-        let recipe = Recipe::Process(ProcessRecipe {
-            cmd: "sh".to_string(),
-            process_args,
-            no_watch: true,
-        });
-
-        let result = execute_recipe(recipe, RecipeExecution::Once, CancelToken::new(), None).await;
-
-        assert!(result.is_err());
-    }
+    use super::pin_render_server_recipe;
 
     #[test]
     fn pins_render_server_recipe_to_current_binary() {

--- a/libs/elodin-editor/src/run.rs
+++ b/libs/elodin-editor/src/run.rs
@@ -10,7 +10,17 @@ use std::{
 #[cfg(not(target_os = "windows"))]
 use stellarator::util::CancelToken;
 
+#[cfg(not(target_os = "windows"))]
 pub use s10::cli::RecipeExecution;
+
+// s10 is not supported on Windows, but the editor's public API and Windows
+// simulation stub still use this type.
+#[cfg(target_os = "windows")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RecipeExecution {
+    Once,
+    Watch,
+}
 
 #[cfg(not(target_os = "windows"))]
 pub async fn run_recipe(

--- a/libs/s10/src/cli.rs
+++ b/libs/s10/src/cli.rs
@@ -7,6 +7,18 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use stellarator::util::CancelToken;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RecipeExecution {
+    Once,
+    Watch,
+}
+
+impl RecipeExecution {
+    fn from_watch(watch: bool) -> Self {
+        if watch { Self::Watch } else { Self::Once }
+    }
+}
+
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 pub struct Args {
@@ -124,12 +136,90 @@ async fn run_recipe_with_token_admitted_inner(
         tokio::signal::ctrl_c().await
     });
 
-    let res = if watch {
-        recipe
-            .watch(recipe_name, release, cancel_token, cgroup)
-            .await
-    } else {
-        recipe.run(recipe_name, release, cancel_token, cgroup).await
+    execute_recipe_with_token_in_cgroup(
+        recipe_name,
+        recipe,
+        RecipeExecution::from_watch(watch),
+        release,
+        cancel_token,
+        cgroup,
+    )
+    .await
+}
+
+/// Execute a recipe without adding admission control or signal handling.
+///
+/// This is the shared run-vs-watch dispatch used by normal headless/editor
+/// execution and by the admitted wrapper used for Monte Carlo runs.
+pub async fn execute_recipe_with_token_in_cgroup(
+    recipe_name: String,
+    recipe: Recipe,
+    execution: RecipeExecution,
+    release: bool,
+    cancel_token: CancelToken,
+    cgroup: Option<Arc<CgroupScope>>,
+) -> miette::Result<()> {
+    let result = match execution {
+        RecipeExecution::Watch => {
+            recipe
+                .watch(recipe_name, release, cancel_token, cgroup)
+                .await
+        }
+        RecipeExecution::Once => recipe.run(recipe_name, release, cancel_token, cgroup).await,
     };
-    Ok(res?)
+    Ok(result?)
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::collections::HashMap;
+    use std::time::Duration;
+
+    use stellarator::util::CancelToken;
+
+    use super::{RecipeExecution, execute_recipe_with_token_in_cgroup};
+    use crate::{ProcessArgs, ProcessRecipe, Recipe, RestartPolicy};
+
+    #[test]
+    fn watch_flag_maps_to_shared_execution_mode() {
+        assert_eq!(RecipeExecution::from_watch(false), RecipeExecution::Once);
+        assert_eq!(RecipeExecution::from_watch(true), RecipeExecution::Watch);
+    }
+
+    #[tokio::test]
+    async fn one_shot_execution_propagates_process_failure() {
+        let recipe = Recipe::Process(ProcessRecipe {
+            cmd: "sh".to_string(),
+            process_args: ProcessArgs {
+                args: vec!["-c".to_string(), "exit 7".to_string()],
+                cwd: None,
+                env: HashMap::new(),
+                restart_policy: RestartPolicy::Never,
+                fail_on_error: true,
+                log_path: None,
+                silence: false,
+                depends_on: Vec::new(),
+                ready: None,
+                ready_timeout: None,
+                own_process_group: false,
+            },
+            no_watch: true,
+        });
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(2),
+            execute_recipe_with_token_in_cgroup(
+                "test".to_string(),
+                recipe,
+                RecipeExecution::Once,
+                false,
+                CancelToken::new(),
+                None,
+            ),
+        )
+        .await
+        .expect("one-shot execution waited instead of returning the process error");
+
+        assert!(result.is_err());
+    }
 }

--- a/scripts/ci/test-headless-s10-exit.sh
+++ b/scripts/ci/test-headless-s10-exit.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+elodin_bin="${ELODIN_BIN:-${root}/target/release/elodin}"
+python_bin="${PYTHON:-$(command -v python3)}"
+work="$(mktemp -d "${TMPDIR:-/tmp}/elodin-headless-s10.XXXXXX")"
+
+cleanup() {
+    local pid_file pid
+    while IFS= read -r pid_file; do
+        pid="$(cat "${pid_file}" 2>/dev/null || true)"
+        if [[ "${pid}" =~ ^[0-9]+$ ]] && kill -0 "${pid}" 2>/dev/null; then
+            kill "${pid}" 2>/dev/null || true
+            for _ in {1..50}; do
+                kill -0 "${pid}" 2>/dev/null || break
+                sleep 0.02
+            done
+            kill -9 "${pid}" 2>/dev/null || true
+        fi
+    done < <(find "${work}" -name sidecar.pid -type f 2>/dev/null)
+    rm -rf "${work}"
+}
+trap cleanup EXIT INT TERM
+
+if [[ ! -x "${elodin_bin}" ]]; then
+    echo "FAIL: elodin binary is not executable: ${elodin_bin}" >&2
+    exit 1
+fi
+
+sidecar="${work}/sidecar.sh"
+cat >"${sidecar}" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$$" >"${SIDECAR_PID_FILE:?}"
+exec sleep 60
+SH
+chmod +x "${sidecar}"
+
+sim="${work}/sim.py"
+cat >"${sim}" <<'PY'
+import os
+import sys
+import time
+from pathlib import Path
+
+pid_file = Path(os.environ["SIDECAR_PID_FILE"])
+deadline = time.monotonic() + 5.0
+while not pid_file.exists() and time.monotonic() < deadline:
+    time.sleep(0.01)
+if not pid_file.exists():
+    print("SIM_FIXTURE_ERROR=sidecar-pid-timeout", flush=True)
+    sys.exit(99)
+
+exit_code = int(os.environ["SIM_EXIT_CODE"])
+print(f"SIM_FIXTURE_EXIT={exit_code}", flush=True)
+time.sleep(0.1)
+sys.exit(exit_code)
+PY
+
+fail_case() {
+    local name="$1"
+    local message="$2"
+    local log="${work}/${name}/elodin.log"
+    echo "FAIL [${name}]: ${message}" >&2
+    if [[ -f "${log}" ]]; then
+        echo "--- ${name} log ---" >&2
+        tail -100 "${log}" >&2
+    fi
+    return 1
+}
+
+run_case() {
+    local name="$1"
+    local sim_exit="$2"
+    local expected="$3"
+    local case_dir="${work}/${name}"
+    local pid_file="${case_dir}/sidecar.pid"
+    local plan="${case_dir}/s10.toml"
+    local log="${case_dir}/elodin.log"
+    local status pid
+
+    mkdir -p "${case_dir}"
+    cat >"${plan}" <<TOML
+type = "group"
+refs = []
+
+[recipes.sidecar]
+type = "process"
+cmd = "${sidecar}"
+args = []
+restart_policy = "never"
+fail_on_error = false
+silence = false
+depends_on = []
+own_process_group = false
+no_watch = true
+
+[recipes.sidecar.env]
+SIDECAR_PID_FILE = "${pid_file}"
+
+[recipes.sim]
+type = "sim"
+path = "${sim}"
+addr = "127.0.0.1:0"
+optimize = false
+depends-on = []
+own-process-group = false
+
+[recipes.sim.env]
+SIDECAR_PID_FILE = "${pid_file}"
+SIM_EXIT_CODE = "${sim_exit}"
+TOML
+
+    set +e
+    ELODIN_PYTHON="${python_bin}" timeout --signal=TERM --kill-after=2s 15s \
+        "${elodin_bin}" run "${plan}" >"${log}" 2>&1
+    status=$?
+    set -e
+
+    if [[ "${status}" -eq 124 || "${status}" -eq 137 ]]; then
+        fail_case "${name}" "elodin run timed out with status ${status}"
+        return
+    fi
+    if [[ "${expected}" == "success" && "${status}" -ne 0 ]]; then
+        fail_case "${name}" "expected status 0, got ${status}"
+        return
+    fi
+    if [[ "${expected}" == "failure" && "${status}" -eq 0 ]]; then
+        fail_case "${name}" "expected a nonzero status"
+        return
+    fi
+    if ! grep -q "SIM_FIXTURE_EXIT=${sim_exit}" "${log}"; then
+        fail_case "${name}" "simulation fixture did not reach its intended exit"
+        return
+    fi
+    if [[ ! -s "${pid_file}" ]]; then
+        fail_case "${name}" "sidecar did not write its PID file"
+        return
+    fi
+
+    pid="$(cat "${pid_file}")"
+    for _ in {1..50}; do
+        kill -0 "${pid}" 2>/dev/null || break
+        sleep 0.02
+    done
+    if kill -0 "${pid}" 2>/dev/null; then
+        fail_case "${name}" "sidecar PID ${pid} survived elodin exit"
+        return
+    fi
+
+    rm -f "${pid_file}"
+    echo "PASS [${name}]: elodin status=${status}, sidecar ${pid} reaped"
+}
+
+run_case success 0 success
+run_case failure 7 failure


### PR DESCRIPTION
# PR: Align headless recipe execution with s10 orchestration                                                                                                                                             
                                                                                                                                                                                                         
## Summary                                                                                                                                                                                               
                                                                                                                                                                                                         
- move `RecipeExecution` and run-vs-watch dispatch into `s10::cli`                                                                                                                                       
- make both normal headless/editor execution and the admitted Monte Carlo wrapper                                                                                                                        
  call the same lower-level execution helper
- retain watched error recovery for `elodin editor` and one-shot behavior for
  `elodin run`
- preserve `elodin_editor::run::RecipeExecution` through a re-export and retain
  the existing watched `run_recipe_at(...)` default
- add a public-CLI lifecycle regression for successful and failed simulation
  leaders, verifying long-running sidecar teardown in both cases
- run the lifecycle regression in a dedicated Buildkite step

## Why

PR #837 fixed headless failure propagation, but duplicated the run-vs-watch
conditional already used by s10's admitted runner. The behavior matched Monte
Carlo (`Recipe::run`), but that alignment was not structural and lacked a real
process-level regression. This follow-up centralizes the dispatch and tests the
outer `elodin run` boundary.

`scripts/ci/regress.sh` is not orchestration coverage: it invokes Python examples
directly in bench mode and does not generate or execute s10 plans.

## Verification

```bash
cargo fmt -p s10 -p elodin-editor -p elodin -- --check
cargo test --release -p s10
cargo test --release -p elodin-editor
cargo build --release -p elodin
ELODIN_BIN=target/release/elodin ./scripts/ci/test-headless-s10-exit.sh
python3 -m py_compile .buildkite/pipeline.py
bash -n scripts/ci/test-headless-s10-exit.sh
```

The Monte Carlo path is structurally covered by this refactor because its
existing admitted wrapper now calls the same shared s10 execution helper with
one-shot mode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared orchestration used by headless `elodin run`, editor sim runs, and admitted/Monte Carlo paths; regression risk is mitigated by moved unit tests and new end-to-end lifecycle checks.
> 
> **Overview**
> **Centralizes s10 run-vs-watch dispatch** in `s10::cli` via a new public `RecipeExecution` enum and `execute_recipe_with_token_in_cgroup`, so the admitted CLI path (including Monte Carlo) and headless/editor runs share the same `Recipe::run` / `Recipe::watch` branch instead of duplicating it in `elodin-editor`.
> 
> **`elodin-editor`** re-exports `RecipeExecution` from s10 on Unix, keeps a local stub on Windows, and routes cgroup-backed recipe runs through the shared helper; the editor-local `execute_recipe` helper and its failure-propagation test are removed in favor of tests in `s10`.
> 
> **Adds process-level CI** with `scripts/ci/test-headless-s10-exit.sh`, which runs `elodin run` against temporary s10 plans for sim exit 0 and 7 and asserts exit codes plus that a long-lived sidecar is reaped. A new Buildkite step **headless s10 lifecycle** builds release `elodin` and runs that script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abd4d56e728226518c6c900f765e900e6336405d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->