### PR TITLE
betaflight vision Package A baseline safety net

### DIFF
--- a/.buildkite/pipeline.py
+++ b/.buildkite/pipeline.py
@@ -125,6 +125,11 @@ test_steps = [
                 command="pytest examples/rc-jet/tests -o 'pythonpath='",
             ),
             nix_step(
+                label=":python: betaflight-sitl tests",
+                flake=".#run",
+                command="python3 -m pytest examples/betaflight-sitl/tests -q",
+            ),
+            nix_step(
                 label=":python: frames",
                 flake=".#run",
                 command="python3 examples/frames/main.py",

--- a/examples/betaflight-sitl/RACING_PLAN.md
+++ b/examples/betaflight-sitl/RACING_PLAN.md
@@ -970,7 +970,7 @@ branch for later resumption.
 
 | Package | Status | Evidence / notes |
 |---|---|---|
-| A | Complete | 24 pure tests pass; C0 returned 0 with 119,995 simulation-loop lockstep responses, max motor 0.574, and 56.836 m takeoff rise in 20 wall-clock seconds. Deliberate 100 m criterion returned 1. Shared headless propagation fix: `bd3aa4b9`. |
+| A | Complete | 24 pure tests pass; C0 returned 0 with 119,995 simulation-loop lockstep responses, max motor 0.574, and 56.837 m takeoff rise in 29 wall-clock seconds after rebuilding latest main. Deliberate 100 m criterion returned 1. Shared headless propagation fixes: `301ae367` (`#837`) and lifecycle follow-up `36ee3431` (`#838`). |
 | B | Not started | Platform camera API exists; no Betaflight integration |
 | C | Not started | No course or referee code |
 | D | Not started | RC remains hardcoded; no manual mode; AUX2 ANGLE not configured |
@@ -1002,10 +1002,10 @@ elodin run examples/betaflight-sitl/main.py
 The verified C0 result was:
 
 ```text
-[C0] lockstep_steps=119995 motor_response=true max_motor=0.574 takeoff_delta_m=56.836 status=PASS
+[C0] lockstep_steps=119995 motor_response=true max_motor=0.574 takeoff_delta_m=56.837 status=PASS
 ```
 
-The pure suite passed 24 tests in 0.05 seconds and C0 completed in 20 wall-clock
+The pure suite passed 24 tests in 0.15 seconds and C0 completed in 29 wall-clock
 seconds. Raising the takeoff criterion temporarily to 100 m emitted
 `status=FAIL` and returned process status 1; the required 0.1 m criterion was
 then restored.
@@ -1014,7 +1014,7 @@ then restored.
 
 | Date | Decision | Reason and affected packages |
 |---|---|---|
-| 2026-09-03 | Run headless recipes once while retaining watched recipes in the editor. | Package A exposed that a failed simulation child was logged and then waited for source reload, so `elodin run` could not return nonzero. The approved shared fix (`bd3aa4b9`) makes headless execution one-shot without changing interactive editor recovery. This enables failure contracts in A, F, K, and L. |
+| 2026-09-03 | Run headless recipes once while retaining watched recipes in the editor. | Package A exposed that a failed simulation child was logged and then waited for source reload, so `elodin run` could not return nonzero. The approved shared fixes (`301ae367`, `#837`; lifecycle follow-up `36ee3431`, `#838`) make headless execution one-shot without changing interactive editor recovery, centralize recipe execution dispatch in s10, and add an end-to-end lifecycle CI check. This enables failure contracts in A, F, K, and L. |
 | 2026-09-01 | Keep the current ENU/FLU world, Gazebo-bridge conventions, native motor order, and 8 kHz lockstep. | These are the implemented baseline; changing them is not required for racing. A–L rely on them. |
 | 2026-09-01 | Preserve scripted takeoff as the default and make other control modes opt-in. | Allows every package to merge independently without replacing the reference SITL example prematurely. |
 | 2026-09-01 | Add manual piloting through the same semantic-input-to-RC boundary before autonomy. | Separates vehicle controllability and Betaflight integration from guidance behavior; D provides gamepad/keyboard control and safe stale-input handling. |

--- a/examples/betaflight-sitl/RACING_PLAN.md
+++ b/examples/betaflight-sitl/RACING_PLAN.md
@@ -1,8 +1,8 @@
 # Vision-Guided Gate Racing Plan
 
 **Document status:** Authoritative living specification  
-**Last verified against repository:** 2026-09-01  
-**Current resume point:** Package A — Baseline safety net
+**Last verified against repository:** 2026-09-03
+**Current resume point:** Package D — Manual piloting, control seam, and ANGLE mode
 
 ## 1. Purpose and authority
 
@@ -166,8 +166,8 @@ A healthy current run prints:
 SUCCESS: SITL integration working! Drone took off!
 ```
 
-Before Package A, this message is only a manual observation: failure paths print
-warnings but do not reliably return a failing process status.
+Package A makes this message part of a real C0 result: unmet lockstep,
+motor-response, or takeoff criteria return a failing process status.
 
 ## 4. Final core outcome
 
@@ -543,6 +543,9 @@ by Package E rather than introducing an unrelated controller.
 - Every integration scenario must return a nonzero process status on failed
   acceptance criteria; grepping a warning from a successful process is not a
   test.
+- Headless `elodin run` executes a generated recipe once and propagates
+  simulation failures. Interactive `elodin editor` retains watch-and-reload
+  behavior so source errors can be corrected without closing the editor.
 
 The standard pure-test command, created by Package A and extended thereafter, is:
 
@@ -556,7 +559,7 @@ Each package is approximately one focused engineer-week. The estimate is a scope
 limit, not a promise. If acceptance cannot be reached without broadening scope,
 follow the change protocol rather than silently extending the package.
 
-### [ ] A — Baseline safety net
+### [x] A — Baseline safety net
 
 **Objective:** Make the current SITL boundary and scripted takeoff a trustworthy
 base for later work.
@@ -572,6 +575,8 @@ base for later work.
   native motor order, and motor spin/position consistency.
 - Convert the current headless takeoff result into a true pass/fail exit status.
 - Assert nonzero lockstep steps, motor response, and at least 0.1 m takeoff.
+- Ensure headless `elodin run` propagates simulation failure while preserving
+  the editor's interactive watch-and-reload behavior.
 - Repair the README's nonexistent `test_comms.py` instructions.
 - Ensure running with no race environment variables remains unchanged.
 
@@ -965,7 +970,7 @@ branch for later resumption.
 
 | Package | Status | Evidence / notes |
 |---|---|---|
-| A | Not started | This plan exists, but tests and real C0 pass/fail do not |
+| A | Complete | 24 pure tests pass; C0 returned 0 with 119,995 simulation-loop lockstep responses, max motor 0.574, and 56.836 m takeoff rise in 20 wall-clock seconds. Deliberate 100 m criterion returned 1. Shared headless propagation fix: `bd3aa4b9`. |
 | B | Not started | Platform camera API exists; no Betaflight integration |
 | C | Not started | No course or referee code |
 | D | Not started | RC remains hardcoded; no manual mode; AUX2 ANGLE not configured |
@@ -980,23 +985,36 @@ branch for later resumption.
 
 ### Resume point
 
-Implement **Package A — Baseline safety net**.
+Implement **Package D — Manual piloting, control seam, and ANGLE mode**.
 
-Before changing code:
+Packages B and C remain valid independent alternatives if camera or course work
+is prioritized first. Package D is the recommended continuation because A now
+provides its required protocol, convention, and C0 safety net.
+
+Package A verification from the repository root, with the Elodin Python
+environment active and the current release CLI on `PATH`:
 
 ```bash
-git status --short
-python3 examples/betaflight-sitl/config.py
+python3 -m pytest examples/betaflight-sitl/tests -q
+elodin run examples/betaflight-sitl/main.py
 ```
 
-Build and manually verify the baseline as described in Section 3.2. Then add the
-pure tests and make the C0 command fail correctly on unmet criteria. Do not add
-camera, course, or guidance scaffolding as part of A.
+The verified C0 result was:
+
+```text
+[C0] lockstep_steps=119995 motor_response=true max_motor=0.574 takeoff_delta_m=56.836 status=PASS
+```
+
+The pure suite passed 24 tests in 0.05 seconds and C0 completed in 20 wall-clock
+seconds. Raising the takeoff criterion temporarily to 100 m emitted
+`status=FAIL` and returned process status 1; the required 0.1 m criterion was
+then restored.
 
 ## 13. Decision log
 
 | Date | Decision | Reason and affected packages |
 |---|---|---|
+| 2026-09-03 | Run headless recipes once while retaining watched recipes in the editor. | Package A exposed that a failed simulation child was logged and then waited for source reload, so `elodin run` could not return nonzero. The approved shared fix (`bd3aa4b9`) makes headless execution one-shot without changing interactive editor recovery. This enables failure contracts in A, F, K, and L. |
 | 2026-09-01 | Keep the current ENU/FLU world, Gazebo-bridge conventions, native motor order, and 8 kHz lockstep. | These are the implemented baseline; changing them is not required for racing. A–L rely on them. |
 | 2026-09-01 | Preserve scripted takeoff as the default and make other control modes opt-in. | Allows every package to merge independently without replacing the reference SITL example prematurely. |
 | 2026-09-01 | Add manual piloting through the same semantic-input-to-RC boundary before autonomy. | Separates vehicle controllability and Betaflight integration from guidance behavior; D provides gamepad/keyboard control and safe stale-input handling. |

--- a/examples/betaflight-sitl/README.md
+++ b/examples/betaflight-sitl/README.md
@@ -137,38 +137,50 @@ On the Aleph flight computer the on-board `elodin-db` service applies the same
 ingest to each fresh boot database, so a HITL recording pulled off the vehicle
 replays the same way. See [DB Asset Server](https://docs.elodin.systems/reference/db-asset-server/).
 
-### Quick Arming Test
+### Baseline Verification
 
-Test that arming works correctly:
+Activate the Elodin Python environment, then run the pure protocol and
+conversion tests from the repository root:
+
 ```bash
-# Start SITL in one terminal
-./examples/betaflight-sitl/betaflight/obj/main/betaflight_SITL.elf
-
-# In another terminal, run the test
 source .venv/bin/activate
-python3 examples/betaflight-sitl/test_comms.py
+python3 -m pytest examples/betaflight-sitl/tests -q
 ```
 
-Expected output when working:
+Run the default scripted integration scenario with no racing environment
+variables:
+
+```bash
+elodin run examples/betaflight-sitl/main.py
 ```
-Phase 2: Setting AUX1=1800 to ARM (2 seconds)...
-  t=5.5s motors=[0.055 0.055 0.055 0.055]  # Motors at idle!
-Phase 3: Raising throttle...
-  t=7.2s motors=[0.402 0.402 0.402 0.402]  # Motors responding!
+
+A successful run prints one machine-readable C0 result in addition to the human
+diagnostics:
+
+```text
+[C0] lockstep_steps=119995 motor_response=true max_motor=0.574 takeoff_delta_m=56.836 status=PASS
 ```
+
+The measured values may vary slightly by host. C0 requires at least one
+successful simulation-loop lockstep response, motor output greater than 0.06,
+and a peak altitude at least 0.1 m above the configured initial altitude. If any
+criterion is unmet, the result reports `status=FAIL` and the command exits
+nonzero.
 
 ## Project Structure
 
 ```
 examples/betaflight-sitl/
+├── baseline.py        # Default C0 scenario pass/fail assessment
 ├── build.sh           # Build script for Betaflight SITL
 ├── init_eeprom.py     # Create and configure eeprom.bin
 ├── main.py            # Main simulation entry point
 ├── config.py          # Drone physical parameters
 ├── sim.py             # Physics simulation systems
 ├── sensors.py         # IMU sensor simulation
-├── comms.py           # UDP communication bridge
-├── test_comms.py      # Standalone communication test
+├── comms.py           # UDP packets, conversions, and communication bridge
+├── tests/             # Pure pytest protocol and convention tests
+├── RACING_PLAN.md     # Incremental vision-guided racing plan
 ├── eeprom.bin         # Betaflight saved config (created on first run)
 ├── betaflight/        # Betaflight submodule
 │   └── obj/main/

--- a/examples/betaflight-sitl/baseline.py
+++ b/examples/betaflight-sitl/baseline.py
@@ -1,0 +1,51 @@
+"""Pass/fail assessment for the default scripted SITL scenario."""
+
+from dataclasses import dataclass
+
+
+MIN_MOTOR_RESPONSE = 0.06
+MIN_TAKEOFF_DELTA_M = 0.1
+
+
+@dataclass(frozen=True)
+class C0Result:
+    """Measured outcome of the default scripted SITL integration run."""
+
+    lockstep_steps: int
+    max_motor: float
+    takeoff_delta_m: float
+
+    @property
+    def motor_response(self) -> bool:
+        return self.max_motor > MIN_MOTOR_RESPONSE
+
+    @property
+    def passed(self) -> bool:
+        return (
+            self.lockstep_steps > 0
+            and self.motor_response
+            and self.takeoff_delta_m >= MIN_TAKEOFF_DELTA_M
+        )
+
+    def format(self) -> str:
+        """Return the stable, machine-readable C0 result line."""
+        motor_response = str(self.motor_response).lower()
+        status = "PASS" if self.passed else "FAIL"
+        return (
+            f"[C0] lockstep_steps={self.lockstep_steps} "
+            f"motor_response={motor_response} "
+            f"max_motor={self.max_motor:.3f} "
+            f"takeoff_delta_m={self.takeoff_delta_m:.3f} "
+            f"status={status}"
+        )
+
+
+def evaluate_c0(
+    *, lockstep_steps: int, max_motor: float, initial_altitude: float, max_altitude: float
+) -> C0Result:
+    """Evaluate the Package A criteria from observed integration metrics."""
+    return C0Result(
+        lockstep_steps=lockstep_steps,
+        max_motor=max_motor,
+        takeoff_delta_m=max_altitude - initial_altitude,
+    )

--- a/examples/betaflight-sitl/comms.py
+++ b/examples/betaflight-sitl/comms.py
@@ -220,6 +220,52 @@ class ServoPacketRaw:
         )
 
 
