### PR TITLE
chore: release v0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ## v0.19
 
+### v0.19.1
+- **(feat)** Add H.264 and gray8 sensor-camera outputs, with hardware-accelerated live encoding (NVENC, VideoToolbox) and an OpenH264 fallback. (#827)
+- **(feat)** Add `StepContext.read_msg_latest()` and the `sensor_visible` flag on `Object3D`. (#827)
+- **(fix)** Fix plot line flicker on auto-refreshing query plots. (#829)
+- **(fix)** Propagate headless simulation failures to the `elodin` exit code. (#837, #838)
+- **(chore)** Bump Bevy Hanabi and update the Falcon 9 effects. (#836)
+- **(chore)** Add `nix run .#elodin` as an alias for `nix run .`. (#828)
+- **(chore)** Install FFmpeg for release editor builds and add a post-merge release dry-run. (#831, #835, #839)
+- **(doc)** Add an incremental Betaflight racing plan. (#830)
+
 ### v0.19.0
 - **(feat)** Report CPU, GPU, and plot-buffer usage in the status bar, with a `Dump GPU Allocations` command. (#817)
 - **(feat)** Open a recorded database directly with `elodin editor <path-to-db-folder>`. (#807)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-serial-bridge"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "blackbox",
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-setup"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "fastrand 1.9.0",
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-status"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "db-macros",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_ai_skybox"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "bevy",
  "chrono",
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "blackbox"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "zerocopy",
 ]
@@ -4244,7 +4244,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-mlir"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "blake3",
  "cranelift-codegen",
@@ -5211,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "db-macros"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "convert_case 0.6.0",
  "darling 0.20.11",
@@ -5515,7 +5515,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elodin"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "base64 0.22.1",
  "bevy",
@@ -5549,7 +5549,7 @@ dependencies = [
 
 [[package]]
 name = "elodin-db"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5642,7 +5642,7 @@ dependencies = [
 
 [[package]]
 name = "elodin-db-tests"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "arrow",
  "elodin-db",
@@ -5665,7 +5665,7 @@ dependencies = [
 
 [[package]]
 name = "elodin-editor"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "ab_glyph",
  "arc-swap",
@@ -5752,7 +5752,7 @@ dependencies = [
 
 [[package]]
 name = "elodin-macros"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "convert_case 0.6.0",
  "darling 0.20.11",
@@ -5972,7 +5972,7 @@ checksum = "f8970033a4282a7bcf899b38b5ed3a58b732fe093d03785d58648515d8d309da"
 
 [[package]]
 name = "eql"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "bevy_geo_frames",
  "bevy_math",
@@ -7092,7 +7092,7 @@ checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
 
 [[package]]
 name = "gst-elodin-plugin"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "gst-plugin-version-helper",
@@ -7286,7 +7286,7 @@ dependencies = [
 
 [[package]]
 name = "hamann-chen-line"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "clap 4.6.1",
@@ -7955,7 +7955,7 @@ checksum = "40fac9d56ed6437b198fddba683305e8e2d651aa42647f00f5ae542e7f5c94a2"
 
 [[package]]
 name = "impeller2"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "bevy",
  "const-fnv1a-hash",
@@ -7978,7 +7978,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-bbq"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "bbqueue",
  "impeller2",
@@ -7987,7 +7987,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-bevy"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "bbqueue",
  "bevy",
@@ -8011,7 +8011,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-cli"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -8040,7 +8040,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-frame"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "cobs 0.2.3",
  "impeller2",
@@ -8048,7 +8048,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-kdl"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "bevy_geo_frames",
  "impeller2",
@@ -8063,7 +8063,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-stellar"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "bbqueue",
  "fastrand 2.4.1",
@@ -8084,7 +8084,7 @@ dependencies = [
 
 [[package]]
 name = "impeller2-wkt"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "bevy",
  "bevy_geo_frames",
@@ -8242,7 +8242,7 @@ checksum = "d57a1694cff80cdd6c8a4cae63984578e2617528d3c266e53f56dfd3e279e9f7"
 
 [[package]]
 name = "inscriber"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "clap 4.6.1",
@@ -8917,7 +8917,7 @@ dependencies = [
 
 [[package]]
 name = "lqr"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "clap 4.6.1",
@@ -9228,7 +9228,7 @@ dependencies = [
 
 [[package]]
 name = "mekf"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "clap 4.6.1",
@@ -9429,7 +9429,7 @@ dependencies = [
 
 [[package]]
 name = "monte-carlo"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "chrono",
  "csv",
@@ -9975,7 +9975,7 @@ dependencies = [
 
 [[package]]
 name = "nox"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "approx",
  "bevy_math",
@@ -10004,14 +10004,14 @@ dependencies = [
 
 [[package]]
 name = "nox-array"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "zerocopy",
 ]
 
 [[package]]
 name = "nox-frames"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "approx",
  "hifitime",
@@ -10021,7 +10021,7 @@ dependencies = [
 
 [[package]]
 name = "nox-py"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "approx",
  "arrow",
@@ -11377,7 +11377,7 @@ dependencies = [
 
 [[package]]
 name = "postcard-c-codegen"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "clap 4.6.1",
  "convert_case 0.6.0",
@@ -12258,7 +12258,7 @@ dependencies = [
 
 [[package]]
 name = "rc-jet-controller"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "clap 4.6.1",
@@ -12628,7 +12628,7 @@ dependencies = [
 
 [[package]]
 name = "roci"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "bbqueue",
@@ -12654,7 +12654,7 @@ dependencies = [
 
 [[package]]
 name = "roci-adcs"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "approx",
  "nox",
@@ -12727,14 +12727,14 @@ dependencies = [
 
 [[package]]
 name = "rtsp-ingest"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "rtsp-streamer"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "clap 4.6.1",
@@ -12922,7 +12922,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s10"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-watcher",
  "cargo_metadata",
@@ -13687,7 +13687,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stellarator"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "blocking",
  "futures",
@@ -13715,11 +13715,11 @@ dependencies = [
 
 [[package]]
 name = "stellarator-buf"
-version = "0.19.0"
+version = "0.19.1"
 
 [[package]]
 name = "stellarator-macros"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -14133,7 +14133,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tegrastats-bridge"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "db-macros",
@@ -15354,7 +15354,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "video-streamer"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -15373,7 +15373,7 @@ dependencies = [
 
 [[package]]
 name = "video-toolbox"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "bitflags 2.11.1",
  "block2 0.6.2",
@@ -16729,7 +16729,7 @@ dependencies = [
 
 [[package]]
 name = "wmm"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "approx",
  "bindgen 0.70.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ members = [
 exclude = ["fsw/sensor-fw", "fsw/blackbox", "docs/memserve"]
 
 [workspace.package]
-version = "0.19.0"
+version = "0.19.1"
 edition = "2024"
 repository = "https://github.com/elodin-sys/elodin"
 

--- a/docs/public/config.toml
+++ b/docs/public/config.toml
@@ -38,7 +38,7 @@ github = "https://github.com/elodin-sys"
 twitter = "https://twitter.com/elodinsystems"
 email = "info@elodin.systems"
 ganalytics = ""
-version = "v0.19.0"
+version = "v0.19.1"
 
 # If running on netlify.app site, set to true
 is_netlify = false

--- a/docs/public/content/releases/changelog.md
+++ b/docs/public/content/releases/changelog.md
@@ -15,7 +15,19 @@ order = 1
 
 ## v0.19
 
+### v0.19.1
+- **(feat)** Add H.264 and gray8 sensor-camera outputs, with hardware-accelerated live encoding (NVENC, VideoToolbox) and an OpenH264 fallback. (#827)
+- **(feat)** Add `StepContext.read_msg_latest()` and the `sensor_visible` flag on `Object3D`. (#827)
+- **(fix)** Fix plot line flicker on auto-refreshing query plots. (#829)
+- **(fix)** Propagate headless simulation failures to the `elodin` exit code. (#837, #838)
+- **(chore)** Bump Bevy Hanabi and update the Falcon 9 effects. (#836)
+- **(chore)** Add `nix run .#elodin` as an alias for `nix run .`. (#828)
+- **(chore)** Install FFmpeg for release editor builds and add a post-merge release dry-run. (#831, #835, #839)
+- **(doc)** Add an incremental Betaflight racing plan. (#830)
+
 ### v0.19.0
+- **(feat)** Report CPU, GPU, and plot-buffer usage in the status bar, with a `Dump GPU Allocations` command. (#817)
+- **(feat)** Open a recorded database directly with `elodin editor <path-to-db-folder>`. (#807)
 - **(feat)** Add a native Earth environment. (#778, #795)
 - **(feat)** Add heliocentric relative dynamics to Voyager. (#789)
 - **(feat)** Add Voyager trajectory error telemetry. (#769)
@@ -23,12 +35,18 @@ order = 1
 - **(feat)** Add an artificial horizon gauge. (#753)
 - **(feat)** Add headless video capture. (#754, #757)
 - **(feat)** Add --kdl to allow local KDL and asset development. (#763)
+- **(feat:examples)** Model the RC-jet on measured BDX aero data, with WGS84 ECEF trim, a Mojave RC field scene, and an LWIR sensor camera. (#820)
+- **(feat:examples)** Update Betaflight SITL to 2026.6.1 with 8 kHz real-time lockstep. (#815, #818)
 - **(feat:aleph)** Add initrd-based one-shot Aleph UEFI and OS flashing over USB-C. (#748)
 - **(feat:db)** Add Elodin DB gRPC. (#772)
 - **(feat:db)** Add `elodin-db export --format mcap`. (#746)
+- **(fix)** Fix video-stream GStreamer plugin discovery and Apollo `elodin run` exit. (#812)
+- **(fix)** Fix cinematic viewport lighting and overlays leaking into regular panes. (#811)
+- **(fix)** Limit viewport `far` to frustum visualization only. (#802)
+- **(fix)** Scale the viewport grid from camera distance. (#800)
 - **(fix)** Fix view-cube ECEF face labels, zoom in/out. (#796, #790, #758)
 - **(fix)** Fix Betaflight takeoff. (#791)
-- **(fix)** Fix GPU OOM and fins animation. (#788)
+- **(fix)** Fix GPU OOM and fins animation. (#788, #817)
 - **(fix)** Generate schematic planes in Z-up so identity pose is ground. (#786, #793)
 - **(fix)** Fix ECEF translate and add `ned_to_ecef()`. (#774)
 - **(fix)** Prevent an editor crash when scrubbing with particles. (#777)
@@ -40,8 +58,10 @@ order = 1
 - **(fix)** Restore minimal terrain rendering. (#761)
 - **(fix:examples)** Put Apollo thruster particles in schematic Z-up. (#797)
 - **(fix:impeller2)** Skip and log malformed fields instead of dropping the table. (#762)
+- **(perf)** Bump to Rust 1.98 and use algebraic float methods on hot paths. (#798)
 - **(perf)** Improve editor FPS on DB playback. (#771)
 - **(chore)** Bump Bevy Hanabi. (#773)
+- **(doc)** Index the examples by domain and by Elodin object. (#819)
 
 ## v0.18
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version and changelog-only changes with no runtime code modifications.
> 
> **Overview**
> **Release v0.19.1** — bumps the workspace and all crates from `0.19.0` to `0.19.1` in `Cargo.toml`, `Cargo.lock`, and docs site config (`docs/public/config.toml`).
> 
> Documents **v0.19.1** in `CHANGELOG.md` and the public changelog, including sensor-camera H.264/gray8 encoding, `StepContext.read_msg_latest()` / `Object3D.sensor_visible`, plot flicker and headless exit-code fixes, Hanabi/Falcon 9 updates, Nix/FFmpeg release CI tweaks, and a Betaflight racing doc.
> 
> The published **v0.19.0** section is also expanded with entries that were missing from the docs changelog (examples, fixes, perf, doc index).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8c5c843501e92db30af70564c13769e446d25eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->