### PR TITLE
fix(ci): Refresh the Homebrew index before macOS release builds.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,6 +145,13 @@ jobs:
           pattern: artifacts-*
           path: target/distrib/
           merge-multiple: true
+      # Runner images ship a frozen Homebrew index. ffmpeg@8 only entered
+      # homebrew-core on 2026-09-01, and `brew bundle` never updates, so an
+      # older image resolves ffmpeg@8 to the pre-9.0 alias or not at all.
+      - name: Refresh the Homebrew index
+        if: runner.os == 'macOS'
+        shell: bash
+        run: brew update --quiet
       - name: Install dependencies
         run: |
           ${{ matrix.packages_install }}
@@ -442,6 +449,7 @@ jobs:
           python-version: "3.13"
       - name: Install dependencies
         run: |
+          brew update --quiet
           brew install protobuf ffmpeg@8
           prefix="$(brew --prefix ffmpeg@8)"
           echo "PKG_CONFIG_PATH=${prefix}/lib/pkgconfig:${PKG_CONFIG_PATH:-}" >> "$GITHUB_ENV"


### PR DESCRIPTION
brew bundle never updates, so build-local-artifacts resolved ffmpeg@8 against whatever index the runner image froze. Older images still had it as an alias for the pre-9.0 ffmpeg; newer ones predate the 2026-09-01 homebrew-core formula and fail outright.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that refreshes Homebrew metadata before installs; no application or release artifact logic is modified.
> 
> **Overview**
> macOS release CI was installing **ffmpeg@8** against GitHub runner images’ **stale Homebrew formula index**, so `brew bundle` / `brew install` could resolve the wrong FFmpeg or fail after ffmpeg@8 landed in homebrew-core.
> 
> The workflow now runs **`brew update --quiet`** on macOS before dependency install in **`build-local-artifacts`** (dedicated step, macOS-only) and in **`macos-app`** (prepended to the existing install script). Existing **pkg-config / PATH** setup for keg-only **ffmpeg@8** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aae5b0cd35d88b11e022107d5a89d14098fd8b74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->