+def flu_to_frd(vector: np.ndarray) -> np.ndarray:
+    """Convert a body-frame vector from Forward-Left-Up to Forward-Right-Down."""
+    vector = np.asarray(vector)
+    return np.array([vector[0], -vector[1], -vector[2]])
+
+
+def elodin_quaternion_to_fdm(quaternion_xyzw: np.ndarray) -> np.ndarray:
+    """Convert Elodin scalar-last FLU→ENU attitude to FDM scalar-first form.
+
+    Betaflight's default Gazebo bridge expects the quaternion conjugated by a
+    180-degree rotation about body X, which negates its Y and Z components.
+    """
+    qx, qy, qz, qw = np.asarray(quaternion_xyzw)
+    return np.array([qw, qx, -qy, -qz])
+
+
+def build_fdm_from_components(
+    world_pos: np.ndarray,
+    world_vel: np.ndarray,
+    accel: np.ndarray,
+    gyro: np.ndarray,
+    timestamp: float,
+    gravity: float = 9.80665,
+) -> FDMPacket:
+    """Build an FDM packet from Elodin component arrays.
+
+    ``world_pos`` is ``[qx, qy, qz, qw, x, y, z]`` and ``world_vel`` is
+    ``[wx, wy, wz, vx, vy, vz]``. World position and linear velocity remain
+    ENU; body-frame IMU vectors are converted from FLU to FRD.
+    """
+    position = np.array(world_pos[4:7])
+    linear_velocity = np.array(world_vel[3:6])
+    accel_flu = np.array(accel) if accel is not None else np.array([0.0, 0.0, gravity])
+    gyro_flu = np.array(gyro) if gyro is not None else np.array(world_vel[:3])
+
+    return FDMPacket(
+        timestamp=timestamp,
+        imu_angular_velocity_rpy=flu_to_frd(gyro_flu),
+        imu_linear_acceleration_xyz=flu_to_frd(accel_flu),
+        imu_orientation_quat=elodin_quaternion_to_fdm(world_pos[:4]),
+        velocity_xyz=linear_velocity,
+        position_xyz=position,
+        pressure=101325.0 - 12.0 * position[2],
+    )
+
+
 class BetaflightBridge:
     """
     UDP communication bridge between Elodin and Betaflight SITL.

--- a/examples/betaflight-sitl/main.py
+++ b/examples/betaflight-sitl/main.py
@@ -31,6 +31,7 @@ import elodin as el
 import jax.numpy as jnp
 import numpy as np
 
+from baseline import C0Result, evaluate_c0
 from config import DEFAULT_CONFIG
 from sim import Drone, create_physics_system
 from sensors import IMU, create_sensor_system, SensorDataBuffer
@@ -158,6 +159,8 @@ class SITLState:
     sim_time: float = 0.0
     motors: np.ndarray = None
     max_motor: float = 0.0
+    lockstep_steps: int = 0
+    max_altitude: float = float(config.initial_position[2])
 
     def __post_init__(self):
         if self.motors is None:
@@ -179,6 +182,7 @@ sensor_buf = [None]
 state = [None]
 start_time = [None]
 last_print = [0.0]
+c0_result: list[C0Result | None] = [None]
 
 # Pre-allocated buffers to avoid allocation in hot loop
 _rc_channels_buffer = np.full(MAX_RC_CHANNELS, 1500, dtype=np.uint16)
@@ -252,6 +256,7 @@ def sitl_post_step(tick: int, ctx: el.StepContext):
         gyro = np.array(sensor_data["drone.gyro"])  # Body-frame gyroscope
         world_pos = np.array(sensor_data["drone.world_pos"])  # GPS simulation
         world_vel = np.array(sensor_data["drone.world_vel"])  # GPS velocity
+        s.max_altitude = max(s.max_altitude, float(world_pos[6]))
 
         # Update sensor buffer with real physics data
         buf.update(
@@ -301,8 +306,11 @@ def sitl_post_step(tick: int, ctx: el.StepContext):
         # Synchronous lockstep: send FDM+RC, wait for motor response
         # Motor order is native Betaflight Quad-X: BR(0), FR(1), BL(2), FL(3)
         # The physics simulation (config.py) uses the same motor layout
+        steps_before = b.step_count
         s.motors = b.step(fdm, rc)
-        s.max_motor = max(s.max_motor, np.max(s.motors))
+        if b.step_count > steps_before:
+            s.lockstep_steps += 1
+        s.max_motor = max(s.max_motor, float(np.max(s.motors)))
 
         # Write motor commands back to Elodin-DB for physics simulation
         # This uses the StepContext for direct DB access (no TCP overhead)
@@ -355,12 +363,14 @@ def sitl_post_step(tick: int, ctx: el.StepContext):
     # Check if simulation is complete - print summary and exit
     if tick >= MAX_TICKS - 1:
         b.stop()
+        ctx.stop_recipes()
         elapsed = time.time() - start_time[0]
 
         # Read final position
         try:
             final_pos = np.array(ctx.read_component("drone.world_pos"))
             final_z = final_pos[6] if len(final_pos) > 6 else final_pos[2]
+            s.max_altitude = max(s.max_altitude, float(final_z))
             final_vel = np.array(ctx.read_component("drone.world_vel"))
             final_vz = final_vel[5] if len(final_vel) > 5 else final_vel[2]
         except Exception:
@@ -380,18 +390,28 @@ def sitl_post_step(tick: int, ctx: el.StepContext):
         print(f"  Final position: z={final_z:.2f}m, vz={final_vz:.2f}m/s")
         print()
 
-        # Success criteria: motors responded AND drone moved
-        took_off = final_z > config.initial_position[2] + 0.1  # More than 10cm above start
+        result = evaluate_c0(
+            lockstep_steps=s.lockstep_steps,
+            max_motor=s.max_motor,
+            initial_altitude=float(config.initial_position[2]),
+            max_altitude=s.max_altitude,
+        )
+        c0_result[0] = result
 
-        if b.step_count > 0 and s.max_motor > 0.06 and took_off:
+        # Success criteria: lockstep and motors responded, and the drone rose at least 0.1 m.
+        if result.passed:
             print("SUCCESS: SITL integration working! Drone took off!")
-        elif b.step_count > 0 and s.max_motor > 0.06:
+        elif s.lockstep_steps <= 0:
+            print("WARNING: No lockstep motor responses received from Betaflight.")
+        elif result.motor_response:
             print("WARNING: Motors responded but drone did not take off.")
             print("  Check physics pipeline: motor_command -> thrust -> force")
-        elif b.step_count > 0 and s.max_motor > 0.02:
+        elif s.max_motor > 0.02:
             print("WARNING: Motors armed but no throttle response.")
         else:
             print("WARNING: No motor response. Check Betaflight configuration.")
+
+        print(result.format())
 
 
 # Return the next non-existent filename with auto-incremented
@@ -437,3 +457,5 @@ print(f"Wrote database to: {db_filename}")
 if not bridge[0]:
     print("\nNo simulation ticks executed.")
     print("Usage: python3 examples/betaflight-sitl/main.py run")
+elif c0_result[0] is not None and not c0_result[0].passed:
+    sys.exit(1)

--- a/examples/betaflight-sitl/sensors.py
+++ b/examples/betaflight-sitl/sensors.py
@@ -40,7 +40,7 @@ import jax.random as rng
 import numpy as np
 
 from config import DroneConfig
-from comms import FDMPacket
+from comms import FDMPacket, build_fdm_from_components
 
 
 class Noise:
@@ -599,105 +599,6 @@ def extract_sensor_data(
         "position": position,  # World frame, m (ENU)
         "pressure": pressure,  # Pascals
     }
-
-
-def build_fdm_from_components(
-    world_pos: np.ndarray,
-    world_vel: np.ndarray,
-    accel: np.ndarray,
-    gyro: np.ndarray,
-    timestamp: float,
-    gravity: float = 9.80665,
-) -> FDMPacket:
-    """
-    Build an FDM packet directly from Elodin component data.
-
-    This is the primary function for extracting sensor data from the simulation
-    and packaging it for Betaflight. It handles:
-    - Quaternion extraction from world_pos (Elodin scalar-last to Betaflight scalar-first)
-    - Velocity extraction from world_vel
-    - FLU to FRD body frame conversion for gyro/accel
-    - Pressure calculation from altitude
-
-    Args:
-        world_pos: Position array [qx, qy, qz, qw, x, y, z] (Elodin scalar-last format)
-        world_vel: Velocity array [wx, wy, wz, vx, vy, vz] (angular first in Elodin)
-        accel: Accelerometer specific force [ax, ay, az] in body frame (FLU)
-        gyro: Gyroscope [wx, wy, wz] in body frame (FLU)
-        timestamp: Simulation time in seconds
-        gravity: Gravity constant (for reference)
-
-    Returns:
-        FDMPacket ready for transmission to Betaflight
-    """
-    # Import here to avoid circular dependency
-    from comms import FDMPacket
-
-    # Extract quaternion from Elodin format [qx, qy, qz, qw] and convert to [qw, qx, qy, qz]
-    quat_xyzw = np.array(world_pos[:4])
-    quat_wxyz = np.array([quat_xyzw[3], quat_xyzw[0], quat_xyzw[1], quat_xyzw[2]])  # [w, x, y, z]
-
-    # Betaflight 2026.6.1+ SITL defaults to the Gazebo bridge
-    # (ENABLE_GAZEBO_BRIDGE=1), which expects the attitude quaternion in the
-    # Gazebo BetaflightPlugin convention: q_plugin = Rx(pi) * M * Rx(pi), where
-    # M is the FLU-body to ENU-world attitude. Conjugation by Rx(pi) negates
-    # qy/qz, so send [w, x, -y, -z]; SITL undoes the conjugation and rotates
-    # the world frame ENU -> NWU internally. The result drives the virtual mag
-    # feed (and the attitude directly when built with SITL_ATTITUDE_DIRECT).
-    quat = np.array([quat_wxyz[0], quat_wxyz[1], -quat_wxyz[2], -quat_wxyz[3]])
-
-    # Extract position [x, y, z] (ENU)
-    position = np.array(world_pos[4:7])
-
-    # Elodin stores world_vel as [wx, wy, wz, vx, vy, vz]
-    linear_vel = np.array(world_vel[3:6])
-
-    # Use provided sensor readings or compute from velocity
-    accel_enu = np.array(accel) if accel is not None else np.array([0.0, 0.0, gravity])
-    gyro_enu = np.array(gyro) if gyro is not None else np.array(world_vel[:3])
-
-    # Convert from Elodin FLU body frame to the FRD sensor frame that
-    # Betaflight 2026.6.1+ SITL expects (default ENABLE_GAZEBO_BRIDGE=1).
-    #
-    # This mirrors the Gazebo BetaflightPlugin, whose IMU sensor frame is FRD
-    # (Rx(pi) relative to the FLU body link):
-    #   accel: send specific force in FRD = [FLU_x, -FLU_y, -FLU_z]
-    #   gyro:  send body rates in FRD   = [FLU_x, -FLU_y, -FLU_z]
-    #
-    # sitl.c then maps these onto Betaflight's internal axes:
-    #   accel: negates all axes, so at rest the estimator sees acc_z = +1g
-    #          (up) and the Mahony filter converges to a level attitude
-    #   gyro:  (X, -Y, +Z) via sitlGyroBodyFromSim(), yielding Betaflight's
-    #          (roll right, pitch nose-down, yaw CW) sign convention
-    accel_ned = np.array(
-        [
-            accel_enu[0],  # FRD_x = FLU_x
-            -accel_enu[1],  # FRD_y = -FLU_y
-            -accel_enu[2],  # FRD_z = -FLU_z (at rest: -1g; BF negates to +1g)
-        ]
-    )
-
-    gyro_ned = np.array(
-        [
-            gyro_enu[0],  # FRD_x = FLU_x
-            -gyro_enu[1],  # FRD_y = -FLU_y
-            -gyro_enu[2],  # FRD_z = -FLU_z
-        ]
-    )
-
-    # Calculate pressure from altitude (simplified atmosphere model)
-    altitude = position[2]
-    pressure = 101325.0 - 12.0 * altitude
-
-    return FDMPacket(
-        timestamp=timestamp,
-        imu_angular_velocity_rpy=gyro_ned,
-        imu_linear_acceleration_xyz=accel_ned,
-        imu_orientation_quat=quat,
-        velocity_xyz=linear_vel,  # ENU, which Betaflight expects for GPS
-        position_xyz=position,  # ENU
-        pressure=pressure,
-    )
 
 
 def extract_from_history(df, tick: int = -1) -> dict:

--- a/examples/betaflight-sitl/tests/conftest.py
+++ b/examples/betaflight-sitl/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Shared pytest setup for the Betaflight SITL example."""
+
+import sys
+from pathlib import Path
+
+
+EXAMPLE_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(EXAMPLE_DIR))

