### PR TITLE
fix(ci): Install FFmpeg for Release editor builds.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -402,7 +402,9 @@ jobs:
             curl libssl-dev \
             g++ pkg-config libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0 \
             libwayland-dev libxkbcommon-dev libopenblas-dev gfortran gfortran-12 libgfortran-12-dev liblzma-dev \
-            protobuf-compiler
+            protobuf-compiler \
+            libavutil-dev libavcodec-dev libavformat-dev libavdevice-dev \
+            libavfilter-dev libswscale-dev libswresample-dev libclang-dev
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install cargo-deb
         run: cargo install cargo-deb
@@ -433,7 +435,7 @@ jobs:
           python-version: "3.13"
       - name: Install dependencies
         run: |
-          brew install protobuf
+          brew install protobuf ffmpeg
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install cargo-deb
         run: cargo install cargo-bundle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,6 +148,13 @@ jobs:
       - name: Install dependencies
         run: |
           ${{ matrix.packages_install }}
+      - name: Point pkg-config at keg-only Homebrew FFmpeg 8
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          prefix="$(brew --prefix ffmpeg@8)"
+          echo "PKG_CONFIG_PATH=${prefix}/lib/pkgconfig:${PKG_CONFIG_PATH:-}" >> "$GITHUB_ENV"
+          echo "${prefix}/bin" >> "$GITHUB_PATH"
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -435,7 +442,10 @@ jobs:
           python-version: "3.13"
       - name: Install dependencies
         run: |
-          brew install protobuf ffmpeg
+          brew install protobuf ffmpeg@8
+          prefix="$(brew --prefix ffmpeg@8)"
+          echo "PKG_CONFIG_PATH=${prefix}/lib/pkgconfig:${PKG_CONFIG_PATH:-}" >> "$GITHUB_ENV"
+          echo "${prefix}/bin" >> "$GITHUB_PATH"
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install cargo-deb
         run: cargo install cargo-bundle

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -64,7 +64,9 @@ libclang-dev = '*'
 
 [dist.dependencies.homebrew]
 protobuf = '*'
-ffmpeg = '*'
+# ffmpeg-next 8.1.0 wraps FFmpeg 8. Unversioned `ffmpeg` is 9 and will not compile.
+# ffmpeg@8 is keg-only; release.yml prepends its pkgconfig on macOS.
+"ffmpeg@8" = '*'
 
 [dist.dependencies.chocolatey]
 cmake = '*'

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -52,9 +52,19 @@ gfortran = '*'
 gfortran-12 = '*'
 libgfortran-12-dev = '*'
 protobuf-compiler = '*'
+# ffmpeg-next / ffmpeg-sys-next (live sensor-camera H.264). Windows skips this crate.
+libavutil-dev = '*'
+libavcodec-dev = '*'
+libavformat-dev = '*'
+libavdevice-dev = '*'
+libavfilter-dev = '*'
+libswscale-dev = '*'
+libswresample-dev = '*'
+libclang-dev = '*'
 
 [dist.dependencies.homebrew]
 protobuf = '*'
+ffmpeg = '*'
 
 [dist.dependencies.chocolatey]
 cmake = '*'


### PR DESCRIPTION
ffmpeg-next needs libavutil on macOS and Linux gnu; cargo-dist and cargo-deb never installed it after #827.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and packaging dependency wiring only; no application runtime or auth logic changes.
> 
> **Overview**
> Release CI was failing because **ffmpeg-next** / **ffmpeg-sys-next** (live sensor-camera H.264) need FFmpeg dev libraries on Linux and macOS; those were not installed after the dependency landed.
> 
> **cargo-dist** (`dist-workspace.toml`): adds Debian **libav\*** dev packages plus **libclang-dev**, and Homebrew **`ffmpeg@8`** (pinned because unversioned Homebrew FFmpeg is v9 and does not match **ffmpeg-next** 8.x).
> 
> **`.github/workflows/release.yml`**: mirrors that on **cargo-deb** (apt packages) and **macos-app** (brew + `PKG_CONFIG_PATH` / `PATH` for keg-only **ffmpeg@8**). A dedicated macOS step in **build-local-artifacts** applies the same pkg-config wiring for dist matrix builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4105942eee9cf980f2f1a9dab9c1cb95c4a68ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->