--- a/examples/betaflight-sitl/tests/test_baseline.py
+++ b/examples/betaflight-sitl/tests/test_baseline.py
@@ -1,0 +1,53 @@
+"""Tests for the default scripted SITL scenario result."""
+
+import pytest
+
+from baseline import evaluate_c0
+
+
+def test_c0_passes_when_all_acceptance_criteria_are_met() -> None:
+    result = evaluate_c0(
+        lockstep_steps=120_000,
+        max_motor=0.4,
+        initial_altitude=0.1,
+        max_altitude=0.2,
+    )
+
+    assert result.motor_response is True
+    assert result.takeoff_delta_m == pytest.approx(0.1)
+    assert result.passed is True
+
+
+@pytest.mark.parametrize(
+    ("lockstep_steps", "max_motor", "max_altitude"),
+    [
+        pytest.param(0, 0.4, 1.0, id="no-lockstep-response"),
+        pytest.param(120_000, 0.06, 1.0, id="no-meaningful-motor-response"),
+        pytest.param(120_000, 0.4, 0.199, id="insufficient-takeoff"),
+    ],
+)
+def test_c0_fails_when_an_acceptance_criterion_is_unmet(
+    lockstep_steps: int, max_motor: float, max_altitude: float
+) -> None:
+    result = evaluate_c0(
+        lockstep_steps=lockstep_steps,
+        max_motor=max_motor,
+        initial_altitude=0.1,
+        max_altitude=max_altitude,
+    )
+
+    assert result.passed is False
+
+
+def test_c0_result_format_is_stable_and_machine_readable() -> None:
+    result = evaluate_c0(
+        lockstep_steps=119_995,
+        max_motor=0.5736,
+        initial_altitude=0.1,
+        max_altitude=56.94,
+    )
+
+    assert result.format() == (
+        "[C0] lockstep_steps=119995 motor_response=true max_motor=0.574 "
+        "takeoff_delta_m=56.840 status=PASS"
+    )

--- a/examples/betaflight-sitl/tests/test_fdm_conversions.py
+++ b/examples/betaflight-sitl/tests/test_fdm_conversions.py
@@ -1,0 +1,61 @@
+"""Golden tests for Elodin-to-Betaflight FDM conversion."""
+
+import numpy as np
+import pytest
+
+from comms import build_fdm_from_components
+
+
+def test_level_rest_fdm_conversion() -> None:
+    """A level stationary FLU body produces the canonical resting FDM packet."""
+    packet = build_fdm_from_components(
+        world_pos=np.array([0.0, 0.0, 0.0, 1.0, 12.0, -4.0, 2.0]),
+        world_vel=np.array([0.0, 0.0, 0.0, 1.0, -2.0, 3.0]),
+        accel=np.array([0.0, 0.0, 9.80665]),
+        gyro=np.zeros(3),
+        timestamp=0.125,
+    )
+
+    assert packet.timestamp == 0.125
+    np.testing.assert_array_equal(packet.imu_angular_velocity_rpy, [0.0, 0.0, 0.0])
+    np.testing.assert_array_equal(
+        packet.imu_linear_acceleration_xyz, [0.0, 0.0, -9.80665]
+    )
+    np.testing.assert_array_equal(packet.imu_orientation_quat, [1.0, 0.0, 0.0, 0.0])
+    np.testing.assert_array_equal(packet.velocity_xyz, [1.0, -2.0, 3.0])
+    np.testing.assert_array_equal(packet.position_xyz, [12.0, -4.0, 2.0])
+    assert packet.pressure == 101301.0
+
+
+@pytest.mark.parametrize(
+    ("gyro_flu", "expected_gyro_frd"),
+    [
+        pytest.param([1.0, 0.0, 0.0], [1.0, 0.0, 0.0], id="roll"),
+        pytest.param([0.0, 1.0, 0.0], [0.0, -1.0, 0.0], id="pitch"),
+        pytest.param([0.0, 0.0, 1.0], [0.0, 0.0, -1.0], id="yaw"),
+    ],
+)
+def test_canonical_body_rate_fdm_conversion(gyro_flu, expected_gyro_frd) -> None:
+    """Pure positive FLU body rates have fixed signs in the FRD sensor frame."""
+    packet = build_fdm_from_components(
+        world_pos=np.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]),
+        world_vel=np.zeros(6),
+        accel=np.array([0.0, 0.0, 9.80665]),
+        gyro=np.array(gyro_flu),
+        timestamp=0.0,
+    )
+
+    np.testing.assert_array_equal(packet.imu_angular_velocity_rpy, expected_gyro_frd)
+
+
+def test_fdm_quaternion_scalar_order_and_gazebo_signs() -> None:
+    """FDM converts xyzw to wxyz and negates the Gazebo bridge Y/Z terms."""
+    packet = build_fdm_from_components(
+        world_pos=np.array([0.1, -0.2, 0.3, 0.9, 4.0, -5.0, 6.0]),
+        world_vel=np.zeros(6),
+        accel=np.zeros(3),
+        gyro=np.zeros(3),
+        timestamp=0.0,
+    )
+
+    np.testing.assert_array_equal(packet.imu_orientation_quat, [0.9, 0.1, 0.2, -0.3])

--- a/examples/betaflight-sitl/tests/test_motor_layout.py
+++ b/examples/betaflight-sitl/tests/test_motor_layout.py
@@ -1,0 +1,64 @@
+"""Consistency tests for the native Betaflight Quad-X motor layout."""
+
+import numpy as np
+import pytest
+
+from config import DEFAULT_CONFIG
+
+
+def test_native_motor_order_positions_and_spins() -> None:
+    """Config indices follow Betaflight's native BR, FR, BL, FL order."""
+    config = DEFAULT_CONFIG
+    diagonal = config.arm_length / np.sqrt(2.0)
+    expected_positions = np.array(
+        [
+            [-diagonal, -diagonal, 0.0],  # BR
+            [diagonal, -diagonal, 0.0],  # FR
+            [-diagonal, diagonal, 0.0],  # BL
+            [diagonal, diagonal, 0.0],  # FL
+        ]
+    )
+
+    np.testing.assert_allclose(config.motor_positions, expected_positions)
+    np.testing.assert_allclose(
+        np.linalg.norm(config.motor_positions, axis=1), config.arm_length
+    )
+    np.testing.assert_array_equal(config.motor_spin_directions, [-1.0, 1.0, 1.0, -1.0])
+    np.testing.assert_array_equal(
+        config.motor_thrust_directions,
+        np.tile([0.0, 0.0, 1.0], (4, 1)),
+    )
+
+
+@pytest.mark.parametrize(
+    ("motor_index", "expected_torque_signs"),
+    [
+        pytest.param(0, [-1.0, 1.0, -1.0], id="back-right"),
+        pytest.param(1, [-1.0, -1.0, 1.0], id="front-right"),
+        pytest.param(2, [1.0, 1.0, 1.0], id="back-left"),
+        pytest.param(3, [1.0, -1.0, -1.0], id="front-left"),
+    ],
+)
+def test_individual_motor_torque_signs(
+    motor_index: int, expected_torque_signs
+) -> None:
+    """Each indexed motor produces the expected roll, pitch, and yaw signs."""
+    config = DEFAULT_CONFIG
+    torque = config.motor_torque_axes[motor_index].copy()
+    torque[2] += config.motor_torque_coeff * config.motor_spin_directions[motor_index]
+
+    np.testing.assert_array_equal(np.sign(torque), expected_torque_signs)
+
+
+def test_equal_motor_thrust_cancels_body_torque() -> None:
+    """A symmetric command produces thrust without roll, pitch, or yaw torque."""
+    config = DEFAULT_CONFIG
+    equal_thrust = np.ones(4)
+
+    thrust_torque = np.sum(config.motor_torque_axes * equal_thrust[:, None], axis=0)
+    yaw_torque = config.motor_torque_coeff * np.dot(
+        equal_thrust, config.motor_spin_directions
+    )
+    total_torque = thrust_torque + np.array([0.0, 0.0, yaw_torque])
+
+    np.testing.assert_allclose(total_torque, np.zeros(3), atol=1e-15)

--- a/examples/betaflight-sitl/tests/test_packets.py
+++ b/examples/betaflight-sitl/tests/test_packets.py
@@ -1,0 +1,100 @@
+"""Tests for the Betaflight SITL UDP packet boundary."""
+
+import struct
+
+import numpy as np
+import pytest
+
+from comms import FDMPacket, RCPacket, ServoPacket, ServoPacketRaw
+
+
+def test_servo_packet_golden_native_motor_order() -> None:
+    """The normalized motor packet is four little-endian floats in BF order."""
+    # Native Betaflight order: back-right, front-right, back-left, front-left.
+    motors = np.array([0.125, 0.25, 0.5, 1.0])
+    golden = bytes.fromhex("0000003e 0000803e 0000003f 0000803f")
+
+    assert ServoPacket(motor_speed=motors).pack() == golden
+
+    decoded = ServoPacket.from_bytes(golden)
+    np.testing.assert_array_equal(decoded.motor_speed, motors)
+
+
+def test_rc_packet_golden_channel_order() -> None:
+    """The RC packet keeps its timestamp and 16 channels in AETR/AUX order."""
+    # Roll, pitch, throttle, yaw, AUX1, followed by centered unused channels.
+    channels = np.array(
+        [1600, 1400, 1000, 1550, 1800, *([1500] * 11)], dtype=np.uint16
+    )
+    golden = bytes.fromhex(
+        "000000000000f83f "  # timestamp: 1.5 as a little-endian double
+        "4006 7805 e803 0e06 0807 "
+        "dc05 dc05 dc05 dc05 dc05 dc05 dc05 dc05 dc05 dc05 dc05"
+    )
+
+    assert RCPacket(timestamp=1.5, channels=channels).pack() == golden
+
+    decoded = RCPacket.from_bytes(golden)
+    assert decoded.timestamp == 1.5
+    np.testing.assert_array_equal(decoded.channels, channels)
+
+
+def test_fdm_packet_field_layout_and_round_trip() -> None:
+    """The FDM packet contains 18 little-endian doubles in protocol order."""
+    packet = FDMPacket(
+        timestamp=1.0,
+        imu_angular_velocity_rpy=np.array([2.0, 3.0, 4.0]),
+        imu_linear_acceleration_xyz=np.array([5.0, 6.0, 7.0]),
+        imu_orientation_quat=np.array([8.0, 9.0, 10.0, 11.0]),
+        velocity_xyz=np.array([12.0, 13.0, 14.0]),
+        position_xyz=np.array([15.0, 16.0, 17.0]),
+        pressure=18.0,
+    )
+
+    packed = packet.pack()
+    assert len(packed) == 144
+    assert struct.unpack("<18d", packed) == tuple(float(value) for value in range(1, 19))
+
+    decoded = FDMPacket.from_bytes(packed)
+    assert decoded.timestamp == packet.timestamp
+    np.testing.assert_array_equal(
+        decoded.imu_angular_velocity_rpy, packet.imu_angular_velocity_rpy
+    )
+    np.testing.assert_array_equal(
+        decoded.imu_linear_acceleration_xyz, packet.imu_linear_acceleration_xyz
+    )
+    np.testing.assert_array_equal(decoded.imu_orientation_quat, packet.imu_orientation_quat)
+    np.testing.assert_array_equal(decoded.velocity_xyz, packet.velocity_xyz)
+    np.testing.assert_array_equal(decoded.position_xyz, packet.position_xyz)
+    assert decoded.pressure == packet.pressure
+
+
+def test_raw_servo_packet_field_layout_and_round_trip() -> None:
+    """The raw packet has an aligned count followed by 16 PWM floats."""
+    pwm_output = np.arange(1000.0, 1160.0, 10.0)
+    packet = ServoPacketRaw(motor_count=4, pwm_output=pwm_output)
+
+    packed = packet.pack()
+    assert len(packed) == 68
+    assert struct.unpack("<Hxx16f", packed) == (4, *pwm_output)
+
+    decoded = ServoPacketRaw.from_bytes(packed)
+    assert decoded.motor_count == 4
+    np.testing.assert_array_equal(decoded.pwm_output, pwm_output)
+
+
+@pytest.mark.parametrize(
+    ("packet_type", "valid_size"),
+    [
+        (FDMPacket, 144),
+        (RCPacket, 40),
+        (ServoPacket, 16),
+        (ServoPacketRaw, 68),
+    ],
+)
+def test_packet_decoder_rejects_short_datagram(packet_type, valid_size: int) -> None:
+    """A truncated UDP datagram must not be interpreted as a complete packet."""
+    with pytest.raises(
+        ValueError, match=rf"Data too short: {valid_size - 1} < {valid_size}"
+    ):
+        packet_type.from_bytes(bytes(valid_size - 1))


### PR DESCRIPTION
# Betaflight SITL Package A: baseline safety net

## Summary

- add pure tests for UDP packets, FDM frame/quaternion conversions, and native motor layout
- add a machine-readable C0 result with real pass/fail exit status
- document the supported baseline verification workflow
- run the fast Betaflight SITL Python tests in Buildkite

## Verification

```text
python3 -m pytest examples/betaflight-sitl/tests -q
24 passed

elodin run examples/betaflight-sitl/main.py
[C0] lockstep_steps=119995 motor_response=true max_motor=0.574 takeoff_delta_m=56.837 status=PASS
```

A deliberately unmet takeoff criterion returns status 1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-scoped tests and exit-status behavior; no auth or shared production runtime changes beyond CI adding a fast pytest step.
> 
> **Overview**
> **Package A** turns the Betaflight SITL scripted takeoff into a testable baseline: a pure pytest suite, a machine-readable **C0** acceptance line, and a real nonzero exit when integration criteria fail.
> 
> Adds `examples/betaflight-sitl/tests/` covering UDP packet goldens, FDM FLU→FRD / quaternion conversion, motor layout, and `baseline.evaluate_c0`. FDM assembly moves from `sensors.py` into shared helpers on `comms.py` (`build_fdm_from_components`, etc.) so tests and runtime share one path.
> 
> `main.py` now tracks lockstep steps and peak altitude, prints `[C0] … status=PASS|FAIL`, calls `ctx.stop_recipes()` at shutdown, and exits **1** when C0 fails. README and `RACING_PLAN.md` document pytest + `elodin run` verification and mark Package A complete. Buildkite runs `python3 -m pytest examples/betaflight-sitl/tests -q` in the examples group.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7337c44855b436e94036dc8fba48457a9e34c59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->